### PR TITLE
Ignore teleport engine

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -49,7 +49,8 @@ let aliases = map({
 });
 
 let ignore = [
-  "npm" // we'll never satisfy this for obvious reasons
+  "npm", // we'll never satisfy this for obvious reasons
+  "telport", // a module bundler used by some modules
 ];
 
 export default class PackageCompatibility {


### PR DESCRIPTION
This engine is specified by the `q` library and is also specified in various other modules. The `teleport` module uses this engine field to identify that the module is compatible.
