### PR TITLE
fixes bugs in error logging

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -98,8 +98,7 @@ async function run(
       await clean(cwd, removeLock);
     }
   } catch (err) {
-    console.log(out);
-    throw err;
+    throw `${err} \nConsole output:\n ${out}`;
   }
 }
 


### PR DESCRIPTION
stream.Writable converts strings to buffers by default.
Because of this error logs were not printed in test output.
