### PR TITLE
Improved `yarn run` command.

### DIFF
--- a/__tests__/reporters/__snapshots__/console.js.snap
+++ b/__tests__/reporters/__snapshots__/console.js.snap
@@ -78,10 +78,10 @@ Object {
 exports[`test ConsoleReporter.select 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[34minfo[39m Ayo
+  "stdout": "[2K[1G[34minfo[39m Ayo?
 [2K[1G  [2m1)[22m foo
 [2K[1G  [2m2)[22m bar
-[1G[0JSelect one?: [14G1"
+[1G[0JSelect one: [13G1"
 }
 `;
 

--- a/__tests__/reporters/base.js
+++ b/__tests__/reporters/base.js
@@ -92,7 +92,7 @@ test('BaseReporter.select', async () => {
   let reporter = new BaseReporter();
   let error;
   try {
-    await reporter.select('', '', []);
+    await reporter.select('?', '', []);
   } catch (e) {
     error = e;
   }

--- a/__tests__/reporters/console.js
+++ b/__tests__/reporters/console.js
@@ -82,7 +82,7 @@ test('ConsoleReporter.select', async () => {
       streams.stdin.end();
     });
 
-    let res = await r.select('Ayo', 'Select one', [{
+    let res = await r.select('Ayo?', 'Select one', [{
       name: 'foo',
       value: 'foo',
     }, {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "validate-npm-package-license": "^3.0.1"
   },
   "devDependencies": {
-    "babel-core": "^6.10.4",
+    "babel-core": "^6.17.0",
     "babel-eslint": "^6.1.2",
     "babel-jest": "^14.0.0",
     "babel-loader": "^6.2.5",

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -281,7 +281,7 @@ export default class ConsoleReporter extends BaseReporter {
       }
 
       let ask = () => {
-        rl.question(`${question}?: `, (input) => {
+        rl.question(`${question}: `, (input) => {
           let index = toIndex(input);
 
           if (isNaN(index)) {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -13,7 +13,7 @@ let messages = {
   cleaningModules: 'Cleaning modules',
   bumpingVersion: 'Bumping version',
   savingHar: 'Saving HAR file: $0',
-  answer: 'Answer',
+  answer: 'Answer?',
   usage: 'Usage',
   installCommandRenamed: '`install` has been replaced with `add` to add new dependencies.',
   waitingInstance: 'Waiting until the other yarn instance finish',
@@ -54,7 +54,9 @@ let messages = {
   shrinkwrapWarning: 'npm-shrinkwrap.json found. This will not be updated or respected. See [TODO] for more information.',
 
   commandNotSpecified: 'No command specified.',
-  possibleCommands: 'Possible commands',
+  binCommands: 'Commands available from binary scripts: ',
+  possibleCommands: 'Project commands',
+  commandQuestion: 'Which command would you like to run?',
   commandFailed: 'Command failed with exit code $0.',
 
   foundIncompatible: 'Found incompatible module',

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,9 +40,9 @@ agent-base@2:
 ajv-keywords@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz#02550bc605a3e576041565628af972e06c549d50"
-ajv@^4.7.0:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-4.7.4.tgz#a1cbebe691f5b2abe3338ca2c4db7beec5cfb5e1"
+ajv@^4.7.0, ajv@>=4.2.0:
+  version "4.7.6"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-4.7.6.tgz#a5c1da3f901ab7943e874a6c7820510f375aa996"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -95,8 +95,8 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.0 || ^1.1.13"
 argparse@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz#c289506480557810f14a8bc62d7a06f63ed7f951"
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
   dependencies:
     sprintf-js "~1.0.2"
 arr-diff@^2.0.0:
@@ -114,8 +114,8 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 array-find-index@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz#0bc25ddac941ec8a496ae258fd4ac188003ef3af"
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 array-index@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz#ec56a749ee103e4e08c790b9c353df16055b97f9"
@@ -189,11 +189,10 @@ aws-sign2@~0.6.0:
 aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
-babel-code-frame@^6.8.0:
-  version "6.11.0"
-  resolved "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz#9072dd2353fb0f85b6b57d2c97f0d134d188aed8"
+babel-code-frame@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz#f90e60da0862909d3ce098733b5d3987c97cb8de"
   dependencies:
-    babel-runtime "^6.0.0"
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^2.0.0"
@@ -247,20 +246,20 @@ babel-core@^5.8.33:
     to-fast-properties "^1.0.0"
     trim-right "^1.0.0"
     try-resolve "^1.0.0"
-babel-core@^6.0.0, babel-core@^6.0.2, babel-core@^6.10.4, babel-core@^6.11.4, babel-core@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.14.0.tgz#c9e13ed4e2f97329215496fd9fb48f2b3bcb9b42"
+babel-core@^6.0.0, babel-core@^6.0.2, babel-core@^6.11.4, babel-core@^6.16.0, babel-core@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz#6c4576447df479e241e58c807e4bc7da4db7f425"
   dependencies:
-    babel-code-frame "^6.8.0"
-    babel-generator "^6.14.0"
-    babel-helpers "^6.8.0"
+    babel-code-frame "^6.16.0"
+    babel-generator "^6.17.0"
+    babel-helpers "^6.16.0"
     babel-messages "^6.8.0"
-    babel-register "^6.14.0"
+    babel-register "^6.16.0"
     babel-runtime "^6.9.1"
-    babel-template "^6.14.0"
-    babel-traverse "^6.14.0"
-    babel-types "^6.14.0"
-    babylon "^6.9.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
+    babylon "^6.11.0"
     convert-source-map "^1.1.0"
     debug "^2.1.1"
     json5 "^0.4.0"
@@ -289,14 +288,15 @@ babel-eslint@^6.1.2:
     babylon "^6.0.18"
     lodash.assign "^4.0.0"
     lodash.pickby "^4.0.0"
-babel-generator@^6.11.3, babel-generator@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.14.0.tgz#0f3f173e9cb95d501b1a735598b1a593dbee3705"
+babel-generator@^6.11.3, babel-generator@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz#b894e3808beef7800f2550635bfe024b6226cf33"
   dependencies:
     babel-messages "^6.8.0"
     babel-runtime "^6.9.0"
-    babel-types "^6.14.0"
+    babel-types "^6.16.0"
     detect-indent "^3.0.1"
+    jsesc "^1.3.0"
     lodash "^4.2.0"
     source-map "^0.5.0"
 babel-helper-bindify-decorators@^6.8.0:
@@ -386,31 +386,31 @@ babel-helper-regex@^6.8.0:
     babel-runtime "^6.9.0"
     babel-types "^6.9.0"
     lodash "^4.2.0"
-babel-helper-remap-async-to-generator@^6.8.0:
-  version "6.11.2"
-  resolved "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.11.2.tgz#fe482d566355d36f946d7db162fd4eb56258a6ff"
+babel-helper-remap-async-to-generator@^6.16.0, babel-helper-remap-async-to-generator@^6.16.2:
+  version "6.16.2"
+  resolved "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.16.2.tgz#24315bde8326c60022dc053cce84cfe38d724b82"
   dependencies:
     babel-helper-function-name "^6.8.0"
     babel-runtime "^6.0.0"
-    babel-template "^6.8.0"
-    babel-traverse "^6.8.0"
-    babel-types "^6.8.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
 babel-helper-replace-supers@^6.14.0, babel-helper-replace-supers@^6.8.0:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.14.0.tgz#038e13824d6de0e412fbd6708fd3611a7683d869"
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz#21c97623cc7e430855753f252740122626a39e6b"
   dependencies:
     babel-helper-optimise-call-expression "^6.8.0"
     babel-messages "^6.8.0"
     babel-runtime "^6.0.0"
-    babel-template "^6.14.0"
-    babel-traverse "^6.14.0"
-    babel-types "^6.14.0"
-babel-helpers@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz#321c56f9c9cac1a297f827fdff638b27a6292503"
+    babel-template "^6.16.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
+babel-helpers@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz#1095ec10d99279460553e67eb3eee9973d3867e3"
   dependencies:
     babel-runtime "^6.0.0"
-    babel-template "^6.8.0"
+    babel-template "^6.16.0"
 babel-jest@^14.0.0:
   version "14.1.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-14.1.0.tgz#29a20bfe8b3c4789a620162a1c52e7db4fb500e9"
@@ -424,7 +424,7 @@ babel-jest@^15.0.0:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^2.0.0"
     babel-preset-jest "^15.0.0"
-babel-loader:
+babel-loader@^6.2.5:
   version "6.2.5"
   resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.5.tgz#576d548520689a5e6b70c65b85d76af1ffedd005"
   dependencies:
@@ -499,6 +499,9 @@ babel-plugin-runtime@^1.0.7:
 babel-plugin-syntax-async-functions@^6.5.0, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
 babel-plugin-syntax-class-constructor-call@^6.8.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.13.0.tgz#96fb2e9f177dca22824065de4392f2fe3486b765"
@@ -532,11 +535,18 @@ babel-plugin-syntax-object-rest-spread@^6.5.0, babel-plugin-syntax-object-rest-s
 babel-plugin-syntax-trailing-function-commas@^6.3.13, babel-plugin-syntax-trailing-function-commas@^6.5.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz#2b84b7d53dd744f94ff1fad7669406274b23f541"
-babel-plugin-transform-async-to-generator@^6.3.13, babel-plugin-transform-async-to-generator@^6.7.0:
-  version "6.8.0"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.8.0.tgz#fbb154f2912e00b9f0972131d7e03ebbe45684c2"
+babel-plugin-transform-async-generator-functions@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz#d0b5a2b2f0940f2b245fa20a00519ed7bc6cae54"
   dependencies:
-    babel-helper-remap-async-to-generator "^6.8.0"
+    babel-helper-remap-async-to-generator "^6.16.2"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.0.0"
+babel-plugin-transform-async-to-generator@^6.16.0, babel-plugin-transform-async-to-generator@^6.7.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz#19ec36cb1486b59f9f468adfa42ce13908ca2999"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.16.0"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.0.0"
 babel-plugin-transform-class-constructor-call@^6.3.13:
@@ -546,9 +556,9 @@ babel-plugin-transform-class-constructor-call@^6.3.13:
     babel-plugin-syntax-class-constructor-call "^6.8.0"
     babel-runtime "^6.0.0"
     babel-template "^6.8.0"
-babel-plugin-transform-class-properties@^6.3.13:
-  version "6.11.5"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.11.5.tgz#429c7a4e7d8ac500448eb14ec502604bc568c91c"
+babel-plugin-transform-class-properties@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.16.0.tgz#969bca24d34e401d214f36b8af5c1346859bc904"
   dependencies:
     babel-helper-function-name "^6.8.0"
     babel-plugin-syntax-class-properties "^6.8.0"
@@ -608,9 +618,9 @@ babel-plugin-transform-es2015-computed-properties@^6.3.13:
     babel-helper-define-map "^6.8.0"
     babel-runtime "^6.0.0"
     babel-template "^6.8.0"
-babel-plugin-transform-es2015-destructuring@^6.6.5, babel-plugin-transform-es2015-destructuring@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz#f55747f62534866a51b4c4fdb255e6d85e8604d6"
+babel-plugin-transform-es2015-destructuring@^6.16.0, babel-plugin-transform-es2015-destructuring@^6.6.5:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz#050fe0866f5d53b36062ee10cdf5bfe64f929627"
   dependencies:
     babel-runtime "^6.9.0"
 babel-plugin-transform-es2015-duplicate-keys@^6.6.0:
@@ -619,7 +629,7 @@ babel-plugin-transform-es2015-duplicate-keys@^6.6.0:
   dependencies:
     babel-runtime "^6.0.0"
     babel-types "^6.8.0"
-babel-plugin-transform-es2015-for-of@^6.6.0, babel-plugin-transform-es2015-for-of@^6.8.0:
+babel-plugin-transform-es2015-for-of@^6.6.0:
   version "6.8.0"
   resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz#82eda139ba4270dda135c3ec1b1f2813fa62f23c"
   dependencies:
@@ -643,14 +653,14 @@ babel-plugin-transform-es2015-modules-amd@^6.8.0:
     babel-plugin-transform-es2015-modules-commonjs "^6.8.0"
     babel-runtime "^6.0.0"
     babel-template "^6.8.0"
-babel-plugin-transform-es2015-modules-commonjs@^6.14.0, babel-plugin-transform-es2015-modules-commonjs@^6.7.0, babel-plugin-transform-es2015-modules-commonjs@^6.7.4, babel-plugin-transform-es2015-modules-commonjs@^6.8.0:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.14.0.tgz#db731640c67ea6ebaecf90eb9cdabddb584aeb36"
+babel-plugin-transform-es2015-modules-commonjs@^6.16.0, babel-plugin-transform-es2015-modules-commonjs@^6.7.0, babel-plugin-transform-es2015-modules-commonjs@^6.7.4, babel-plugin-transform-es2015-modules-commonjs@^6.8.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz#0a34b447bc88ad1a70988b6d199cca6d0b96c892"
   dependencies:
     babel-plugin-transform-strict-mode "^6.8.0"
     babel-runtime "^6.0.0"
-    babel-template "^6.14.0"
-    babel-types "^6.14.0"
+    babel-template "^6.16.0"
+    babel-types "^6.16.0"
 babel-plugin-transform-es2015-modules-systemjs@^6.14.0:
   version "6.14.0"
   resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz#c519b5c73e32388e679c9b1edf41b2fc23dc3303"
@@ -671,16 +681,16 @@ babel-plugin-transform-es2015-object-super@^6.3.13:
   dependencies:
     babel-helper-replace-supers "^6.8.0"
     babel-runtime "^6.0.0"
-babel-plugin-transform-es2015-parameters@^6.7.0, babel-plugin-transform-es2015-parameters@^6.9.0:
-  version "6.11.4"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.11.4.tgz#2d41e88c3e4319797e305f87027ef43f4dc739c4"
+babel-plugin-transform-es2015-parameters@^6.16.0, babel-plugin-transform-es2015-parameters@^6.7.0:
+  version "6.17.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz#e06d30cef897f46adb4734707bbe128a0d427d58"
   dependencies:
     babel-helper-call-delegate "^6.8.0"
     babel-helper-get-function-arity "^6.8.0"
     babel-runtime "^6.9.0"
-    babel-template "^6.9.0"
-    babel-traverse "^6.11.4"
-    babel-types "^6.9.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
 babel-plugin-transform-es2015-shorthand-properties@^6.3.13, babel-plugin-transform-es2015-shorthand-properties@^6.5.0:
   version "6.8.0"
   resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz#f0a4c5fd471630acf333c2d99c3d677bf0952149"
@@ -741,9 +751,9 @@ babel-plugin-transform-function-bind@^6.3.13:
   dependencies:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.0.0"
-babel-plugin-transform-object-rest-spread@^6.3.13, babel-plugin-transform-object-rest-spread@^6.6.5:
-  version "6.8.0"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz#03d1308e257a9d8e1a815ae1fd3db21bdebf08d9"
+babel-plugin-transform-object-rest-spread@^6.16.0, babel-plugin-transform-object-rest-spread@^6.6.5:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz#db441d56fffc1999052fdebe2e2f25ebd28e36a9"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.0.0"
@@ -771,18 +781,12 @@ babel-plugin-transform-react-jsx@^6.3.13:
     babel-helper-builder-react-jsx "^6.8.0"
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.0.0"
-babel-plugin-transform-regenerator@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.14.0.tgz#119119b20c8b4283f6c77f0170d404c3c654bec8"
+babel-plugin-transform-regenerator@^6.16.0:
+  version "6.16.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz#a75de6b048a14154aae14b0122756c5bed392f59"
   dependencies:
-    babel-core "^6.14.0"
-    babel-plugin-syntax-async-functions "^6.8.0"
-    babel-plugin-transform-es2015-block-scoping "^6.14.0"
-    babel-plugin-transform-es2015-for-of "^6.8.0"
     babel-runtime "^6.9.0"
-    babel-traverse "^6.14.0"
-    babel-types "^6.14.0"
-    babylon "^6.9.0"
+    babel-types "^6.16.0"
     private "~0.1.5"
 babel-plugin-transform-runtime@^6.4.3:
   version "6.15.0"
@@ -804,8 +808,8 @@ babel-plugin-undefined-to-void@^1.1.6:
   version "1.1.6"
   resolved "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
 babel-polyfill@^6.7.2:
-  version "6.13.0"
-  resolved "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.13.0.tgz#5978215c25d49a697eb78afc54e63c9d3a73d5ec"
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz#2d45021df87e26a374b6d4d1a9c65964d17f2422"
   dependencies:
     babel-runtime "^6.9.1"
     core-js "^2.4.0"
@@ -823,8 +827,8 @@ babel-preset-es2015-node4@^2.1.0:
     babel-plugin-transform-es2015-sticky-regex "^6.5.0"
     babel-plugin-transform-es2015-unicode-regex "^6.5.0"
 babel-preset-es2015@^6.3.13:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.14.0.tgz#cd2437a96f02a4d19bb87e87980bf0b0288d13eb"
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz#59acecd1efbebaf48f89404840f2fe78c4d2ad5c"
   dependencies:
     babel-plugin-check-es2015-constants "^6.3.13"
     babel-plugin-transform-es2015-arrow-functions "^6.3.13"
@@ -832,24 +836,24 @@ babel-preset-es2015@^6.3.13:
     babel-plugin-transform-es2015-block-scoping "^6.14.0"
     babel-plugin-transform-es2015-classes "^6.14.0"
     babel-plugin-transform-es2015-computed-properties "^6.3.13"
-    babel-plugin-transform-es2015-destructuring "^6.9.0"
+    babel-plugin-transform-es2015-destructuring "^6.16.0"
     babel-plugin-transform-es2015-duplicate-keys "^6.6.0"
     babel-plugin-transform-es2015-for-of "^6.6.0"
     babel-plugin-transform-es2015-function-name "^6.9.0"
     babel-plugin-transform-es2015-literals "^6.3.13"
     babel-plugin-transform-es2015-modules-amd "^6.8.0"
-    babel-plugin-transform-es2015-modules-commonjs "^6.14.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.16.0"
     babel-plugin-transform-es2015-modules-systemjs "^6.14.0"
     babel-plugin-transform-es2015-modules-umd "^6.12.0"
     babel-plugin-transform-es2015-object-super "^6.3.13"
-    babel-plugin-transform-es2015-parameters "^6.9.0"
+    babel-plugin-transform-es2015-parameters "^6.16.0"
     babel-plugin-transform-es2015-shorthand-properties "^6.3.13"
     babel-plugin-transform-es2015-spread "^6.3.13"
     babel-plugin-transform-es2015-sticky-regex "^6.3.13"
     babel-plugin-transform-es2015-template-literals "^6.6.0"
     babel-plugin-transform-es2015-typeof-symbol "^6.6.0"
     babel-plugin-transform-es2015-unicode-regex "^6.3.13"
-    babel-plugin-transform-regenerator "^6.14.0"
+    babel-plugin-transform-regenerator "^6.16.0"
 babel-preset-jest@^14.1.0:
   version "14.1.0"
   resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-14.1.0.tgz#55da655d620ad10005b2bedf46accc525ad9c2a7"
@@ -878,8 +882,8 @@ babel-preset-node5@^10.2.0:
     babel-plugin-transform-strict-mode "^6.6.5"
     babel-polyfill "^6.7.2"
 babel-preset-react@^6.0.0:
-  version "6.11.1"
-  resolved "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.11.1.tgz#98ac2bd3c1b76f3062ae082580eade154a19b590"
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz#aa117d60de0928607e343c4828906e4661824316"
   dependencies:
     babel-plugin-syntax-flow "^6.3.13"
     babel-plugin-syntax-jsx "^6.3.13"
@@ -889,77 +893,78 @@ babel-preset-react@^6.0.0:
     babel-plugin-transform-react-jsx-self "^6.11.0"
     babel-plugin-transform-react-jsx-source "^6.3.13"
 babel-preset-stage-0@^6.0.0:
-  version "6.5.0"
-  resolved "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.5.0.tgz#8b8479b2077482b8f3dc8f8f5f0c9c79788cde22"
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.16.0.tgz#f5a263c420532fd57491f1a7315b3036e428f823"
   dependencies:
     babel-plugin-transform-do-expressions "^6.3.13"
     babel-plugin-transform-function-bind "^6.3.13"
-    babel-preset-stage-1 "^6.3.13"
-babel-preset-stage-1@^6.3.13:
-  version "6.13.0"
-  resolved "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.13.0.tgz#51bf411fa6c4d629fb6ca5e1baf272af648850cc"
+    babel-preset-stage-1 "^6.16.0"
+babel-preset-stage-1@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.16.0.tgz#9d31fbbdae7b17c549fd3ac93e3cf6902695e479"
   dependencies:
     babel-plugin-transform-class-constructor-call "^6.3.13"
     babel-plugin-transform-export-extensions "^6.3.13"
-    babel-preset-stage-2 "^6.13.0"
-babel-preset-stage-2@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.13.0.tgz#7a3d9e24209a8621dac4b0c2a163a5477ff410e3"
+    babel-preset-stage-2 "^6.16.0"
+babel-preset-stage-2@^6.16.0:
+  version "6.17.0"
+  resolved "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.17.0.tgz#dc4f84582781353cef36c41247eae5e36c4cae0d"
   dependencies:
-    babel-plugin-transform-class-properties "^6.3.13"
+    babel-plugin-transform-class-properties "^6.16.0"
     babel-plugin-transform-decorators "^6.13.0"
-    babel-plugin-transform-object-rest-spread "^6.3.13"
-    babel-preset-stage-3 "^6.11.0"
-babel-preset-stage-3@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.11.0.tgz#1315059fde5b65f6e4cec4f2b591627470213065"
+    babel-preset-stage-3 "^6.17.0"
+babel-preset-stage-3@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz#b6638e46db6e91e3f889013d8ce143917c685e39"
   dependencies:
     babel-plugin-syntax-trailing-function-commas "^6.3.13"
-    babel-plugin-transform-async-to-generator "^6.3.13"
+    babel-plugin-transform-async-generator-functions "^6.17.0"
+    babel-plugin-transform-async-to-generator "^6.16.0"
     babel-plugin-transform-exponentiation-operator "^6.3.13"
-babel-register@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.14.0.tgz#1261f94ee375808b564e24a800cc2179afbf0067"
+    babel-plugin-transform-object-rest-spread "^6.16.0"
+babel-register@^6.16.0:
+  version "6.16.3"
+  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz#7b0c0ca7bfdeb9188ba4c27e5fcb7599a497c624"
   dependencies:
-    babel-core "^6.14.0"
+    babel-core "^6.16.0"
     babel-runtime "^6.11.6"
     core-js "^2.4.0"
     home-or-tmp "^1.0.0"
     lodash "^4.2.0"
     mkdirp "^0.5.1"
     path-exists "^1.0.0"
-    source-map-support "^0.2.10"
+    source-map-support "^0.4.2"
 babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.11.6"
   resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
-babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.8.0, babel-template@^6.9.0:
-  version "6.15.0"
-  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.15.0.tgz#a0f249c89d5d57e806fc50d0ec522fbddeade1f2"
+babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0, babel-template@^6.9.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
   dependencies:
     babel-runtime "^6.9.0"
-    babel-traverse "^6.15.0"
-    babel-types "^6.15.0"
-    babylon "^6.9.0"
+    babel-traverse "^6.16.0"
+    babel-types "^6.16.0"
+    babylon "^6.11.0"
     lodash "^4.2.0"
-babel-traverse@^6.0.20, babel-traverse@^6.11.4, babel-traverse@^6.14.0, babel-traverse@^6.15.0, babel-traverse@^6.8.0, babel-traverse@^6.9.0:
-  version "6.15.0"
-  resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.15.0.tgz#f0114c8c84cfee32c94eca02bcd0d2cbc8928478"
+babel-traverse@^6.0.20, babel-traverse@^6.14.0, babel-traverse@^6.15.0, babel-traverse@^6.16.0, babel-traverse@^6.8.0, babel-traverse@^6.9.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz#fba85ae1fd4d107de9ce003149cc57f53bef0c4f"
   dependencies:
-    babel-code-frame "^6.8.0"
+    babel-code-frame "^6.16.0"
     babel-messages "^6.8.0"
     babel-runtime "^6.9.0"
-    babel-types "^6.15.0"
-    babylon "^6.9.0"
+    babel-types "^6.16.0"
+    babylon "^6.11.0"
     debug "^2.2.0"
     globals "^8.3.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
-babel-types@^6.0.19, babel-types@^6.10.2, babel-types@^6.13.0, babel-types@^6.14.0, babel-types@^6.15.0, babel-types@^6.8.0, babel-types@^6.9.0:
-  version "6.15.0"
-  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.15.0.tgz#413d4fef4750a48570de819f18a64d39a4f3dc38"
+babel-types@^6.0.19, babel-types@^6.10.2, babel-types@^6.13.0, babel-types@^6.14.0, babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.8.0, babel-types@^6.9.0:
+  version "6.16.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz#71cca1dbe5337766225c5c193071e8ebcbcffcfe"
   dependencies:
     babel-runtime "^6.9.1"
     esutils "^2.0.2"
@@ -968,9 +973,9 @@ babel-types@^6.0.19, babel-types@^6.10.2, babel-types@^6.13.0, babel-types@^6.14
 babylon@^5.8.38:
   version "5.8.38"
   resolved "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
-babylon@^6.0.18, babylon@^6.5.0, babylon@^6.8.1, babylon@^6.9.0:
-  version "6.11.2"
-  resolved "https://registry.npmjs.org/babylon/-/babylon-6.11.2.tgz#3a64361fedee6d9f8276a9abc0c88a9e5237ff7a"
+babylon@^6.0.18, babylon@^6.11.0, babylon@^6.5.0, babylon@^6.8.1:
+  version "6.11.4"
+  resolved "https://registry.npmjs.org/babylon/-/babylon-6.11.4.tgz#75e1f52187efa0cde5a541a7f7fdda38f6eb5bd2"
 balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -992,8 +997,8 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 binary-extensions@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz#aa2184cbc434d29862c66a69bf81cc0a3383ee79"
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz#6c1610db163abfb34edfe42fa423343a1e01185d"
 bl@^1.0.0, bl@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz#fdca871a99713aa00d19e3bbba41c44787a65398"
@@ -1229,8 +1234,8 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 code-point-at@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz#f69b192d3f7d91e382e4b71bddb77878619ab0c6"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz#1104cd34f9b5b45d3eba88f1babc1924e1ce35fb"
   dependencies:
     number-is-nan "^1.0.0"
 colors@1.0.3:
@@ -1628,16 +1633,16 @@ eslint-plugin-react@^5.2.2:
   dependencies:
     doctrine "^1.2.2"
     jsx-ast-utils "^1.2.1"
-eslint@^3.3.0, eslint@^3.3.1:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/eslint/-/eslint-3.6.0.tgz#591eafde2e686867669cc5ab49e4c492c6d53faf"
+eslint@^3.0.0, eslint@^3.3.0, eslint@^3.3.1, eslint@>=1.0.0, eslint@>=2.0.0:
+  version "3.7.1"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-3.7.1.tgz#7faa84599e0fea422f04bc32db49054051a3f11a"
   dependencies:
     chalk "^1.1.3"
     concat-stream "^1.4.6"
     debug "^2.1.1"
     doctrine "^1.2.2"
     escope "^3.6.0"
-    espree "^3.2.0"
+    espree "^3.3.1"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -1665,9 +1670,9 @@ eslint@^3.3.0, eslint@^3.3.1:
     table "^3.7.8"
     text-table "~0.2.0"
     user-home "^2.0.0"
-espree@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/espree/-/espree-3.3.0.tgz#9b32fc5127eeea573c339b99873046638ed91761"
+espree@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
   dependencies:
     acorn "^4.0.1"
     acorn-jsx "^3.0.0"
@@ -1750,8 +1755,8 @@ fancy-log@^1.1.0:
     chalk "^1.1.1"
     time-stamp "^1.0.0"
 fast-levenshtein@~2.0.4:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.4.tgz#e31e729eea62233c60a7bc9dce2bdcc88b4fffe3"
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz#bd33145744519ab1c36c3ee9f31f08e9079b67f2"
 fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz#6f268f1f347a6b3c875d1e89da7e1ed79adfc0ec"
@@ -1819,6 +1824,11 @@ fined@^1.0.1:
 first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
+first-chunk-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
+  dependencies:
+    readable-stream "^2.0.2"
 flagged-respawn@^0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz#ff191eddcd7088a675b2610fffc976be9b8074b5"
@@ -1942,6 +1952,11 @@ glob-parent@^2.0.0:
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
   dependencies:
     is-glob "^2.0.0"
+glob-parent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz#c7bdeb5260732196c740de9274c08814056014bb"
+  dependencies:
+    is-glob "^3.0.0"
 glob-stream@^3.1.5:
   version "3.1.18"
   resolved "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz#9170a5f12b790306fdfe598f313f8f7954fd143b"
@@ -2047,8 +2062,8 @@ graceful-fs@^3.0.0:
   dependencies:
     natives "^1.1.0"
 graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz#514c38772b31bee2e08bedc21a0aeb3abf54c19e"
+  version "4.1.9"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz#baacba37d19d11f9d146d3578bc99958c3787e29"
 graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
@@ -2069,8 +2084,8 @@ gulp-babel@^6.0.0:
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
 gulp-newer@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.2.0.tgz#918f2ecfc8d0110e6374c4245bab086c6477b685"
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.3.0.tgz#d50ecacbb822eda492b57324a6c85a07fd9a55c1"
   dependencies:
     glob "^7.0.3"
     gulp-util "^3.0.7"
@@ -2104,18 +2119,18 @@ gulp-util@^3, gulp-util@^3.0.0, gulp-util@^3.0.6, gulp-util@^3.0.7:
     through2 "^2.0.0"
     vinyl "^0.5.0"
 gulp-watch@^4.3.5:
-  version "4.3.9"
-  resolved "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.9.tgz#dbf51d2a9cd38303ec5eae2720ac037c66d0a2f5"
+  version "4.3.10"
+  resolved "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.10.tgz#776920ab54595c95f3597fb5444e61fc7bbd58a3"
   dependencies:
     anymatch "^1.3.0"
     chokidar "^1.5.2"
-    glob-parent "^2.0.0"
+    glob-parent "^3.0.0"
     gulp-util "^3.0.6"
     object-assign "^4.1.0"
     path-is-absolute "^1.0.0"
     readable-stream "^2.0.1"
-    vinyl "^0.5.0"
-    vinyl-file "^1.2.1"
+    vinyl "^1.2.0"
+    vinyl-file "^2.0.0"
 gulp@^3.9.0:
   version "3.9.1"
   resolved "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz#571ce45928dd40af6514fc4011866016c13845b4"
@@ -2324,9 +2339,12 @@ is-extendable@^0.1.1:
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+is-extglob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz#a9b92c1ae2d7a975ad307be0722049c7e4ea2f13"
 is-finite@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz#6438603eaebe2793948ff4a4262ec8db3d62597b"
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
   dependencies:
     number-is-nan "^1.0.0"
 is-fullwidth-code-point@^1.0.0:
@@ -2339,18 +2357,23 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+is-glob@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz#e433c222db9d77844084d72db1eff047845985c1"
+  dependencies:
+    is-extglob "^2.0.0"
 is-integer@^1.0.4:
   version "1.0.6"
   resolved "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz#5273819fada880d123e1ac00a938e7172dd8d95e"
   dependencies:
     is-finite "^1.0.0"
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
-  version "2.14.0"
-  resolved "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz#47bf808609b2df5d48c969c74becd09fbca02725"
+  version "2.15.0"
+  resolved "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
-    jsonpointer "2.0.0"
+    jsonpointer "^4.0.0"
     xtend "^4.0.0"
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
@@ -2468,8 +2491,8 @@ istanbul-lib-report@^1.0.0-alpha:
     rimraf "^2.4.3"
     supports-color "^3.1.2"
 istanbul-lib-source-maps@^1.0.0-alpha:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.1.tgz#92393f1b1f11b5916beea382c1901398a81b7d4c"
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.2.tgz#9e91b0e5ae6ed203f67c69a34e6e98b10bb69a49"
   dependencies:
     istanbul-lib-coverage "^1.0.0-alpha.0"
     mkdirp "^0.5.1"
@@ -2682,8 +2705,8 @@ jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 jsdom@^9.4.0:
-  version "9.5.0"
-  resolved "https://registry.npmjs.org/jsdom/-/jsdom-9.5.0.tgz#cb7194c2a2a07c92af905f7822e45694196e27a0"
+  version "9.6.0"
+  resolved "https://registry.npmjs.org/jsdom/-/jsdom-9.6.0.tgz#e0e9b15ba07e90b1d9ec083f9bedee0f6800a4fb"
   dependencies:
     abab "^1.0.0"
     acorn "^2.4.0"
@@ -2702,10 +2725,13 @@ jsdom@^9.4.0:
     webidl-conversions "^3.0.1"
     whatwg-url "^3.0.0"
     xml-name-validator ">= 2.0.1 < 3.0.0"
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
-json-loader:
+json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
 json-schema@0.2.3:
@@ -2728,9 +2754,9 @@ json5@^0.5.0:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-jsonpointer@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz#3af1dd20fe85463910d469a385e33017d2a030d9"
+jsonpointer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz#6661e161d2fc445f19f98430231343722e1fcbd5"
 jsprim@^1.2.2:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz#2a7256f70412a29ee3670aaca625994c4dcff252"
@@ -2980,8 +3006,8 @@ lodash@^3.10.0, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 lodash@^4.0.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0:
-  version "4.16.2"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz#3e626db827048a699281a8a125226326cfc0e652"
+  version "4.16.3"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz#0ba761439529127c7a38c439114ca153efa999a2"
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -3022,7 +3048,7 @@ marked-terminal@^1.6.2:
     cli-table "^0.3.1"
     lodash.assign "^4.2.0"
     node-emoji "^1.3.1"
-marked@^0.3.6:
+marked@^0.3.3, marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 memory-fs@^0.3.0, memory-fs@~0.3.0:
@@ -3116,8 +3142,8 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, "mkdirp@>=0.5 0", mkdirp@~0.5.0, mkdirp@0.5.x:
   dependencies:
     minimist "0.0.8"
 mock-stdin@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/mock-stdin/-/mock-stdin-0.3.0.tgz#f40d2a513a114e6d547480625b5ef5190744bd4d"
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/mock-stdin/-/mock-stdin-0.3.1.tgz#c657d9642d90786435c64ca5e99bbd4d09bd7dd3"
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -3262,8 +3288,8 @@ npmlog@4.x:
     gauge "~2.6.0"
     set-blocking "~2.0.0"
 number-is-nan@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz#c020f529c5282adfdd233d91d4b181c3d686dc4b"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 "nwmatcher@>= 1.3.7 < 2.0.0":
   version "1.3.8"
   resolved "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz#34edb93de1aa6cb4448b573c9f2a059300241157"
@@ -3328,16 +3354,16 @@ os-browserify@~0.2.0:
   version "0.2.1"
   resolved "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 os-homedir@^1.0.0, os-homedir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz#0d62bdf44b916fd3bbdcf2cab191948fb094f007"
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 os-locale@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz#e9b423a1edaf479882562e92ed71d7743a071b6e"
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 osenv@^0.1.3, osenv@0:
   version "0.1.3"
   resolved "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz#83cf05c6d6458fc4d5ac6362ea325d92f2754217"
@@ -3403,8 +3429,8 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 path-is-absolute@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz#263dada66ab3f2fb10bf7f9d24dd8f3e570ef912"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
@@ -3431,7 +3457,7 @@ pbkdf2@^3.0.3:
   resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz#2f8abf16ebecc82277945d748aba1d78761f61e2"
   dependencies:
     create-hmac "^1.1.2"
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 pinkie-promise@^2.0.0:
@@ -3855,6 +3881,11 @@ source-map-support@^0.2.10:
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz#ea5a3900a1c1cb25096a0ae8cc5c2b4b10ded3dc"
   dependencies:
     source-map "0.1.32"
+source-map-support@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz#693c8383d4389a4569486987c219744dfc601685"
+  dependencies:
+    source-map "^0.5.3"
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -3891,8 +3922,8 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 sshpk@^1.7.0:
-  version "1.10.0"
-  resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz#104d6ba2afb2ac099ab9567c0d193977f29c6dfa"
+  version "1.10.1"
+  resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz#30e1a5d329244974a1af61511339d595af6638b0"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -3903,7 +3934,7 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
-    tweetnacl "~0.13.0"
+    tweetnacl "~0.14.0"
 stable@~0.1.3:
   version "0.1.5"
   resolved "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz#08232f60c732e9890784b5bed0734f8b32a887b9"
@@ -3943,11 +3974,11 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
-strip-bom-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz#e7144398577d51a6bed0fa1994fa05f43fd988ee"
+strip-bom-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz#f87db5ef2613f6968aa545abfe1ec728b6a829ca"
   dependencies:
-    first-chunk-stream "^1.0.0"
+    first-chunk-stream "^2.0.0"
     strip-bom "^2.0.0"
 strip-bom@^1.0.0:
   version "1.0.0"
@@ -4029,12 +4060,12 @@ temp@^0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 test-exclude@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.2.tgz#186d69b8d8f01e99868ef04f7332a5a1b7c1ae73"
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz#a8d8968e1da83266f9864f2852c55e220f06434a"
   dependencies:
     arrify "^1.0.1"
-    lodash.assign "^4.1.0"
     micromatch "^2.3.11"
+    object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 testcheck@^0.1.0:
@@ -4104,12 +4135,9 @@ tty-browserify@0.0.0:
 tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
-tweetnacl@^0.14.3:
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.3"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz#3da382f670f25ded78d7b3d1792119bca0b7132d"
-tweetnacl@~0.13.0:
-  version "0.13.3"
-  resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz#d628b56f3bcc3d5ae74ba9d4c1a704def5ab4b56"
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -4176,13 +4204,15 @@ verror@1.3.6:
   resolved "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
-vinyl-file@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.3.0.tgz#aa05634d3a867ba91447bedbb34afcb26f44f6e7"
+vinyl-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz#a7ebf5ffbefda1b7d18d140fcb07b223efb6751a"
   dependencies:
     graceful-fs "^4.1.2"
+    pify "^2.3.0"
+    pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
-    strip-bom-stream "^1.0.0"
+    strip-bom-stream "^2.0.0"
     vinyl "^1.1.0"
 vinyl-fs@^0.3.0:
   version "0.3.14"
@@ -4214,7 +4244,7 @@ vinyl@^0.5.0:
     clone "^1.0.0"
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
-vinyl@^1.1.0:
+vinyl@^1.1.0, vinyl@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz#5c88036cf565e5df05558bfc911f8656df218884"
   dependencies:
@@ -4250,7 +4280,7 @@ webpack-sources@^0.1.0:
   dependencies:
     source-list-map "~0.1.0"
     source-map "~0.5.3"
-webpack@^2.1.0-beta.25:
+webpack@^2.1.0-beta.25, "webpack@1 || ^2.1.0-beta":
   version "2.1.0-beta.25"
   resolved "https://registry.npmjs.org/webpack/-/webpack-2.1.0-beta.25.tgz#c35ff4da4ee70344a2f14c35258d95412709e9ed"
   dependencies:


### PR DESCRIPTION
**Summary**
While it is nice that `yarn run` can run binaries installed by dependencies, the flat install structure also means that a lot of binaries will be available that aren't directly used. On small projects such as Jest, the list is huge. This changes the list to a single sentence for all binaries and lists all project scripts in a list. It also prompts to enter a command which is generally a nicer experience.

On top of that, `yarn run` now also supports passing in arguments.

**Test plan**
- `yarn run`

<img width="962" alt="screen shot 2016-10-04 at 3 00 23 pm" src="https://cloud.githubusercontent.com/assets/13352/19064400/18a244a0-8a48-11e6-94ed-7bbc5d02fe47.png">
<img width="962" alt="screen shot 2016-10-04 at 3 02 11 pm" src="https://cloud.githubusercontent.com/assets/13352/19064399/18a114ae-8a48-11e6-9caa-fde86113feae.png">
