### PR TITLE
Remove Jest from dependencies (it's in devDependencies too)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "ini": "^1.3.4",
     "invariant": "^2.2.0",
     "is-builtin-module": "^1.0.0",
-    "jest": "^16.0.1",
     "leven": "^2.0.0",
     "loud-rejection": "^1.2.0",
     "minimatch": "^3.0.3",


### PR DESCRIPTION
Jest is already in devDependencies, it shouldn't be in dependencies too.

```
Dependency 'jest' exists in both dependencies and devDependencies
```
