### PR TITLE
Clarify mirror path flow types

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -525,7 +525,7 @@ export class Install {
     }
 
     let mirror = this.config.getOfflineMirrorPath();
-    if (mirror) {
+    if (mirror != null) {
       opts.push(`mirror:${mirror}`);
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -186,31 +186,31 @@ export default class Config {
    * Second time the same package needs to be installed it will be loaded from there
    */
 
-  getOfflineMirrorPath(tarUrl: ?string): string {
+  getOfflineMirrorPath(tarUrl: ?string): ?string {
     let registry = this.registries.npm;
-    if (!registry) {
-      return '';
+    if (registry == null) {
+      return null;
     }
 
     //
     const mirrorPath = registry.config['yarn-offline-mirror'];
-    if (!mirrorPath) {
-      return '';
+    if (mirrorPath == null) {
+      return null;
     }
 
     //
-    if (!tarUrl) {
+    if (tarUrl == null) {
       return mirrorPath;
     }
 
     //
-    const parsed = url.parse(tarUrl);
-    if (!parsed || !parsed.pathname) {
+    const {pathname} = url.parse(tarUrl);
+    if (pathname == null) {
       return mirrorPath;
     }
 
     //
-    return path.join(mirrorPath, path.basename(parsed.pathname));
+    return path.join(mirrorPath, path.basename(pathname));
   }
 
   /**


### PR DESCRIPTION
**Summary**
It wasn't entirely clear when it was ok to have a "maybe" mirror vs an "empty" string mirror. Fixes #350.

It's unfortunate that the prevalent js style for checking for nullness is to check for falseness. Because Flow lets you express "maybe" as `null` or `undefined`, using falsey checks instead of `!= null`, leads to a lot of loss of information.

**Test plan**
`npm test`
