### PR TITLE
Fix gulp path rewrite to work with any base dir

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,18 +29,14 @@ function build(lib, opts) {
         gutil.log(err.stack);
       }
     }))
+    .pipe(newer(lib))
     .pipe(through.obj(function (file, enc, callback) {
-      file._path = file.path;
-      file.path = file.path.replace("src", lib);
-      callback(null, file);
-    }))
-    .pipe(newer("lib"))
-    .pipe(through.obj(function (file, enc, callback) {
-      gutil.log("Compiling", "'" + chalk.cyan(file._path) + "' to '" + chalk.cyan(file.path) + "'...");
+      const dest = path.join(file.cwd, lib, file.relative);
+      gutil.log("Compiling", "'" + chalk.cyan(file.path) + "' to '" + chalk.cyan(dest) + "'...");
       callback(null, file);
     }))
     .pipe(babel(opts))
-    .pipe(gulp.dest("lib"));
+    .pipe(gulp.dest(lib));
 }
 
 gulp.task("default", ["build"]);


### PR DESCRIPTION
Previously, if you had fbkpm in a directory with `src` in the name, the new name would be mangled. Example: `~/src/fbkpm`.

I could've just fixed the step where `file.path` is rewritten, but that only seemed to be done for logging purposes. It's better to remove the cruft.
