### PR TITLE
Changed Tilde to $HOME

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -20,7 +20,7 @@ yarn_get_tarball() {
 yarn_link() {
   printf "$cyan> Adding to \$PATH...$reset\n"
   YARN_PROFILE="$(yarn_detect_profile)"
-  SOURCE_STR="\nexport PATH=\"~/.yarn/bin:\$PATH\"\n"
+  SOURCE_STR="\nexport PATH=\"\$HOME/.yarn/bin:\$PATH\"\n"
 
   if [ -z "${YARN_PROFILE-}" ] ; then
     printf "$red> Profile not found. Tried ${YARN_PROFILE} (as defined in \$PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile.\n"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Using ZSH when the file would add `export $PATH="~/.yarn/bin:$PATH" to my .zshrc file, the quotes were causing the tilde to not be evaluated to $HOME. This diff changes the tilde to be `$HOME` so even in quotes it is evaluated.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Verified this change caused my `which yarn` to be exposed.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

