### PR TITLE
Why updates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "preferGlobal": true,
   "dependencies": {
     "babel-runtime": "^6.0.0",
+    "bytes": "^2.4.0",
     "camelcase": "^3.0.0",
     "chalk": "^1.1.1",
     "cmd-shim": "^2.0.1",

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -1,16 +1,19 @@
 /* @flow */
 
-
+import type {HoistManifest} from '../../package-hoister.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
+
 import {Install} from './install.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import {METADATA_FILENAME, TARBALL_FILENAME} from '../../constants.js';
 import * as fs from '../../util/fs.js';
+import Lockfile from '../../lockfile/wrapper.js';
 
 export const requireLockfile = true;
 
-const invariant = require('invariant');
+const bytes = require('bytes');
 const emoji = require('node-emoji');
+const invariant = require('invariant');
 const path = require('path');
 
 async function cleanQuery(config: Config, query: string): Promise<string> {
@@ -32,6 +35,59 @@ async function cleanQuery(config: Config, query: string): Promise<string> {
   return query;
 }
 
+async function getPackageSize(info: HoistManifest): Promise<number> {
+  const files = await fs.walk(info.loc, null, new Set([
+    METADATA_FILENAME,
+    TARBALL_FILENAME,
+  ]));
+  const sizes = await Promise.all(
+    files.map(
+      (walkFile) => fs.stat(walkFile.absolute)
+        .then((stat) => stat.size),
+    ),
+  );
+  return sum(sizes);
+}
+
+
+const sum = (array) => array.length ? array.reduce((a, b) => a + b, 0) : 0;
+const collect = (hoistManifests, allDependencies, dependency, {recursive} = {recursive: false}) => {
+  const deps = dependency.pkg.dependencies;
+  if (!deps) {
+    return allDependencies;
+  }
+
+  const dependencyKeys = new Set(Object.keys(deps));
+  const directDependencies = [];
+  for (const [, info] of hoistManifests) {
+    if (!allDependencies.has(info) && dependencyKeys.has(info.key)) {
+      allDependencies.add(info);
+      directDependencies.push(info);
+    }
+  }
+
+  if (recursive) {
+    directDependencies.forEach(
+      (dependency) => collect(hoistManifests, allDependencies, dependency, {recursive: true}),
+    );
+  }
+
+  return allDependencies;
+};
+const getSharedDependencies = (hoistManifests, transitiveKeys) => {
+  const sharedDependencies = new Set();
+  for (const [, info] of hoistManifests) {
+    if (!transitiveKeys.has(info.key) && info.pkg.dependencies) {
+      Object.keys(info.pkg.dependencies).forEach((dependency) => {
+        if (transitiveKeys.has(dependency) && !sharedDependencies.has(dependency)) {
+          sharedDependencies.add(dependency);
+        }
+      });
+    }
+  }
+  return sharedDependencies;
+};
+
 export async function run(
   config: Config,
   reporter: Reporter,
@@ -40,10 +96,10 @@ export async function run(
 ): Promise<void> {
   const query = await cleanQuery(config, args[0]);
 
-  reporter.step(1, 3, reporter.lang('whyStart', args[0]), emoji.get('thinking_face'));
+  reporter.step(1, 4, reporter.lang('whyStart', args[0]), emoji.get('thinking_face'));
 
   // init
-  reporter.step(2, 3, reporter.lang('whyInitGraph'), emoji.get('truck'));
+  reporter.step(2, 4, reporter.lang('whyInitGraph'), emoji.get('truck'));
   const lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
   const install = new Install(flags, config, reporter, lockfile);
   const [depRequests, patterns] = await install.fetchRequestFromCwd();
@@ -51,7 +107,7 @@ export async function run(
   const hoisted = await install.linker.getFlatHoistedTree(patterns);
 
   // finding
-  reporter.step(3, 3, reporter.lang('whyFinding'), emoji.get('mag'));
+  reporter.step(3, 4, reporter.lang('whyFinding'), emoji.get('mag'));
 
   let match;
   for (const [, info] of hoisted) {
@@ -129,6 +185,19 @@ export async function run(
     }
   }
 
+  // package sizes
+  reporter.step(4, 4, reporter.lang('whyCalculating'), emoji.get('aerial_tramway'));
+
+  const packageSize = await getPackageSize(match);
+  const dependencies = Array.from(collect(hoisted, new Set(), match));
+  const transitiveDependencies = Array.from(collect(hoisted, new Set(), match, {recursive: true}));
+
+  const directSizes = await Promise.all(dependencies.map(getPackageSize));
+  const transitiveSizes = await Promise.all(transitiveDependencies.map(getPackageSize));
+
+  const transitiveKeys = new Set(transitiveDependencies.map((info) => info.key));
+  const sharedDependencies = getSharedDependencies(hoisted, transitiveKeys);
+
   //
   if (reasons.length === 1) {
     reporter.info(reporter.lang(reasons[0].typeSimple, reasons[0].value));
@@ -142,14 +211,14 @@ export async function run(
   }
 
   // stats: file size of this dependency without any dependencies
-  reporter.info(reporter.lang('whyDiskSizeWithout', '0MB'));
+  reporter.info(reporter.lang('whyDiskSizeWithout', bytes(packageSize)));
 
   // stats: file size of this dependency including dependencies that aren't shared
-  reporter.info(reporter.lang('whyDiskSizeUnique', '0MB'));
+  reporter.info(reporter.lang('whyDiskSizeUnique', bytes(packageSize + sum(directSizes))));
 
   // stats: file size of this dependency including dependencies
-  reporter.info(reporter.lang('whyDiskSizeTransitive', '0MB'));
+  reporter.info(reporter.lang('whyDiskSizeTransitive', bytes(packageSize + sum(transitiveSizes))));
 
   // stats: shared transitive dependencies
-  reporter.info(reporter.lang('whySharedDependencies', 0));
+  reporter.info(reporter.lang('whySharedDependencies', sharedDependencies.size));
 }

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -48,7 +48,7 @@ export default class PackageInstallScripts {
   }
 
   async walk(loc: string): Promise<Map<string, number>> {
-    const files = await fs.walk(loc, null, this.config.registryFolders);
+    const files = await fs.walk(loc, null, new Set(this.config.registryFolders));
     const mtimes = new Map();
     for (const file of files) {
       mtimes.set(file.relative, file.mtime);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -142,6 +142,7 @@ const messages = {
 
   whyStart: 'Why do we have the module $0?',
   whyFinding: 'Finding dependency',
+  whyCalculating: 'Calculating file sizes',
   whyUnknownMatch: "We couldn't find a match!",
   whyInitGraph: 'Initialising dependency graph',
   whyWhoKnows: "We don't know why this module exists",

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -381,13 +381,13 @@ export type WalkFiles = Array<{
 export async function walk(
   dir: string,
   relativeDir?: ?string,
-  ignoreBasenames?: Array<string> = [],
+  ignoreBasenames?: Set<string> = new Set(),
 ): Promise<WalkFiles> {
   let files = [];
 
   let filenames = await readdir(dir);
-  if (ignoreBasenames.length) {
-    filenames = filenames.filter((name): boolean => ignoreBasenames.indexOf(name) < 0);
+  if (ignoreBasenames.size) {
+    filenames = filenames.filter((name) => !ignoreBasenames.has(name));
   }
 
   for (const name of filenames) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,6 +1303,10 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bytes:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"


### PR DESCRIPTION
**Summary**
I'm a bit unclear on how to traverse the dependency graph so I rolled my own traversal. Could use some input from @kittens. I'm not sure whether keys are the best way to track dependencies.

Something seems wrong with the file sizes here because `du -sh` gives me different numbers (40mb for Jest vs. 20 in Yarn). I'm reading the file sizes from the yarn cache instead of directly going to node_modules. I wasn't sure how to properly resolve a module in case it isn't hoisted and figured that they should mirror each other anyway.

Fixes #470
Depends on #539 (only look at last commit on this diff)

**Test plan**
<img width="955" alt="screen shot 2016-10-07 at 6 34 30 pm" src="https://cloud.githubusercontent.com/assets/13352/19185463/b37d3496-8cbc-11e6-8623-6784ed2ff886.png">
