### PR TITLE
Remove github OAuth token

### DIFF
--- a/src/cli/commands/self-update.js
+++ b/src/cli/commands/self-update.js
@@ -35,13 +35,6 @@ export async function run(
     timeout: 5000,
   });
 
-  // while yarn is close sourced we need an auth token to be passed
-  const githubAuth0Token = process.env.YARN_AUTH_TOKEN || process.env.KPM_AUTH_TOKEN;
-  github.authenticate({
-    type: 'oauth',
-    token: githubAuth0Token,
-  });
-
   let release;
   const gitTag = args[0];
   if (gitTag) {
@@ -83,7 +76,7 @@ export async function run(
   const fetcher = new TarballFetcher(locToUnzip, {
     type: 'tarball',
     registry: 'npm',
-    reference: `${assets[0].url}?access_token=${String(githubAuth0Token)}`,
+    reference: assets[0].url,
     hash: null,
   }, config, false);
   await fetcher.fetch();


### PR DESCRIPTION
**Summary**

Fixes #612
This does not call `github.authenticate()` if there is no token provided. Maybe even removing the call at all now that yarn is OS?

This only fixes the authentication issue, after I fixed this it seems yarn is trying to download an rpm file on my mac. Going to look into this next.
```
info Downloading asset "yarn-0.15.0-1.noarch.rpm" from release "v0.15.0"
error https://api.github.com/repos/yarnpkg/yarn/releases/assets/2456563?access_token=undefined: invalid tar file
    at Extract.Parse._startEntry (/Users/danieltschinder/.yarn/node_modules/tar/lib/parse.js:149:13)
    at Extract.Parse._process (/Users/danieltschinder/.yarn/node_modules/tar/lib/parse.js:131:12)
    at BlockStream.<anonymous> (/Users/danieltschinder/.yarn/node_modules/tar/lib/parse.js:47:8)
    at emitOne (events.js:77:13)
    at BlockStream.emit (events.js:169:7)
    at BlockStream._emitChunk (/Users/danieltschinder/.yarn/node_modules/block-stream/block-stream.js:145:10)
    at BlockStream.flush (/Users/danieltschinder/.yarn/node_modules/block-stream/block-stream.js:70:8)
    at BlockStream.end (/Users/danieltschinder/.yarn/node_modules/block-stream/block-stream.js:66:8)
    at Extract.Parse.end (/Users/danieltschinder/.yarn/node_modules/tar/lib/parse.js:86:23)
    at UnpackStream.onend (_stream_readable.js:498:10)
```

**Test plan**

Well, there are tests for self-update but seems they are disabled. I try to disable them in the upcoming PR :)
