### PR TITLE
Store cache in LocalAppData rather than AppData

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -26,22 +26,10 @@ export const CHILD_CONCURRENCY = 5;
 
 export const REQUIRED_PACKAGE_KEYS = ['name', 'version', '_uid'];
 
-export function getAppData(env: Env): ?string {
-  for (const key in env) {
-    if (key.toLowerCase() === 'appdata') {
-      return env[key];
-    }
-  }
-  return null;
-}
-
 export function getModuleCacheDirectory(): string {
-  // use %APPDATA%/Yarn on Windows
-  if (process.platform === 'win32') {
-    const appData = getAppData(process.env);
-    if (appData) {
-      return path.join(appData, 'Yarn');
-    }
+  // use %LOCALAPPDATA%/Yarn on Windows
+  if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
+    return path.join(process.env.LOCALAPPDATA, 'Yarn');
   }
 
   // otherwise use ~/.yarn


### PR DESCRIPTION
**Summary**

Windows has two different types of AppData directories:
- `%APPDATA%` (eg. `C:\Users\Daniel\AppData\Roaming\`) - Contains user settings. In a corporate/domain environment, this can be configured to be synchronised across computers, so it should generally only hold things you'd actually need to keep in sync. Settings/config is a good example.
- `%LOCALAPPDATA%` (eg. `C:\Users\Daniel\AppData\Local\`) - Contains other random junk. It's like AppData except for stuff that wouldn't need to be kept in sync across machines. Per-user temporary files and local caches fall into this category.

Additionally, the environment variable is always in uppercase, so we can just access it directly rather than doing a linear search through `process.env` to find it.

**Test plan**
`yarn install` in a test project, ensure cache files end up in `C:\Users\Daniel\AppData\Local\Yarn`

cc @wycats (not sure if we have any other Windows users on the team at the moment)
