### PR TITLE
fix: support scoped packages with yarn info

### DIFF
--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -5,6 +5,7 @@ import type Config from '../../config.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 
 let semver = require('semver');
+const PKG_INPUT = /(^\S[^\s@]+)(?:@(\S+))?$/;
 
 function clean(object: any): any {
   if (Array.isArray(object)) {
@@ -46,16 +47,14 @@ export async function run(
     return;
   }
 
-  let moduleName = NpmRegistry.escapeName(args.shift());
-  let version;
+  let packageInput = NpmRegistry.escapeName(args.shift());
   const field = args.shift();
-  const parts = moduleName.split('@');
-  if (parts.length > 1) {
-    moduleName = parts.shift();
-    version = parts.join('@');
-  }
 
-  let result = await config.registries.npm.request(moduleName);
+  const parts = PKG_INPUT.exec(packageInput);
+  const packageName = parts[1];
+  const packageVersion = parts[2];
+
+  let result = await config.registries.npm.request(packageName);
   if (!result) {
     reporter.error(reporter.lang('infoFail'));
     return;
@@ -66,7 +65,7 @@ export async function run(
   const versions = result.versions;
   // $FlowFixMe
   result.versions = Object.keys(versions).sort(semver.compareLoose);
-  result.version = version || result.versions[result.versions.length - 1];
+  result.version = packageVersion || result.versions[result.versions.length - 1];
   result = Object.assign(result, versions[result.version]);
 
   // Readmes can be long so exclude them unless explicitly asked for.


### PR DESCRIPTION
**Summary**

This fails because the input is incorrectly parsed due to the assumption that @ separator is used only for version numbers:

yarn info @angular/core

**Test plan**

"yarn info @angular/core" now works. I don't see existing tests for this command otherwise I'd have added one.
