### PR TITLE
Fix .gitattributes for binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto
 * text eol=lf
+*.bin binary


### PR DESCRIPTION
**Summary**

Based off of https://github.com/flowtype/flow-bin/blob/a0051b8/.gitattributes, which has worked well. Fixes #494.

**Test plan**

`git status` -> no "warning: CRLF will be replaced by LF in..."

cc: @bestander 
