### PR TITLE
Ignore errors getting Git repo URL in "yarn init"

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -32,7 +32,11 @@ export async function run(
   };
   if (await fs.exists(path.join(config.cwd, '.git'))) {
     // get git origin of the cwd
-    gitUrl = await child.spawn('git', ['config', 'remote.origin.url'], {cwd: config.cwd});
+    try {
+      gitUrl = await child.spawn('git', ['config', 'remote.origin.url'], {cwd: config.cwd});
+    } catch (ex) {
+      // Ignore - Git repo may not have an origin URL yet (eg. if it only exists locally)
+    }
 
     // get author default based on git config
     author.name = author.name || await child.spawn('git', ['config', 'user.name']);


### PR DESCRIPTION
**Summary**

`yarn init` shouldn't fail if directory is a Git repo but doesn't have a remote called "origin". Setting the repository URL in `package.json` is just a "nice to have", we shouldn't fall apart if it's not possible.

**Test plan**

```
mkdir foo && cd foo && git init && yarn init
```

Used to die with:

```
error Command failed.
Exit code: 1
Command: git
Arguments: config remote.origin.url
```

Now it works.

Fixes #577
