### PR TITLE
chore(package,yarn): remove eslint-plugin-flow-vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-config-fbjs": "^1.0.0",
     "eslint-config-kittens": "^2.0.1",
     "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-flow-vars": "^0.4.0",
     "eslint-plugin-flowtype": "^2.15.0",
     "eslint-plugin-no-async-without-await": "^1.0.0",
     "eslint-plugin-yarn-internal": "file:scripts/eslint-rules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,10 +1862,6 @@ eslint-plugin-flow-vars@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.1.3.tgz#50f70bffde5f1d438e1e474200540fd343919204"
 
-eslint-plugin-flow-vars@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.4.0.tgz#b3acca59997cc93f6cbd3ca069eb790995951ffa"
-
 eslint-plugin-flowtype@^2.15.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.20.0.tgz#69b90576174ee6a305362c777720825e7db9464b"


### PR DESCRIPTION
eslint-plugin-flow-vars is deprecated and has been merged into eslint-plugin-flowtype.