### PR TITLE
Normalize git urls that start with git+

### DIFF
--- a/__tests__/resolvers/git.js
+++ b/__tests__/resolvers/git.js
@@ -1,9 +1,0 @@
-/* @flow */
-
-import GitResolver from '../../src/resolvers/exotics/git-resolver.js';
-
-test("cleanUrl", () => {
-  expect(GitResolver.cleanUrl('git+https://github.com/npm-opam/ocamlfind.git')).toEqual('https://github.com/npm-opam/ocamlfind.git');
-  expect(GitResolver.cleanUrl('https://github.com/npm-opam/ocamlfind.git')).toEqual('https://github.com/npm-opam/ocamlfind.git');
-  expect(GitResolver.cleanUrl('git://github.com/npm-opam/ocamlfind.git')).toEqual('git://github.com/npm-opam/ocamlfind.git');
-});

--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import Git from '../../src/util/git.js';
+
+test('cleanUrl', () => {
+  expect(Git.cleanUrl('git+https://github.com/npm-opam/ocamlfind.git'))
+    .toEqual('https://github.com/npm-opam/ocamlfind.git');
+  expect(Git.cleanUrl('https://github.com/npm-opam/ocamlfind.git'))
+    .toEqual('https://github.com/npm-opam/ocamlfind.git');
+  expect(Git.cleanUrl('git://github.com/npm-opam/ocamlfind.git'))
+    .toEqual('git://github.com/npm-opam/ocamlfind.git');
+});

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -22,16 +22,12 @@ export default class GitResolver extends ExoticResolver {
     super(request, fragment);
 
     let {url, hash} = versionUtil.explodeHashedUrl(fragment);
-    this.url = GitResolver.cleanUrl(url);
+    this.url = url;
     this.hash = hash;
   }
 
   url: string;
   hash: string;
-
-  static cleanUrl(url: string): string {
-    return url.replace(/^git\+/, '');
-  }
 
   static isVersion(pattern: string): boolean {
     // this pattern hasn't been exploded yet, we'll hit this code path again later once

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -30,7 +30,7 @@ export default class Git {
     this.config = config;
     this.hash = hash;
     this.ref = hash;
-    this.url = url;
+    this.url = Git.cleanUrl(url);
     this.cwd = this.config.getTemp(crypto.hash(this.url));
   }
 
@@ -41,6 +41,11 @@ export default class Git {
   ref: string;
   cwd: string;
   url: string;
+
+
+  static cleanUrl(url): string {
+    return url.replace(/^git\+/, '');
+  }
 
   /**
    * Check if the host specified in the input `gitUrl` has archive capability.


### PR DESCRIPTION
Need to run the normalize logic on both resolver and fetcher, so put it into util/git.js
