### PR TITLE
Quick fix

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -147,18 +147,12 @@ const runEventually = (): Promise<void> => {
 
       socket.on("connect", () => {}).on("data", () => {
         socket.unref();
-        ok(runEventually().then(process.exit));
+        setTimeout(() => {
+          ok(runEventually().then(process.exit))
+        }, 200);
       }).on("error", (e) => {
-        // the process finished while we were handling the error.
-        if (e.code === "ECONNREFUSED") {
-          try {
-            fs.unlinkSync(socketFile);
-          } catch (e) {} // some other instance won the race to delete the file
-        }
-
         ok(runEventually().then(process.exit));
       });
-
     });
 
     const clean = () => {
@@ -167,6 +161,9 @@ const runEventually = (): Promise<void> => {
         client.write("closing. kthanx, bye.");
       });
       unixServer.close();
+      try {
+        fs.unlinkSync(socketFile);
+      } catch (e) {}
       process.exit();
     };
 


### PR DESCRIPTION
Quick fix for https://github.com/facebook/fbkpm/issues/195.
The problem was that previously any process could delete the socket file.
That may cause a race condition that allowed multiple process to open the socket.
I've tried multiple way to solve the issue (eg using a delete socket) but the only working one is to allow only the same process that owns the socket to clean after itself.
This may cause a problem is kpm sigfaults and the unix socket file is still there (death should handle all the other cases).
We'll probably need some way to understand that a kpm process has died of unnatural causes and there is a file leftover (probably by using file timestamp).

Fixes #195 
