### PR TITLE
Prune extraneous files/modules

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -12,7 +12,6 @@
 import type { Reporter } from '../../reporters/index.js';
 import type { DependencyRequestPatterns } from '../../types.js';
 import type Config from '../../config.js';
-import {run as check} from './check.js';
 import Lockfile from '../../lockfile/index.js';
 import lockStringify from '../../lockfile/stringify.js';
 import PackageInstallScripts from '../../package-install-scripts.js';
@@ -160,34 +159,20 @@ export class Install {
       }
     }
 
-    this.reporter.step(1, 4, 'Checking current installation of node_modules', emoji.get('heavy_check_mark'));
-    try {
-      await check(this.config, this.reporter, {}, []);
-      if (this.args.length === 0 && this.action === 'install') {
-        // current node_modules satisfies the lock file
-        this.reporter.success('node_modules are consistent with the lock file, finishing');
-        return;
-      }
-    } catch (error) {
-      // cleanup node_modules
-      this.reporter.info('Removing node_modules to have a clean installation');
-      await fs.unlink(path.join(this.config.cwd, 'node_modules'));
-    }
-
     //
-    this.reporter.step(2, 4, 'Resolving and fetching packages', emoji.get('truck'));
+    this.reporter.step(1, 3, 'Resolving and fetching packages', emoji.get('truck'));
     await this.resolver.init(depRequests);
     let patterns = await this.flatten(rawPatterns);
     await this.compatibility.init();
 
     //
-    this.reporter.step(3, 4, 'Linking dependencies', emoji.get('link'));
+    this.reporter.step(2, 3, 'Linking dependencies', emoji.get('link'));
     await this.linker.init(patterns);
 
     //
     this.reporter.step(
-      4,
-      4,
+      3,
+      3,
       this.flags.rebuild ? 'Rebuilding all packages' : 'Building fresh packages',
       emoji.get('page_with_curl')
     );

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -172,12 +172,23 @@ export default class PackageRequest {
     let range = 'latest';
     let name  = pattern;
 
-    // matches a version tuple in the form of NAME@VERSION. allows the first character to
-    // be an @ for scoped packages
-    let match = pattern.match(/^([^@]{1,})@(.*?)$/);
-    if (match) {
-      name = match[1];
-      range = match[2] || '*';
+    // if we're a scope then remove the @ and add it back later
+    let isScoped = false;
+    if (name[0] === '@') {
+      isScoped = true;
+      name = name.slice(1);
+    }
+
+    // take first part as the name
+    let parts = name.split('@');
+    if (parts.length > 1) {
+      name = parts.shift();
+      range = parts.join('@') || '*';
+    }
+
+    // add back @ scope suffix
+    if (isScoped) {
+      name = `@${name}`;
     }
 
     return { name, range };

--- a/src/registries/bower.js
+++ b/src/registries/bower.js
@@ -19,6 +19,7 @@ let _ = require('lodash');
 export default class BowerRegistry extends Registry {
   static alwaysFlatten = true;
   static filenames = ['bower.json'];
+  static directory = 'bower_components';
 
   async loadConfig(): Promise<void> {
     // docs: http://bower.io/docs/config/

--- a/src/registries/npm.js
+++ b/src/registries/npm.js
@@ -38,6 +38,7 @@ function getGlobalPrefix(): string {
 
 export default class NpmRegistry extends Registry {
   static filenames = ['package.json'];
+  static directory = 'node_modules';
 
   async loadConfig(): Promise<void> {
     // docs: https://docs.npmjs.com/misc/config


### PR DESCRIPTION
We pass a list of paths that are possibly extraneous to `fs.copyBulk` and if the files listed aren't found then we remove them.
