### PR TITLE
Add info command. Fixes #445.

### DIFF
--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -27,6 +27,9 @@ export {team};
 import * as link from './link.js';
 export {link};
 
+import * as info from './info.js';
+export {info};
+
 import * as outdated from './outdated.js';
 export {outdated};
 

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -1,0 +1,78 @@
+/* @flow */
+
+import type {Reporter} from '../../reporters/index.js';
+import type Config from '../../config.js';
+import NpmRegistry from '../../registries/npm-registry.js';
+
+let semver = require('semver');
+
+function clean(object: any): any {
+  if (Array.isArray(object)) {
+    const result = [];
+    object.forEach((item) => {
+      item = clean(item);
+      if (item) {
+        result.push(item);
+      }
+    });
+    return result;
+  } else if (typeof object === 'object') {
+    const result = {};
+    for (const key in object) {
+      if (key.startsWith('_')) {
+        continue;
+      }
+
+      const item = clean(object[key]);
+      if (item) {
+        result[key] = item;
+      }
+    }
+    return result;
+  } else if (object) {
+    return object;
+  } else {
+    return null;
+  }
+}
+
+export async function run(
+ config: Config,
+ reporter: Reporter,
+ flags: Object,
+ args: Array<string>,
+): Promise<void> {
+  if (args.length !== 1 && args.length !== 2) {
+    return;
+  }
+
+  let moduleName = NpmRegistry.escapeName(args.shift());
+  let version;
+  const field = args.shift();
+  const parts = moduleName.split('@');
+  if (parts.length > 1) {
+    moduleName = parts.shift();
+    version = parts.join('@');
+  }
+
+  let result = await config.registries.npm.request(moduleName);
+  if (!result) {
+    reporter.error(reporter.lang('infoFail'));
+    return;
+  }
+
+  result = clean(result);
+
+  const versions = result.versions;
+  // $FlowFixMe
+  result.versions = Object.keys(versions).sort(semver.compareLoose);
+  result.version = version || result.versions[result.versions.length - 1];
+  result = Object.assign(result, versions[result.version]);
+
+  // Readmes can be long so exclude them unless explicitly asked for.
+  if (field !== 'readme') {
+    delete result.readme;
+  }
+
+  reporter.inspect(field ? result[field] : result);
+}

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -135,6 +135,9 @@ export default class BaseReporter {
   // a shell command has been executed
   command(command: string) {}
 
+  // inspect and pretty-print any value
+  inspect(value: any) {}
+
   // the screen shown at the very start of the CLI
   header(command: string, pkg: Package) {}
 

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -13,10 +13,11 @@ import Spinner from './spinner-progress.js';
 import {clearLine} from './util.js';
 import {removeSuffix} from '../../util/misc.js';
 
-let readline = require('readline');
-let repeat = require('repeating');
+let {inspect} = require('util');
 let chalk = require('chalk');
 let read = require('read');
+let readline = require('readline');
+let repeat = require('repeating');
 
 function sortTrees(trees: Trees = []): Trees {
   return trees.sort(function(tree1, tree2): number {
@@ -42,6 +43,19 @@ export default class ConsoleReporter extends BaseReporter {
     }
 
     this.log(`${chalk.grey(`[${current}/${total}]`)} ${msg}`);
+  }
+
+  inspect(value: any) {
+    if (typeof value !== 'number' && typeof value !== 'string') {
+      value = inspect(value, {
+        breakLength: 0,
+        colors: true,
+        depth: null,
+        maxArrayLength: null,
+      });
+    }
+
+    this.log(value);
   }
 
   list(key: string, items: Array<string>) {

--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -34,6 +34,10 @@ export default class JSONReporter extends BaseReporter {
     this._dump('step', {message, current, total});
   }
 
+  inspect(value: any) {
+    this._dump('inspect', value);
+  }
+
   footer() {
     this._dump('finished', this.getTotalTime());
   }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -145,6 +145,8 @@ let messages = {
   publishNoName: `Package doesn't have a name.`,
   published: 'Published.',
   publishing: 'Publishing',
+
+  infoFail: 'Received invalid response from npm.',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
**Summary**
This implements a basic info command similar to `npm info`. I think it makes sense to do most of the same things but happy to customize in any way you guys like.

**Test plan**
yarn info jest
yarn info jest@14.0.0
yarn info babel-jest readme
yarn info jest version

<img width="757" alt="screen shot 2016-09-26 at 7 28 04 pm" src="https://cloud.githubusercontent.com/assets/13352/18831196/5efb0010-841f-11e6-9d2f-11803c1376ff.png">
