### PR TITLE
Don't use colons in HAR file name

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -341,7 +341,8 @@ export class Install {
 
     if (this.flags.har) {
       steps.push(async (curr: number, total: number) => {
-        const filename = `yarn-install_${new Date().toISOString()}.har`;
+        const formattedDate = new Date().toISOString().replace(/:/g, '-');
+        const filename = `yarn-install_${formattedDate}.har`;
         this.reporter.step(
           curr,
           total,


### PR DESCRIPTION
**Summary**

I encountered this while trying to test #536. Colons are not valid in file names on Windows, but Yarn was trying to use them in the name of HAR files generated via `yarn install --har`

**Test plan**

`rm -rf node_modules` and `rm -rf %AppData%/Yarn` to delete local cache, then ran `yarn install --har` on one of my random test projects. It worked:

```
yarn install v0.14.0
warning No license field
[1/5] Resolving packages...
[2/5] Fetching packages...
[3/5] Linking dependencies...
warning Unmet peer dependency "rxjs@5.0.0-beta.12".
warning Unmet peer dependency "zone.js@^0.6.21".
[4/5] Building fresh packages...
[5/5] Saving HAR file: "yarn-install_2016-10-09T00-00-25.284Z.har"...
success Saved lockfile.
Done in 5.17s.
```

Previously it was throwing:

```
error ENOENT: no such file or directory, open 'C:\temp\yarn-test-8\yarn-install_2016-10-08T23:56:06.398Z.har'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.fs.writeFileSync (fs.js:1333:33)
    at HarWrapper.saveHar (c:\src\yarn\node_modules\request-capture-har\request-capture-har.js:53:6)
    at RequestManager.saveHar (c:\src\yarn\lib\util\request-manager.js:303:29)
    at c:\src\yarn\lib\cli\commands\install.js:429:48
    at next (native)
    at step (c:\src\yarn\node_modules\babel-runtime\helpers\asyncToGenerator.js:17:30)
    at c:\src\yarn\node_modules\babel-runtime\helpers\asyncToGenerator.js:35:14
    at Promise.F (c:\src\yarn\node_modules\core-js\library\modules\_export.js:35:28)
```

"ENOENT: no such file or directory" obviously means "the file name is invalid". Thanks Node.js. (reported as https://github.com/nodejs/node/issues/8987)

References #536
