### PR TITLE
Add --offline flag to query local cache for matching packages

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -37,6 +37,7 @@ let args = process.argv;
 // set global options
 commander.version(pkg.version);
 commander.usage("[command] [flags]");
+commander.option("--offline");
 commander.option("--json", "");
 commander.option("--modules-folder [path]", "rather than installing modules into the node_modules " +
                                             "folder relative to the cwd, output them here");
@@ -91,6 +92,7 @@ reporter.initPeakMemoryCounter();
 let config = new Config(reporter, {
   modulesFolder: commander.modulesFolder,
   packagesRoot: commander.packagesRoot,
+  offline: commander.offline,
 });
 
 // print header
@@ -108,7 +110,10 @@ if (commander.yes) {
 
 //
 if (network.isOffline()) {
-  reporter.warn("You don't appear to have an internet connection.");
+  reporter.warn(
+    "You don't appear to have an internet connection. " +
+    "Try the --offline flag to use the cache for registry queries."
+  );
 }
 
 //

--- a/src/fetchers/_base.js
+++ b/src/fetchers/_base.js
@@ -24,10 +24,12 @@ export default class BaseFetcher {
     this.reference      = remote.reference;
     this.registry       = remote.registry;
     this.hash           = remote.hash;
+    this.remote         = remote;
     this.config         = config;
     this.saveForOffline = !!saveForOffline;
   }
 
+  remote: PackageRemote;
   registry: RegistryNames;
   reference: string;
   config: Config;
@@ -47,6 +49,7 @@ export default class BaseFetcher {
       let pkg = await this.config.readManifest(dest, this.registry);
 
       await fs.writeFile(path.join(dest, constants.METADATA_FILENAME), JSON.stringify({
+        remote: this.remote,
         registry: this.registry,
         hash
       }, null, "  "));


### PR DESCRIPTION
I'm about to board a plane, figured this would come in handy. Basically you provide the flag `--offline` and it will crawl the cache of installed modules and match against the versions you have installed.

``` sh
$ kpm install --offline
```
