### PR TITLE
Find optional dependencies before normal dependencies

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -201,7 +201,7 @@ export default class PackageRequest {
 
   async find(): Promise<void> {
     // find version info for this package pattern
-    let info: ?Manifest = await this.findVersionInfo();
+    const info: ?Manifest = await this.findVersionInfo();
     if (!info) {
       throw new MessageError(this.reporter.lang('unknownPackagePattern', this.pattern));
     }


### PR DESCRIPTION
**Note: this is a redo of #315**

Fixes #314

The issue with #314 ended up being that the NPM registry duplicates optional dependencies inside the `dependencies` key in the package info. For example, http://registry.npmjs.org/7zip-bin, if you look at version 2.0.1 (latest), `7zip-bin-[linux|win|osx]` deps are duplicated. This breaks kpm because once a dep is marked as not optional, it's explicitly not allowed to be marked optional again (https://github.com/facebook/fbkpm/blob/master/src/package-reference.js#L131). 

By looping through the optional deps first (and also skipping any duplicate deps listed in dependencies _as well as_ optionalDependencies), we can resolve this problem.
