### PR TITLE
Pin flow version and prefer `<PROJECT_ROOT>` for ignore paths

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,8 +1,8 @@
 [ignore]
-.*/node_modules/babel.*
-.*/node_modules/y18n/test/.*
-.*/updates/.*
-.*/dist/.*
+<PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/node_modules/babel.*
+<PROJECT_ROOT>/node_modules/y18n/test/.*
+<PROJECT_ROOT>/updates/.*
 
 [include]
 
@@ -12,3 +12,6 @@
 strip_root=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 esproposal.class_static_fields=enable
+
+[version]
+0.31.0


### PR DESCRIPTION
Pinned the flow version because under [flow 0.32.0](https://github.com/facebook/flow/releases/tag/v0.32.0) (released a few days ago), new flow errors surface. Switched to `<PROJECT_ROOT>` for ignores for clarity.
