### PR TITLE
Add build-dist script for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
     "mock-stdin": "^0.3.0",
     "temp": "^0.8.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/yarnpkg/yarn.git"
+  },
   "bin": {
     "kpm": "./bin/yarn.js",
     "yarn": "./bin/yarn.js"

--- a/scripts/build-dist.ps1
+++ b/scripts/build-dist.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+
+npm run build
+npm pack
+if (Test-Path dist) {
+  rm dist -Recurse
+}
+mkdir dist
+mv yarn-*.tgz dist/pack.tgz
+
+cd dist
+tar -xzf pack.tgz --strip 1
+rm pack.tgz
+npm install --production
+rm node_modules/*/test -Recurse
+rm node_modules/*/dist -Recurse
+cd ..


### PR DESCRIPTION
Adds a version of `build-dist` that runs natively on Windows. It doesn't build the `tar.gz` as doing that just on Linux is fine.

Requires `tar` and `gzip` to be installed.
