### PR TITLE
Fix test dirs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@
 *.log
 /.nyc_output
 /coverage
-/test/.tmp
-/test/fixtures/**/kpm_modules
-/test/fixtures/**/node_modules
+/__tests__/fixtures/**/.kpm
+/__tests__/fixtures/**/node_modules
 /dist
 /updates
-fbkpm_modules
-test/fixtures/**/.fbkpm


### PR DESCRIPTION
**Summary**
Fixed `.gitignore` for test dir changes. I often see left over `.kpm` and `node_modules` when a test run fails. I don't think the other dirs exist anymore.

I did notice though that these files still remain untracked sometimes - should they be ignored or the test changed?

```
?? __tests__/fixtures/install/root-install-with-optional-dependency/yarn.lock
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/async-each/-/async-each-1.0.1.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/for-in/-/for-in-0.1.6.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/form-data/-/form-data-2.0.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/glob/-/glob-7.1.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz.bin
?? __tests__/fixtures/request-cache/GET/registry.npmjs.org/request/-/request-2.75.0.tgz.bin
```

**Test plan**
`npm test` and confirmed no untracked files.
