### PR TITLE
Add RPM packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /coverage
 /__tests__/fixtures/**/_*
 /dist
+/artifacts
 /updates
 /.roadrunner.json
 /resources/winsetup/generated.wxs

--- a/resources/debian/description
+++ b/resources/debian/description
@@ -1,0 +1,16 @@
+Package manager for the npm and bower package repositories
+Yarn is a package manager for the npm and bower registries with a few specific
+focuses.
+
+Determinism: Based around a version lockfile which ensures that operations on
+the dependency graph can be easily transitioned. We check module directories
+and verify their integrity to ensure yarn install always produces the same file
+structure.
+
+Security: Strict guarantees are placed around package installation. You have
+control over whether lifecycle scripts are executed for packages and package
+hashes are stored in the lockfile to ensure you get the same package each time.
+
+Performance: We are always performing operations such as package resolving and
+fetching in parallel. This ensures little idle time and maximum resource
+utilization.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -2,36 +2,45 @@
 
 set -ex
 
+# Ensure all the tools we need are available
+ensureAvailable() {
+  eval $1 --version >/dev/null || (echo "You need to install $1" && exit 2)
+}
+ensureAvailable dpkg-deb
+ensureAvailable fpm
+ensureAvailable fakeroot
+ensureAvailable lintian
+ensureAvailable rpmbuild
+
 PACKAGE_TMPDIR=tmp/debian_pkg
 VERSION=`node dist/bin/yarn --version`
 TARBALL_NAME=dist/yarn-v$VERSION.tar.gz
-PACKAGE_NAME=yarn_$VERSION'_all.deb'
+DEB_PACKAGE_NAME=yarn_$VERSION'_all.deb'
+OUTPUT_DIR=artifacts
 
 if [ ! -e $TARBALL_NAME ]; then
   echo "Hey! Listen! You need to run build-dist.sh first."
   exit 1
 fi;
 
+mkdir -p $OUTPUT_DIR
 # Remove old packages
-rm -f dist/*.deb
+rm -f dist/*.deb $OUTPUT_DIR/*.deb $OUTPUT_DIR/*.rpm
 
 # Extract to a temporary directory
 rm -rf $PACKAGE_TMPDIR
 mkdir -p $PACKAGE_TMPDIR/
 tar zxf $TARBALL_NAME -C $PACKAGE_TMPDIR/
 
-# Create Debian structure
-mkdir -p $PACKAGE_TMPDIR/DEBIAN
+# Create Linux package structure
 mkdir -p $PACKAGE_TMPDIR/usr/share/yarn/
 mkdir -p $PACKAGE_TMPDIR/usr/share/doc/yarn/
-mkdir -p $PACKAGE_TMPDIR/usr/share/lintian/overrides/
 mv $PACKAGE_TMPDIR/dist/bin $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/lib $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/lib-legacy $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/node_modules $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/package.json $PACKAGE_TMPDIR/usr/share/yarn/
 cp resources/debian/copyright $PACKAGE_TMPDIR/usr/share/doc/yarn/copyright
-cp resources/debian/lintian-overrides $PACKAGE_TMPDIR/usr/share/lintian/overrides/yarn
 
 # These are unneeded and throw lintian lint errors
 rm -f $PACKAGE_TMPDIR/usr/share/yarn/node_modules/node-uuid/benchmark/bench.gnu
@@ -46,16 +55,30 @@ rm -rf $PACKAGE_TMPDIR/dist
 mkdir -p $PACKAGE_TMPDIR/usr/bin/
 ln -s ../share/yarn/bin/yarn.js $PACKAGE_TMPDIR/usr/bin/yarn
 
+# Common FPM parameters for all packages we'll build using FPM
+FPM="fpm --input-type dir --chdir $PACKAGE_TMPDIR --name yarn --version $VERSION "`
+  `"--vendor 'Yarn Contributors <yarn@dan.cx>' --maintainer 'Yarn Contributors <yarn@dan.cx>' "`
+  `"--url https://yarnpkg.com/ --license BSD --description '$(cat resources/debian/description)'"
+
+##### Build RPM (CentOS, Fedora) package
+eval "$FPM --output-type rpm  --architecture noarch --depends nodejs --category 'Development/Languages' ."
+mv *.rpm $OUTPUT_DIR
+
+##### Build DEB (Debian, Ubuntu) package
+mkdir -p $PACKAGE_TMPDIR/DEBIAN
+mkdir -p $PACKAGE_TMPDIR/usr/share/lintian/overrides/
+cp resources/debian/lintian-overrides $PACKAGE_TMPDIR/usr/share/lintian/overrides/yarn
+
 # Debian/Ubuntu call the Node.js binary "nodejs", not "node".
 sed -i 's/env node/env nodejs/' $PACKAGE_TMPDIR/usr/share/yarn/bin/yarn.js
 
 # Replace variables in Debian package control file
 INSTALLED_SIZE=`du -sk $PACKAGE_TMPDIR | cut -f 1`
 sed -e "s/\$VERSION/$VERSION/;s/\$INSTALLED_SIZE/$INSTALLED_SIZE/" < resources/debian/control.in > $PACKAGE_TMPDIR/DEBIAN/control
+fakeroot dpkg-deb -b $PACKAGE_TMPDIR $DEB_PACKAGE_NAME
+mv $DEB_PACKAGE_NAME $OUTPUT_DIR
 
-# This is the moment we've all been waiting for
-fakeroot dpkg-deb -b $PACKAGE_TMPDIR $PACKAGE_NAME
-mv $PACKAGE_NAME dist/
 rm -rf $PACKAGE_TMPDIR
 
-lintian dist/$PACKAGE_NAME
+# Lint the Debian package to ensure we're not doing something silly
+lintian $OUTPUT_DIR/$DEB_PACKAGE_NAME


### PR DESCRIPTION
**Summary**

Adds RPM packaging. We use CentOS at work and it's fairly popular in the web hosting industry, so I suspect RPM packages will be useful to other people too.  The script is still called `build-deb.sh`, maybe I'll rename it.  ¯\_(ツ)_/¯

The [fpm](https://github.com/jordansissel/fpm) utility is wonderful and made this pretty easy to do, it wraps all the messiness of creating RPM packages. `fpm` also supports Solaris, FreeBSD, pacman (Arch Linux) and Mac OS X .pkg files, if we ever want to add more. I think it's good to keep the number of packages relatively small though, just the most commonly used/required types.

**Test plan**

Ran `./scripts/build-deb.sh`
`rpm -qpil yarn-0.14.0-1.noarch.rpm  | less` to inspect metadata of package, verified it looks good:

```
Name        : yarn
Version     : 0.14.0
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Development/Languages
Size        : 21600936
License     : BSD
Signature   : (none)
Source RPM  : yarn-0.14.0-1.src.rpm
Build Date  : Sun 09 Oct 2016 12:41:27 AM PDT
Build Host  : Daniel-PC
Relocations : /
Packager    : Yarn Contributors <yarn@dan.cx>
Vendor      : Yarn Contributors <yarn@dan.cx>
URL         : https://yarnpkg.com/
Summary     : Package manager for the npm and bower package repositories
Description :
Package manager for the npm and bower package repositories
Yarn is a package manager for the npm and bower registries with a few specific
...... omitted for brevity
```

Install via `rpm -Uvh yarn-0.14.0-1.noarch.rpm`, ensure `yarn --version` and basic commands (`yarn init`, `yarn add`) work fine.
