### PR TITLE
Default to install command when none is specified

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -58,7 +58,7 @@ commander.option(
 );
 
 // get command name
-let commandName = args.splice(2, 1)[0] || '';
+let commandName: string = args.splice(2, 1)[0] || '';
 
 // if command name looks like a flag or doesn't exist then print help
 if (!commandName || commandName[0] === '-') {
@@ -69,7 +69,8 @@ if (!commandName || commandName[0] === '-') {
 }
 
 // handle aliases: i -> install
-if (commandName && _.has(aliases, commandName)) {
+// $FlowFixMe: this is a perfectly fine pattern
+if (commandName && typeof aliases[commandName] === 'string') {
   commandName = aliases[commandName];
 }
 


### PR DESCRIPTION
This makes:

``` sh
$ kpm
```

Alias to:

``` sh
$ kpm install
```

This is similar in vain to Bundler which allows you to run `bundle` as shorthand for `bundle install`.
