### PR TITLE
Enable parallel installation

### DIFF
--- a/src/reporters/BaseReporter.js
+++ b/src/reporters/BaseReporter.js
@@ -111,7 +111,7 @@ export default class BaseReporter {
   }
 
   //
-  activityStep(current: number, total: number, message: string, emoji?: string): ReporterSpinner {
+  activityStep(current: number, total: number, message: string, runId?: number, emoji?: string): ReporterSpinner {
     return this.activity();
   }
 

--- a/src/reporters/JSONReporter.js
+++ b/src/reporters/JSONReporter.js
@@ -71,7 +71,7 @@ export default class JSONReporter extends BaseReporter {
     this._dump('info', msg);
   }
 
-  activityStep(current: number, total: number, message: string, emoji?: string): ReporterSpinner {
+  activityStep(current: number, total: number, message: string, runId?: number, emoji?: string): ReporterSpinner {
     return this._activity({step: true, current, total, message});
   }
 

--- a/src/reporters/console/ConsoleReporter.js
+++ b/src/reporters/console/ConsoleReporter.js
@@ -153,14 +153,14 @@ export default class ConsoleReporter extends BaseReporter {
     }
   }
 
-  activityStep(current: number, total: number, msg: string, emoji?: string): ReporterSpinner {
+  activityStep(current: number, total: number, msg: string, lineNumber?: number, emoji?: string): ReporterSpinner {
     if (!this.isTTY) {
       return this.activity();
     }
 
     msg = this._prependEmoji(msg, emoji);
 
-    let spinner = new Spinner(this.stderr, `${chalk.grey(`[${current}/${total}]`)} `);
+    let spinner = new Spinner(this.stderr, `${chalk.grey(`[${current}/${total}]`)} `, lineNumber);
     spinner.start();
     spinner.setText(msg);
 

--- a/src/reporters/console/SpinnerProgress.js
+++ b/src/reporters/console/SpinnerProgress.js
@@ -10,12 +10,13 @@
  */
 
 import type {Stdout} from '../types.js';
-import {clearLine} from './util.js';
+import {writeOnNthLine, clearNthLine} from './util.js';
 
 export default class Spinner {
-  constructor(stdout: Stdout = process.stderr, prefix?: string = '') {
+  constructor(stdout: Stdout = process.stderr, prefix?: string = '', lineNumber?: number = 0) {
     this.current = 0;
     this.prefix = prefix;
+    this.lineNumber = lineNumber;
     this.stdout = stdout;
     this.delay = 60;
     this.chars = Spinner.spinners[28].split('');
@@ -26,6 +27,7 @@ export default class Spinner {
   stdout: Stdout;
   prefix: string;
   current: number;
+  lineNumber: number;
   delay: number;
   chars: Array<string>;
   text: string;
@@ -81,8 +83,7 @@ export default class Spinner {
     let msg = `${this.prefix}${this.chars[this.current]} ${this.text}`;
     msg = msg.slice(0, this.stdout.columns || 100);
 
-    clearLine(this.stdout);
-    this.stdout.write(msg);
+    writeOnNthLine(this.stdout, this.lineNumber, msg);
 
     this.current = ++this.current % this.chars.length;
     this.id = setTimeout((): void => this.render(), this.delay);
@@ -94,6 +95,6 @@ export default class Spinner {
       this.id = null;
     }
 
-    clearLine(this.stdout);
+    clearNthLine(this.stdout, this.lineNumber);
   }
 }

--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -17,3 +17,28 @@ export function clearLine(stdout: Stdout) {
   readline.clearLine(stdout, 0);
   readline.cursorTo(stdout, 0);
 }
+
+export function writeOnNthLine(stdout: Stdout, n: number, msg: string) {
+  if (n == 0) {
+    clearLine(stdout);
+    stdout.write(msg);
+    return;
+  }
+  readline.cursorTo(stdout, 0);
+  readline.moveCursor(stdout, 0, -n);
+  readline.clearLine(stdout, 0);
+  stdout.write(msg);
+  readline.cursorTo(stdout, 0);
+  readline.moveCursor(stdout, 0, n);
+}
+
+export function clearNthLine(stdout: Stdout, n: number) {
+  if (n == 0) {
+    clearLine(stdout);
+    return;
+  }
+  readline.cursorTo(stdout, 0);
+  readline.moveCursor(stdout, 0, -n);
+  readline.clearLine(stdout, 0);
+  readline.moveCursor(stdout, 0, n);
+}


### PR DESCRIPTION
Fixes #249.

(Very excited about kpm so was just tweaking by my own, feel free to close this and provide your own implementation)

Enable parallel installation by spinning up several workers that eagerly install package whose dependencies are already fulfilled. 

This can reduce installation time of jengaboot (the entire reason toolchain) by 50%.
