### PR TITLE
Respect ignore engines flag.

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -148,7 +148,7 @@ export class Install {
 
     this.resolver = new PackageResolver(config, lockfile);
     this.fetcher = new PackageFetcher(config, this.resolver);
-    this.compatibility = new PackageCompatibility(config, this.resolver);
+    this.compatibility = new PackageCompatibility(config, this.resolver, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver, this.flags.ignoreOptional);
     this.scripts = new PackageInstallScripts(config, this.resolver, this.flags.force);
   }

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -94,15 +94,17 @@ export function testEngine(name: string, range: string, versions: Versions, loos
 }
 
 export default class PackageCompatibility {
-  constructor(config: Config, resolver: PackageResolver) {
+  constructor(config: Config, resolver: PackageResolver, ignoreEngines: boolean) {
     this.reporter = config.reporter;
     this.resolver = resolver;
     this.config = config;
+    this.ignoreEngines = ignoreEngines;
   }
 
   resolver: PackageResolver;
   reporter: Reporter;
   config: Config;
+  ignoreEngines: boolean;
 
   static isValidArch(archs: Array<string>): boolean {
     return isValid(archs, process.arch);
@@ -148,7 +150,7 @@ export default class PackageCompatibility {
       }
     }
 
-    if (!this.config.ignoreEngines && typeof info.engines === 'object') {
+    if (!this.ignoreEngines && typeof info.engines === 'object') {
       for (const entry of entries(info.engines)) {
         let name = entry[0];
         const range = entry[1];


### PR DESCRIPTION
### Test plan

package.json
```
{
  "dependencies": {
  "cosmiconfig": "2.0.1"
  }
}
```

`yarn install`

Fails
...

`yarn install --ignore-flags`

works


Fixes #638