### PR TITLE
Added build-dist and check-lockfile to Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,9 @@ test:
     - nvm use 6 && nvm alias default 6
     - node -v
     - npm run test-ci
+    - npm run build-dist
+    - npm run check-lockfile
+
 deployment:
   release:
     tag: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
Until we get Travis as stable as Circle I rely on Circle green badge when accepting PRs.
This change adds the 2 missing commands to Circle.
