### PR TITLE
Ignore isTTY flow error (fix build)

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -95,6 +95,7 @@ if (commander.json) {
   Reporter = JSONReporter;
 }
 let reporter = new Reporter({
+  // $FlowFixMe
   emoji: process.stdout.isTTY && process.platform === 'darwin',
 });
 reporter.initPeakMemoryCounter();


### PR DESCRIPTION
**Summary**
- Ignore isTTY flow error.

I looked at the typing for this and it's a little tangled up. I'll fix it later, but for now, just unblock the build.

**Test plan**
`npm test`
