### PR TITLE
Cleanup manifest validation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "only": "*.js",
   "env": {
     "pre-node5": {
       "presets": ["es2015-node4"],

--- a/__tests__/fixtures/normalise-manifest/throw name blacklist/expected.json
+++ b/__tests__/fixtures/normalise-manifest/throw name blacklist/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": "Name is blacklisted"
+  "_error": "node_modules: Name is blacklisted"
 }

--- a/__tests__/fixtures/normalise-manifest/throw name illegal character/expected.json
+++ b/__tests__/fixtures/normalise-manifest/throw name illegal character/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": "Name contains illegal characters"
+  "_error": "foo%bar: Name contains illegal characters"
 }

--- a/__tests__/fixtures/normalise-manifest/throw name illegal character/warnings.json
+++ b/__tests__/fixtures/normalise-manifest/throw name illegal character/warnings.json
@@ -1,1 +1,1 @@
-["No license field"]
+["foo%bar: No license field"]

--- a/__tests__/fixtures/normalise-manifest/throw name non-string/expected.json
+++ b/__tests__/fixtures/normalise-manifest/throw name non-string/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": "name is not a string"
+  "_error": "\"name\" is not a string"
 }

--- a/__tests__/fixtures/normalise-manifest/throw name start dot/expected.json
+++ b/__tests__/fixtures/normalise-manifest/throw name start dot/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": "Name can't start with a dot"
+  "_error": ".foobar: Name can't start with a dot"
 }

--- a/__tests__/fixtures/normalise-manifest/throw name start dot/warnings.json
+++ b/__tests__/fixtures/normalise-manifest/throw name start dot/warnings.json
@@ -1,1 +1,1 @@
-["No license field"]
+[".foobar: No license field"]

--- a/__tests__/fixtures/normalise-manifest/throw name url encode required/expected.json
+++ b/__tests__/fixtures/normalise-manifest/throw name url encode required/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": "Name contains illegal characters"
+  "_error": "foo$bar: Name contains illegal characters"
 }

--- a/__tests__/fixtures/normalise-manifest/throw name url encode required/warnings.json
+++ b/__tests__/fixtures/normalise-manifest/throw name url encode required/warnings.json
@@ -1,1 +1,1 @@
-["No license field"]
+["foo$bar: No license field"]

--- a/__tests__/fixtures/normalise-manifest/warn builtin module collision/warnings.json
+++ b/__tests__/fixtures/normalise-manifest/warn builtin module collision/warnings.json
@@ -1,4 +1,4 @@
 [
-  "fs: fs is also the name of a node core module",
+  "fs: \"fs\" is also the name of a node core module",
   "fs: No license field"
 ]

--- a/__tests__/fixtures/normalise-manifest/warn invalid license/warnings.json
+++ b/__tests__/fixtures/normalise-manifest/warn invalid license/warnings.json
@@ -1,1 +1,1 @@
-["license should be a valid SPDX license expression"]
+["License should be a valid SPDX license expression"]

--- a/__tests__/fixtures/normalise-manifest/warn typo/warnings.json
+++ b/__tests__/fixtures/normalise-manifest/warn typo/warnings.json
@@ -1,4 +1,4 @@
 [
-  "Potential typo dependancies, did you mean dependencies?",
+  "Potential typo \"dependancies\", did you mean \"dependencies\"?",
   "No license field"
 ]

--- a/__tests__/normalise-manifest.js
+++ b/__tests__/normalise-manifest.js
@@ -51,7 +51,7 @@ for (let name of nativeFs.readdirSync(fixturesLoc)) {
     }
 
     try {
-      actual = await normaliseManifest(actual, loc, config);
+      actual = await normaliseManifest(actual, loc, config, true);
     } catch (err) {
       if (error && err.message === error) {
         return;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ var fs      = require("fs");
 var babelRc = JSON.parse(fs.readFileSync(path.join(__dirname, ".babelrc"), "utf8"));
 
 function build(lib, opts) {
-  return gulp.src("src/**/*.js")
+  return gulp.src("src/**/*")
     .pipe(plumber({
       errorHandler: function (err) {
         gutil.log(err.stack);
@@ -52,7 +52,7 @@ gulp.task("build-legacy", function () {
 });
 
 gulp.task("watch", ["build"], function () {
-  watch("src/**/*.js", function () {
+  watch("src/**/*", function () {
     gulp.start("build");
   });
 });

--- a/src/cli/commands/_execute-lifecycle-script.js
+++ b/src/cli/commands/_execute-lifecycle-script.js
@@ -22,7 +22,7 @@ export default function(action: string): { run: Function, argumentLength: number
     argumentLength: 0,
 
     async run(config: Config): Promise<void> {
-      const pkg = await config.readManifest(config.cwd);
+      const pkg = await config.readRootManifest();
 
       // build up list of commands for this script
       let scripts = pkg.scripts || {};

--- a/src/cli/commands/dist-tag.js
+++ b/src/cli/commands/dist-tag.js
@@ -22,7 +22,7 @@ export async function getName(args: Array<string>, config: Config): Promise<stri
   let name = args.shift();
 
   if (!name) {
-    let pkg = await config.readManifest(config.cwd);
+    let pkg = await config.readRootManifest();
     name = pkg.name;
   }
 

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -67,16 +67,17 @@ function addEntry(packer: any, entry: Object, buffer?: ?Buffer): Promise<void> {
 }
 
 export async function pack(config: Config, dir: string): Promise<stream$Duplex> {
-  let pkg = await config.readManifest(config.cwd);
+  let pkg = await config.readRootManifest();
 
   //
   let filters: Array<IgnoreFilter> = DEFAULT_IGNORE.slice();
 
   //
-  if (pkg.bundledDependencies) {
+  let {bundledDependencies} = pkg;
+  if (bundledDependencies) {
     let folder = config.getFolder(pkg);
     filters = ignoreLinesToRegex(
-      pkg.bundledDependencies.map((name): string => `!${folder}/${name}`),
+      bundledDependencies.map((name): string => `!${folder}/${name}`),
       '.',
     );
   }
@@ -165,7 +166,7 @@ export async function run(
  flags: Object,
  args: Array<string>,
 ): Promise<void> {
-  let pkg = await config.readManifest(config.cwd);
+  let pkg = await config.readRootManifest();
   let filename = flags.filename || path.join(config.cwd, `${pkg.name}-v${pkg.version}.tgz`);
 
   let stream = await pack(config, config.cwd);

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -118,7 +118,7 @@ export async function run(
  args: Array<string>,
 ): Promise<void> {
   // validate package fields that are required for publishing
-  let pkg = await config.readManifest(config.cwd);
+  let pkg = await config.readRootManifest();
   if (pkg.private) {
     throw new MessageError(reporter.lang('publishPrivate'));
   }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -35,7 +35,9 @@ export async function run(
  flags: Object,
  args: Array<string>,
 ): Promise<void> {
-  let pkg = await config.readManifest(config.cwd);
+  let pkg = await config.readRootManifest();
+  let pkgLoc = pkg._loc;
+  invariant(pkgLoc, 'expected package location');
 
   // get old version
   let oldVersion = pkg.version;
@@ -69,9 +71,9 @@ export async function run(
 
   // update version
   reporter.info(`${reporter.lang('newVersion')}: ${newVersion}`);
-  let json = await fs.readJson(pkg._loc);
+  let json = await fs.readJson(pkgLoc);
   pkg.version = json.version = newVersion;
-  await fs.writeFile(pkg._loc, `${stringify(json)}\n`);
+  await fs.writeFile(pkgLoc, `${stringify(json)}\n`);
 
   // add git commit and tag
   let isGit = false;
@@ -91,7 +93,7 @@ export async function run(
     let prefix = 'v'; // TODO tag-version-prefix npm config
 
     // add manifest
-    await spawn('git', ['add', pkg._loc]);
+    await spawn('git', ['add', pkgLoc]);
 
     // create git commit
     await spawn('git', ['commit', '-m', message]);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -30,6 +30,17 @@ let messages = {
   clearedCache: 'Cleared cache.',
   packWroteTarball: 'Wrote tarball to $0.',
 
+  manifestPotentialType: 'Potential typo $0, did you mean $1?',
+  manifestBuiltinModule: '$0 is also the name of a node core module',
+  manifestNameDot: "Name can't start with a dot",
+  manifestNameIllegalChars: 'Name contains illegal characters',
+  manifestNameBlacklisted: 'Name is blacklisted',
+  manifestLicenseInvalid: 'License should be a valid SPDX license expression',
+  manifestLicenseNone: 'No license field',
+  manifestStringExpected: '$0 is not a string',
+  manifestDependencyBuiltin: 'Dependency $0 listed in $1 is the name of a built-in module',
+  manifestDependencyCollision: '$0 has dependency $1 with range $2 that collides with a dependecy in $3 of the same name with version $4',
+
   couldntFindMatch: "Couldn't find match for $0 in $1 for $2.",
   couldntFindPackageInCache: "Couldn't find any versions for $0 that matches $1 in our cache. Possible versions: $2",
   moduleNotInManifest: "This module isn't specified in a manifest.",

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -16,6 +16,7 @@ import ExoticResolver from './exotic-resolver.js';
 import * as util from '../../util/misc.js';
 import * as fs from '../../util/fs.js';
 
+let invariant = require('invariant');
 let path = require('path');
 
 export default class FileResolver extends ExoticResolver {
@@ -38,10 +39,12 @@ export default class FileResolver extends ExoticResolver {
     }
 
     let manifest = await this.config.readManifest(loc, this.registry);
+    let registry = manifest._registry;
+    invariant(registry, 'expected registry');
 
     manifest._remote = {
       type: 'copy',
-      registry: manifest._registry,
+      registry,
       reference: loc,
     };
 

--- a/src/util/normalise-manifest/index.js
+++ b/src/util/normalise-manifest/index.js
@@ -14,23 +14,44 @@ import type Config from '../../config.js';
 import validate from './validate.js';
 import fix from './fix.js';
 
-export default async function (info: Object, moduleLoc: string, config: Config): Promise<Manifest> {
+let path = require('path');
+
+export default async function (
+  info: Object,
+  moduleLoc: string,
+  config: Config,
+  isRoot: boolean,
+): Promise<Manifest> {
   await fix(info, moduleLoc, config.reporter);
 
+  // create human readable name
   let {name, version} = info;
   let human: ?string;
   if (typeof name === 'string') {
     human = name;
   }
-  if (human && typeof version === 'string') {
-    name += `@${version}`;
+  if (human && typeof version === 'string' && version) {
+    human += `@${version}`;
   }
-  validate(info, (msg: string) => {
+  if (isRoot && info._loc) {
+    human = path.relative(config.cwd, info._loc);
+  }
+
+  function warn(msg: string) {
     if (human) {
       msg = `${human}: ${msg}`;
     }
     config.reporter.warn(msg);
-  });
+  }
+
+  try {
+    validate(info, isRoot, config.reporter, warn);
+  } catch (err) {
+    if (human) {
+      err.message = `${human}: ${err.message}`;
+    }
+    throw err;
+  }
 
   return info;
 }

--- a/src/util/normalise-manifest/infer-license.js
+++ b/src/util/normalise-manifest/infer-license.js
@@ -9,21 +9,66 @@
  * @flow
  */
 
+const path = require('path');
+const fs = require('fs');
+
+function clean(str: string): string {
+  return str
+    .replace(/[^A-Za-z\s]/g, ' ')
+    .replace(/[\s]+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function createExplicitLicenseRegex(license: string): RegExp {
+  let regex = clean(license);
+  regex = regex.replace(/ wildcard /g, '(.*?| )');
+  regex += '$'; // matches end of string
+  return new RegExp(regex, 'g');
+}
+
+const LICENSES = {};
+const licensesDir = path.join(__dirname, 'licenses');
+for (let name of fs.readdirSync(licensesDir)) {
+  let regex = createExplicitLicenseRegex(fs.readFileSync(
+    path.join(licensesDir, name),
+    'utf8',
+  ));
+  let key = name.replace(/_(\d)+$/g, '');
+  let existing = LICENSES[key];
+  if (existing) {
+    LICENSES[key] = new RegExp(`(${regex.source}|${existing.source})`, 'g');
+  } else {
+    LICENSES[key] = regex;
+  }
+}
+
 const REGEXES = {
   WTFPL: [/DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE/, /WTFPL\b/],
   ISC: [/The ISC License/, /ISC\b/],
-  APACHE: [/Apache License\b/],
+  Apache: [/Apache License\b/],
   MIT: [/MIT\b/],
   BSD: [/BSD\b/],
 };
 
-export default function(license: string): ?string {
+export default function inferLicense(license: string): ?string {
+  // check if we have any explicit licenses
+  const cleanLicense = clean(license);
+  for (const licenseName in LICENSES) {
+    const testLicense = LICENSES[licenseName];
+    if (cleanLicense.search(testLicense) >= 0) {
+      return licenseName;
+    }
+  }
+
+  // infer based on some keywords
   for (const licenseName in REGEXES) {
     for (const regex of REGEXES[licenseName]) {
-      if (regex.test(license)) {
+      if (license.search(regex) >= 0) {
         return `${licenseName}*`;
       }
     }
   }
+
   return null;
 }

--- a/src/util/normalise-manifest/licenses/Apache-2.0_1
+++ b/src/util/normalise-manifest/licenses/Apache-2.0_1
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/src/util/normalise-manifest/licenses/Apache-2.0_2
+++ b/src/util/normalise-manifest/licenses/Apache-2.0_2
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/util/normalise-manifest/licenses/BSD-2-Clause_1
+++ b/src/util/normalise-manifest/licenses/BSD-2-Clause_1
@@ -1,0 +1,17 @@
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL __WILDCARD__ BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/src/util/normalise-manifest/licenses/BSD-2-Clause_2
+++ b/src/util/normalise-manifest/licenses/BSD-2-Clause_2
@@ -1,0 +1,17 @@
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS __WILDCARD__ IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL __WILDCARD__ BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS __WILDCARD__, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/src/util/normalise-manifest/licenses/BSD-3-Clause_1
+++ b/src/util/normalise-manifest/licenses/BSD-3-Clause_1
@@ -1,0 +1,20 @@
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name __WILDCARD__ nor the names of __WILDCARD__ contributors may be used to endorse or
+promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY __WILDCARD__ "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL __WILDCARD__ BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/src/util/normalise-manifest/licenses/BSD-3-Clause_2
+++ b/src/util/normalise-manifest/licenses/BSD-3-Clause_2
@@ -1,0 +1,21 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/util/normalise-manifest/licenses/BSD-3-Clause_3
+++ b/src/util/normalise-manifest/licenses/BSD-3-Clause_3
@@ -1,0 +1,21 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of __WILDCARD__ nor the
+      names of the contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL __WILDCARD__ BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/util/normalise-manifest/licenses/MIT_1
+++ b/src/util/normalise-manifest/licenses/MIT_1
@@ -1,0 +1,14 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/util/normalise-manifest/util.js
+++ b/src/util/normalise-manifest/util.js
@@ -11,7 +11,12 @@
 
 import type {PersonObject} from '../../types.js';
 
+const validateLicense = require('validate-npm-package-license');
 const _ = require('lodash');
+
+export function isValidLicense(license: string): boolean {
+  return validateLicense(license).validForNewPackages;
+}
 
 export function stringifyPerson(person: any): any | string {
   if (!_.isPlainObject(person)) {

--- a/src/util/normalise-manifest/validate.js
+++ b/src/util/normalise-manifest/validate.js
@@ -9,14 +9,21 @@
  * @flow
  */
 
+import type {Reporter} from '../../reporters/index.js';
+import {isValidLicense} from './util.js';
 import typos from './typos.js';
 
-const validateLicense = require('validate-npm-package-license');
 const isBuiltinModule = require('is-builtin-module');
 
 const strings = [
   'name',
   'version',
+];
+
+const dependencyKeys = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
 ];
 
 function isValidName(name: string): boolean {
@@ -36,50 +43,101 @@ export function isValidPackageName(name: string): boolean {
   return isValidName(name) || isValidScopedName(name);
 }
 
-export default function(info: Object, warn: (msg: string) => void) {
-  for (const key in typos) {
-    if (key in info) {
-      warn(`Potential typo ${key}, did you mean ${typos[key]}?`);
+export default function(info: Object, isRoot: boolean, reporter: Reporter, warn: (msg: string) => void) {
+  if (isRoot) {
+    for (const key in typos) {
+      if (key in info) {
+        warn(reporter.lang('manifestPotentialType', key, typos[key]));
+      }
     }
   }
 
-  const name = info.name;
+  // validate name
+  const {name} = info;
   if (typeof name === 'string') {
-    if (isBuiltinModule(name)) {
-      warn(`${name} is also the name of a node core module`);
+    if (isRoot && isBuiltinModule(name)) {
+      warn(reporter.lang('manifestBuiltinModule', name));
     }
 
     // cannot start with a dot
     if (name[0] === '.') {
-      throw new TypeError("Name can't start with a dot");
+      throw new TypeError(reporter.lang('manifestNameDot'));
     }
 
     // cannot contain the following characters
     if (!isValidPackageName(name)) {
-      throw new TypeError('Name contains illegal characters');
+      throw new TypeError(reporter.lang('manifestNameIllegalChars'));
     }
 
     // cannot equal node_modules or favicon.ico
     const lower = name.toLowerCase();
     if (lower === 'node_modules' || lower === 'favicon.ico') {
-      throw new TypeError('Name is blacklisted');
+      throw new TypeError(reporter.lang('manifestNameBlacklisted'));
     }
   }
 
   // validate license
-  if (typeof info.license === 'string') {
-    if (!validateLicense(info.license).validForNewPackages) {
-      warn('license should be a valid SPDX license expression');
+  if (isRoot && !info.private) {
+    if (typeof info.license === 'string') {
+      let license = info.license.replace(/\*$/g, '');
+      if (!isValidLicense(license)) {
+        warn(reporter.lang('manifestLicenseInvalid'));
+      }
+    } else {
+      warn(reporter.lang('manifestLicenseNone'));
     }
-  } else {
-    warn('No license field');
   }
 
-  // validate types
+  // validate strings
   for (const key of strings) {
     const val = info[key];
     if (val && typeof val !== 'string') {
-      throw new TypeError(`${key} is not a string`);
+      throw new TypeError(reporter.lang('manifestStringExpected', key));
+    }
+  }
+
+  // get dependency objects
+  let depTypes = [];
+  for (let type of dependencyKeys) {
+    let deps = info[type];
+    if (!deps || typeof deps !== 'object') {
+      continue;
+    }
+    depTypes.push([type, deps]);
+  }
+
+  // check root dependencies for builtin module names
+  if (isRoot) {
+    for (let [type, deps] of depTypes) {
+      for (let name in deps) {
+        if (isBuiltinModule(name)) {
+          warn(reporter.lang('manifestDependencyBuiltin', name, type));
+        }
+      }
+    }
+  }
+
+  // ensure that dependencies don't have ones that can collide
+  for (let [type, deps] of depTypes) {
+    for (let name in deps) {
+      let version = deps[name];
+      if (version === '*') {
+        continue;
+      }
+
+      // check collisions
+      for (let [type2, deps2] of depTypes) {
+        let version2 = deps2[name];
+        if (!version2 || version2 === '*') {
+          continue;
+        }
+
+        if (version !== version2) {
+          throw new TypeError(
+            reporter.lang('manifestDependencyCollision', type, name, version, type2, version2),
+          );
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Currently in `master` we have warnings for transitive dependencies turned on which are super noisy and not really relevant.
