### PR TITLE
Add packages-root as a cli option

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -33,7 +33,8 @@ commander.usage("[command] [flags]");
 commander.option("--json", "");
 commander.option("--modules-folder [path]", "rather than installing modules into the node_modules " +
                                             "folder relative to the cwd, output them here");
-
+commander.option("--packages-root [path]", "rather than storing modules into a global packages root," +
+                                           "store them here");
 // get command name
 let commandName = args.splice(2, 1)[0] || "";
 
@@ -77,7 +78,8 @@ reporter.initPeakMemoryCounter();
 
 //
 let config = new Config(reporter, {
-  modulesFolder: commander.modulesFolder
+  modulesFolder: commander.modulesFolder,
+  packagesRoot: commander.packagesRoot,
 });
 
 // print header

--- a/src/config.js
+++ b/src/config.js
@@ -90,7 +90,9 @@ export default class Config {
       this.cwd = opts.cwd;
     }
 
-    this.packagesRoot = await this.getPackageRoot(opts);
+    if (!this.packagesRoot) {
+      this.packagesRoot = await this.getPackageRoot(opts);
+    }
 
     if (!this.tempFolder) {
       this.tempFolder = await this.getTempFolder();


### PR DESCRIPTION
~/.fbkpm is shared amongst all processes of kpm. This is an issue when there are concurrent installs reading/writing to this packages root.

This diff adds a CLI flag that will allow us to specify a packages-root for each instance and avoid stepping on each-other.
