### PR TITLE
Enable warning for invalid engine names

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -122,8 +122,7 @@ export default class PackageCompatibility {
             pushError(`The engine ${name} is incompatible with this module. Expected version ${range}.`);
           }
         } else if (!_.includes(ignore, name)) {
-          // TODO: this causes a lot of warnings
-          //this.reporter.warn(`${human}: The engine ${name} appears to be invalid.`);
+          this.reporter.warn(`${human}: The engine ${name} appears to be invalid.`);
         }
       }
     }


### PR DESCRIPTION
Previously this would cause a lot of log pollution. Lots of these packages have since been fixed and if the few that remain bother users/us then we can just submit PRs.
