### PR TITLE
Lazy load "request" module

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -244,7 +244,7 @@ export class Install {
           this.reporter.lang('savingHar', filename),
           emoji.get('black_circle_for_record'),
         );
-        await this.config.requestManager.requestCaptureHar.saveHar(filename);
+        await this.config.requestManager.saveHar(filename);
       });
     }
 


### PR DESCRIPTION
**Summary**
I'm not a big fan of manually inlining requires but the perf wins are too big to pass up. `request` accounts for ~120ms of startup time (~30%), and it's often not necessary at all.

```
# before
$ time node bin/yarn.js -h > /dev/null
node bin/yarn.js -h > /dev/null  0.37s user 0.09s system 102% cpu 0.445 total

# after
$ time node bin/yarn.js -h > /dev/null
node bin/yarn.js -h > /dev/null  0.26s user 0.07s system 103% cpu 0.312 total
```

```
# before
$ time node bin/yarn.js install
yarn install v0.13.0
success Already up-to-date.
✨  Done in 0.10s.
node bin/yarn.js install  0.46s user 0.10s system 102% cpu 0.542 total

# after
$ time node bin/yarn.js install
yarn install v0.13.0
success Already up-to-date.
✨  Done in 0.10s.
node bin/yarn.js install  0.36s user 0.08s system 102% cpu 0.423 total
```

**Compare `time-require` results (`node -r time-require bin/yarn.js --sorted -h`)**

<details>
  <summary>

Before</summary>



```
Start time: (2016-09-26 00:18:34 UTC) [treshold=1%,sorted]
 # [order]  module                                                             time  %
  1 [1391]  ./commands/index.js (lib/cli/commands/index.js)                   297ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 77%
  2 [1163]  ./ls.js (lib/cli/commands/ls.js)                                  223ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 58%
  3 [1160]  ./install.js (lib/cli/commands/install.js)                        220ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 57%
  4 [1119]  ../../package-resolver.js (lib/package-resolver.js)               126ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 33%
  5 [1114]  ./util/request-manager.js (lib/util/request-manager.js)           125ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 32%
  6 [1109]  request (node_modules/request/index.js)                           123ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 32%
  7 [1108]  ./request (node_modules/request/request.js)                       106ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 28%
  8  [591]  ../../util/normalise-manifest/i...l/normalise-manifest/index.js)   69ms  ▇▇▇▇▇▇▇▇▇▇▇▇ 18%
  9  [589]  ./fix.js (lib/util/normalise-manifest/fix.js)                      60ms  ▇▇▇▇▇▇▇▇▇▇▇ 16%
 10  [581]  ../../resolvers/index.js (lib/resolvers/index.js)                  57ms  ▇▇▇▇▇▇▇▇▇▇ 15%
 11  [201]  ../reporters/index.js (lib/reporters/index.js)                     57ms  ▇▇▇▇▇▇▇▇▇▇ 15%
 12  [179]  ./console/console-reporter.js (...s/console/console-reporter.js)   53ms  ▇▇▇▇▇▇▇▇▇ 14%
 13  [153]  ../base-reporter.js (lib/reporters/base-reporter.js)               37ms  ▇▇▇▇▇▇▇ 10%
 14  [519]  ./registries/bower-resolver.js.../registries/bower-resolver.js)    36ms  ▇▇▇▇▇▇▇ 9%
 15  [999]  http-signature (node_modules/http-signature/lib/index.js)          35ms  ▇▇▇▇▇▇ 9%
 16  [518]  ../exotics/git-resolver.js (lib...lvers/exotics/git-resolver.js)   35ms  ▇▇▇▇▇▇ 9%
 17  [149]  babel-runtime/helpers/asyncToGe...e/helpers/asyncToGenerator.js)   35ms  ▇▇▇▇▇▇ 9%
 18  [148]  ../core-js/promise (node_module...el-runtime/core-js/promise.js)   34ms  ▇▇▇▇▇▇ 9%
 19  [147]  core-js/library/fn/promise (nod...core-js/library/fn/promise.js)   34ms  ▇▇▇▇▇▇ 9%
 20  [973]  ./parser (node_modules/http-signature/lib/parser.js)               30ms  ▇▇▇▇▇▇ 8%
 21  [516]  ../../util/git.js (lib/util/git.js)                                28ms  ▇▇▇▇▇ 7%
 22  [972]  ./utils (node_modules/http-signature/lib/utils.js)                 27ms  ▇▇▇▇▇ 7%
 23  [970]  sshpk (node_modules/sshpk/lib/index.js)                            26ms  ▇▇▇▇▇ 7%
 24  [267]  ./cache.js (lib/cli/commands/cache.js)                             25ms  ▇▇▇▇▇ 6%
 25  [963]  ./key (node_modules/sshpk/lib/key.js)                              25ms  ▇▇▇▇▇ 6%
 26  [266]  ../../util/fs.js (lib/util/fs.js)                                  24ms  ▇▇▇▇▇ 6%
 27  [515]  tar (node_modules/tar/tar.js)                                      22ms  ▇▇▇▇ 6%
 28  [943]  ./fingerprint (node_modules/sshpk/lib/fingerprint.js)              21ms  ▇▇▇▇ 5%
 29   [81]  ../modules/es6.string.iterator...odules/es6.string.iterator.js)    21ms  ▇▇▇▇ 5%
 30  [941]  ./certificate (node_modules/sshpk/lib/certificate.js)              19ms  ▇▇▇▇ 5%
 31  [493]  ./lib/pack.js (node_modules/tar/lib/pack.js)                       19ms  ▇▇▇▇ 5%
 32   [80]  ./_iter-define (node_modules/co...brary/modules/_iter-define.js)   18ms  ▇▇▇▇ 5%
 33  [480]  ./entry-writer.js (node_modules/tar/lib/entry-writer.js)           16ms  ▇▇▇ 4%
 34  [689]  ./lib/cookies (node_modules/request/lib/cookies.js)                15ms  ▇▇▇ 4%
 35  [688]  tough-cookie (node_modules/tough-cookie/lib/cookie.js)             15ms  ▇▇▇ 4%
 36  [889]  ./signature (node_modules/sshpk/lib/signature.js)                  15ms  ▇▇▇ 4%
 37 [1249]  ./pack.js (lib/cli/commands/pack.js)                               14ms  ▇▇▇ 4%
 38  [886]  ./utils (node_modules/sshpk/lib/utils.js)                          14ms  ▇▇▇ 4%
 39  [473]  ./entry.js (node_modules/tar/lib/entry.js)                         14ms  ▇▇▇ 4%
 40  [259]  rimraf (node_modules/rimraf/rimraf.js)                             14ms  ▇▇▇ 4%
 41  [884]  ./private-key (node_modules/sshpk/lib/private-key.js)              13ms  ▇▇▇ 3%
 42  [258]  glob (node_modules/glob/glob.js)                                   13ms  ▇▇▇ 3%
 43  [472]  fstream (node_modules/fstream/fstream.js)                          13ms  ▇▇▇ 3%
 44 [1325]  ./publish.js (lib/cli/commands/publish.js)                         12ms  ▇▇▇ 3%
 45 [1247]  tar-stream (node_modules/tar-stream/index.js)                      11ms  ▇▇ 3%
 46  [676]  ./pubsuffix (node_modules/tough-cookie/lib/pubsuffix.js)           11ms  ▇▇ 3%
 47  [878]  ./formats/auto (node_modules/sshpk/lib/formats/auto.js)            11ms  ▇▇ 3%
 48 [1322]  concat-stream (node_modules/concat-stream/index.js)                10ms  ▇▇ 3%
 49 [1077]  ./lib/har (node_modules/request/lib/har.js)                        10ms  ▇▇ 3%
 50 [1030]  form-data (node_modules/form-data/lib/form_data.js)                10ms  ▇▇ 3%
 51  [869]  ./pem (node_modules/sshpk/lib/formats/pem.js)                      10ms  ▇▇ 3%
 52  [145]  ../modules/es6.promise (node_mo...ibrary/modules/es6.promise.js)   10ms  ▇▇ 3%
 53  [758]  hawk (node_modules/hawk/lib/index.js)                               9ms  ▇▇ 2%
 54 [1075]  har-validator (node_modules/har-validator/lib/index.js)             9ms  ▇▇ 2%
 55 [1351]  github (node_modules/github/lib/index.js)                           9ms  ▇▇ 2%
 56 [1320]  readable-stream (node_modules/c...s/readable-stream/readable.js)    9ms  ▇▇ 2%
 57  [330]  ./registries/npm-resolver.js (l...rs/registries/npm-resolver.js)    9ms  ▇▇ 2%
 58 [1352]  ./self-update.js (lib/cli/commands/self-update.js)                  9ms  ▇▇ 2%
 59 [1028]  async (node_modules/async/dist/async.js)                            8ms  ▇▇ 2%
 60 [1236]  ./extract (node_modules/tar-stream/extract.js)                      8ms  ▇▇ 2%
 61 [1073]  ./runner (node_modules/har-validator/lib/runner.js)                 8ms  ▇▇ 2%
 62  [325]  ../../registries/npm-registry.j...ib/registries/npm-registry.js)    8ms  ▇▇ 2%
 63  [300]  ./validate.js (lib/util/normalise-manifest/validate.js)             8ms  ▇▇ 2%
 64   [72]  ./_iter-create (node_modules/co...brary/modules/_iter-create.js)    8ms  ▇▇ 2%
 65  [724]  bl (node_modules/bl/bl.js)                                          8ms  ▇▇ 2%
 66  [722]  readable-stream/duplex (node_mo...les/readable-stream/duplex.js)    7ms  ▇▇ 2%
 67   [30]  ./_export (node_modules/core-js/library/modules/_export.js)         7ms  ▇▇ 2%
 68 [1234]  readable-stream (node_modules/readable-stream/readable.js)          7ms  ▇▇ 2%
 69  [551]  ./exotics/tarball-resolver.js (...s/exotics/tarball-resolver.js)    7ms  ▇▇ 2%
 70  [420]  ./lib/reader.js (node_modules/fstream/lib/reader.js)                7ms  ▇▇ 2%
 71 [1003]  mime-types (node_modules/mime-types/index.js)                       7ms  ▇▇ 2%
 72   [58]  ./_object-dps (node_modules/cor...ibrary/modules/_object-dps.js)    6ms  ▇▇ 2%
 73  [721]  ./lib/_stream_duplex.js (node_m...-stream/lib/_stream_duplex.js)    6ms  ▇▇ 2%
 74  [213]  ./blocking-queue.js (lib/util/blocking-queue.js)                    6ms  ▇▇ 2%
 75  [410]  graceful-fs (node_modules/graceful-fs/graceful-fs.js)               6ms  ▇▇ 2%
 76  [296]  ./util.js (lib/util/normalise-manifest/util.js)                     6ms  ▇▇ 2%
 77   [61]  ./_object-create (node_modules/...ary/modules/_object-create.js)    6ms  ▇▇ 2%
 78  [231]  minimatch (node_modules/minimatch/minimatch.js)                     5ms  ▇ 1%
 79  [159]  ./progress-bar.js (lib/reporters/console/progress-bar.js)           5ms  ▇ 1%
 80  [368]  ../../registries/index.js (lib/registries/index.js)                 5ms  ▇ 1%
 81   [56]  ./_object-keys (node_modules/co...brary/modules/_object-keys.js)    5ms  ▇ 1%
 82 [1150]  ./clean.js (lib/cli/commands/clean.js)                              5ms  ▇ 1%
 83  [992]  ./signer (node_modules/http-signature/lib/signer.js)                5ms  ▇ 1%
 84  [212]  debug (node_modules/debug/node.js)                                  5ms  ▇ 1%
 85   [29]  ./_hide (node_modules/core-js/library/modules/_hide.js)             5ms  ▇ 1%
 86 [1305]  ./lib/_stream_writable.js (node...tream/lib/_stream_writable.js)    5ms  ▇ 1%
 87  [544]  ../../fetchers/tarball-fetcher....b/fetchers/tarball-fetcher.js)    5ms  ▇ 1%
 88  [295]  validate-npm-package-license (n...-npm-package-license/index.js)    5ms  ▇ 1%
 89 [1346]  mime (node_modules/mime/mime.js)                                    5ms  ▇ 1%
 90 [1072]  is-my-json-valid (node_modules/is-my-json-valid/index.js)           4ms  ▇ 1%
 91  [174]  chalk (node_modules/chalk/index.js)                                 4ms  ▇ 1%
 92  [693]  http (http)                                                         4ms  ▇ 1%
 93  [195]  ./buffer-reporter.js (lib/reporters/buffer-reporter.js)             4ms  ▇ 1%
 94  [250]  ./sync.js (node_modules/glob/sync.js)                               4ms  ▇ 1%
 95   [26]  ./_object-dp (node_modules/core...library/modules/_object-dp.js)    4ms  ▇ 1%
 96  [359]  ./yarn-registry.js (lib/registries/yarn-registry.js)                4ms  ▇ 1%
 97  [163]  crypto (crypto)                                                     4ms  ▇ 1%
 98  [846]  ./pkcs1 (node_modules/sshpk/lib/formats/pkcs1.js)                   4ms  ▇ 1%
 99  [292]  spdx-expression-parse (node_mod...pdx-expression-parse/index.js)    4ms  ▇ 1%
100  [694]  https (https)                                                       4ms  ▇ 1%
101  [164]  ../../util/misc.js (lib/util/misc.js)                               4ms  ▇ 1%
102  [383]  ./child.js (lib/util/child.js)                                      4ms  ▇ 1%
103   [54]  ./_object-keys-internal (node_m...ules/_object-keys-internal.js)    4ms  ▇ 1%
Total require(): 1441
Total time: 385ms
```

</details>

<details>
  <summary>

After</summary>



```
Start time: (2016-09-26 02:58:14 UTC) [treshold=1%,sorted]
# [order]  module                                                                   time  %
 1  [979]  ./commands/index.js (lib/cli/commands/index.js)                         170ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 66%
 2  [726]  ./ls.js (lib/cli/commands/ls.js)                                        100ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 39%
 3  [723]  ./install.js (lib/cli/commands/install.js)                               97ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 37%
 4  [591]  ../../util/normalise-manifest/inde...util/normalise-manifest/index.js)   69ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 27%
 5  [589]  ./fix.js (lib/util/normalise-manifest/fix.js)                            61ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 24%
 6  [201]  ../reporters/index.js (lib/reporters/index.js)                           58ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22%
 7  [581]  ../../resolvers/index.js (lib/resolvers/index.js)                        58ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22%
 8  [179]  ./console/console-reporter.js (lib...ters/console/console-reporter.js)   53ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 20%
 9  [153]  ../base-reporter.js (lib/reporters/base-reporter.js)                     37ms  ▇▇▇▇▇▇▇▇▇▇ 14%
10  [149]  babel-runtime/helpers/asyncToGener...time/helpers/asyncToGenerator.js)   36ms  ▇▇▇▇▇▇▇▇▇▇ 14%
11  [519]  ./registries/bower-resolver.js (li...ers/registries/bower-resolver.js)   36ms  ▇▇▇▇▇▇▇▇▇▇ 14%
12  [148]  ../core-js/promise (node_modules/babel-runtime/core-js/promise.js)       35ms  ▇▇▇▇▇▇▇▇▇▇ 14%
13  [518]  ../exotics/git-resolver.js (lib/resolvers/exotics/git-resolver.js)       35ms  ▇▇▇▇▇▇▇▇▇▇ 14%
14  [147]  core-js/library/fn/promise (node_m...es/core-js/library/fn/promise.js)   34ms  ▇▇▇▇▇▇▇▇▇▇ 13%
15  [516]  ../../util/git.js (lib/util/git.js)                                      28ms  ▇▇▇▇▇▇▇▇ 11%
16  [267]  ./cache.js (lib/cli/commands/cache.js)                                   26ms  ▇▇▇▇▇▇▇▇ 10%
17  [266]  ../../util/fs.js (lib/util/fs.js)                                        24ms  ▇▇▇▇▇▇▇ 9%
18  [515]  tar (node_modules/tar/tar.js)                                            22ms  ▇▇▇▇▇▇ 8%
19  [493]  ./lib/pack.js (node_modules/tar/lib/pack.js)                             19ms  ▇▇▇▇▇▇ 7%
20  [837]  ./pack.js (lib/cli/commands/pack.js)                                     19ms  ▇▇▇▇▇▇ 7%
21   [81]  ../modules/es6.string.iterator (no...y/modules/es6.string.iterator.js)   19ms  ▇▇▇▇▇▇ 7%
22  [480]  ./entry-writer.js (node_modules/tar/lib/entry-writer.js)                 17ms  ▇▇▇▇▇ 7%
23   [80]  ./_iter-define (node_modules/core-js/library/modules/_iter-define.js)    17ms  ▇▇▇▇▇ 7%
24  [835]  tar-stream (node_modules/tar-stream/index.js)                            16ms  ▇▇▇▇▇ 6%
25  [259]  rimraf (node_modules/rimraf/rimraf.js)                                   14ms  ▇▇▇▇ 5%
26  [473]  ./entry.js (node_modules/tar/lib/entry.js)                               14ms  ▇▇▇▇ 5%
27  [824]  ./extract (node_modules/tar-stream/extract.js)                           14ms  ▇▇▇▇ 5%
28  [472]  fstream (node_modules/fstream/fstream.js)                                13ms  ▇▇▇▇ 5%
29  [258]  glob (node_modules/glob/glob.js)                                         13ms  ▇▇▇▇ 5%
30  [145]  ../modules/es6.promise (node_modul...s/library/modules/es6.promise.js)   10ms  ▇▇▇ 4%
31  [913]  ./publish.js (lib/cli/commands/publish.js)                                9ms  ▇▇▇ 3%
32  [330]  ./registries/npm-resolver.js (lib/...lvers/registries/npm-resolver.js)    9ms  ▇▇▇ 3%
33   [72]  ./_iter-create (node_modules/core-js/library/modules/_iter-create.js)     8ms  ▇▇▇ 3%
34  [325]  ../../registries/npm-registry.js (lib/registries/npm-registry.js)         8ms  ▇▇▇ 3%
35  [782]  bl (node_modules/bl/bl.js)                                                7ms  ▇▇ 3%
36  [300]  ./validate.js (lib/util/normalise-manifest/validate.js)                   7ms  ▇▇ 3%
37  [551]  ./exotics/tarball-resolver.js (lib...vers/exotics/tarball-resolver.js)    7ms  ▇▇ 3%
38  [940]  ./self-update.js (lib/cli/commands/self-update.js)                        7ms  ▇▇ 3%
39  [910]  concat-stream (node_modules/concat-stream/index.js)                       7ms  ▇▇ 3%
40  [908]  readable-stream (node_modules/conc...ules/readable-stream/readable.js)    7ms  ▇▇ 3%
41   [61]  ./_object-create (node_modules/cor...ibrary/modules/_object-create.js)    7ms  ▇▇ 3%
42   [30]  ./_export (node_modules/core-js/library/modules/_export.js)               7ms  ▇▇ 3%
43  [420]  ./lib/reader.js (node_modules/fstream/lib/reader.js)                      7ms  ▇▇ 3%
44  [544]  ../../fetchers/tarball-fetcher.js (lib/fetchers/tarball-fetcher.js)       6ms  ▇▇ 2%
45  [368]  ../../registries/index.js (lib/registries/index.js)                       6ms  ▇▇ 2%
46  [213]  ./blocking-queue.js (lib/util/blocking-queue.js)                          6ms  ▇▇ 2%
47  [410]  graceful-fs (node_modules/graceful-fs/graceful-fs.js)                     6ms  ▇▇ 2%
48  [939]  github (node_modules/github/lib/index.js)                                 6ms  ▇▇ 2%
49  [822]  readable-stream (node_modules/readable-stream/readable.js)                5ms  ▇▇ 2%
50  [779]  ./lib/_stream_duplex.js (node_modu...ble-stream/lib/_stream_duplex.js)    5ms  ▇▇ 2%
51  [296]  ./util.js (lib/util/normalise-manifest/util.js)                           5ms  ▇▇ 2%
52   [54]  ./_object-keys-internal (node_modu...modules/_object-keys-internal.js)    5ms  ▇▇ 2%
53  [250]  ./sync.js (node_modules/glob/sync.js)                                     5ms  ▇▇ 2%
54  [231]  minimatch (node_modules/minimatch/minimatch.js)                           5ms  ▇▇ 2%
55  [212]  debug (node_modules/debug/node.js)                                        5ms  ▇▇ 2%
56  [780]  readable-stream/duplex (node_modul...odules/readable-stream/duplex.js)    5ms  ▇▇ 2%
57   [29]  ./_hide (node_modules/core-js/library/modules/_hide.js)                   5ms  ▇▇ 2%
58  [713]  ./clean.js (lib/cli/commands/clean.js)                                    5ms  ▇▇ 2%
59  [164]  ../../util/misc.js (lib/util/misc.js)                                     5ms  ▇▇ 2%
60  [163]  crypto (crypto)                                                           5ms  ▇▇ 2%
61   [58]  ./_object-dps (node_modules/core-js/library/modules/_object-dps.js)       5ms  ▇▇ 2%
62   [56]  ./_object-keys (node_modules/core-js/library/modules/_object-keys.js)     5ms  ▇▇ 2%
63  [249]  ./common.js (node_modules/glob/common.js)                                 4ms  ▇▇ 2%
64  [174]  chalk (node_modules/chalk/index.js)                                       4ms  ▇▇ 2%
65  [295]  validate-npm-package-license (node...ate-npm-package-license/index.js)    4ms  ▇▇ 2%
66  [646]  ../../package-fetcher.js (lib/package-fetcher.js)                         4ms  ▇▇ 2%
67  [195]  ./buffer-reporter.js (lib/reporters/buffer-reporter.js)                   4ms  ▇▇ 2%
68  [359]  ./yarn-registry.js (lib/registries/yarn-registry.js)                      4ms  ▇▇ 2%
69  [159]  ./progress-bar.js (lib/reporters/console/progress-bar.js)                 4ms  ▇▇ 2%
70  [628]  ../../lockfile/wrapper.js (lib/lockfile/wrapper.js)                       4ms  ▇▇ 2%
71  [383]  ./child.js (lib/util/child.js)                                            3ms  ▇ 1%
72    [8]  semver (node_modules/semver/semver.js)                                    3ms  ▇ 1%
73 [1026]  proper-lockfile (node_modules/proper-lockfile/index.js)                   3ms  ▇ 1%
74  [893]  ./lib/_stream_writable.js (node_mo...e-stream/lib/_stream_writable.js)    3ms  ▇ 1%
75  [934]  mime (node_modules/mime/mime.js)                                          3ms  ▇ 1%
76    [7]  chalk (../../../../../usr/local/li...uire/node_modules/chalk/index.js)    3ms  ▇ 1%
77  [799]  ./lib/_stream_readable.js (node_mo...e-stream/lib/_stream_readable.js)    3ms  ▇ 1%
78  [291]  ./parser (node_modules/spdx-expression-parse/parser.js)                   3ms  ▇ 1%
79  [382]  child_process (child_process)                                             3ms  ▇ 1%
80  [292]  spdx-expression-parse (node_modules/spdx-expression-parse/index.js)       3ms  ▇ 1%
81  [405]  ./polyfills.js (node_modules/graceful-fs/polyfills.js)                    3ms  ▇ 1%
82  [230]  brace-expansion (node_modules/brace-expansion/index.js)                   3ms  ▇ 1%
83  [702]  ../../package-linker.js (lib/package-linker.js)                           3ms  ▇ 1%
84   [92]  ../modules/web.dom.iterable (node_...rary/modules/web.dom.iterable.js)    3ms  ▇ 1%
85  [450]  ./lib/writer.js (node_modules/fstream/lib/writer.js)                      3ms  ▇ 1%
86  [682]  ../../package-resolver.js (lib/package-resolver.js)                       3ms  ▇ 1%
87   [26]  ./_object-dp (node_modules/core-js/library/modules/_object-dp.js)         3ms  ▇ 1%
88  [643]  ./fetchers/index.js (lib/fetchers/index.js)                               3ms  ▇ 1%
89  [194]  ./json-reporter.js (lib/reporters/json-reporter.js)                       3ms  ▇ 1%
90  [654]  ../../package-install-scripts.js (lib/package-install-scripts.js)         3ms  ▇ 1%
Total require(): 1029
Total time: 259ms
```

</details>

**Test plan**
`npm test`

`bin/yarn.js install --har`

---

Next up I'm going to get rid of `concat-stream`, and hopefully drop one tar module (not sure which one yet).
