### PR TITLE
Fix CLI documentation link

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -65,7 +65,7 @@ let command;
 
 //
 const hyphenate = (string) => string.replace(/[A-Z]/g, (match) => ('-' + match.charAt(0).toLowerCase()));
-const getDocsLink = (name) => `http://yarnpkg.com/en/docs/${name || ''}`;
+const getDocsLink = (name) => `http://yarnpkg.com/en/docs/cli/${name || ''}`;
 const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
 
 //


### PR DESCRIPTION
All CLI command documentation is under `docs/cli/`
