### PR TITLE
var/let -> const

### DIFF
--- a/__tests__/__mocks__/request.js
+++ b/__tests__/__mocks__/request.js
@@ -45,13 +45,13 @@ module.exports = function(params: Object): Request {
 
 module.exports.Request = Request;
 
-let httpMock = {
+const httpMock = {
   request(options: Object, callback?: ?Function): ClientRequest {
-    let alias = getRequestAlias(options);
-    let loc = path.join(CACHE_DIR, `${alias}.bin`);
+    const alias = getRequestAlias(options);
+    const loc = path.join(CACHE_DIR, `${alias}.bin`);
 
     // TODO better way to do this
-    let httpModule = options.port === 443 ? https : http;
+    const httpModule = options.port === 443 ? https : http;
 
     if (fs.existsSync(loc)) {
       // cached
@@ -63,9 +63,9 @@ let httpMock = {
       return httpModule.request(options, callback);
     } else {
       // not cached
-      let req = httpModule.request(options, callback);
+      const req = httpModule.request(options, callback);
       let errored = false;
-      let bufs = [];
+      const bufs = [];
 
       req.once('socket', function(socket) {
         socket.setMaxListeners(Infinity);

--- a/__tests__/_temp.js
+++ b/__tests__/_temp.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-let temp = require('temp');
+const temp = require('temp');
 
 export default function(filename?: string): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/__tests__/commands/_install.js
+++ b/__tests__/commands/_install.js
@@ -10,11 +10,11 @@ import * as fs from '../../src/util/fs.js';
 import {Install} from '../../src/cli/commands/install.js';
 import Config from '../../src/config.js';
 
-let stream = require('stream');
-let path = require('path');
-let os = require('os');
+const stream = require('stream');
+const path = require('path');
+const os = require('os');
 
-let fixturesLoc = path.join(__dirname, '..', 'fixtures', 'install');
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'install');
 
 export function runInstall(
   flags: Object,
@@ -28,11 +28,11 @@ export function runInstall(
 }
 
 export async function createLockfile(dir: string): Promise<Lockfile> {
-  let lockfileLoc = path.join(dir, constants.LOCKFILE_FILENAME);
+  const lockfileLoc = path.join(dir, constants.LOCKFILE_FILENAME);
   let lockfile;
 
   if (await fs.exists(lockfileLoc)) {
-    let rawLockfile = await fs.readFile(lockfileLoc);
+    const rawLockfile = await fs.readFile(lockfileLoc);
     lockfile = parse(rawLockfile);
   }
 
@@ -44,8 +44,8 @@ export function explodeLockfile(lockfile: string): Array<string> {
 }
 
 export async function getPackageVersion(config: Config, packagePath: string): Promise<string> {
-  let loc = path.join(config.cwd, `node_modules/${packagePath.replace(/\//g, '/node_modules/')}/package.json`);
-  let json = JSON.parse(await fs.readFile(loc));
+  const loc = path.join(config.cwd, `node_modules/${packagePath.replace(/\//g, '/node_modules/')}/package.json`);
+  const json = JSON.parse(await fs.readFile(loc));
   return json.version;
 }
 
@@ -55,21 +55,21 @@ export async function run(
   checkInstalled: ?(config: Config, reporter: Reporter, install: Install) => ?Promise<void>,
   beforeInstall: ?(cwd: string) => ?Promise<void>,
 ): Promise<void> {
-  let cwd = path.join(
+  const cwd = path.join(
     os.tmpdir(),
     `yarn-${path.basename(dir)}-${Math.random()}`,
   );
   await fs.unlink(cwd);
   await fs.copy(dir, cwd);
 
-  for (let {basename, absolute} of await fs.walk(cwd)) {
+  for (const {basename, absolute} of await fs.walk(cwd)) {
     if (basename.toLowerCase() === '.ds_store') {
       await fs.unlink(absolute);
     }
   }
 
   let out = '';
-  let stdout = new stream.Writable({
+  const stdout = new stream.Writable({
     decodeStrings: false,
     write(data, encoding, cb) {
       out += data;
@@ -77,21 +77,21 @@ export async function run(
     },
   });
 
-  let reporter = new reporters.ConsoleReporter({stdout, stderr: stdout});
+  const reporter = new reporters.ConsoleReporter({stdout, stderr: stdout});
 
   if (beforeInstall) {
     await beforeInstall(cwd);
   }
 
   // remove the lockfile if we create one and it didn't exist before
-  let lockfile = await createLockfile(cwd);
+  const lockfile = await createLockfile(cwd);
 
   // create directories
   await fs.mkdirp(path.join(cwd, '.yarn'));
   await fs.mkdirp(path.join(cwd, 'node_modules'));
 
   try {
-    let config = new Config(reporter);
+    const config = new Config(reporter);
     await config.init({
       cwd,
       globalFolder: path.join(cwd, '.yarn/.global'),
@@ -99,7 +99,7 @@ export async function run(
       linkFolder: path.join(cwd, '.yarn/.link'),
     });
 
-    let install = factory(config, reporter, lockfile);
+    const install = factory(config, reporter, lockfile);
     await install.init();
 
     // self check to verify consistency after installation

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -16,9 +16,9 @@ import semver from 'semver';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
-let path = require('path');
+const path = require('path');
 
-let fixturesLoc = path.join(__dirname, '..', 'fixtures', 'add');
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'add');
 
 function runAdd(
   flags: Object,
@@ -55,8 +55,8 @@ test.concurrent('add should ignore cache', (): Promise<void> => {
       '1.1.0',
     );
 
-    let lockfile = await createLockfile(config.cwd);
-    let install = new Add(['left-pad@1.1.0'], {}, config, reporter, lockfile);
+    const lockfile = await createLockfile(config.cwd);
+    const install = new Add(['left-pad@1.1.0'], {}, config, reporter, lockfile);
     await install.init();
     assert.equal(
       await getPackageVersion(config, 'left-pad'),
@@ -67,12 +67,12 @@ test.concurrent('add should ignore cache', (): Promise<void> => {
       {'left-pad': '1.1.0'},
     );
 
-    let mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
+    const mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
     assert.equal(mirror.length, 1);
     assert.equal(mirror[0].relative, 'left-pad-1.1.0.tgz');
 
-    let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines = explodeLockfile(lockFileWritten);
+    const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileWritten);
     assert.equal(lockFileLines[0], 'left-pad@1.1.0:');
     assert.equal(lockFileLines.length, 3);
     assert.notEqual(lockFileLines[2].indexOf('resolved left-pad-1.1.0.tgz'), -1);
@@ -110,8 +110,8 @@ test.concurrent('add with new dependency should be deterministic 3', (): Promise
     await fs.copy(path.join(config.cwd, 'yarn.lock.after'), path.join(config.cwd, 'yarn.lock'));
     await fs.copy(path.join(config.cwd, 'package.json.after'), path.join(config.cwd, 'package.json'));
 
-    let lockfile = await createLockfile(config.cwd);
-    let install = new Install({}, config, reporter, lockfile);
+    const lockfile = await createLockfile(config.cwd);
+    const install = new Install({}, config, reporter, lockfile);
     await install.init();
 
     let allCorrect = true;
@@ -126,21 +126,21 @@ test.concurrent('add with new dependency should be deterministic 3', (): Promise
 
 test.concurrent('install --initMirror should add init mirror deps from package.json',
 (): Promise<void> => {
-  let mirrorPath = 'mirror-for-offline';
-  let fixture = 'install-init-mirror';
+  const mirrorPath = 'mirror-for-offline';
+  const fixture = 'install-init-mirror';
 
   // initMirror gets converted to save flag in cli/install.js
   return runAdd({}, [], fixture, async (config) => {
     assert.equal(await getPackageVersion(config, 'mime-types'), '2.0.0');
     assert(semver.satisfies(await getPackageVersion(config, 'mime-db'), '~1.0.1'));
 
-    let mirror = await fs.walk(path.join(config.cwd, mirrorPath));
+    const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
     assert.equal(mirror.length, 2);
     assert.equal(mirror[0].relative.indexOf('mime-db-1.0.'), 0);
     assert.equal(mirror[1].relative, 'mime-types-2.0.0.tgz');
 
-    let lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines = explodeLockfile(lockFileContent);
+    const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileContent);
     assert.equal(lockFileLines.length, 8);
     assert.equal(lockFileLines[0].indexOf('mime-db@'), 0);
     assert.equal(lockFileLines[3].indexOf('mime-types@2.0.0'), 0);
@@ -151,8 +151,8 @@ test.concurrent('add with new dependency should be deterministic', (): Promise<v
   // mime-types@2.0.0->mime-db@1.0.3 is saved in local mirror and is deduped
   // install mime-db@1.23.0 should move mime-db@1.0.3 deep into mime-types
 
-  let mirrorPath = 'mirror-for-offline';
-  let fixture = 'install-deterministic';
+  const mirrorPath = 'mirror-for-offline';
+  const fixture = 'install-deterministic';
 
   return runInstall({}, path.join('..', 'add', fixture), async (config): Promise<void> => {
     assert(semver.satisfies(
@@ -184,12 +184,12 @@ test.concurrent('add with new dependency should be deterministic', (): Promise<v
         },
       );
 
-      let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-      let lockFileLines = explodeLockfile(lockFileWritten);
+      const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      const lockFileLines = explodeLockfile(lockFileWritten);
       assert.equal(lockFileLines.length, 11);
 
 
-      let mirror = await fs.walk(path.join(config.cwd, mirrorPath));
+      const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
       assert.equal(mirror.length, 3);
       assert.equal(mirror[1].relative, 'mime-db-1.23.0.tgz');
     });
@@ -201,8 +201,8 @@ xit('add with new dependency should be deterministic 2', (): Promise<void> => {
   // mime-types@2.0.0->mime-db@1.0.1 is saved in local mirror and is deduped
   // install mime-db@1.0.3 should replace mime-db@1.0.1 in root
 
-  let mirrorPath = 'mirror-for-offline';
-  let fixture = 'install-deterministic-2';
+  const mirrorPath = 'mirror-for-offline';
+  const fixture = 'install-deterministic-2';
 
   return runInstall({}, path.join('..', 'add', fixture), async (config): Promise<void> => {
     assert.equal(
@@ -231,11 +231,11 @@ xit('add with new dependency should be deterministic 2', (): Promise<void> => {
         },
       );
 
-      let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-      let lockFileLines = explodeLockfile(lockFileWritten);
+      const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      const lockFileLines = explodeLockfile(lockFileWritten);
       assert.equal(lockFileLines.length, 8);
 
-      let mirror = await fs.walk(path.join(config.cwd, mirrorPath));
+      const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
       assert.equal(mirror.length, 3);
       assert.equal(mirror[1].relative, 'mime-db-1.0.3.tgz');
     });
@@ -243,16 +243,16 @@ xit('add with new dependency should be deterministic 2', (): Promise<void> => {
 });
 
 test.concurrent('add with offline mirror', (): Promise<void> => {
-  let mirrorPath = 'mirror-for-offline';
+  const mirrorPath = 'mirror-for-offline';
   return runAdd({}, ['is-array@^1.0.1'], 'install-with-save-offline-mirror', async (config) => {
-    let allFiles = await fs.walk(config.cwd);
+    const allFiles = await fs.walk(config.cwd);
 
     assert(allFiles.findIndex((file): boolean => {
       return file.relative === path.join(mirrorPath, 'is-array-1.0.1.tgz');
     }) !== -1);
 
-    let rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
-    let lockfile = parse(rawLockfile);
+    const rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
+    const lockfile = parse(rawLockfile);
     assert.equal(
       lockfile['is-array@^1.0.1']['resolved'],
       'is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a',
@@ -261,17 +261,17 @@ test.concurrent('add with offline mirror', (): Promise<void> => {
 });
 
 test.concurrent('install with --save and without offline mirror', (): Promise<void> => {
-  let mirrorPath = 'mirror-for-offline';
+  const mirrorPath = 'mirror-for-offline';
   return runAdd({}, ['is-array@^1.0.1'], 'install-with-save-no-offline-mirror', async (config) => {
 
-    let allFiles = await fs.walk(config.cwd);
+    const allFiles = await fs.walk(config.cwd);
 
     assert(allFiles.findIndex((file): boolean => {
       return file.relative === `${mirrorPath}/is-array-1.0.1.tgz`;
     }) === -1);
 
-    let rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
-    let lockfile = parse(rawLockfile);
+    const rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
+    const lockfile = parse(rawLockfile);
     assert.equal(lockfile['is-array@^1.0.1']['resolved'],
       'https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a');
   });
@@ -281,7 +281,7 @@ test.concurrent('upgrade scenario', (): Promise<void> => {
   // left-pad first installed 0.0.9 then updated to 1.1.0
   // files in mirror, yarn.lock, package.json and node_modules should reflect that
 
-  let mirrorPath = 'mirror-for-offline';
+  const mirrorPath = 'mirror-for-offline';
 
   return runAdd({}, ['left-pad@0.0.9'], 'install-upgrade-scenario', async (config, reporter): Promise<void> => {
     assert.equal(
@@ -293,13 +293,13 @@ test.concurrent('upgrade scenario', (): Promise<void> => {
       {'left-pad': '0.0.9'},
     );
 
-    let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines = explodeLockfile(lockFileWritten);
+    const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileWritten);
     assert.equal(lockFileLines[0], 'left-pad@0.0.9:');
     assert.equal(lockFileLines.length, 3);
     assert.notEqual(lockFileLines[2].indexOf('resolved left-pad-0.0.9.tgz'), -1);
 
-    let mirror = await fs.walk(path.join(config.cwd, mirrorPath));
+    const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
     assert.equal(mirror.length, 1);
     assert.equal(mirror[0].relative, 'left-pad-0.0.9.tgz');
 
@@ -316,13 +316,13 @@ test.concurrent('upgrade scenario', (): Promise<void> => {
       {'left-pad': '1.1.0'},
     );
 
-    let lockFileWritten2 = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines2 = explodeLockfile(lockFileWritten2);
+    const lockFileWritten2 = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines2 = explodeLockfile(lockFileWritten2);
     assert.equal(lockFileLines2[0], 'left-pad@1.1.0:');
     assert.equal(lockFileLines2.length, 3);
     assert.notEqual(lockFileLines2[2].indexOf('resolved left-pad-1.1.0.tgz'), -1);
 
-    let mirror2 = await fs.walk(path.join(config.cwd, mirrorPath));
+    const mirror2 = await fs.walk(path.join(config.cwd, mirrorPath));
     assert.equal(mirror2.length, 2);
     assert.equal(mirror2[1].relative, 'left-pad-1.1.0.tgz');
   });
@@ -332,8 +332,8 @@ test.concurrent('upgrade scenario 2 (with sub dependencies)', (): Promise<void> 
   // mime-types@2.0.0 is saved in local mirror and gets updated to mime-types@2.1.11
   // files in mirror, yarn.lock, package.json and node_modules should reflect that
 
-  let mirrorPath = 'mirror-for-offline';
-  let fixture = 'install-upgrade-scenario-2';
+  const mirrorPath = 'mirror-for-offline';
+  const fixture = 'install-upgrade-scenario-2';
 
   return runInstall({}, path.join('..', 'add', fixture), async (config): Promise<void> => {
     assert(semver.satisfies(
@@ -355,16 +355,16 @@ test.concurrent('upgrade scenario 2 (with sub dependencies)', (): Promise<void> 
         '2.1.11',
       );
 
-      let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-      let lockFileLines = explodeLockfile(lockFileWritten);
+      const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      const lockFileLines = explodeLockfile(lockFileWritten);
       assert.equal(lockFileLines[0], 'mime-db@~1.23.0:');
       assert.notEqual(lockFileLines[2].indexOf('resolved mime-db-'), -1);
       assert.equal(lockFileLines[3], 'mime-types@^2.1.11:');
       assert.notEqual(lockFileLines[5].indexOf('resolved mime-types-2.1.11.tgz'), -1);
 
-      let mirror = await fs.walk(path.join(config.cwd, mirrorPath));
+      const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
       assert.equal(mirror.length, 4);
-      let newFilesInMirror = mirror.filter((elem): boolean => {
+      const newFilesInMirror = mirror.filter((elem): boolean => {
         return elem.relative !== 'mime-db-1.0.3.tgz' && elem.relative !== 'mime-types-2.0.0.tgz';
       });
 
@@ -387,14 +387,14 @@ test.concurrent('downgrade scenario', (): Promise<void> => {
       {'left-pad': '1.1.0'},
     );
 
-    let mirrorPath = 'mirror-for-offline';
-    let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines = explodeLockfile(lockFileWritten);
+    const mirrorPath = 'mirror-for-offline';
+    const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileWritten);
     assert.equal(lockFileLines[0], 'left-pad@1.1.0:');
     assert.equal(lockFileLines.length, 3);
     assert.notEqual(lockFileLines[2].indexOf('resolved left-pad-1.1.0.tgz'), -1);
 
-    let mirror = await fs.walk(path.join(config.cwd, mirrorPath));
+    const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
     assert.equal(mirror.length, 1);
     assert.equal(mirror[0].relative, 'left-pad-1.1.0.tgz');
 
@@ -412,13 +412,13 @@ test.concurrent('downgrade scenario', (): Promise<void> => {
       {'left-pad': '0.0.9'},
     );
 
-    let lockFileWritten2 = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines2 = explodeLockfile(lockFileWritten2);
+    const lockFileWritten2 = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines2 = explodeLockfile(lockFileWritten2);
     assert.equal(lockFileLines2[0], 'left-pad@0.0.9:');
     assert.equal(lockFileLines2.length, 3);
     assert.notEqual(lockFileLines2[2].indexOf('resolved left-pad-0.0.9.tgz'), -1);
 
-    let mirror2 = await fs.walk(path.join(config.cwd, mirrorPath));
+    const mirror2 = await fs.walk(path.join(config.cwd, mirrorPath));
     assert.equal(mirror2.length, 2);
     assert.equal(mirror2[0].relative, 'left-pad-0.0.9.tgz');
   });
@@ -452,7 +452,7 @@ test.concurrent('modules resolved multiple times should save to mirror correctly
 });
 
 test.concurrent('add should put a git dependency to mirror', (): Promise<void> => {
-  let mirrorPath = 'mirror-for-offline';
+  const mirrorPath = 'mirror-for-offline';
 
   return runAdd(
     {},
@@ -467,8 +467,8 @@ test.concurrent('add should put a git dependency to mirror', (): Promise<void> =
       assert.equal(mirror.length, 1);
       expect(mirror[0].relative).toMatch(/mime-db\.git.*/);
 
-      let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-      let lockFileLines = explodeLockfile(lockFileWritten);
+      const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      const lockFileLines = explodeLockfile(lockFileWritten);
       // lock file contains mirror resolved line
       expect(lockFileLines.find((line) => line.match(/.*resolved mime-db\.git\-.*/))).toBeDefined();
 

--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -13,34 +13,34 @@ import {getPackageVersion, explodeLockfile, runInstall, createLockfile} from './
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
-let path = require('path');
+const path = require('path');
 
-let fixturesLoc = path.join(__dirname, '..', 'fixtures', 'install');
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'install');
 
 test.concurrent('integrity hash respects flat and production flags', async () => {
-  let cwd = path.join(fixturesLoc, 'noop');
-  let reporter = new reporters.NoopReporter();
-  let config = new Config(reporter);
+  const cwd = path.join(fixturesLoc, 'noop');
+  const reporter = new reporters.NoopReporter();
+  const config = new Config(reporter);
   await config.init({cwd});
 
-  let lockfile = new Lockfile();
+  const lockfile = new Lockfile();
 
-  let install = new Install({}, config, reporter, lockfile);
+  const install = new Install({}, config, reporter, lockfile);
 
-  let install2 = new Install({flat: true}, config, reporter, lockfile);
+  const install2 = new Install({flat: true}, config, reporter, lockfile);
   assert(install2.generateIntegrityHash('foo', []) !== install.generateIntegrityHash('foo', []));
 
-  let install3 = new Install({production: true}, config, reporter, lockfile);
+  const install3 = new Install({production: true}, config, reporter, lockfile);
   assert(install3.generateIntegrityHash('foo', []) !== install.generateIntegrityHash('foo', []));
   assert(install3.generateIntegrityHash('foo', []) !== install2.generateIntegrityHash('foo', []));
 });
 
 test.concurrent('flat arg is inherited from root manifest', async (): Promise<void> => {
-  let cwd = path.join(fixturesLoc, 'top-level-flat-parameter');
-  let reporter = new reporters.NoopReporter();
-  let config = new Config(reporter);
+  const cwd = path.join(fixturesLoc, 'top-level-flat-parameter');
+  const reporter = new reporters.NoopReporter();
+  const config = new Config(reporter);
   await config.init({cwd});
-  let install = new Install({}, config, reporter, new Lockfile());
+  const install = new Install({}, config, reporter, new Lockfile());
   return install.fetchRequestFromCwd().then(function([,, manifest]) {
     assert.equal(manifest.flat, true);
     assert.equal(install.flags.flat, true);
@@ -87,12 +87,12 @@ test.concurrent('install file: protocol', (): Promise<void> => {
 
 test.concurrent('install renamed packages', (): Promise<void> => {
   return runInstall({}, 'install-renamed-packages', async (config): Promise<void> => {
-    let dir = path.join(config.cwd, 'node_modules');
+    const dir = path.join(config.cwd, 'node_modules');
 
-    let json = await fs.readJson(path.join(dir, 'left-pad', 'package.json'));
+    const json = await fs.readJson(path.join(dir, 'left-pad', 'package.json'));
     assert.equal(json.version, '1.0.0');
 
-    let json2 = await fs.readJson(path.join(dir, 'left-pad2', 'package.json'));
+    const json2 = await fs.readJson(path.join(dir, 'left-pad2', 'package.json'));
     assert.equal(json2.version, '1.1.0');
   });
 });
@@ -100,7 +100,7 @@ test.concurrent('install renamed packages', (): Promise<void> => {
 test.concurrent('install from offline mirror', (): Promise<void> => {
   return runInstall({}, 'install-from-offline-mirror', async (config): Promise<void> => {
 
-    let allFiles = await fs.walk(config.cwd);
+    const allFiles = await fs.walk(config.cwd);
 
     assert(allFiles.findIndex((file): boolean => {
       return file.relative === path.join('node_modules', 'fake-dependency', 'package.json');
@@ -382,7 +382,7 @@ test.concurrent(
 test.concurrent(
   'uninstall should remove dependency from package.json, yarn.lock and node_modules',
   (): Promise<void> => {
-    let mirrorPath = 'mirror-for-offline';
+    const mirrorPath = 'mirror-for-offline';
 
     return runInstall({}, 'uninstall-should-clean', async (config, reporter) => {
       assert.equal(
@@ -404,8 +404,8 @@ test.concurrent(
           {},
         );
 
-        let lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-        let lockFileLines = explodeLockfile(lockFileContent);
+        const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+        const lockFileLines = explodeLockfile(lockFileContent);
         assert.equal(lockFileLines.length, 0);
       } finally {
         await fs.unlink(path.join(config.cwd, 'yarn.lock'));
@@ -427,7 +427,7 @@ test.concurrent('uninstall should remove subdependencies', (): Promise<void> => 
 
   // C@1
 
-  let mirrorPath = 'mirror-for-offline';
+  const mirrorPath = 'mirror-for-offline';
 
   return runInstall({}, 'uninstall-should-remove-subdependencies', async (config, reporter) => {
     try {
@@ -462,8 +462,8 @@ test.concurrent('uninstall should remove subdependencies', (): Promise<void> => 
         {'dep-c': '^1.0.0'},
       );
 
-      let lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-      let lockFileLines = explodeLockfile(lockFileContent);
+      const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      const lockFileLines = explodeLockfile(lockFileContent);
       assert.equal(lockFileLines.length, 3);
       assert.equal(lockFileLines[0], 'dep-c@^1.0.0:');
     } finally {
@@ -480,7 +480,7 @@ test.concurrent('uninstall should remove subdependencies', (): Promise<void> => 
 test.concurrent('check should verify that top level dependencies are installed correctly', (): Promise<void> => {
   return runInstall({}, 'check-top-correct', async (config, reporter) => {
 
-    let pkgDep = JSON.parse(await fs.readFile(path.join(
+    const pkgDep = JSON.parse(await fs.readFile(path.join(
       config.cwd,
       'node_modules/fake-yarn-dependency/package.json',
     )));
@@ -555,14 +555,14 @@ test.concurrent(
       assert(semver.satisfies(await getPackageVersion(config, 'mime-db'), '~1.0.1'));
       assert.equal(await getPackageVersion(config, 'fake-yarn-dependency'), '1.0.1');
 
-      let mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
+      const mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
       assert.equal(mirror.length, 3);
       assert.equal(mirror[0].relative, 'fake-yarn-dependency-1.0.1.tgz');
       assert.equal(mirror[1].relative.indexOf('mime-db-1.0.'), 0);
       assert.equal(mirror[2].relative, 'mime-types-2.0.0.tgz');
 
-      let lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-      let lockFileLines = explodeLockfile(lockFileContent);
+      const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      const lockFileLines = explodeLockfile(lockFileContent);
       assert.equal(lockFileLines.length, 11);
       assert.equal(lockFileLines[3].indexOf('mime-db@'), 0);
       assert.equal(lockFileLines[6].indexOf('mime-types@2.0.0'), 0);
@@ -600,16 +600,16 @@ xit('install should update a dependency to yarn and mirror (PR import scenario 2
       '2.1.11',
     );
 
-    let lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    let lockFileLines = explodeLockfile(lockFileWritten);
+    const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileWritten);
     assert.equal(lockFileLines[0], 'mime-db@~1.23.0:');
     assert.notEqual(lockFileLines[2].indexOf('resolved mime-db-'), -1);
     assert.equal(lockFileLines[3], 'mime-types@2.1.11:');
     assert.notEqual(lockFileLines[5].indexOf('resolved mime-types-2.1.11.tgz'), -1);
 
-    let mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
+    const mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
     assert.equal(mirror.length, 4);
-    let newFilesInMirror = mirror.filter((elem): boolean => {
+    const newFilesInMirror = mirror.filter((elem): boolean => {
       return elem.relative !== 'mime-db-1.0.3.tgz' && elem.relative !== 'mime-types-2.0.0.tgz';
     });
 
@@ -625,8 +625,8 @@ if (process.platform !== 'win32') {
       expect(await fs.exists(symlink)).toBe(true);
       await fs.unlink(path.resolve(config.cwd, 'node_modules'));
 
-      let lockfile = await createLockfile(config.cwd);
-      let install = new Install({}, config, reporter, lockfile);
+      const lockfile = await createLockfile(config.cwd);
+      const install = new Install({}, config, reporter, lockfile);
       await install.init();
 
       expect(await fs.exists(symlink)).toBe(true);

--- a/__tests__/commands/self-update.js
+++ b/__tests__/commands/self-update.js
@@ -38,7 +38,7 @@ let queueCounter = 0;
 function run(checks: (reporter: reporters.Reporter, config: Config) => Promise<void>): Promise<void> {
   return queue.push(`${queueCounter++}`, async () => {
     let out = '';
-    let stdout = new stream.Writable({
+    const stdout = new stream.Writable({
       decodeStrings: false,
       write(data, encoding, cb) {
         out += data;

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -10,17 +10,17 @@ import Config from '../src/config.js';
 import mkdir from './_temp.js';
 import * as fs from '../src/util/fs.js';
 
-let path = require('path');
+const path = require('path');
 
 async function createConfig(): Promise<Config> {
-  let config = new Config(new NoopReporter());
+  const config = new Config(new NoopReporter());
   await config.init();
   return config;
 }
 
 test('BaseFetcher.fetch', async () => {
-  let dir = await mkdir('base-fetcher');
-  let fetcher = new BaseFetcher(dir, {
+  const dir = await mkdir('base-fetcher');
+  const fetcher = new BaseFetcher(dir, {
     type: 'base',
     registry: 'npm',
     reference: '',
@@ -36,12 +36,12 @@ test('BaseFetcher.fetch', async () => {
 });
 
 test('CopyFetcher.fetch', async () => {
-  let a = await mkdir('copy-fetcher-a');
+  const a = await mkdir('copy-fetcher-a');
   await fs.writeFile(path.join(a, 'package.json'), '{}');
   await fs.writeFile(path.join(a, 'foo'), 'bar');
 
-  let b = await mkdir('copy-fetcher-b');
-  let fetcher = new CopyFetcher(b, {
+  const b = await mkdir('copy-fetcher-b');
+  const fetcher = new CopyFetcher(b, {
     type: 'copy',
     reference: a,
     registry: 'npm',
@@ -54,8 +54,8 @@ test('CopyFetcher.fetch', async () => {
 });
 
 test('GitFetcher.fetch', async () => {
-  let dir = await mkdir('git-fetcher');
-  let fetcher = new GitFetcher(dir, {
+  const dir = await mkdir('git-fetcher');
+  const fetcher = new GitFetcher(dir, {
     type: 'git',
     reference: 'https://github.com/PolymerElements/font-roboto',
     hash: '2fd5c7bd715a24fb5b250298a140a3ba1b71fe46',
@@ -67,8 +67,8 @@ test('GitFetcher.fetch', async () => {
 });
 
 test('TarballFetcher.fetch', async () => {
-  let dir = await mkdir('tarball-fetcher');
-  let fetcher = new TarballFetcher(dir, {
+  const dir = await mkdir('tarball-fetcher');
+  const fetcher = new TarballFetcher(dir, {
     type: 'tarball',
     hash: '9689b3b48d63ff70f170a192bec3c01b04f58f45',
     reference: 'https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz',
@@ -81,9 +81,9 @@ test('TarballFetcher.fetch', async () => {
 });
 
 test('TarballFetcher.fetch throws', async () => {
-  let dir = await mkdir('tarball-fetcher');
-  let url = 'https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz';
-  let fetcher = new TarballFetcher(dir, {
+  const dir = await mkdir('tarball-fetcher');
+  const url = 'https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz';
+  const fetcher = new TarballFetcher(dir, {
     type: 'tarball',
     hash: 'foo',
     reference: url,
@@ -99,8 +99,8 @@ test('TarballFetcher.fetch throws', async () => {
 });
 
 test('TarballFetcher.fetch supports local ungzipped tarball', async () => {
-  let dir = await mkdir('tarball-fetcher');
-  let fetcher = new LocalTarballFetcher(dir, {
+  const dir = await mkdir('tarball-fetcher');
+  const fetcher = new LocalTarballFetcher(dir, {
     type: 'tarball',
     hash: '76d4316a3965259f7074f167f44a7a7a393884be',
     reference: path.join(__dirname, 'fixtures', 'fetchers', 'tarball', 'ungzipped.tar'),

--- a/__tests__/fixtures/src/dep-a-symlink/package/index.js
+++ b/__tests__/fixtures/src/dep-a-symlink/package/index.js
@@ -3,13 +3,13 @@
  * isArray
  */
 
-var isArray = Array.isArray;
+const isArray = Array.isArray;
 
 /**
  * toString
  */
 
-var str = Object.prototype.toString;
+const str = Object.prototype.toString;
 
 /**
  * Whether or not the given `val`

--- a/__tests__/fixtures/src/dep-a-symlink/package/postinstall.js
+++ b/__tests__/fixtures/src/dep-a-symlink/package/postinstall.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+const fs = require('fs');
 
 if (!fs.existsSync('dep-a-built')) {
   fs.symlinkSync('index.js', 'link-index.js', 'file');

--- a/__tests__/fixtures/src/dep-a/package/index.js
+++ b/__tests__/fixtures/src/dep-a/package/index.js
@@ -3,13 +3,13 @@
  * isArray
  */
 
-var isArray = Array.isArray;
+const isArray = Array.isArray;
 
 /**
  * toString
  */
 
-var str = Object.prototype.toString;
+const str = Object.prototype.toString;
 
 /**
  * Whether or not the given `val`

--- a/__tests__/fixtures/src/dep-a/package/postinstall.js
+++ b/__tests__/fixtures/src/dep-a/package/postinstall.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+const fs = require('fs');
 
 if (!fs.existsSync('../dep-b/dep-b-built')) {
   process.exit(1);

--- a/__tests__/fixtures/src/dep-b/package/index.js
+++ b/__tests__/fixtures/src/dep-b/package/index.js
@@ -3,13 +3,13 @@
  * isArray
  */
 
-var isArray = Array.isArray;
+const isArray = Array.isArray;
 
 /**
  * toString
  */
 
-var str = Object.prototype.toString;
+const str = Object.prototype.toString;
 
 /**
  * Whether or not the given `val`

--- a/__tests__/fixtures/src/dep-b/package/postinstall.js
+++ b/__tests__/fixtures/src/dep-b/package/postinstall.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+const fs = require('fs');
 
 if (!fs.existsSync('../dep-c/dep-c-built')) {
   process.exit(1);

--- a/__tests__/fixtures/src/dep-c/package/index.js
+++ b/__tests__/fixtures/src/dep-c/package/index.js
@@ -3,13 +3,13 @@
  * isArray
  */
 
-var isArray = Array.isArray;
+const isArray = Array.isArray;
 
 /**
  * toString
  */
 
-var str = Object.prototype.toString;
+const str = Object.prototype.toString;
 
 /**
  * Whether or not the given `val`

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -6,7 +6,7 @@ import stringify from "../src/lockfile/stringify.js";
 import parse from "../src/lockfile/parse.js";
 import nullify from "../src/util/map.js";
 
-let objs = [
+const objs = [
   {foo: "bar"},
   {foo: {}},
   {foo: "foo", bar: "bar"},
@@ -41,7 +41,7 @@ test("parse", () => {
 });
 
 test("stringify", () => {
-  let obj = {foo: "bar"};
+  const obj = {foo: "bar"};
   expect(stringify({a: obj, b: obj}, true)).toEqual("a, b:\n  foo bar\n");
 });
 
@@ -50,7 +50,7 @@ test("Lockfile.fromDirectory", () => {
 });
 
 test("Lockfile.getLocked", () => {
-  let lockfile = new Lockfile({
+  const lockfile = new Lockfile({
     foo: "bar",
     bar: {},
   });
@@ -58,7 +58,7 @@ test("Lockfile.getLocked", () => {
 });
 
 test("Lockfile.getLocked pointer", () => {
-  let lockfile = new Lockfile({
+  const lockfile = new Lockfile({
     foo: "bar",
     bar: {},
   });
@@ -70,7 +70,7 @@ test("Lockfile.getLocked no cache", () => {
 });
 
 test("Lockfile.getLocked defaults", () => {
-  let pattern = new Lockfile({
+  const pattern = new Lockfile({
     foobar: {
       version: "0.0.0",
     },
@@ -85,7 +85,7 @@ test("Lockfile.getLocked unknown", () => {
 });
 
 test("Lockfile.getLockfile", () => {
-  let patterns = {
+  const patterns = {
     foobar: {
       name: "foobar",
       version: "0.0.0",
@@ -127,9 +127,9 @@ test("Lockfile.getLockfile", () => {
 
   patterns["foobar@2"] = patterns.foobar;
 
-  let actual = new Lockfile().getLockfile(patterns);
+  const actual = new Lockfile().getLockfile(patterns);
 
-  let expectedFoobar = {
+  const expectedFoobar = {
     version: "0.0.0",
     uid: undefined,
     resolved: "http://example.com/foobar",
@@ -139,7 +139,7 @@ test("Lockfile.getLockfile", () => {
     permissions: undefined,
   };
 
-  let expected = {
+  const expected = {
     barfoo: {
       version: "0.0.1",
       uid: "0.1.0",
@@ -157,7 +157,7 @@ test("Lockfile.getLockfile", () => {
 });
 
 test("Lockfile.getLockfile (sorting)", () => {
-  let patterns = {
+  const patterns = {
     foobar2: {
       name: "foobar",
       version: "0.0.0",
@@ -178,9 +178,9 @@ test("Lockfile.getLockfile (sorting)", () => {
 
   patterns.foobar1 = patterns.foobar2;
 
-  let actual = new Lockfile().getLockfile(patterns);
+  const actual = new Lockfile().getLockfile(patterns);
 
-  let expectedFoobar = {
+  const expectedFoobar = {
     name: "foobar",
     version: "0.0.0",
     uid: undefined,
@@ -191,7 +191,7 @@ test("Lockfile.getLockfile (sorting)", () => {
     permissions: undefined,
   };
 
-  let expected = {
+  const expected = {
     foobar1: expectedFoobar,
     foobar2: expectedFoobar,
   };

--- a/__tests__/normalize-manifest.js
+++ b/__tests__/normalize-manifest.js
@@ -8,12 +8,12 @@ import map from '../src/util/map.js';
 import * as util from '../src/util/normalize-manifest/util.js';
 import * as fs from '../src/util/fs.js';
 
-let nativeFs = require('fs');
-let path     = require('path');
+const nativeFs = require('fs');
+const path     = require('path');
 
-let fixturesLoc = path.join(__dirname, 'fixtures', 'normalize-manifest');
+const fixturesLoc = path.join(__dirname, 'fixtures', 'normalize-manifest');
 
-for (let name of nativeFs.readdirSync(fixturesLoc)) {
+for (const name of nativeFs.readdirSync(fixturesLoc)) {
   if (name[0] === '.') {
     continue;
   }
@@ -21,21 +21,21 @@ for (let name of nativeFs.readdirSync(fixturesLoc)) {
   let loc = path.join(fixturesLoc, name);
 
   test(name, async () => {
-    let actualWarnings   = [];
-    let expectedWarnings = await fs.readJson(path.join(loc, 'warnings.json'));
+    const actualWarnings   = [];
+    const expectedWarnings = await fs.readJson(path.join(loc, 'warnings.json'));
 
-    let reporter = new NoopReporter();
+    const reporter = new NoopReporter();
 
     // $FlowFixMe: investigate
     reporter.warn = function(msg) {
       actualWarnings.push(msg);
     };
 
-    let config = new Config(reporter);
+    const config = new Config(reporter);
     await config.init({cwd: loc});
 
     let actual   = await fs.readJson(path.join(loc, 'actual.json'));
-    let expected = await fs.readJson(path.join(loc, 'expected.json'));
+    const expected = await fs.readJson(path.join(loc, 'expected.json'));
 
     let isRoot = actual._root;
     if (isRoot == null) {
@@ -44,7 +44,7 @@ for (let name of nativeFs.readdirSync(fixturesLoc)) {
       delete actual._root;
     }
 
-    let error = expected._error;
+    const error = expected._error;
     if (error) {
       delete expected._error;
     }
@@ -132,13 +132,13 @@ function normalizePaths(paths: mixed): ?string[] {
 }
 
 function normalizePathDict(paths: mixed): ?{ [key: string]: mixed } {
-  let out = {};
+  const out = {};
 
   if (!paths || typeof paths !== 'object') {
     return null;
   }
 
-  for (let prop in paths) {
+  for (const prop in paths) {
     if (typeof paths[prop] === 'string') {
       out[prop] = normalizePath(paths[prop]);
     } else {

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -11,24 +11,24 @@ import * as fs from '../src/util/fs.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
-let path = require('path');
+const path = require('path');
 
 function addTest(pattern, registry = 'npm') {
   test.concurrent(`resolve ${pattern}`, async () => {
-    let lockfile = new Lockfile();
-    let reporter = new reporters.NoopReporter({});
+    const lockfile = new Lockfile();
+    const reporter = new reporters.NoopReporter({});
 
-    let loc = await makeTemp();
+    const loc = await makeTemp();
     await fs.mkdirp(path.join(loc, 'node_modules'));
     await fs.mkdirp(path.join(loc, constants.MODULE_CACHE_DIRECTORY));
 
-    let config = new Config(reporter);
+    const config = new Config(reporter);
     await config.init({
       cwd: loc,
       packagesRoot: loc,
       tempFolder: loc,
     });
-    let resolver = new PackageResolver(config, lockfile);
+    const resolver = new PackageResolver(config, lockfile);
     await resolver.init([{pattern, registry}]);
     await reporter.close();
   });

--- a/__tests__/reporters/_mock.js
+++ b/__tests__/reporters/_mock.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import type Reporter from '../../src/reporters/base-reporter.js';
-let Stdin = require('mock-stdin').stdin.Class;
-let {Writable} = require('stream');
+const Stdin = require('mock-stdin').stdin.Class;
+const {Writable} = require('stream');
 
 export type MockData = {
   stdout: string,
@@ -18,13 +18,13 @@ export default function<T>(
   interceptor: Interceptor<T>,
 ): (callback: MockCallback) => Promise<T> {
   return async function (callback: MockCallback): * {
-    let data: MockData = {
+    const data: MockData = {
       stderr: '',
       stdout: '',
     };
 
-    let buildStream = (key): Writable => {
-      let stream = new Writable();
+    const buildStream = (key): Writable => {
+      const stream = new Writable();
 
       // $FlowFixMe: TODO add to flow definition
       stream.columns = 1000;
@@ -38,14 +38,14 @@ export default function<T>(
       return stream;
     };
 
-    let opts = {
+    const opts = {
       stdin: new Stdin(),
       stdout: buildStream('stdout'),
       stderr: buildStream('stderr'),
       emoji: true,
     };
 
-    let reporter = new Reporter(opts);
+    const reporter = new Reporter(opts);
 
     reporter.peakMemory = 0;
     reporter.isTTY = true;
@@ -54,7 +54,7 @@ export default function<T>(
     await callback(reporter, opts);
     reporter.close();
 
-    for (let key in data) {
+    for (const key in data) {
       data[key] = data[key].trim();
     }
 

--- a/__tests__/reporters/base.js
+++ b/__tests__/reporters/base.js
@@ -4,81 +4,81 @@
 import BaseReporter from '../../src/reporters/base-reporter.js';
 
 test('BaseReporter.getTotalTime', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   expect(reporter.getTotalTime() <= 1).toBeTruthy();
   reporter.close();
 });
 
 test('BaseReporter.step', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.step(1, 5, 'foo');
   reporter.close();
 });
 
 test('BaseReporter.error', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.error('');
   reporter.close();
 });
 
 test('BaseReporter.warn', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.warn('');
   reporter.close();
 });
 
 test('BaseReporter.info', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.info('');
   reporter.close();
 });
 
 test('BaseReporter.success', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.success('');
   reporter.close();
 });
 
 test('BaseReporter.log', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.log('');
   reporter.close();
 });
 
 test('BaseReporter.info', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.log('');
   reporter.close();
 });
 
 test('BaseReporter.command', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.command('');
   reporter.close();
 });
 
 test('BaseReporter.header', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.header('', {name: '', version: ''});
   reporter.close();
 });
 
 test('BaseReporter.footer', () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   reporter.footer(false);
   reporter.close();
 });
 
 test('BaseReporter.activity', () => {
-  let reporter = new BaseReporter();
-  let activity = reporter.activity();
+  const reporter = new BaseReporter();
+  const activity = reporter.activity();
   activity.tick('');
   activity.end();
   reporter.close();
 });
 
 test('BaseReporter.question', async () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   let error;
   try {
     await reporter.question('');
@@ -90,7 +90,7 @@ test('BaseReporter.question', async () => {
 });
 
 test('BaseReporter.select', async () => {
-  let reporter = new BaseReporter();
+  const reporter = new BaseReporter();
   let error;
   try {
     await reporter.select('?', '', []);
@@ -102,8 +102,8 @@ test('BaseReporter.select', async () => {
 });
 
 test('BaseReporter.progress', () => {
-  let reporter = new BaseReporter();
-  let tick = reporter.progress(1);
+  const reporter = new BaseReporter();
+  const tick = reporter.progress(1);
   tick();
   reporter.close();
 });

--- a/__tests__/reporters/buffer.js
+++ b/__tests__/reporters/buffer.js
@@ -3,7 +3,7 @@
 import BufferReporter from '../../src/reporters/buffer-reporter.js';
 import build from './_mock.js';
 
-let getBuff = build(BufferReporter, (data, reporter: any): Array<Object> => reporter.getBuffer());
+const getBuff = build(BufferReporter, (data, reporter: any): Array<Object> => reporter.getBuffer());
 
 test('BufferReporter.finished', async () => {
   expect(await getBuff((r) => {

--- a/__tests__/reporters/console.js
+++ b/__tests__/reporters/console.js
@@ -6,8 +6,8 @@ import Spinner from '../../src/reporters/console/spinner-progress.js';
 import ConsoleReporter from '../../src/reporters/console/console-reporter.js';
 import build from './_mock.js';
 
-let getConsoleBuff = build(ConsoleReporter, (data): MockData => data);
-let stream = require('stream');
+const getConsoleBuff = build(ConsoleReporter, (data): MockData => data);
+const stream = require('stream');
 
 test('ConsoleReporter.step', async () => {
   expect(await getConsoleBuff((r) => {
@@ -69,7 +69,7 @@ test('ConsoleReporter.warn', async () => {
 
 test('ConsoleReporter.activity', async () => {
   expect(await getConsoleBuff(function(r) {
-    let activity = r.activity();
+    const activity = r.activity();
     activity.tick('foo');
     activity.end();
   })).toMatchSnapshot();
@@ -82,7 +82,7 @@ test('ConsoleReporter.select', async () => {
       streams.stdin.end();
     });
 
-    let res = await r.select('Ayo?', 'Select one', [{
+    const res = await r.select('Ayo?', 'Select one', [{
       name: 'foo',
       value: 'foo',
     }, {
@@ -95,20 +95,20 @@ test('ConsoleReporter.select', async () => {
 
 test('ConsoleReporter.progress', async () => {
   expect(await getConsoleBuff((r) => {
-    let tick = r.progress(2);
+    const tick = r.progress(2);
     tick();
     jest.runAllTimers();
     tick();
   })).toMatchSnapshot();
 
   expect(await getConsoleBuff((r) => {
-    let tick = r.progress(0);
+    const tick = r.progress(0);
     tick();
   })).toMatchSnapshot();
 
   expect(await getConsoleBuff((r) => {
     r.isTTY = false;
-    let tick = r.progress(2);
+    const tick = r.progress(2);
     tick();
     tick();
   })).toMatchSnapshot();
@@ -128,7 +128,7 @@ test('ProgressBar', () => {
       return true;
     }
   }
-  let bar = new ProgressBar(2, new TestStream());
+  const bar = new ProgressBar(2, new TestStream());
 
   bar.render();
   expect(data).toBe('\u001b[2K\u001b[1G░░ 0/2');
@@ -151,7 +151,7 @@ test('Spinner', () => {
       return true;
     }
   }
-  let spinner = new Spinner(new TestStream());
+  const spinner = new Spinner(new TestStream());
 
   spinner.start();
   expect(data).toBe('\u001b[2K\u001b[1G⠁ ');

--- a/__tests__/reporters/json.js
+++ b/__tests__/reporters/json.js
@@ -5,7 +5,7 @@ import type {MockData} from "./_mock.js";
 import JSONReporter from "../../src/reporters/json-reporter.js";
 import build from "./_mock.js";
 
-let getJSONBuff = build(JSONReporter, (data): MockData => data);
+const getJSONBuff = build(JSONReporter, (data): MockData => data);
 
 test("JSONReporter.step", async () => {
   expect(await getJSONBuff((r) => {
@@ -57,7 +57,7 @@ test("JSONReporter.info", async () => {
 
 test("JSONReporter.activity", async () => {
   expect(await getJSONBuff(async function (r): Promise<void> {
-    let activity = await r.activity();
+    const activity = await r.activity();
     activity.tick("foo");
     activity.tick("bar");
     activity.end();
@@ -66,7 +66,7 @@ test("JSONReporter.activity", async () => {
 
 test("JSONReporter.progress", async () => {
   expect(await getJSONBuff(async function (r): Promise<void> {
-    let tick = await r.progress(2);
+    const tick = await r.progress(2);
     tick();
     tick();
   })).toMatchSnapshot();

--- a/__tests__/util/blocking-queue.js
+++ b/__tests__/util/blocking-queue.js
@@ -3,7 +3,7 @@
 import BlockingQueue from '../../src/util/blocking-queue.js';
 
 test('max concurrency', async function (): Promise<void> {
-  let queue = new BlockingQueue('test', 5);
+  const queue = new BlockingQueue('test', 5);
   let i = 0;
   let running = 0;
 

--- a/__tests__/util/promise.js
+++ b/__tests__/util/promise.js
@@ -27,7 +27,7 @@ test('promisify', async function (): Promise<void> {
 });
 
 test('promisifyObject', async function (): Promise<void> {
-  let obj = promise.promisifyObject({
+  const obj = promise.promisifyObject({
     foo(callback) {
       callback(null, 'foo');
     },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
         120
       ],
       "prefer-arrow-callback": 0,
-      "prefer-const": 0,
       "babel/arrow-parens": [
         2,
         "always"

--- a/src/cli/commands/_build-sub-commands.js
+++ b/src/cli/commands/_build-sub-commands.js
@@ -26,7 +26,7 @@ type Return = {
 type Usage = Array<string>;
 
 export default function(rootCommandName: string, subCommands: SubCommands, usage?: Usage = []): Return {
-  let subCommandNames = Object.keys(subCommands);
+  const subCommandNames = Object.keys(subCommands);
 
   function setFlags(commander: Object) {
     commander.usage(`${rootCommandName} [${subCommandNames.join('|')}] [flags]`);
@@ -38,18 +38,18 @@ export default function(rootCommandName: string, subCommands: SubCommands, usage
     flags: Object,
     args: Array<string>,
   ): Promise<void> {
-    let subName = camelCase(args.shift() || '');
-    let isValidCommand = subName && subCommandNames.indexOf(subName) >= 0;
+    const subName = camelCase(args.shift() || '');
+    const isValidCommand = subName && subCommandNames.indexOf(subName) >= 0;
     if (isValidCommand) {
-      let command: RunCommand = subCommands[subName];
-      let res = await command(config, reporter, flags, args);
+      const command: RunCommand = subCommands[subName];
+      const res = await command(config, reporter, flags, args);
       if (res !== false) {
         return Promise.resolve();
       }
     }
 
     reporter.error(`${reporter.lang('usage')}:`);
-    for (let msg of usage) {
+    for (const msg of usage) {
       reporter.error(`yarn ${rootCommandName} ${msg}`);
     }
     return Promise.reject(new MessageError('Invalid arguments.'));

--- a/src/cli/commands/_execute-lifecycle-script.js
+++ b/src/cli/commands/_execute-lifecycle-script.js
@@ -21,7 +21,7 @@ export async function execFromManifest(config: Config, commandName: string, pkg:
 }
 
 export async function execCommand(config: Config, cmd: string, cwd: string): Promise<void> {
-  let {reporter} = config;
+  const {reporter} = config;
   try {
     reporter.command(cmd);
     await executeLifecycleScript(config, cwd, cmd);

--- a/src/cli/commands/access.js
+++ b/src/cli/commands/access.js
@@ -2,7 +2,7 @@
 
 import buildSubCommands from './_build-sub-commands.js';
 
-export let {run, setFlags} = buildSubCommands('access', {
+export const {run, setFlags} = buildSubCommands('access', {
   public(): Promise<void> {
     return Promise.reject(new Error('TODO'));
   },

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -11,7 +11,7 @@ import {buildTree} from './ls.js';
 import {Install, _setFlags} from './install.js';
 import {MessageError} from '../../errors.js';
 
-let invariant = require('invariant');
+const invariant = require('invariant');
 
 export class Add extends Install {
   constructor(
@@ -32,9 +32,9 @@ export class Add extends Install {
    */
 
   prepare(patterns: Array<string>, requests: DependencyRequestPatterns): Promise<InstallPrepared> {
-    let requestsWithArgs = requests.slice();
+    const requestsWithArgs = requests.slice();
 
-    for (let pattern of this.args) {
+    for (const pattern of this.args) {
       requestsWithArgs.push({
         pattern,
         registry: 'npm',
@@ -55,7 +55,7 @@ export class Add extends Install {
    */
 
   async init(): Promise<Array<string>> {
-    let patterns = await Install.prototype.init.call(this);
+    const patterns = await Install.prototype.init.call(this);
     await this.maybeOutputSaveTree(patterns);
     await this.savePackages();
     return patterns;
@@ -74,7 +74,7 @@ export class Add extends Install {
    */
 
   async maybeOutputSaveTree(patterns: Array<string>): Promise<void> {
-    let {trees, count} = await buildTree(this.resolver, this.linker, patterns, true, true);
+    const {trees, count} = await buildTree(this.resolver, this.linker, patterns, true, true);
     this.reporter.success(
       count === 1 ?
         this.reporter.lang('savedNewDependency')
@@ -89,10 +89,10 @@ export class Add extends Install {
    */
 
   async savePackages(): Promise<void> {
-    let {dev, exact, tilde, optional, peer} = this.flags;
+    const {dev, exact, tilde, optional, peer} = this.flags;
 
     // get all the different registry manifests in this folder
-    let jsons = await this.getRootManifests();
+    const jsons = await this.getRootManifests();
 
     // add new patterns to their appropriate registry manifest
     for (const pattern of this.resolver.dedupePatterns(this.args)) {
@@ -173,7 +173,7 @@ export async function run(
     throw new MessageError(reporter.lang('missingAddDependencies'));
   }
 
-  let lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
+  const lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
   const install = new Add(args, flags, config, reporter, lockfile);
   await install.init();
 }

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import buildSubCommands from './_build-sub-commands.js';
 import * as fs from '../../util/fs.js';
 
-export let {run, setFlags} = buildSubCommands('cache', {
+export const {run, setFlags} = buildSubCommands('cache', {
   ls(): Promise<void> {
     return Promise.reject(new Error('TODO'));
   },

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -40,7 +40,7 @@ export async function run(
   }
 
   // get patterns that are installed when running `yarn install`
-  let [depRequests, rawPatterns] = await install.fetchRequestFromCwd();
+  const [depRequests, rawPatterns] = await install.fetchRequestFromCwd();
 
   // check if patterns exist in lockfile
   for (const pattern of rawPatterns) {
@@ -54,7 +54,7 @@ export async function run(
     const integrityLoc = await install.getIntegrityHashLocation();
 
     if (integrityLoc && await fs.exists(integrityLoc)) {
-      let match = await install.matchesIntegrityHash(rawPatterns);
+      const match = await install.matchesIntegrityHash(rawPatterns);
       if (match.matches === false) {
         reportError(`Integrity hashes don't match, expected ${match.expected} but got ${match.actual}`);
       }

--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -7,7 +7,7 @@ import {sortFilter, ignoreLinesToRegex} from '../../util/filter.js';
 import {CLEAN_FILENAME} from '../../constants.js';
 import * as fs from '../../util/fs.js';
 
-let path = require('path');
+const path = require('path');
 
 export const requireLockfile = true;
 export const noArguments = true;
@@ -72,38 +72,38 @@ export async function clean(config: Config, reporter: Reporter): Promise<{
 }> {
   let loc = path.join(config.cwd, CLEAN_FILENAME);
   let file = await fs.readFile(loc);
-  let lines = file.split('\n');
-  let filters = DEFAULT_FILTERS.concat(ignoreLinesToRegex(lines));
+  const lines = file.split('\n');
+  const filters = DEFAULT_FILTERS.concat(ignoreLinesToRegex(lines));
 
   let removedFiles = 0;
   let removedSize = 0;
 
   // build list of possible module folders
-  let locs = new Set();
+  const locs = new Set();
   if (config.modulesFolder) {
     locs.add(config.modulesFolder);
   }
-  for (let name of registryNames) {
-    let registry = config.registries[name];
+  for (const name of registryNames) {
+    const registry = config.registries[name];
     locs.add(path.join(config.cwd, registry.folder));
   }
 
-  for (let folder of locs) {
+  for (const folder of locs) {
     if (!(await fs.exists(folder))) {
       continue;
     }
 
-    let spinner = reporter.activity();
-    let files = await fs.walk(folder);
-    let {ignoreFiles} = sortFilter(files, filters);
+    const spinner = reporter.activity();
+    const files = await fs.walk(folder);
+    const {ignoreFiles} = sortFilter(files, filters);
     spinner.end();
 
-    let tick = reporter.progress(ignoreFiles.size);
+    const tick = reporter.progress(ignoreFiles.size);
     // TODO make sure `main` field of all modules isn't ignored
 
     for (let file of ignoreFiles) {
       let loc = path.join(folder, file);
-      let stat = await fs.lstat(loc);
+      const stat = await fs.lstat(loc);
       removedSize += stat.size;
       removedFiles++;
     }
@@ -128,7 +128,7 @@ export async function run(
   await fs.writeFile(path.join(config.cwd, CLEAN_FILENAME), '\n');
 
   reporter.step(2, 2, reporter.lang('cleaning'));
-  let {removedFiles, removedSize} = await clean(config, reporter);
+  const {removedFiles, removedSize} = await clean(config, reporter);
   reporter.info(reporter.lang('cleanRemovedFiles', removedFiles));
   reporter.info(reporter.lang('cleanSavedSize', (removedSize / 1024 / 1024).toFixed(2)));
 }

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -5,7 +5,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import buildSubCommands from './_build-sub-commands.js';
 
-export let {run, setFlags} = buildSubCommands('access', {
+export const {run, setFlags} = buildSubCommands('access', {
   async set(
     config: Config,
     reporter: Reporter,

--- a/src/cli/commands/dist-tag.js
+++ b/src/cli/commands/dist-tag.js
@@ -13,7 +13,7 @@ export async function getName(args: Array<string>, config: Config): Promise<stri
   let name = args.shift();
 
   if (!name) {
-    let pkg = await config.readRootManifest();
+    const pkg = await config.readRootManifest();
     name = pkg.name;
   }
 
@@ -28,7 +28,7 @@ export async function getName(args: Array<string>, config: Config): Promise<stri
   }
 }
 
-export let {run, setFlags, examples} = buildSubCommands('dist-tag', {
+export const {run, setFlags, examples} = buildSubCommands('dist-tag', {
   async add(
     config: Config,
     reporter: Reporter,
@@ -50,10 +50,10 @@ export let {run, setFlags, examples} = buildSubCommands('dist-tag', {
     const tag = args.shift();
 
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    let revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter);
 
     reporter.step(2, 3, reporter.lang('creatingTag', tag, range));
-    let result = await config.registries.npm.request(
+    const result = await config.registries.npm.request(
       `-/package/${NpmRegistry.escapeName(name)}/dist-tags/${encodeURI(tag)}`,
       {
         method: 'PUT',
@@ -91,7 +91,7 @@ export let {run, setFlags, examples} = buildSubCommands('dist-tag', {
     const tag = args.shift();
 
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    let revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter);
 
     reporter.step(2, 3, reporter.lang('deletingTags'));
     const result = await config.registries.npm.request(`-/package/${name}/dist-tags/${encodeURI(tag)}`, {
@@ -121,7 +121,7 @@ export let {run, setFlags, examples} = buildSubCommands('dist-tag', {
     args: Array<string>,
   ): Promise<void> {
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    let revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter);
 
     reporter.step(2, 3, reporter.lang('gettingTags'));
     const name = await getName(args, config);

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -27,7 +27,7 @@ class GlobalAdd extends Add {
   }
 }
 
-let path = require('path');
+const path = require('path');
 
 async function updateCwd(config: Config): Promise<void> {
   await config.init({cwd: config.globalFolder});
@@ -35,21 +35,21 @@ async function updateCwd(config: Config): Promise<void> {
 
 async function getBins(config: Config): Promise<Set<string>> {
   // build up list of registry folders to search for binaries
-  let dirs = [];
+  const dirs = [];
   for (const registryName of Object.keys(registries)) {
     const registry = config.registries[registryName];
     dirs.push(registry.loc);
   }
 
   // build up list of binary files
-  let paths = new Set();
+  const paths = new Set();
   for (const dir of dirs) {
     const binDir = path.join(dir, '.bin');
     if (!await fs.exists(binDir)) {
       continue;
     }
 
-    for (let name of await fs.readdir(binDir)) {
+    for (const name of await fs.readdir(binDir)) {
       paths.add(path.join(binDir, name));
     }
   }
@@ -73,7 +73,7 @@ async function checkOwnership(cwd: string, binLoc: string): Promise<boolean> {
 async function initUpdateBins(config: Config, reporter: Reporter): Promise<() => Promise<void>> {
   const beforeBins = await getBins(config);
 
-  let binFolder = '/Users/sebmck/Scratch/test-global';
+  const binFolder = '/Users/sebmck/Scratch/test-global';
 
   return async function(): Promise<void> {
     const afterBins = await getBins(config);
@@ -141,7 +141,7 @@ function ls(manifest: Manifest, reporter: Reporter, saved: boolean) {
   }
 }
 
-export let {run, setFlags} = buildSubCommands('global', {
+export const {run, setFlags} = buildSubCommands('global', {
   async add(
     config: Config,
     reporter: Reporter,
@@ -150,7 +150,7 @@ export let {run, setFlags} = buildSubCommands('global', {
   ): Promise<void> {
     await updateCwd(config);
 
-    let updateBins = await initUpdateBins(config, reporter);
+    const updateBins = await initUpdateBins(config, reporter);
 
     // install module
     const lockfile = await Lockfile.fromDirectory(config.cwd);
@@ -189,7 +189,7 @@ export let {run, setFlags} = buildSubCommands('global', {
   ): Promise<void> {
     await updateCwd(config);
 
-    let updateBins = await initUpdateBins(config, reporter);
+    const updateBins = await initUpdateBins(config, reporter);
 
     // remove module
     await runRemove(config, reporter, flags, args);

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -86,14 +86,14 @@ export {run};
 
 import buildUseless from './_useless.js';
 
-export let lockfile = buildUseless(
+export const lockfile = buildUseless(
   "The lockfile command isn't necessary. `yarn install` will produce a lockfile.",
 );
 
-export let dedupe = buildUseless(
+export const dedupe = buildUseless(
   "The dedupe command isn't necessary. `yarn install` will already dedupe.",
 );
 
-export let prune = buildUseless(
+export const prune = buildUseless(
   "The prune command isn't necessary. `yarn install` will prune extraneous packages.",
 );

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -4,7 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 
-let semver = require('semver');
+const semver = require('semver');
 const PKG_INPUT = /(^\S[^\s@]+)(?:@(\S+))?$/;
 
 function clean(object: any): any {
@@ -47,7 +47,7 @@ export async function run(
     return;
   }
 
-  let packageInput = NpmRegistry.escapeName(args.shift());
+  const packageInput = NpmRegistry.escapeName(args.shift());
   const field = args.shift();
 
   const parts = PKG_INPUT.exec(packageInput);

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -25,7 +25,7 @@ export async function run(
   const manifests = await install.getRootManifests();
 
   let gitUrl;
-  let author = {
+  const author = {
     name: config.getOption('init-author-name'),
     email: config.getOption('init-author-email'),
     url: config.getOption('init-author-url'),
@@ -105,9 +105,9 @@ export async function run(
   }
 
   // save answers
-  let targetManifests = [];
+  const targetManifests = [];
   for (let registryName of registryNames) {
-    let info = manifests[registryName];
+    const info = manifests[registryName];
     if (info.exists) {
       targetManifests.push(info);
     }
@@ -115,7 +115,7 @@ export async function run(
   if (!targetManifests.length) {
     targetManifests.push(manifests.npm);
   }
-  for (let targetManifest of targetManifests) {
+  for (const targetManifest of targetManifests) {
     Object.assign(targetManifest.object, pkg);
     reporter.success(`Saved ${path.basename(targetManifest.loc)}`);
   }

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -263,9 +263,9 @@ export class Install {
 
   async init(): Promise<Array<string>> {
     let [depRequests, rawPatterns] = await this.fetchRequestFromCwd();
-    let match = await this.matchesIntegrityHash(rawPatterns);
+    const match = await this.matchesIntegrityHash(rawPatterns);
 
-    let prepared = await this.prepare(rawPatterns, depRequests, match);
+    const prepared = await this.prepare(rawPatterns, depRequests, match);
     rawPatterns = prepared.patterns;
     depRequests = prepared.requests;
     if (prepared.skip) {
@@ -282,7 +282,7 @@ export class Install {
 
     //
     let patterns = rawPatterns;
-    let steps: Array<(curr: number, total: number) => Promise<void>> = [];
+    const steps: Array<(curr: number, total: number) => Promise<void>> = [];
 
     steps.push(async (curr: number, total: number) => {
       this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));
@@ -337,7 +337,7 @@ export class Install {
     }
 
     let currentStep = 0;
-    for (let step of steps) {
+    for (const step of steps) {
       await step(++currentStep, steps.length);
     }
 
@@ -364,11 +364,11 @@ export class Install {
       return patterns;
     }
 
-    let flattenedPatterns = [];
+    const flattenedPatterns = [];
 
     for (const name of this.resolver.getAllDependencyNamesByLevelOrder(patterns)) {
       const infos = this.resolver.getAllInfoForPackageName(name).filter((manifest: Manifest): boolean => {
-        let ref = manifest._reference;
+        const ref = manifest._reference;
         invariant(ref, 'expected package reference');
         return !ref.ignore;
       });
@@ -385,7 +385,7 @@ export class Install {
       }
 
       const options = infos.map((info): ReporterSelectOption => {
-        let ref = info._reference;
+        const ref = info._reference;
         invariant(ref, 'expected reference');
         return {
           // TODO `and is required by {PARENT}`,
@@ -415,18 +415,18 @@ export class Install {
 
     // save resolutions to their appropriate root manifest
     if (Object.keys(this.resolutions).length) {
-      let jsons = await this.getRootManifests();
+      const jsons = await this.getRootManifests();
 
       for (let name in this.resolutions) {
         let version = this.resolutions[name];
 
-        let patterns = this.resolver.patternsByPackage[name];
+        const patterns = this.resolver.patternsByPackage[name];
         if (!patterns) {
           continue;
         }
 
         let manifest;
-        for (let pattern of patterns) {
+        for (const pattern of patterns) {
           manifest = this.resolver.getResolvedPattern(pattern);
           if (manifest) {
             break;
@@ -434,10 +434,10 @@ export class Install {
         }
         invariant(manifest, 'expected manifest');
 
-        let ref = manifest._reference;
+        const ref = manifest._reference;
         invariant(ref, 'expected reference');
 
-        let object = jsons[ref.registry].object;
+        const object = jsons[ref.registry].object;
         object.resolutions = object.resolutions || {};
         object.resolutions[name] = version;
       }
@@ -453,8 +453,8 @@ export class Install {
    */
 
   async getRootManifests(): Promise<RootManifests> {
-    let manifests: RootManifests = {};
-    for (let registryName of registryNames) {
+    const manifests: RootManifests = {};
+    for (const registryName of registryNames) {
       const registry = registries[registryName];
       const jsonLoc = path.join(this.config.cwd, registry.filename);
 
@@ -474,13 +474,13 @@ export class Install {
    */
 
   async saveRootManifests(manifests: RootManifests): Promise<void> {
-    for (let registryName of registryNames) {
-      let {loc, object, exists} = manifests[registryName];
+    for (const registryName of registryNames) {
+      const {loc, object, exists} = manifests[registryName];
       if (!exists && !Object.keys(object).length) {
         continue;
       }
 
-      for (let field of constants.DEPENDENCY_TYPES) {
+      for (const field of constants.DEPENDENCY_TYPES) {
         if (object[field]) {
           object[field] = sortObject(object[field]);
         }
@@ -544,7 +544,7 @@ export class Install {
    */
 
   async matchesIntegrityHash(patterns: Array<string>): Promise<IntegrityMatch> {
-    let loc = await this.getIntegrityHashLocation();
+    const loc = await this.getIntegrityHashLocation();
     if (!await fs.exists(loc)) {
       return {
         actual: '',
@@ -554,8 +554,8 @@ export class Install {
       };
     }
 
-    let actual = this.generateIntegrityHash(this.lockfile.source, patterns);
-    let expected = (await fs.readFile(loc)).trim();
+    const actual = this.generateIntegrityHash(this.lockfile.source, patterns);
+    const expected = (await fs.readFile(loc)).trim();
 
     return {
       actual,
@@ -572,7 +572,7 @@ export class Install {
 
   async getIntegrityHashLocation(): Promise<string> {
     // build up possible folders
-    let possibleFolders = [];
+    const possibleFolders = [];
     if (this.config.modulesFolder) {
       possibleFolders.push(this.config.modulesFolder);
     }
@@ -585,16 +585,16 @@ export class Install {
     }
 
     // ensure we only write to a registry folder that was used
-    for (let name of checkRegistryNames) {
+    for (const name of checkRegistryNames) {
       let loc = path.join(this.config.cwd, this.config.registries[name].folder);
       possibleFolders.push(loc);
     }
 
     // if we already have an integrity hash in one of these folders then use it's location otherwise use the
     // first folder
-    let possibles = possibleFolders.map((folder): string => path.join(folder, constants.INTEGRITY_FILENAME));
+    const possibles = possibleFolders.map((folder): string => path.join(folder, constants.INTEGRITY_FILENAME));
     let loc = possibles[0];
-    for (let possibleLoc of possibles) {
+    for (const possibleLoc of possibles) {
       if (await fs.exists(possibleLoc)) {
         loc = possibleLoc;
         break;
@@ -607,7 +607,7 @@ export class Install {
    */
 
   async writeIntegrityHash(lockSource: string, patterns: Array<string>): Promise<void> {
-    let loc = await this.getIntegrityHashLocation();
+    const loc = await this.getIntegrityHashLocation();
     invariant(loc, 'expected integrity hash location');
     await fs.writeFile(loc, this.generateIntegrityHash(lockSource, patterns));
   }
@@ -617,7 +617,7 @@ export class Install {
    */
 
   generateIntegrityHash(lockfile: string, patterns: Array<string>): string {
-    let opts = [lockfile];
+    const opts = [lockfile];
 
     opts.push(`patterns:${patterns.join(',')}`);
 
@@ -629,12 +629,12 @@ export class Install {
       opts.push('production');
     }
 
-    let linkedModules = this.config.linkedModules;
+    const linkedModules = this.config.linkedModules;
     if (linkedModules.length) {
       opts.push(`linked:${linkedModules.join(',')}`);
     }
 
-    let mirror = this.config.getOfflineMirrorPath();
+    const mirror = this.config.getOfflineMirrorPath();
     if (mirror != null) {
       opts.push(`mirror:${mirror}`);
     }
@@ -682,7 +682,7 @@ export async function run(
   }
 
   if (args.length) {
-    let exampleArgs = args.slice();
+    const exampleArgs = args.slice();
     if (flags.saveDev) {
       exampleArgs.push('--dev');
     }

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -11,7 +11,7 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] != 'generate-disclaimer';
 }
 
-export let {setFlags, run} = buildSubCommands('licenses', {
+export const {setFlags, run} = buildSubCommands('licenses', {
   ls(): Promise<void> {
     return Promise.reject(new Error('TODO'));
   },
@@ -53,7 +53,7 @@ export let {setFlags, run} = buildSubCommands('licenses', {
       return a.name.localeCompare(b.name);
     });
 
-    for (let {name, license, licenseText, repository} of manifests) {
+    for (const {name, license, licenseText, repository} of manifests) {
       console.log('-----');
       console.log();
 

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -7,7 +7,7 @@ import * as fs from '../../util/fs.js';
 
 export const noArguments = true;
 
-let path = require('path');
+const path = require('path');
 
 export async function run(
   config: Config,
@@ -16,13 +16,13 @@ export async function run(
   args: Array<string>,
 ): Promise<void> {
   // add cwd module to the global registry
-  let manifest = await config.readRootManifest();
-  let name = manifest.name;
+  const manifest = await config.readRootManifest();
+  const name = manifest.name;
   if (!name) {
     throw new MessageError(reporter.lang('unknownPackageName'));
   }
 
-  let linkLoc = path.join(config.linkFolder, name);
+  const linkLoc = path.join(config.linkFolder, name);
   if (await fs.exists(linkLoc)) {
     throw new MessageError(reporter.lang('linkCollision', name));
   } else {

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -36,7 +36,7 @@ async function getCredentials(config: Config, reporter: Reporter): Promise<?{
 export async function getToken(config: Config, reporter: Reporter): Promise<
   () => Promise<void>
 > {
-  let env = process.env.YARN_AUTH_TOKEN || process.env.KPM_AUTH_TOKEN || process.env.NPM_AUTH_TOKEN;
+  const env = process.env.YARN_AUTH_TOKEN || process.env.KPM_AUTH_TOKEN || process.env.NPM_AUTH_TOKEN;
   if (env) {
     config.registries.npm.setToken(env);
     return function revoke(): Promise<void> {
@@ -45,10 +45,10 @@ export async function getToken(config: Config, reporter: Reporter): Promise<
     };
   }
 
-  let requestManager = config.requestManager;
+  const requestManager = config.requestManager;
 
   //
-  let creds = await getCredentials(config, reporter);
+  const creds = await getCredentials(config, reporter);
   if (!creds) {
     reporter.warn(reporter.lang('loginAsPublic'));
     return function revoke(): Promise<void> {
@@ -57,11 +57,11 @@ export async function getToken(config: Config, reporter: Reporter): Promise<
     };
   }
 
-  let {username, email} = creds;
-  let password = await reporter.question(reporter.lang('npmPassword'), true);
+  const {username, email} = creds;
+  const password = await reporter.question(reporter.lang('npmPassword'), true);
 
   //
-  let userobj = {
+  const userobj = {
     _id: `org.couchdb.user:${username}`,
     name: username,
     password,
@@ -72,8 +72,8 @@ export async function getToken(config: Config, reporter: Reporter): Promise<
   };
 
   //
-  let url = `${config.registries.npm.config.registry}/-/user/org.couchdb.user:${encodeURIComponent(username)}`;
-  let res = await requestManager.request({
+  const url = `${config.registries.npm.config.registry}/-/user/org.couchdb.user:${encodeURIComponent(username)}`;
+  const res = await requestManager.request({
     url,
     method: 'PUT',
     body: userobj,
@@ -84,7 +84,7 @@ export async function getToken(config: Config, reporter: Reporter): Promise<
   if (res.ok) {
     reporter.success(reporter.lang('loggedIn'));
 
-    let token = res.token;
+    const token = res.token;
     config.registries.npm.setToken(token);
 
     return async function revoke(): Promise<void> {

--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -133,7 +133,7 @@ export async function run(
 ): Promise<void> {
   const lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
   const install = new Install(flags, config, reporter, lockfile);
-  let [depRequests, patterns] = await install.fetchRequestFromCwd();
+  const [depRequests, patterns] = await install.fetchRequestFromCwd();
   await install.resolver.init(depRequests, install.flags.flat);
 
   const {trees} = await buildTree(install.resolver, install.linker, patterns);

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -35,9 +35,9 @@ export async function run(
       throw new MessageError(reporter.lang('lockfileOutdated'));
     }
 
-    let normalized = PackageRequest.normalizePattern(pattern);
+    const normalized = PackageRequest.normalizePattern(pattern);
 
-    let current = locked.version;
+    const current = locked.version;
     let name = locked.name;
 
     let latest = '';

--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -26,22 +26,22 @@ export async function mutate(
     return false;
   }
 
-  let username = args.shift();
-  let name = await getName(args, config);
+  const username = args.shift();
+  const name = await getName(args, config);
   if (!isValidPackageName(name)) {
     throw new MessageError(reporter.lang('invalidPackageName'));
   }
 
-  let msgs = buildMessages(username, name);
+  const msgs = buildMessages(username, name);
   reporter.step(1, 3, reporter.lang('loggingIn'));
-  let revoke = await getToken(config, reporter);
+  const revoke = await getToken(config, reporter);
 
   reporter.step(2, 3, msgs.info);
-  let user = await config.registries.npm.request(`-/user/org.couchdb.user:${username}`);
+  const user = await config.registries.npm.request(`-/user/org.couchdb.user:${username}`);
   let error = false;
   if (user) {
     // get package
-    let pkg = await config.registries.npm.request(NpmRegistry.escapeName(name));
+    const pkg = await config.registries.npm.request(NpmRegistry.escapeName(name));
     if (pkg) {
       pkg.maintainers = pkg.maintainers || [];
       error = mutator({name: user.name, email: user.email}, pkg);
@@ -52,7 +52,7 @@ export async function mutate(
 
     // update package
     if (pkg && !error) {
-      let res = await config.registries.npm.request(`${NpmRegistry.escapeName(name)}/-rev/${pkg._rev}`, {
+      const res = await config.registries.npm.request(`${NpmRegistry.escapeName(name)}/-rev/${pkg._rev}`, {
         method: 'PUT',
         body: {
           _id: pkg._id,
@@ -83,7 +83,7 @@ export async function mutate(
   }
 }
 
-export let {run, setFlags} = buildSubCommands('owner', {
+export const {run, setFlags} = buildSubCommands('owner', {
   add(
     config: Config,
     reporter: Reporter,
@@ -100,7 +100,7 @@ export let {run, setFlags} = buildSubCommands('owner', {
         error: reporter.lang('ownerAddingFailed'),
       }),
       (user: Object, pkg: Object): boolean => {
-        for (let owner of pkg.maintainers) {
+        for (const owner of pkg.maintainers) {
           if (owner.name === user) {
             reporter.error(reporter.lang('ownerAlready'));
             return true;
@@ -133,7 +133,7 @@ export let {run, setFlags} = buildSubCommands('owner', {
         let found = false;
 
         pkg.maintainers = pkg.maintainers.filter((o): boolean => {
-          let match = o.name === user.name;
+          const match = o.name === user.name;
           found = found || match;
           return !match;
         });
@@ -157,19 +157,19 @@ export let {run, setFlags} = buildSubCommands('owner', {
       return false;
     }
 
-    let name = await getName(args, config);
+    const name = await getName(args, config);
 
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    let revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter);
 
     reporter.step(2, 3, reporter.lang('ownerGetting', name));
-    let pkg = await config.registries.npm.request(name);
+    const pkg = await config.registries.npm.request(name);
     if (pkg) {
-      let owners = pkg.maintainers;
+      const owners = pkg.maintainers;
       if (!owners || !owners.length) {
         reporter.warn(reporter.lang('ownerNone'));
       } else {
-        for (let owner of owners) {
+        for (const owner of owners) {
           reporter.info(`${owner.name} <${owner.email}>`);
         }
       }

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -11,10 +11,10 @@ import * as fs from '../../util/fs.js';
 import {pack} from './pack.js';
 import {getToken} from './login.js';
 
-let invariant = require('invariant');
-let crypto = require('crypto');
-let url = require('url');
-let fs2 = require('fs');
+const invariant = require('invariant');
+const crypto = require('crypto');
+const url = require('url');
+const fs2 = require('fs');
 
 export function setFlags(commander: Object) {
   versionSetFlags(commander);
@@ -29,16 +29,16 @@ async function publish(
   flags: Object,
   dir: string,
 ): Promise<void> {
-  let registry = config.registries.npm.config.registry;
+  const registry = config.registries.npm.config.registry;
 
   // validate access argument
-  let access = flags.access;
+  const access = flags.access;
   if (access && access !== 'public' && access !== 'restricted') {
     throw new MessageError(config.reporter.lang('invalidAccess'));
   }
 
   // get tarball stream
-  let stat = await fs.lstat(dir);
+  const stat = await fs.lstat(dir);
   let stream;
   if (stat.isDirectory()) {
     stream = await pack(config, dir);
@@ -48,27 +48,27 @@ async function publish(
     throw new Error("Don't know how to handle this file type");
   }
   invariant(stream, 'expected stream');
-  let buffer = await new Promise((resolve, reject) => {
+  const buffer = await new Promise((resolve, reject) => {
     stream.pipe(new ConcatStream(resolve)).on('error', reject);
   });
 
   // copy normalized package and remove internal keys as they may be sensitive or yarn specific
   pkg = Object.assign({}, pkg);
-  for (let key in pkg) {
+  for (const key in pkg) {
     if (key[0] === '_') {
       delete pkg[key];
     }
   }
 
-  let tag = flags.tag || 'latest';
-  let tbName = `${pkg.name}-${pkg.version}.tgz`;
-  let tbURI = `${pkg.name}/-/${tbName}`;
+  const tag = flags.tag || 'latest';
+  const tbName = `${pkg.name}-${pkg.version}.tgz`;
+  const tbURI = `${pkg.name}/-/${tbName}`;
 
   // TODO this might modify package.json, do we need to reload it?
   await executeLifecycleScript(config, 'prepublish');
 
   // create body
-  let root = {
+  const root = {
     _id: pkg.name,
     access: flags.access,
     name: pkg.name,
@@ -95,7 +95,7 @@ async function publish(
   pkg.dist.tarball = url.resolve(registry, tbURI).replace(/^https:\/\//, 'http://');
 
   // publish package
-  let res = await config.registries.npm.request(NpmRegistry.escapeName(pkg.name), {
+  const res = await config.registries.npm.request(NpmRegistry.escapeName(pkg.name), {
     method: 'PUT',
     body: root,
   });
@@ -115,7 +115,7 @@ export async function run(
  args: Array<string>,
 ): Promise<void> {
   // validate package fields that are required for publishing
-  let pkg = await config.readRootManifest();
+  const pkg = await config.readRootManifest();
   if (pkg.private) {
     throw new MessageError(reporter.lang('publishPrivate'));
   }
@@ -124,7 +124,7 @@ export async function run(
   }
 
   // validate arguments
-  let dir = args[0] || config.cwd;
+  const dir = args[0] || config.cwd;
   if (args.length > 1) {
     throw new MessageError(reporter.lang('tooManyArguments', 1));
   }
@@ -138,7 +138,7 @@ export async function run(
 
   //
   reporter.step(2, 4, reporter.lang('loggingIn'));
-  let revoke = await getToken(config, reporter);
+  const revoke = await getToken(config, reporter);
 
   //
   reporter.step(3, 4, reporter.lang('publishing'));

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -41,7 +41,7 @@ export async function run(
 
     for (const registryName of Object.keys(registries)) {
       const registry = config.registries[registryName];
-      let object = rootManifests[registryName].object;
+      const object = rootManifests[registryName].object;
 
       for (const type of constants.DEPENDENCY_TYPES) {
         const deps = object[type];
@@ -69,7 +69,7 @@ export async function run(
   await install.saveRootManifests(rootManifests);
 
   // run hooks - npm runs these one after another
-  for (let action of ['preuninstall', 'uninstall', 'postuninstall']) {
+  for (const action of ['preuninstall', 'uninstall', 'postuninstall']) {
     for (const [loc, manifest] of manifests) {
       await execFromManifest(config, action, manifest, loc);
     }

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -17,8 +17,8 @@ import {registries} from '../../resolvers/index.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
-let leven = require('leven');
-let path = require('path');
+const leven = require('leven');
+const path = require('path');
 
 export async function run(
   config: Config,

--- a/src/cli/commands/unlink.js
+++ b/src/cli/commands/unlink.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
 import * as fs from '../../util/fs.js';
 
-let path = require('path');
+const path = require('path');
 
 export async function run(
   config: Config,
@@ -13,9 +13,9 @@ export async function run(
   flags: Object,
   args: Array<string>,
 ): Promise<void> {
-  let names = args;
+  const names = args;
   if (!names.length) {
-    let manifest = await config.readRootManifest();
+    const manifest = await config.readRootManifest();
     let name = manifest.name;
     if (name) {
       names.push(name);
@@ -25,7 +25,7 @@ export async function run(
   }
 
   for (let name of names) {
-    let linkLoc = path.join(config.linkFolder, name);
+    const linkLoc = path.join(config.linkFolder, name);
     if (await fs.exists(linkLoc)) {
       await fs.unlink(linkLoc);
       reporter.success(reporter.lang('linkUnregistered', name));

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -19,7 +19,7 @@ export async function run(
   flags: Object,
   args: Array<string>,
 ): Promise<void> {
-  let lockfile = args.length ? await Lockfile.fromDirectory(config.cwd, reporter) : new Lockfile();
+  const lockfile = args.length ? await Lockfile.fromDirectory(config.cwd, reporter) : new Lockfile();
   const install = new Add(args, flags, config, reporter, lockfile);
   await install.init();
 }

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -8,9 +8,9 @@ import {stringify} from '../../util/misc.js';
 import {spawn} from '../../util/child.js';
 import * as fs from '../../util/fs.js';
 
-let invariant = require('invariant');
-let semver = require('semver');
-let path = require('path');
+const invariant = require('invariant');
+const semver = require('semver');
+const path = require('path');
 
 const NEW_VERSION_FLAG = '--new-version [version]';
 function isValidNewVersion(oldVersion: string, newVersion: string, looseSemver: boolean): boolean {

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -46,7 +46,7 @@ export async function run(
   reporter.step(2, 3, reporter.lang('whyInitGraph'), emoji.get('truck'));
   const lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
   const install = new Install(flags, config, reporter, lockfile);
-  let [depRequests, patterns] = await install.fetchRequestFromCwd();
+  const [depRequests, patterns] = await install.fetchRequestFromCwd();
   await install.resolver.init(depRequests, install.flags.flat);
   const hoisted = await install.linker.getFlatHoistedTree(patterns);
 
@@ -54,7 +54,7 @@ export async function run(
   reporter.step(3, 3, reporter.lang('whyFinding'), emoji.get('mag'));
 
   let match;
-  for (let [, info] of hoisted) {
+  for (const [, info] of hoisted) {
     if (info.key === query || info.previousKeys.indexOf(query) >= 0) {
       match = info;
       break;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -68,7 +68,7 @@ if (commandName === 'help' && !args.length) {
   commander.on('--help', function() {
     console.log('  Commands:');
     console.log();
-    for (let name of Object.keys(commands).sort(sortAlpha)) {
+    for (const name of Object.keys(commands).sort(sortAlpha)) {
       if (commands[name].useless) {
         continue;
       }
@@ -128,7 +128,7 @@ if (commandName === 'help' || args.indexOf('--help') >= 0 || args.indexOf('-h') 
   commander.on('--help', function() {
     console.log('  Examples:');
     console.log();
-    for (let example of examples) {
+    for (const example of examples) {
       console.log(`    $ yarn ${example}`);
     }
     console.log();
@@ -155,13 +155,13 @@ let Reporter = ConsoleReporter;
 if (commander.json) {
   Reporter = JSONReporter;
 }
-let reporter = new Reporter({
+const reporter = new Reporter({
   emoji: process.stdout.isTTY && process.platform === 'darwin',
 });
 reporter.initPeakMemoryCounter();
 
 //
-let config = new Config(reporter);
+const config = new Config(reporter);
 
 // print header
 let outputWrapper = true;
@@ -241,7 +241,7 @@ const runEventuallyWithNetwork = (mutexPort: ?string): Promise<void> => {
     server.on('error', () => {
       // another yarnn instance exists, let's connect to it to know when it dies.
       reporter.warn(reporter.lang('waitingInstance'));
-      let socket = net.createConnection(connectionOptions);
+      const socket = net.createConnection(connectionOptions);
 
       socket
         .on('data', () => {
@@ -319,7 +319,7 @@ config.init({
 
   if (errs) {
     if (Array.isArray(errs)) {
-      for (let err of errs) {
+      for (const err of errs) {
         logError(err);
       }
     } else {

--- a/src/config.js
+++ b/src/config.js
@@ -235,7 +235,7 @@ export default class Config {
    */
 
   getOfflineMirrorPath(tarUrl: ?string): ?string {
-    let registry = this.registries.npm;
+    const registry = this.registries.npm;
     if (registry == null) {
       return null;
     }
@@ -361,7 +361,7 @@ export default class Config {
   getFolder(pkg: Manifest): string {
     let registryName = pkg._registry;
     if (!registryName) {
-      let ref = pkg._reference;
+      const ref = pkg._reference;
       invariant(ref, 'expected reference');
       registryName = ref.registry;
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,7 +56,7 @@ export function getModuleCacheDirectory(): string {
   }
 
   // otherwise use ~/.yarn
-  let name = or(['.fbkpm', '.kpm', '.yarn'], userHome);
+  const name = or(['.fbkpm', '.kpm', '.yarn'], userHome);
   return path.join(userHome, name);
 }
 

--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -38,7 +38,7 @@ export default class BaseFetcher {
   }
 
   fetch(): Promise<FetchedMetadata> {
-    let {dest} = this;
+    const {dest} = this;
 
     return fs.lockQueue.push(dest, async (): Promise<FetchedMetadata> => {
       await fs.mkdirp(dest);

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -25,7 +25,7 @@ export default class GitFetcher extends BaseFetcher {
   }
 
   async fetchFromLocal(pathname: string): Promise<FetchedOverride> {
-    let {reference: ref, config} = this;
+    const {reference: ref, config} = this;
     const offlineMirrorPath = config.getOfflineMirrorPath() || '';
     const localTarball = path.resolve(offlineMirrorPath, ref);
     if (!(await fsUtil.exists(localTarball))) {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -16,13 +16,13 @@ const fs = require('fs');
 
 export default class TarballFetcher extends BaseFetcher {
   async getResolvedFromCached(hash: string): Promise<?string> {
-    let mirrorPath = this.getMirrorPath();
+    const mirrorPath = this.getMirrorPath();
     if (mirrorPath == null) {
       // no mirror
       return null;
     }
 
-    let tarballLoc = path.join(this.dest, constants.TARBALL_FILENAME);
+    const tarballLoc = path.join(this.dest, constants.TARBALL_FILENAME);
     if (!(await fsUtil.exists(tarballLoc))) {
       // no tarball located in the cache
       return null;
@@ -85,7 +85,7 @@ export default class TarballFetcher extends BaseFetcher {
   }
 
   async fetchFromLocal(pathname: ?string): Promise<FetchedOverride> {
-    let {reference: ref, config} = this;
+    const {reference: ref, config} = this;
 
     // path to the local tarball
     let localTarball;
@@ -107,7 +107,7 @@ export default class TarballFetcher extends BaseFetcher {
     }
 
     return new Promise((resolve, reject) => {
-      let {validateStream, extractorStream} = this.createExtractor(null, resolve, reject);
+      const {validateStream, extractorStream} = this.createExtractor(null, resolve, reject);
 
       const cachedStream = fs.createReadStream(localTarball);
 
@@ -129,7 +129,7 @@ export default class TarballFetcher extends BaseFetcher {
   }
 
   fetchFromExternal(): Promise<FetchedOverride> {
-    let {reference: ref} = this;
+    const {reference: ref} = this;
 
     return this.config.requestManager.request({
       url: ref,
@@ -147,7 +147,7 @@ export default class TarballFetcher extends BaseFetcher {
           : null;
 
         //
-        let {
+        const {
           validateStream,
           extractorStream,
         } = this.createExtractor(overwriteResolved, resolve, reject);

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -160,14 +160,14 @@ export class Parser {
   comments: Array<string>;
 
   onComment(token: Token) {
-    let value = token.value;
+    const value = token.value;
     invariant(typeof value === 'string', 'expected token value to be a string');
 
-    let comment = value.trim();
+    const comment = value.trim();
 
-    let versionMatch = comment.match(VERSION_REGEX);
+    const versionMatch = comment.match(VERSION_REGEX);
     if (versionMatch) {
-      let version = +versionMatch[1];
+      const version = +versionMatch[1];
       if (version > LOCKFILE_VERSION) {
         throw new MessageError(
           `Can't install from a lockfile of version ${version} as you're on an old yarn version that only supports ` +

--- a/src/lockfile/stringify.js
+++ b/src/lockfile/stringify.js
@@ -49,7 +49,7 @@ function _stringify(obj: Object, options: Options): string {
   // Sorting order needs to be consistent between runs, we run native sort by name because there are no
   // problems with it being unstable because there are no to keys the same
   // However priorities can be duplicated and native sort can shuffle things from run to run
-  let keys = Object.keys(obj).sort(priorityThenAlphaSort);
+  const keys = Object.keys(obj).sort(priorityThenAlphaSort);
 
   let addedKeys = [];
 
@@ -94,7 +94,7 @@ function _stringify(obj: Object, options: Options): string {
 }
 
 export default function stringify(obj: Object, noHeader?: boolean): string {
-  let val = _stringify(obj, {
+  const val = _stringify(obj, {
     indent: '',
     topLevel: true,
   });

--- a/src/lockfile/wrapper.js
+++ b/src/lockfile/wrapper.js
@@ -9,8 +9,8 @@ import parse from './parse.js';
 import * as constants from '../constants.js';
 import * as fs from '../util/fs.js';
 
-let invariant = require('invariant');
-let path = require('path');
+const invariant = require('invariant');
+const path = require('path');
 
 export {default as parse} from './parse';
 export {default as stringify} from './stringify';
@@ -53,7 +53,7 @@ export default class Lockfile {
 
   static async fromDirectory(dir: string, reporter?: Reporter): Promise<Lockfile> {
     // read the manifest in this directory
-    let lockfileLoc = path.join(dir, constants.LOCKFILE_FILENAME);
+    const lockfileLoc = path.join(dir, constants.LOCKFILE_FILENAME);
     let lockfile;
     let rawLockfile = '';
 
@@ -70,12 +70,12 @@ export default class Lockfile {
   }
 
   getLocked(pattern: string): ?LockManifest {
-    let cache = this.cache;
+    const cache = this.cache;
     if (!cache) {
       return undefined;
     }
 
-    let shrunk = pattern in cache && cache[pattern];
+    const shrunk = pattern in cache && cache[pattern];
 
     if (typeof shrunk === 'string') {
       return this.getLocked(shrunk);
@@ -93,21 +93,21 @@ export default class Lockfile {
   getLockfile(patterns: {
     [packagePattern: string]: Manifest
   }): Object {
-    let lockfile = {};
-    let seen: Map<string, Object> = new Map();
+    const lockfile = {};
+    const seen: Map<string, Object> = new Map();
 
     // order by name so that lockfile manifest is assigned to the first dependency with this manifest
     // the others that have the same remote.resolved will just refer to the first
     // ordering allows for consistency in lockfile when it is serialized
-    let sortedPatternsKeys: Array<string> = Object.keys(patterns).sort(sortAlpha);
+    const sortedPatternsKeys: Array<string> = Object.keys(patterns).sort(sortAlpha);
 
-    for (let pattern of sortedPatternsKeys) {
-      let pkg = patterns[pattern];
-      let {_remote: remote, _reference: ref} = pkg;
+    for (const pattern of sortedPatternsKeys) {
+      const pkg = patterns[pattern];
+      const {_remote: remote, _reference: ref} = pkg;
       invariant(ref, 'Package is missing a reference');
       invariant(remote, 'Package is missing a remote');
 
-      let seenPattern = remote.resolved && seen.get(remote.resolved);
+      const seenPattern = remote.resolved && seen.get(remote.resolved);
       if (seenPattern) {
         // no point in duplicating it
         lockfile[pattern] = seenPattern;
@@ -120,8 +120,8 @@ export default class Lockfile {
         continue;
       }
 
-      let inferredName = getName(pattern);
-      let obj = {
+      const inferredName = getName(pattern);
+      const obj = {
         name: inferredName === pkg.name ? undefined : pkg.name,
         version: pkg.version,
         uid: pkg._uid === pkg.version ? undefined : pkg._uid,

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -24,7 +24,7 @@ export default class PackageFetcher {
   config: Config;
 
   async fetchCache(dest: string, fetcher: Fetchers): Promise<FetchedMetadata> {
-    let {hash, package: pkg} = await this.config.readPackageMetadata(dest);
+    const {hash, package: pkg} = await this.config.readPackageMetadata(dest);
     return {
       package: pkg,
       resolved: await fetcher.getResolvedFromCached(hash),
@@ -97,7 +97,7 @@ export default class PackageFetcher {
       if (newPkg) {
         // read linked module manifest if one exists
         if (ref.shouldLink()) {
-          let linkPkg = await this.config.readManifest(path.join(this.config.linkFolder, ref.name));
+          const linkPkg = await this.config.readManifest(path.join(this.config.linkFolder, ref.name));
 
           // copy over fields that will influence the lockfile
           linkPkg.name = newPkg.name;

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -270,7 +270,7 @@ export default class PackageHoister {
     this.tree.delete(key);
 
     //
-    let {parts, duplicate} = this.getNewParts(key, info, rawParts.slice());
+    const {parts, duplicate} = this.getNewParts(key, info, rawParts.slice());
     const newKey = this.implodeKey(parts);
     const oldKey = key;
     if (duplicate) {
@@ -349,12 +349,12 @@ export default class PackageHoister {
     for (let [key, info] of this.tree.entries()) {
       // decompress the location and push it to the flat tree. this path could be made
       // up of modules from different registries so we need to handle this specially
-      let parts = [];
-      let keyParts = key.split('#');
+      const parts = [];
+      const keyParts = key.split('#');
       for (let i = 0; i < keyParts.length; i++) {
         let key = keyParts.slice(0, i + 1).join('#');
 
-        let hoisted = this.tree.get(key);
+        const hoisted = this.tree.get(key);
         invariant(hoisted, 'expected hoisted manifest');
         parts.push(this.config.getFolder(hoisted.pkg));
         parts.push(keyParts[i]);

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -43,9 +43,9 @@ export default class PackageInstallScripts {
   }
 
   async walk(loc: string): Promise<Map<string, number>> {
-    let files = await fs.walk(loc, null, this.config.registryFolders);
-    let mtimes = new Map();
-    for (let file of files) {
+    const files = await fs.walk(loc, null, this.config.registryFolders);
+    const mtimes = new Map();
+    for (const file of files) {
       mtimes.set(file.relative, file.mtime);
     }
     return mtimes;
@@ -126,7 +126,7 @@ export default class PackageInstallScripts {
         pkg,
         spinner,
         async (): Promise<void> => {
-          for (let cmd of cmds) {
+          for (const cmd of cmds) {
             await executeLifecycleScript(this.config, loc, cmd, spinner);
           }
         },
@@ -177,7 +177,7 @@ export default class PackageInstallScripts {
     invariant(ref, 'expected reference');
 
     const deps = ref.dependencies;
-    for (let dep of deps) {
+    for (const dep of deps) {
       const pkgDep = this.resolver.getStrictResolvedPattern(dep);
       if (seenManifests.has(pkgDep)) {
         // there is a cycle but not with the root
@@ -197,13 +197,13 @@ export default class PackageInstallScripts {
 
   // find the next package to be installed
   findInstallablePackage(workQueue: Set<Manifest>, installed: Set<Manifest>): ?Manifest {
-    for (let pkg of workQueue) {
+    for (const pkg of workQueue) {
       const ref = pkg._reference;
       invariant(ref, 'expected reference');
       const deps = ref.dependencies;
 
       let dependenciesFullfilled = true;
-      for (let dep of deps) {
+      for (const dep of deps) {
         const pkgDep = this.resolver.getStrictResolvedPattern(dep);
         if (!installed.has(pkgDep)) {
           dependenciesFullfilled = false;
@@ -252,7 +252,7 @@ export default class PackageInstallScripts {
         await this.runCommand(spinner, pkg);
       }
       installed.add(pkg);
-      for (let workerResolve of waitQueue) {
+      for (const workerResolve of waitQueue) {
         workerResolve();
       }
       waitQueue.clear();
@@ -260,11 +260,11 @@ export default class PackageInstallScripts {
   }
 
   async init(seedPatterns: Array<string>): Promise<void> {
-    let workQueue = new Set();
-    let installed = new Set();
-    let pkgs = this.resolver.getTopologicalManifests(seedPatterns);
+    const workQueue = new Set();
+    const installed = new Set();
+    const pkgs = this.resolver.getTopologicalManifests(seedPatterns);
     let installablePkgs = 0;
-    for (let pkg of pkgs) {
+    for (const pkg of pkgs) {
       if (this.packageCanBeInstalled(pkg)) {
         installablePkgs += 1;
       }
@@ -273,12 +273,12 @@ export default class PackageInstallScripts {
 
     // waitQueue acts like a semaphore to allow workers to register to be notified
     // when there are more work added to the work queue
-    let waitQueue = new Set();
-    let workers = [];
+    const waitQueue = new Set();
+    const workers = [];
 
     const set = this.reporter.activitySet(installablePkgs, Math.min(constants.CHILD_CONCURRENCY, workQueue.size));
 
-    for (let spinner of set.spinners) {
+    for (const spinner of set.spinners) {
       workers.push(this.worker(spinner, workQueue, installed, waitQueue));
     }
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -46,7 +46,7 @@ export default class PackageLinker {
   async linkSelfDependencies(pkg: Manifest, pkgLoc: string, targetBinLoc: string): Promise<void> {
     targetBinLoc = await fs.realpath(targetBinLoc);
     pkgLoc = await fs.realpath(pkgLoc);
-    for (let [scriptName, scriptCmd] of entries(pkg.bin)) {
+    for (const [scriptName, scriptCmd] of entries(pkg.bin)) {
       const dest = path.join(targetBinLoc, scriptName);
       const src = path.join(pkgLoc, scriptCmd);
       await linkBin(src, dest);
@@ -97,7 +97,7 @@ export default class PackageLinker {
     await fs.mkdirp(binLoc);
 
     // write the executables
-    for (let {dep, loc} of deps) {
+    for (const {dep, loc} of deps) {
       await this.linkSelfDependencies(dep, loc, binLoc);
     }
   }
@@ -110,7 +110,7 @@ export default class PackageLinker {
 
   async copyModules(patterns: Array<string>): Promise<void> {
     let flatTree = await this.getFlatHoistedTree(patterns);
-    let linkedRefs: Array<{
+    const linkedRefs: Array<{
       dest: string,
       name: string,
     }> = [];
@@ -122,7 +122,7 @@ export default class PackageLinker {
 
     //
     const queue = [];
-    for (let [dest, {pkg, loc: src}] of flatTree) {
+    for (const [dest, {pkg, loc: src}] of flatTree) {
       const ref = pkg._reference;
       invariant(ref, 'expected package reference');
       ref.setLocation(dest);
@@ -157,7 +157,7 @@ export default class PackageLinker {
     }
 
     // linked modules
-    for (let {name, dest} of linkedRefs) {
+    for (const {name, dest} of linkedRefs) {
       possibleExtraneous.delete(dest);
 
       this.reporter.info(this.reporter.lang('linkUsing', name));
@@ -197,13 +197,13 @@ export default class PackageLinker {
   }
 
   resolvePeerModules() {
-    for (let pkg of this.resolver.getManifests()) {
+    for (const pkg of this.resolver.getManifests()) {
       this._resolvePeerModules(pkg);
     }
   }
 
   _resolvePeerModules(pkg: Manifest) {
-    let peerDeps = pkg.peerDependencies;
+    const peerDeps = pkg.peerDependencies;
     if (!peerDeps) {
       return;
     }

--- a/src/package-reference.js
+++ b/src/package-reference.js
@@ -89,7 +89,7 @@ export default class PackageReference {
   }
 
   prune() {
-    for (let selfPattern of this.patterns) {
+    for (const selfPattern of this.patterns) {
       // remove ourselves from the resolver
       this.resolver.removePattern(selfPattern);
     }
@@ -118,7 +118,7 @@ export default class PackageReference {
 
     const shrunk = this.lockfile.getLocked(pattern);
     if (shrunk && shrunk.permissions) {
-      for (let [key, perm] of entries(shrunk.permissions)) {
+      for (const [key, perm] of entries(shrunk.permissions)) {
         this.setPermission(key, perm);
       }
     }
@@ -137,7 +137,7 @@ export default class PackageReference {
 
   calculateVisibility() {
     let nowIgnore = false;
-    let stack = this.visibility;
+    const stack = this.visibility;
 
     // if we don't use this module then mark it as ignored
     if (stack[USED] === 0) {

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -35,7 +35,7 @@ export default class PackageRequest {
   }
 
   static getExoticResolver(pattern: string): ?Function { // TODO make this type more refined
-    for (let [, Resolver] of entries(resolvers.exotics)) {
+    for (const [, Resolver] of entries(resolvers.exotics)) {
       if (Resolver.isVersion(pattern)) {
         return Resolver;
       }
@@ -58,7 +58,7 @@ export default class PackageRequest {
 
     let request = this.parentRequest;
     while (request) {
-      let info = this.resolver.getStrictResolvedPattern(request.pattern);
+      const info = this.resolver.getStrictResolvedPattern(request.pattern);
       chain.unshift(info.name);
 
       request = request.parentRequest;
@@ -69,7 +69,7 @@ export default class PackageRequest {
 
   getLocked(remoteType: string): ?Object {
     // always prioritise root lockfile
-    let shrunk = this.lockfile.getLocked(this.pattern);
+    const shrunk = this.lockfile.getLocked(this.pattern);
 
     if (shrunk) {
       const resolvedParts = versionUtil.explodeHashedUrl(shrunk.resolved);
@@ -99,7 +99,7 @@ export default class PackageRequest {
    */
 
   async findVersionOnRegistry(pattern: string): Promise<Manifest> {
-    let {range, name} = PackageRequest.normalizePattern(pattern);
+    const {range, name} = PackageRequest.normalizePattern(pattern);
 
     const exoticResolver = PackageRequest.getExoticResolver(range);
     if (exoticResolver) {
@@ -206,7 +206,7 @@ export default class PackageRequest {
 
   async find(): Promise<void> {
     // find version info for this package pattern
-    let info: ?Manifest = await this.findVersionInfo();
+    const info: ?Manifest = await this.findVersionInfo();
     if (!info) {
       throw new MessageError(this.reporter.lang('unknownPackage', this.pattern));
     }

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -131,17 +131,17 @@ export default class PackageResolver {
    */
 
   getTopologicalManifests(seedPatterns: Array<string>): Iterable<Manifest> {
-    let pkgs: Set<Manifest> = new Set();
-    let skip: Set<Manifest> = new Set();
+    const pkgs: Set<Manifest> = new Set();
+    const skip: Set<Manifest> = new Set();
 
-    let add = (seedPatterns: Array<string>) => {
-      for (let pattern of seedPatterns) {
-        let pkg = this.getStrictResolvedPattern(pattern);
+    const add = (seedPatterns: Array<string>) => {
+      for (const pattern of seedPatterns) {
+        const pkg = this.getStrictResolvedPattern(pattern);
         if (skip.has(pkg)) {
           continue;
         }
 
-        let ref = pkg._reference;
+        const ref = pkg._reference;
         invariant(ref, 'expected reference');
         skip.add(pkg);
         add(ref.dependencies);
@@ -159,14 +159,14 @@ export default class PackageResolver {
    */
 
   getLevelOrderManifests(seedPatterns: Array<string>): Iterable<Manifest> {
-    let pkgs: Set<Manifest> = new Set();
-    let skip: Set<Manifest> = new Set();
+    const pkgs: Set<Manifest> = new Set();
+    const skip: Set<Manifest> = new Set();
 
-    let add = (seedPatterns: Array<string>) => {
-      let refs = [];
+    const add = (seedPatterns: Array<string>) => {
+      const refs = [];
 
-      for (let pattern of seedPatterns) {
-        let pkg = this.getStrictResolvedPattern(pattern);
+      for (const pattern of seedPatterns) {
+        const pkg = this.getStrictResolvedPattern(pattern);
         if (skip.has(pkg)) {
           continue;
         }
@@ -194,8 +194,8 @@ export default class PackageResolver {
    */
 
   getAllDependencyNamesByLevelOrder(seedPatterns: Array<string>): Iterable<string> {
-    let names = new Set();
-    for (let {name} of this.getLevelOrderManifests(seedPatterns)) {
+    const names = new Set();
+    for (const {name} of this.getLevelOrderManifests(seedPatterns)) {
       names.add(name);
     }
     return names;
@@ -227,10 +227,10 @@ export default class PackageResolver {
    */
 
   getPackageReferences(): Array<PackageReference> {
-    let refs = [];
+    const refs = [];
 
     for (const manifest of this.getManifests()) {
-      let ref = manifest._reference;
+      const ref = manifest._reference;
       if (ref) {
         refs.push(ref);
       }
@@ -293,12 +293,12 @@ export default class PackageResolver {
       }
 
       // remove this pattern
-      let ref = this.getStrictResolvedPattern(pattern)._reference;
+      const ref = this.getStrictResolvedPattern(pattern)._reference;
       invariant(ref, 'expected package reference');
       ref.addVisibility(REMOVED_ANCESTOR);
       ref.prune();
 
-      for (let action in ref.visibility) {
+      for (const action in ref.visibility) {
         collapseToReference.visibility[action] += ref.visibility[action];
       }
 
@@ -398,7 +398,7 @@ export default class PackageResolver {
     }
 
     // propagate `visibility` option
-    let {parentRequest} = req;
+    const {parentRequest} = req;
     if (parentRequest && parentRequest.visibility) {
       req.visibility = parentRequest.visibility;
     }

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -4,12 +4,12 @@ import YarnRegistry from './yarn-registry.js';
 import NpmRegistry from './npm-registry.js';
 import BowerRegistry from './bower-registry.js';
 
-export let registries = {
+export const registries = {
   npm: NpmRegistry,
   yarn: YarnRegistry,
   bower: BowerRegistry,
 };
 
-export let registryNames = Object.keys(registries);
+export const registryNames = Object.keys(registries);
 
 export type RegistryNames = $Keys<typeof registries>;

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -49,7 +49,7 @@ export default class NpmRegistry extends Registry {
   request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<?Object> {
     const registry = removeSuffix(String(this.registries.yarn.getOption('registry')), '/');
 
-    let headers = {};
+    const headers = {};
     if (this.token) {
       headers.authorization = `Bearer ${this.token}`;
     }
@@ -64,7 +64,7 @@ export default class NpmRegistry extends Registry {
   }
 
   async checkOutdated(config: Config, name: string, range: string): CheckOutdatedReturn {
-    let req = await this.request(name);
+    const req = await this.request(name);
     if (!req) {
       throw new Error('couldnt find ' + name);
     }
@@ -88,8 +88,8 @@ export default class NpmRegistry extends Registry {
       foldersFromRootToCwd.pop();
     }
 
-    let actuals = [];
-    for (let [isHome, loc] of possibles) {
+    const actuals = [];
+    for (const [isHome, loc] of possibles) {
       if (await fs.exists(loc)) {
         actuals.push([
           isHome,

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -74,8 +74,8 @@ export default class YarnRegistry extends NpmRegistry {
   }
 
   async saveHomeConfig(config: Object): Promise<void> {
-    for (let key in config) {
-      let val = config[key];
+    for (const key in config) {
+      const val = config[key];
 
       // if the current config key was taken from home config then update
       // the global config

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -15,7 +15,7 @@ import type {Formatter} from './format.js';
 import {defaultFormatter} from './format.js';
 import * as languages from './lang/index.js';
 
-let util = require('util');
+const util = require('util');
 
 type Language = $Keys<typeof languages>;
 
@@ -43,7 +43,7 @@ export function stringifyLangArgs(args: Array<any>): Array<string> {
 
 export default class BaseReporter {
   constructor(opts?: ReporterOptions = {}) {
-    let lang = 'en';
+    const lang = 'en';
     this.language = lang;
 
     this.stdout = opts.stdout || process.stdout;
@@ -73,7 +73,7 @@ export default class BaseReporter {
   startTime: number;
 
   lang(key: LanguageKeys, ...args: Array<any>): string {
-    let msg = languages[this.language][key] || languages.en[key];
+    const msg = languages[this.language][key] || languages.en[key];
     if (!msg) {
       throw new ReferenceError(`Unknown language key ${key}`);
     }
@@ -180,7 +180,7 @@ export default class BaseReporter {
 
   //
   async questionAffirm(question: string): Promise<boolean> {
-    let condition = true; // trick eslint
+    const condition = true; // trick eslint
 
     while (condition) {
       let answer = await this.question(question);

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -58,20 +58,20 @@ export default class ConsoleReporter extends BaseReporter {
     head = head.map((field: string): string => this.format.underline(field));
 
     //
-    let rows = [head].concat(body);
+    const rows = [head].concat(body);
 
     // get column widths
-    let cols: Array<number> = [];
+    const cols: Array<number> = [];
     for (let i = 0; i < head.length; i++) {
-      let widths = rows.map((row: Row): number => this.format.stripColor(row[i]).length);
+      const widths = rows.map((row: Row): number => this.format.stripColor(row[i]).length);
       cols[i] = Math.max(...widths);
     }
 
     //
-    let builtRows = rows.map((row: Row): string => {
+    const builtRows = rows.map((row: Row): string => {
       for (let i = 0; i < row.length; i++) {
-        let field = row[i];
-        let padding = cols[i] - this.format.stripColor(field).length;
+        const field = row[i];
+        const padding = cols[i] - this.format.stripColor(field).length;
 
         row[i] = field + repeat(' ', padding);
       }
@@ -108,7 +108,7 @@ export default class ConsoleReporter extends BaseReporter {
 
   list(key: string, items: Array<string>) {
     const gutterWidth = (this._lastCategorySize || 2) - 1;
-    for (let item of items) {
+    for (const item of items) {
       this._log(`${repeat(' ', gutterWidth)}- ${item}`);
     }
   }
@@ -118,10 +118,10 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   footer(showPeakMemory?: boolean) {
-    let totalTime = (this.getTotalTime() / 1000).toFixed(2);
+    const totalTime = (this.getTotalTime() / 1000).toFixed(2);
     let msg = `Done in ${totalTime}s.`;
     if (showPeakMemory) {
-      let peakMemory = (this.peakMemory / 1024 / 1024).toFixed(2);
+      const peakMemory = (this.peakMemory / 1024 / 1024).toFixed(2);
       msg += ` Peak memory usage ${peakMemory}MB.`;
     }
     this.log(this._prependEmoji(msg, '✨'));
@@ -183,9 +183,9 @@ export default class ConsoleReporter extends BaseReporter {
   tree(key: string, trees: Trees) {
     trees = sortTrees(trees);
 
-    let stdout = this.stdout;
+    const stdout = this.stdout;
 
-    let output = ({name, children, hint, color}, level, end) => {
+    const output = ({name, children, hint, color}, level, end) => {
       children = sortTrees(children);
 
       let indent = end ? '└' : '├';
@@ -205,14 +205,14 @@ export default class ConsoleReporter extends BaseReporter {
 
       if (children && children.length) {
         for (let i = 0; i < children.length; i++) {
-          let tree = children[i];
+          const tree = children[i];
           output(tree, level + 1, i === children.length - 1);
         }
       }
     };
 
     for (let i = 0; i < trees.length; i++) {
-      let tree = trees[i];
+      const tree = trees[i];
       output(tree, 0, i === trees.length - 1);
     }
   }
@@ -222,29 +222,29 @@ export default class ConsoleReporter extends BaseReporter {
       return super.activitySet(total, workers);
     }
 
-    let spinners = [];
+    const spinners = [];
 
     for (let i = 1; i < workers; i++) {
       this.log('');
     }
 
     for (let i = 0; i < workers; i++) {
-      let spinner = new Spinner(this.stderr, i);
+      const spinner = new Spinner(this.stderr, i);
       spinner.start();
 
       let prefix: ?string = null;
       let current = 0;
-      let updatePrefix = () => {
+      const updatePrefix = () => {
         spinner.setPrefix(
           `${this.format.grey(`[${current === 0 ? '-' : current}/${total}]`)} `,
         );
       };
-      function clear() {
+      const clear = () => {
         prefix = null;
         current = 0;
         updatePrefix();
         spinner.setText('waiting...');
-      }
+      };
       clear();
 
       spinners.unshift({
@@ -273,7 +273,7 @@ export default class ConsoleReporter extends BaseReporter {
     return {
       spinners,
       end: () => {
-        for (let spinner of spinners) {
+        for (const spinner of spinners) {
           spinner.end();
         }
         readline.moveCursor(this.stdout, 0, -workers + 1);
@@ -289,7 +289,7 @@ export default class ConsoleReporter extends BaseReporter {
       };
     }
 
-    let spinner = new Spinner(this.stderr);
+    const spinner = new Spinner(this.stderr);
     spinner.start();
 
     return {
@@ -308,17 +308,17 @@ export default class ConsoleReporter extends BaseReporter {
       return Promise.reject(new Error("Can't answer a question unless a user TTY"));
     }
 
-    let rl = readline.createInterface({
+    const rl = readline.createInterface({
       input: this.stdin,
       output: this.stdout,
       terminal: true,
     });
 
-    let questions = options.map((opt): string => opt.name);
-    let answers = options.map((opt): string => opt.value);
+    const questions = options.map((opt): string => opt.name);
+    const answers = options.map((opt): string => opt.value);
 
     function toIndex(input: string): number {
-      let index = answers.indexOf(input);
+      const index = answers.indexOf(input);
 
       if (index >= 0) {
         return index;
@@ -334,7 +334,7 @@ export default class ConsoleReporter extends BaseReporter {
         this.log(`  ${this.format.dim(`${i + 1})`)} ${questions[i]}`);
       }
 
-      let ask = () => {
+      const ask = () => {
         rl.question(`${question}: `, (input) => {
           let index = toIndex(input);
 
@@ -374,7 +374,7 @@ export default class ConsoleReporter extends BaseReporter {
       };
     }
 
-    let bar = new Progress(count, this.stderr);
+    const bar = new Progress(count, this.stderr);
 
     bar.render();
 

--- a/src/reporters/format.js
+++ b/src/reporters/format.js
@@ -4,7 +4,7 @@ function formatFunction(...strs: Array<string>): string {
   return strs.join(' ');
 }
 
-export let defaultFormatter = {
+export const defaultFormatter = {
   bold: formatFunction,
   dim: formatFunction,
   italic: formatFunction,

--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -74,7 +74,7 @@ export default class JSONReporter extends BaseReporter {
     const id = this._activityId++;
     this._dump('activitySetStart', {id, total, workers});
 
-    let spinners = [];
+    const spinners = [];
     for (let i = 0; i < workers; i++) {
       let current = 0;
       let header = '';

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -1,7 +1,7 @@
 /* @flow */
  /* eslint max-len: 0 */
 
-let messages = {
+const messages = {
   upToDate: 'Already up-to-date.',
   folderInSync: 'Folder in sync.',
   nothingToInstall: 'Nothing to install.',

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -7,8 +7,8 @@ import ExoticResolver from './exotic-resolver.js';
 import * as util from '../../util/misc.js';
 import * as fs from '../../util/fs.js';
 
-let invariant = require('invariant');
-let path = require('path');
+const invariant = require('invariant');
+const path = require('path');
 
 export default class FileResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
@@ -29,8 +29,8 @@ export default class FileResolver extends ExoticResolver {
       throw new MessageError(this.reporter.lang('doesntExist', loc));
     }
 
-    let manifest = await this.config.readManifest(loc, this.registry);
-    let registry = manifest._registry;
+    const manifest = await this.config.readManifest(loc, this.registry);
+    const registry = manifest._registry;
     invariant(registry, 'expected registry');
 
     manifest._remote = {

--- a/src/resolvers/exotics/gist-resolver.js
+++ b/src/resolvers/exotics/gist-resolver.js
@@ -29,7 +29,7 @@ export default class GistResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
     super(request, fragment);
 
-    let {id, hash} = explodeGistFragment(fragment, this.reporter);
+    const {id, hash} = explodeGistFragment(fragment, this.reporter);
     this.id = id;
     this.hash = hash;
   }

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -21,7 +21,7 @@ export default class GitResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
     super(request, fragment);
 
-    let {url, hash} = versionUtil.explodeHashedUrl(fragment);
+    const {url, hash} = versionUtil.explodeHashedUrl(fragment);
     this.url = url;
     this.hash = hash;
   }

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -43,7 +43,7 @@ export default class HostedGitResolver extends ExoticResolver {
     super(request, fragment);
 
     const exploded = this.exploded = explodeHostedGitFragment(fragment, this.reporter);
-    let {user, repo, hash} = exploded;
+    const {user, repo, hash} = exploded;
     this.user = user;
     this.repo = repo;
     this.hash = hash;

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -15,7 +15,7 @@ export default class TarballResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
     super(request, fragment);
 
-    let {hash, url} = versionUtil.explodeHashedUrl(fragment);
+    const {hash, url} = versionUtil.explodeHashedUrl(fragment);
     this.hash = hash;
     this.url = url;
   }

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -4,7 +4,7 @@ import RegistryNpm from './registries/npm-resolver.js';
 import RegistryBower from './registries/bower-resolver.js';
 import RegistryYarn from './registries/yarn-resolver.js';
 
-export let registries = {
+export const registries = {
   bower: RegistryBower,
   npm: RegistryNpm,
   yarn: RegistryYarn,
@@ -20,7 +20,7 @@ import ExoticGitLab from './exotics/gitlab-resolver.js';
 import ExoticGist from './exotics/gist-resolver.js';
 import ExoticBitbucket from './exotics/bitbucket-resolver.js';
 
-export let exotics = {
+export const exotics = {
   git: ExoticGit,
   tarball: ExoticTarball,
   github: ExoticGitHub,
@@ -35,15 +35,15 @@ export let exotics = {
 import type {Reporter} from '../reporters/index.js';
 import {explodeHostedGitFragment} from './exotics/hosted-git-resolver.js';
 
-export let hostedGit = {
+export const hostedGit = {
   github: ExoticGitHub,
   gitlab: ExoticGitLab,
   bitbucket: ExoticBitbucket,
 };
 
 export function hostedGitFragmentToGitUrl(fragment: string, reporter: Reporter): string {
-  for (let key in hostedGit) {
-    let Resolver = hostedGit[key];
+  for (const key in hostedGit) {
+    const Resolver = hostedGit[key];
     if (Resolver.isVersion(fragment)) {
       return Resolver.getGitHTTPUrl(explodeHostedGitFragment(fragment, reporter));
     }
@@ -56,8 +56,8 @@ export function hostedGitFragmentToGitUrl(fragment: string, reporter: Reporter):
 
 import ExoticRegistryResolver from './exotics/registry-resolver.js';
 
-for (let key in registries) {
-  let RegistryResolver = registries[key];
+for (const key in registries) {
+  const RegistryResolver = registries[key];
 
   exotics[key] = class extends ExoticRegistryResolver {
     static protocol = key;

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -38,7 +38,7 @@ export default class NpmResolver extends RegistryResolver {
 
   async resolveRequest(): Promise<?Manifest> {
     if (this.config.offline) {
-      let res = this.resolveRequestOffline();
+      const res = this.resolveRequestOffline();
       if (res != null) {
         return res;
       }

--- a/src/util/blocking-queue.js
+++ b/src/util/blocking-queue.js
@@ -2,7 +2,7 @@
 
 import map from './map.js';
 
-let debug = require('debug')('yarn');
+const debug = require('debug')('yarn');
 
 export default class BlockingQueue {
   constructor(alias: string, maxConcurrency?: number = Infinity) {
@@ -93,7 +93,7 @@ export default class BlockingQueue {
       return;
     }
 
-    let {resolve, reject, factory} = queue.shift();
+    const {resolve, reject, factory} = queue.shift();
     if (!queue.length) {
       delete this.queue[key];
     }

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -43,7 +43,7 @@ export default async function (
   env[constants.ENV_PATH_KEY] = pathParts.join(path.delimiter);
 
   // get shell
-  let conf = {windowsVerbatimArguments: false};
+  const conf = {windowsVerbatimArguments: false};
   let sh = 'sh';
   let shFlag = '-c';
   if (process.platform === 'win32') {
@@ -59,9 +59,9 @@ export default async function (
     conf.windowsVerbatimArguments = true;
   }
 
-  let stdout = await child.spawn(sh, [shFlag, cmd], {cwd, env, stdio, ...conf}, (data) => {
+  const stdout = await child.spawn(sh, [shFlag, cmd], {cwd, env, stdio, ...conf}, (data) => {
     if (spinner) {
-      let line = data.toString() // turn buffer into string
+      const line = data.toString() // turn buffer into string
         .trim() // trim whitespace
         .split('\n') // split into lines
         .pop() // use only the last line

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -3,8 +3,8 @@
 import type {WalkFiles} from './fs.js';
 import {removeSuffix} from './misc.js';
 
-let minimatch = require('minimatch');
-let path = require('path');
+const minimatch = require('minimatch');
+const path = require('path');
 
 const WHITESPACE_RE = /^\s+$/;
 
@@ -62,7 +62,7 @@ export function sortFilter(
     let parts = path.dirname(file).split(path.sep);
 
     while (parts.length) {
-      let folder = parts.join(path.sep);
+      const folder = parts.join(path.sep);
       if (ignoreFiles.has(folder)) {
         ignoreFiles.add(file);
         break;

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -107,7 +107,7 @@ async function buildActionsForCopy(
 
   //
   async function build(data): Promise<void> {
-    let {src, dest} = data;
+    const {src, dest} = data;
     const onFresh = data.onFresh || noop;
     const onDone = data.onDone || noop;
     files.add(dest);
@@ -174,7 +174,7 @@ async function buildActionsForCopy(
 
     if (srcStat.isSymbolicLink()) {
       onFresh();
-      let linkname = await readlink(src);
+      const linkname = await readlink(src);
       actions.push({
         type: 'symlink',
         dest,
@@ -300,7 +300,7 @@ export function readFileRaw(loc: string): Promise<Buffer> {
 }
 
 export async function readFileAny(files: Array<string>): Promise<?string> {
-  for (let file of files) {
+  for (const file of files) {
     if (await exists(file)) {
       return readFile(file);
     }
@@ -390,7 +390,7 @@ export async function walk(
     filenames = filenames.filter((name): boolean => ignoreBasenames.indexOf(name) < 0);
   }
 
-  for (let name of filenames) {
+  for (const name of filenames) {
     const relative = relativeDir ? path.join(relativeDir, name) : name;
     const loc = path.join(dir, name);
     const stat = await lstat(loc);

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -59,7 +59,7 @@ export default class Git {
       return false;
     }
 
-    let [,, hostname] = match;
+    const [,, hostname] = match;
     const cached = supportsArchiveCache[hostname];
     if (cached != null) {
       return cached;
@@ -198,7 +198,7 @@ export default class Git {
    */
 
   fetch(): Promise<void> {
-    let {url, cwd} = this;
+    const {url, cwd} = this;
 
     return fs.lockQueue.push(url, async () => {
       if (!(await fs.exists(cwd))) {
@@ -344,7 +344,7 @@ export default class Git {
 
     for (const line of refLines) {
       // line example: 64b2c0cee9e829f73c5ad32b8cc8cb6f3bec65bb refs/tags/v4.2.2
-      let [sha, id] = line.split(/\s+/g);
+      const [sha, id] = line.split(/\s+/g);
       let [,, name] = id.split('/');
 
       // TODO: find out why this is necessary. idk it makes it work...

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -106,7 +106,7 @@ export default async function (
   // support array of engine keys
   if (Array.isArray(info.engines)) {
     const engines = {};
-    for (let str of info.engines) {
+    for (const str of info.engines) {
       if (typeof str === 'string') {
         let [name, ...patternParts] = str.trim().split(/ +/g);
         engines[name] = patternParts.join(' ');
@@ -123,7 +123,7 @@ export default async function (
     };
   }
 
-  let repo = info.repository;
+  const repo = info.repository;
 
   // explode info.repository.url if it's a hosted git shorthand
   if (repo && typeof repo === 'object' && typeof repo.url === 'string') {
@@ -190,7 +190,7 @@ export default async function (
     info.scripts = scripts;
   }
 
-  let dirs = info.directories;
+  const dirs = info.directories;
 
   if (dirs && typeof dirs === 'object') {
     const binDir = dirs.bin;
@@ -222,7 +222,7 @@ export default async function (
   delete info.directories;
 
   // normalize licenses field
-  let licenses = info.licenses;
+  const licenses = info.licenses;
   if (Array.isArray(licenses) && !info.license) {
     let licenseTypes = [];
 

--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import validate from './validate.js';
 import fix from './fix.js';
 
-let path = require('path');
+const path = require('path');
 
 export default async function (
   info: Object,
@@ -16,7 +16,7 @@ export default async function (
   await fix(info, moduleLoc, config.reporter, config.looseSemver);
 
   // create human readable name
-  let {name, version} = info;
+  const {name, version} = info;
   let human: ?string;
   if (typeof name === 'string') {
     human = name;

--- a/src/util/normalize-manifest/validate.js
+++ b/src/util/normalize-manifest/validate.js
@@ -79,7 +79,7 @@ export default function(info: Object, isRoot: boolean, reporter: Reporter, warn:
   // validate license
   if (isRoot && !info.private) {
     if (typeof info.license === 'string') {
-      let license = info.license.replace(/\*$/g, '');
+      const license = info.license.replace(/\*$/g, '');
       if (!isValidLicense(license)) {
         warn(reporter.lang('manifestLicenseInvalid'));
       }
@@ -101,7 +101,7 @@ export default function(info: Object, isRoot: boolean, reporter: Reporter, warn:
 
 export function cleanDependencies(info: Object, isRoot: boolean, reporter: Reporter, warn: WarnFunction) {
   // get dependency objects
-  let depTypes = [];
+  const depTypes = [];
   for (let type of dependencyKeys) {
     let deps = info[type];
     if (!deps || typeof deps !== 'object') {
@@ -124,11 +124,11 @@ export function cleanDependencies(info: Object, isRoot: boolean, reporter: Repor
   // ensure that dependencies don't have ones that can collide
   for (let [type, deps] of depTypes) {
     for (let name in deps) {
-      let version = deps[name];
+      const version = deps[name];
 
       // check collisions
-      for (let [type2, deps2] of depTypes) {
-        let version2 = deps2[name];
+      for (const [type2, deps2] of depTypes) {
+        const version2 = deps2[name];
         if (!version2 || version2 === '*') {
           continue;
         }

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -258,7 +258,7 @@ export default class RequestManager {
 
     //
     let calledOnError = false;
-    let onError = (err) => {
+    const onError = (err) => {
       if (calledOnError) {
         return;
       }


### PR DESCRIPTION
**Summary**
This transforms use of var/let to const if possible and enables the `prefer-const` rule using eslint. I fixed a few callsites manually after eslint complained.

Codemod: https://github.com/cpojer/js-codemod/blob/master/transforms/no-vars.js (changed to look at both `let` and `var`).

**Test plan**
jest
