### PR TITLE
Remove bin aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "unexpected": "^10.8.1"
   },
   "bin": {
+    "kpm": "./bin/yarn.js",
     "yarn": "./bin/yarn.js"
   },
   "scripts": {


### PR DESCRIPTION
**Summary**

This gave me an issue a month ago and I had to manually delete the emoji aliases. I still like them a lot but we should remove them before publishing.

**Test plan**

You can't run `🐱 install` or `🐈 check` anymore.
