### PR TITLE
Allowed unknown options in arguments parsing

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -50,6 +50,7 @@ commander.option(
   '--force-single-instance-with-file',
   'pause and wait if other instances are running on the same folder using a operating system lock file',
 );
+commander.allowUnknownOption();
 
 // get command name
 let commandName: string = args.splice(2, 1)[0] || '';


### PR DESCRIPTION
**Summary**

Allows unknown options for forwards compatibility.
Yarn does not break in situations when not all team members have been updated to the same version.

**Test plan**

```
yarn.js check --my-new-unsupported-option
yarn check v0.14.0
....
```
