### PR TITLE
Add support for scoped packages

### DIFF
--- a/__tests__/fixtures/normalise-manifest/throw name url encode required/expected.json
+++ b/__tests__/fixtures/normalise-manifest/throw name url encode required/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": "Name cannot contain character that require URL encoding"
+  "_error": "Name contains illegal characters"
 }

--- a/__tests__/normalise-manifest.js
+++ b/__tests__/normalise-manifest.js
@@ -53,6 +53,10 @@ for (let name of nativeFs.readdirSync(fixturesLoc)) {
       }
     }
 
+    if (error) {
+      throw new Error(`Expected to throw error: ${error}`);
+    }
+
     expect(map(actual)).toEqual(map(expected));
     expect(actualWarnings).toEqual(expectedWarnings);
   });

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -57,3 +57,4 @@ addTest('gulp'); // npm
 addTest('react-native'); // npm
 addTest('ember-cli'); // npm
 addTest('npm:gulp'); // npm
+addTest('@polymer/iron-icon'); // npm scoped package

--- a/src/resolvers/registries/npm.js
+++ b/src/resolvers/registries/npm.js
@@ -71,8 +71,13 @@ export default class NpmResolver extends RegistryResolver {
 
     let registry = removeSuffix(this.registryConfig.registry, '/');
 
+    let name = this.name;
+
+    // scoped packages contain slashes and the npm registry expects them to be escaped
+    name = name.replace('/', '%2F');
+
     let body = await this.config.requestManager.request({
-      url: `${registry}/${this.name}`,
+      url: `${registry}/${name}`,
       json: true,
     });
 

--- a/src/util/normalise-manifest/validate.js
+++ b/src/util/normalise-manifest/validate.js
@@ -19,6 +19,19 @@ let strings = [
   'version',
 ];
 
+function isValidName(name: string): boolean {
+  return !name.match(/[\/@\s\+%:]/) && encodeURIComponent(name) === name;
+}
+
+function isValidScopedName(name: string): boolean {
+  if (name[0] !== '@') {
+    return false;
+  }
+
+  let parts = name.slice(1).split('/');
+  return parts.length === 2 && isValidName(parts[0]) && isValidName(parts[1]);
+}
+
 export default function(info: Object, warn: (msg: string) => void) {
   for (let key in typos) {
     if (key in info) {
@@ -38,13 +51,8 @@ export default function(info: Object, warn: (msg: string) => void) {
     }
 
     // cannot contain the following characters
-    if (name.match(/[\/@\s\+%:]/)) {
+    if (!isValidName(name) && !isValidScopedName(name)) {
       throw new TypeError('Name contains illegal characters');
-    }
-
-    // cannot contain any characters that would need to be encoded for use in a url
-    if (name !== encodeURIComponent(name)) {
-      throw new TypeError('Name cannot contain character that require URL encoding');
     }
 
     // cannot equal node_modules or favicon.ico


### PR DESCRIPTION
We don't actually need to do much to support these besides special case them in the `name` validation and registry resolution logic. The rest will be automatically handled since it includes a slash.
