### PR TITLE
Fix require import

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -17,8 +17,9 @@ let commander = require('commander');
 let invariant = require('invariant');
 let lockfile = require('proper-lockfile');
 let onDeath = require('death');
-let pkg = require('../../package');
 let _ = require('lodash');
+
+let pkg = require('../../package.json');
 
 loudRejection();
 


### PR DESCRIPTION
**Summary**
- Use require for CommonJS modules.
- Use json extension to require json.

Caught these while bundling yarn into a single file. 

**Test plan**
`npm test`
