### PR TITLE
Allow os/cpu whitelists and blacklists to be mixed

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -13,26 +13,30 @@ const invariant = require('invariant');
 const semver = require('semver');
 
 function isValid(items: Array<string>, actual: string): boolean {
+  let isNotWhitelist = true;
   let isBlacklist = false;
 
   for (const item of items) {
-    // whitelist
-    if (item === actual) {
-      return true;
-    }
-
     // blacklist
     if (item[0] === '!') {
-      // we're in a blacklist so anything that doesn't match this is fine to have
       isBlacklist = true;
 
       if (actual === item.slice(1)) {
         return false;
       }
+    // whitelist
+    } else {
+      isNotWhitelist = false;
+
+      if (item === actual) {
+        return true;
+      }
     }
   }
 
-  return isBlacklist;
+  // npm allows blacklists and whitelists to be mixed. Blacklists with
+  // whitelisted items should be treated as whitelists.
+  return isBlacklist && isNotWhitelist;
 }
 
 const aliases = map({


### PR DESCRIPTION
**Summary**

(Weirdly) npm [`package.json#os/cpu`](https://docs.npmjs.com/files/package.json#os) allows you to mix using a blacklist and a whitelist.

``` json
{ "os": ["!win32", "darwin"] }
```

**Test plan**

``` js
isValid(["!win32", "darwin"], "win32"); // false
isValid(["!win32", "darwin"], "linux"); // false
isValid(["!win32", "darwin"], "darwin"); // true

isValid(["!win32"], "win32"); // false
isValid(["!win32"], "darwin"); // true

isValid(["win32"], "win32"); // true
isValid(["win32"], "darwin"); // false
```
