### PR TITLE
Add transform-inline-imports-commonjs plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,15 +4,20 @@
     "pre-node5": {
       "presets": ["es2015-node4"],
       "plugins": [
+        ["transform-inline-imports-commonjs"],
         ["transform-runtime", { "polyfill": true, "regenerator": false }]
       ]
     },
     "test": {
-      "presets": ["es2015-node4"]
+      "presets": ["es2015-node4"],
+      "plugins": [
+        ["transform-inline-imports-commonjs"]
+      ]
     }
   },
   "presets": ["node5", "react", "stage-0"],
   "plugins": [
+    ["transform-inline-imports-commonjs"],
     ["transform-runtime", { "polyfill": false, "regenerator": true }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "dependencies": {
+    "babel-plugin-transform-inline-imports-commonjs": "^1.0.0",
     "babel-runtime": "^6.0.0",
     "bytes": "^2.4.0",
     "camelcase": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,6 +888,12 @@ babel-plugin-transform-function-bind@^6.3.13:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.0.0"
 
+babel-plugin-transform-inline-imports-commonjs:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-imports-commonjs/-/babel-plugin-transform-inline-imports-commonjs-1.0.0.tgz#4b7351b4c021b3922d58200719e98083f7b4709f"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.8.0"
+
 babel-plugin-transform-object-rest-spread@^6.16.0, babel-plugin-transform-object-rest-spread@^6.6.5:
   version "6.16.0"
   resolved "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz#db441d56fffc1999052fdebe2e2f25ebd28e36a9"


### PR DESCRIPTION
**Summary**

Adds [babel-plugin-transform-inline-imports-commonjs](https://github.com/zertosh/babel-plugin-transform-inline-imports-commonjs) transform. Fixes #503.

This improves startup time by lazily requiring (and memoizing) imports.

**Before:**

```
$ for i in {1..5}; do time node lib/cli/index.js -V > /dev/null; done
node lib/cli/index.js -V > /dev/null  0.26s user 0.07s system 103% cpu 0.316 total
node lib/cli/index.js -V > /dev/null  0.26s user 0.06s system 103% cpu 0.310 total
node lib/cli/index.js -V > /dev/null  0.25s user 0.06s system 103% cpu 0.306 total
node lib/cli/index.js -V > /dev/null  0.26s user 0.07s system 103% cpu 0.314 total
node lib/cli/index.js -V > /dev/null  0.25s user 0.07s system 103% cpu 0.306 total

$ for i in {1..5}; do time node lib/cli/index.js install > /dev/null; done
node lib/cli/index.js install > /dev/null  0.35s user 0.07s system 103% cpu 0.409 total
node lib/cli/index.js install > /dev/null  0.42s user 0.09s system 95% cpu 0.533 total
node lib/cli/index.js install > /dev/null  0.35s user 0.07s system 103% cpu 0.407 total
node lib/cli/index.js install > /dev/null  0.36s user 0.08s system 103% cpu 0.423 total
node lib/cli/index.js install > /dev/null  0.36s user 0.07s system 103% cpu 0.414 total
```

**After:**

```
$ for i in {1..5}; do time node lib/cli/index.js -V > /dev/null; done
node lib/cli/index.js -V > /dev/null  0.17s user 0.04s system 103% cpu 0.209 total
node lib/cli/index.js -V > /dev/null  0.17s user 0.05s system 103% cpu 0.212 total
node lib/cli/index.js -V > /dev/null  0.17s user 0.04s system 102% cpu 0.211 total
node lib/cli/index.js -V > /dev/null  0.17s user 0.04s system 103% cpu 0.209 total
node lib/cli/index.js -V > /dev/null  0.17s user 0.04s system 103% cpu 0.211 total

$ for i in {1..5}; do time node lib/cli/index.js install > /dev/null; done
node lib/cli/index.js install > /dev/null  0.33s user 0.07s system 103% cpu 0.384 total
node lib/cli/index.js install > /dev/null  0.33s user 0.07s system 103% cpu 0.380 total
node lib/cli/index.js install > /dev/null  0.34s user 0.07s system 103% cpu 0.402 total
node lib/cli/index.js install > /dev/null  0.33s user 0.07s system 103% cpu 0.389 total
node lib/cli/index.js install > /dev/null  0.33s user 0.07s system 103% cpu 0.379 total
```

**Test plan**

`npm test`

Ran an `install` and an `add` using `lib/cli/index.js` and `dist/ 
