### PR TITLE
Sort package json

### DIFF
--- a/__tests__/commands/__snapshots__/add.js.snap
+++ b/__tests__/commands/__snapshots__/add.js.snap
@@ -1,0 +1,9 @@
+exports[`test install with arg that has install scripts 1`] = `
+"{
+  \"dependencies\": {
+    \"left-pad\": \"^1.1.0\",
+    \"mime-types\": \"^2.0.0\"
+  }
+}
+"
+`;

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -93,13 +93,10 @@ parallelTest('add should not make package.json strict', async (): Promise<void> 
   await fs.copy(path.join(cwd, 'package.json.before'), path.join(cwd, 'package.json'));
 
   return runAdd({}, ['left-pad@^1.1.0'], fixture, async (config) => {
-    assert.deepEqual(
-      JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {
-        'left-pad': '^1.1.0',
-        'mime-types': '^2.0.0',
-      },
-    );
+    // Make sure left-pad is added and the resulting dependencies are sorted properly.
+    expect(
+      await fs.readFile(path.join(config.cwd, 'package.json')),
+    ).toMatchSnapshot();
 
     await fs.unlink(path.join(config.cwd, `${mirrorPath}/left-pad-*.tgz`));
     await fs.unlink(path.join(config.cwd, 'package.json'));

--- a/__tests__/fixtures/add/no-mirror-remote-when-duplicates/package.json
+++ b/__tests__/fixtures/add/no-mirror-remote-when-duplicates/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "node-notifier": "4.6.1",
-    "jest-cli": "15.1.1",
     "cross-spawn": "3.0.1",
-    "cross-spawn-async": "2.2.4"
+    "cross-spawn-async": "2.2.4",
+    "jest-cli": "15.1.1",
+    "node-notifier": "4.6.1"
   }
 }

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -52,6 +52,14 @@ type IntegrityMatch = {
   matches: boolean,
 };
 
+const sortObject = (object) => {
+  const sortedObject = {};
+  Object.keys(object).sort().forEach((item) => {
+    sortedObject[item] = object[item];
+  });
+  return sortedObject;
+};
+
 export class Install {
   constructor(
     flags: Object,
@@ -390,14 +398,25 @@ export class Install {
    * Save root manifests.
    */
 
-  async saveRootManifests(jsons: RootManifests): Promise<void> {
+  async saveRootManifests(manifests: RootManifests): Promise<void> {
     for (let registryName of registryNames) {
-      let [loc, json] = jsons[registryName];
-      if (!Object.keys(json).length) {
+      let [loc, object] = manifests[registryName];
+      if (!Object.keys(object).length) {
         continue;
       }
 
-      await fs.writeFile(loc, stringify(json) + '\n');
+      [
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+        'dependencies',
+      ].forEach((field) => {
+        if (object[field]) {
+          object[field] = sortObject(object[field]);
+        }
+      });
+
+      await fs.writeFile(loc, stringify(object) + '\n');
     }
   }
 


### PR DESCRIPTION
**Summary**
Fixes #478

This is the simplest way to make sure the fields are sorted. The other solutions require a custom version of `json-stable-stringify` that can sort only a sub-object. We don't want to sort the entire `package.json` file and our `add` command should produce the same `package.json` output that `npm` would produce. v8 implements (and ES2015 specifies) iteration over objects in insertion-order and it turns out that `npm` uses the same solution, so it should be good enough for us. While this doesn't properly sort numeric keys, npm wouldn't either and keeping consistency with npm while also solving it in the most minimal possible way makes sense to me.

**Test plan**
- jest
- `yarn add left-pad` will put left pad in the correct alphabetical location.
