### PR TITLE
Collapse duplicate objects in lockfile to single line

### DIFF
--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -114,7 +114,8 @@ export default class Lockfile {
     [packagePattern: string]: Manifest
   }): Object {
     let lockfile = {};
-    let seen: Map<string, string> = new Map;
+    let seen: Map<string, Object> = new Map;
+
     // order by name so that lockfile manifest is assigned to the first dependency with this manifest
     // the others that have the same remote.resovled will just refer to the first
     // oredring allows for consistency in lockfile when it is serialized
@@ -138,7 +139,7 @@ export default class Lockfile {
 
       invariant(remote, "Package is missing a remote");
 
-      lockfile[pattern] = {
+      let obj = {
         name: pkg.name,
         version: pkg.version,
         uid: pkg.uid === pkg.version ? undefined : pkg.uid,
@@ -148,9 +149,10 @@ export default class Lockfile {
         optionalDependencies: _.isEmpty(pkg.optionalDependencies) ? undefined : pkg.optionalDependencies,
         permissions: _.isEmpty(ref.permissions) ? undefined : ref.permissions
       };
+      lockfile[pattern] = obj;
 
       if (remote.resolved) {
-        seen.set(remote.resolved, pattern);
+        seen.set(remote.resolved, obj);
       }
     }
 

--- a/test/lockfile.js
+++ b/test/lockfile.js
@@ -51,8 +51,8 @@ test("parse", (t) => {
 });
 
 test("stringify", (t) => {
-  stringify;
-  t;
+  let obj = { foo: "bar" };
+  t.deepEqual(stringify({ a: obj, b: obj }), "a, b:\n  foo bar");
 });
 
 test("Lockfile.isStrict", (t) => {
@@ -147,17 +147,19 @@ test("Lockfile.getLockfile", (t) => {
 
   let actual = new Lockfile().getLockfile(patterns);
 
+  let expectedFoobar = {
+    name: "foobar",
+    version: "0.0.0",
+    uid: undefined,
+    resolved: "http://example.com/foobar",
+    registry: undefined,
+    dependencies: undefined,
+    optionalDependencies: undefined,
+    permissions: undefined
+  };
+
   let expected = {
-    foobar: {
-      name: "foobar",
-      version: "0.0.0",
-      uid: undefined,
-      resolved: "http://example.com/foobar",
-      registry: undefined,
-      dependencies: undefined,
-      optionalDependencies: undefined,
-      permissions: undefined
-    },
+    foobar: expectedFoobar,
 
     barfoo: {
       name: "barfoo",
@@ -170,7 +172,7 @@ test("Lockfile.getLockfile", (t) => {
       permissions: { foo: "bar" }
     },
 
-    foobar2: "foobar"
+    foobar2: expectedFoobar
   };
 
   t.deepEqual(actual, expected);
@@ -198,19 +200,20 @@ test("Lockfile.getLockfile (sorting)", (t) => {
 
   let actual = new Lockfile().getLockfile(patterns);
 
-  let expected = {
-    foobar1: {
-      name: "foobar",
-      version: "0.0.0",
-      uid: undefined,
-      resolved: "http://example.com/foobar",
-      registry: undefined,
-      dependencies: undefined,
-      optionalDependencies: undefined,
-      permissions: undefined
-    },
+  let expectedFoobar = {
+    name: "foobar",
+    version: "0.0.0",
+    uid: undefined,
+    resolved: "http://example.com/foobar",
+    registry: undefined,
+    dependencies: undefined,
+    optionalDependencies: undefined,
+    permissions: undefined
+  };
 
-    foobar2: "foobar1"
+  let expected = {
+    foobar1: expectedFoobar,
+    foobar2: expectedFoobar
   };
 
   t.deepEqual(actual, expected);


### PR DESCRIPTION
Currently if we have duplicate entries in `fbkpm.lock` we alias them with a string reference like so:

```
xtend@^4.0.0:
  name xtend
  version "4.0.1"
  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
"xtend@>=4.0.0 <4.1.0-0" xtend@^4.0.0
xtend@~4.0.0 xtend@^4.0.0
```

This PR changes this to:

```
xtend@^4.0.0, xtend@~4.0.0, "xtend@>=4.0.0 <4.1.0-0":
  name xtend
  version "4.0.1"
  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
```

This is more compact and should reduce lockfile change noise.
