### PR TITLE
Remove strip_root=true from flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,7 +12,6 @@
 [libs]
 
 [options]
-strip_root=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [version]


### PR DESCRIPTION
**Summary**
This setting only applies to `--json` output, which is normally only used by tooling, and said tooling adds it as appropriate. By forcing it via `.flowconfig`, you break integrations with tools like Nuclide (see https://github.com/facebook/nuclide/issues/662).

If you've used Nuclide, and you were missing errors in the gutter or when hovering over them, it's because of this.

**Test plan**
`flow`
