### PR TITLE
Build Windows installer into artifacts directory.

### DIFF
--- a/resources/winsetup/YarnSetup.wixproj
+++ b/resources/winsetup/YarnSetup.wixproj
@@ -72,7 +72,7 @@
     <!-- Rename installer to yarn-[version].msi -->
     <Copy
       SourceFiles="$(OutputPath)\Yarn.msi"
-      DestinationFiles="$(YarnDistPath)\..\yarn-$(YarnVersion).msi"
+      DestinationFiles="$(YarnDistPath)\..\artifacts\yarn-$(YarnVersion).msi"
     />
   </Target>
 </Project>


### PR DESCRIPTION
Keeping things nice and tidy. Debian/RedHat packages are already built into this directory.

References #548
