### PR TITLE
return only collapsed patterns on flatten

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -283,6 +283,8 @@ export class Install {
       return patterns;
     }
 
+    let flattenedPatterns = [];
+
     for (const name of this.resolver.getAllDependencyNamesByLevelOrder(patterns)) {
       const infos = this.resolver.getAllInfoForPackageName(name).filter((manifest: Manifest): boolean => {
         let ref = manifest._reference;
@@ -327,7 +329,7 @@ export class Install {
         this.resolutions[name] = version;
       }
 
-      patterns.push(this.resolver.collapseAllVersionsOfPackage(name, version));
+      flattenedPatterns.push(this.resolver.collapseAllVersionsOfPackage(name, version));
     }
 
     // save resolutions to their appropriate root manifest
@@ -362,7 +364,7 @@ export class Install {
       await this.saveRootManifests(jsons);
     }
 
-    return patterns;
+    return flattenedPatterns;
   }
 
   /**


### PR DESCRIPTION
**Summary**
Explain the **motivation** for making this change. What existing problem does the pull request solve?
This fixes #423. 

From my understanding, the current logic seems fine - the install class will call the resolver's collapseAllVersionsOfPackage, which handles the pruning of package references that get removed. 

This pull request creates an empty array onto which the collapsed packages will be pushed so that only the collapsed unique packages will be returned.

**Test plan**
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
1. `rm -rf ~/.yarn`
2. `rm -rf ~/.node_modules`
3. `yarn install --flate`
4.  choose 2 for all the choices
5. Screenshots:
   ![screen shot 2016-09-24 at 1 37 03 pm](https://cloud.githubusercontent.com/assets/718423/18811156/d6436da2-825c-11e6-98b9-b273386e827d.png)

![screen shot 2016-09-24 at 1 36 56 pm](https://cloud.githubusercontent.com/assets/718423/18811158/db5d2b5c-825c-11e6-9052-58f668769956.png)
