### PR TITLE
Refer to package.json file as such in case it is missing

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -317,7 +317,7 @@ export default class Config {
         }
       }
 
-      throw new Error(`Couldn't find a package.json file in ${dir}`);
+      throw new Error(`Couldn't find a package.json (or bower.json) file in ${dir}`);
     });
   }
 


### PR DESCRIPTION
I'm not a total noob, but a few minutes ago I was left wondering "what is a manifest!?"

<img width="678" alt="screenshot 2016-09-28 16 02 10" src="https://cloud.githubusercontent.com/assets/1483597/18936067/57d1d586-8599-11e6-9277-23168321e4db.png">

Lets refer to this thing as it is.
