### PR TITLE
Remove the need for `mkdir node_modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ $ npm install
 $ make build
 $ npm link
 # go into some random directory
-$ mkdir node_modules
 $ kpm install your-package
 ```
 


### PR DESCRIPTION
This pull request should not be merged right now, just want to raise awareness of the current situation.

If you don't `mkdir node_modules`, it will go all the way through creating the lock file but throw with

```
Error: ENOENT: no such file or directory, symlink '/Users/vjeux/.kpm/npm-absolute-path-0.0.0' -> '/Users/vjeux/random/react-native/node_modules/absolute-path'
```

because node_modules/ doesn't exist.

Now because the lock file exists, next time you do kpm install, it'll fail with

```
kpm install v0.0.0
SyntaxError: Invalid value type 4:0
    at Parser.unexpected (/Users/vjeux/random/kpm/lib-legacy/lockfile/parse.js:313:13)
    at Parser.parse (/Users/vjeux/random/kpm/lib-legacy/lockfile/parse.js:374:18)
```

Would be nice to either throw an exception early if node_modules folder doesn't exist, or follow npm and just create that folder for the user.
