### PR TITLE
Strict lockfile mode during uninstall process

### DIFF
--- a/src/cli/commands/uninstall.js
+++ b/src/cli/commands/uninstall.js
@@ -34,7 +34,9 @@ export async function run(
   let step = 0;
 
   async function runInstall() {
-    let lockfile = await Lockfile.fromDirectory(config.cwd, reporter, {});
+    let lockfile = await Lockfile.fromDirectory(config.cwd, reporter, {
+      silent: true
+    });
     let install = new Install("uninstall", flags, [], config, new NoopReporter, lockfile);
     await install.init();
     return install;


### PR DESCRIPTION
Figured I'd just open this up as a PR to discuss it. Since new `Lockfile.fromDirectory` creates a new lockfile with strict mode false by default it causes commands like uninstall to output the "Lockfile is not in strict mode." message unless it explicitly passes `strictIfPresent: true` which seems a bit odd.

Maybe its not odd though and this can just be merged
