### PR TITLE
Fix issues with progress bar

### DIFF
--- a/__tests__/reporters/__snapshots__/console.js.snap
+++ b/__tests__/reporters/__snapshots__/console.js.snap
@@ -56,7 +56,7 @@ Object {
 
 exports[`test ConsoleReporter.progress 1`] = `
 Object {
-  "stderr": "[2K[1G░░ 0/2[2K[1G█░ 1/2[2K[1G",
+  "stderr": "[2K[1G[1G░░ 0/2[1G█░ 1/2[2K[1G",
   "stdout": "",
 }
 `;

--- a/__tests__/reporters/console.js
+++ b/__tests__/reporters/console.js
@@ -131,15 +131,15 @@ test('ProgressBar', () => {
   const bar = new ProgressBar(2, new TestStream());
 
   bar.render();
-  expect(data).toBe('\u001b[2K\u001b[1G░░ 0/2');
+  expect(data).toBe('\u001b[2K\u001b[1G\u001b[1G░░ 0/2');
 
   bar.tick();
   bar.render();
-  expect(data).toBe('\u001b[2K\u001b[1G░░ 0/2\u001b[2K\u001b[1G█░ 1/2');
+  expect(data).toBe('\u001b[2K\u001b[1G\u001b[1G░░ 0/2\u001b[1G█░ 1/2');
 
   bar.tick();
   bar.render();
-  expect(data).toBe('\u001b[2K\u001b[1G░░ 0/2\u001b[2K\u001b[1G█░ 1/2\u001b[2K\u001b[1G\u001b[2K\u001b[1G██ 2/2');
+  expect(data).toBe('\u001b[2K\u001b[1G\u001b[1G░░ 0/2\u001b[1G█░ 1/2\u001b[2K\u001b[1G\u001b[1G██ 2/2');
 });
 
 test('Spinner', () => {

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type {Stdout} from '../types.js';
-import {clearLine} from './util.js';
+import {clearLine, toStartOfLine} from './util.js';
 
 const repeat = require('repeating');
 
@@ -12,6 +12,7 @@ export default class ProgressBar {
     this.chars = ProgressBar.bars[0].split('');
     this.delay = 60;
     this.curr = 0;
+    clearLine(stdout);
   }
 
   stdout: Stdout;
@@ -54,15 +55,14 @@ export default class ProgressBar {
 
     // calculate size of actual bar
     // $FlowFixMe: investigate process.stderr.columns flow error
-    const availableSpace = Math.max(0, this.stdout.columns - bar.length);
+    const availableSpace = Math.max(0, this.stdout.columns - bar.length - 1);
     const width = Math.min(this.total, availableSpace);
     const completeLength = Math.round(width * ratio);
     const complete = repeat(this.chars[0], completeLength);
     const incomplete = repeat(this.chars[1], width - completeLength);
     bar = `${complete}${incomplete}${bar}`;
 
-    //
-    clearLine(this.stdout);
+    toStartOfLine(this.stdout);
     this.stdout.write(bar);
   }
 }

--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -9,6 +9,10 @@ export function clearLine(stdout: Stdout) {
   readline.cursorTo(stdout, 0);
 }
 
+export function toStartOfLine(stdout: Stdout) {
+  readline.cursorTo(stdout, 0);
+}
+
 export function writeOnNthLine(stdout: Stdout, n: number, msg: string) {
   if (n == 0) {
     clearLine(stdout);


### PR DESCRIPTION
Tweaks to progress bar:
- Decrease width by 1 to account for the fact that some terminals take an extra character for the cursor. Cmder and cmd.exe definitely do, I think a few terminal emulators on Linux do too.
- When re-rendering, just go to the start of the line rather than clearing the line. This prevents flicker by rendering directly on top of the previous state, rather than totally clearing the line before rendering again. (I didn't notice any flicker in Cmder, I did notice it in cmd.exe though)

This fixes the issues on Windows.

Before:
![05-22 21 01](https://cloud.githubusercontent.com/assets/91933/19141430/2e691946-8b4a-11e6-85e9-2aedfe051473.gif)

After:
![05-22 19 37](https://cloud.githubusercontent.com/assets/91933/19141425/2a636932-8b4a-11e6-927d-38597ca3a8a8.gif)

Confirmed this works in Cmder, cmd.exe and PowerShell.

cc @cpojer @wycats 
