### PR TITLE
Show the units to `yarn clean` saved size report

### DIFF
--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -129,5 +129,5 @@ export async function run(
   reporter.step(2, 2, reporter.lang('cleaning'));
   const {removedFiles, removedSize} = await clean(config, reporter);
   reporter.info(reporter.lang('cleanRemovedFiles', removedFiles));
-  reporter.info(reporter.lang('cleanSavedSize', (removedSize / 1024 / 1024).toFixed(2)));
+  reporter.info(reporter.lang('cleanSavedSize', Number((removedSize / 1024 / 1024).toFixed(2))));
 }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -171,7 +171,7 @@ const messages = {
   uninstallRegenerate: 'Regenerating lockfile and installing missing dependencies',
 
   cleanRemovedFiles: 'Removed $0 files',
-  cleanSavedSize: 'Saved $0.',
+  cleanSavedSize: 'Saved $0 MB.',
 
   npmUsername: 'npm username',
   npmPassword: 'npm password',


### PR DESCRIPTION
**Summary**

Added "MB" to the cleanSavedSize message, converted it to Number so there aren't quotes around the output.

**Test plan**

Before:

```
<...>
info Saved "15.29"
<...>
```

After:
```
$ yarn clean
yarn clean v0.15.1
[1/2] Creating ".yarnclean"...
[2/2] Cleaning modules...
info Removed 3485 files
info Saved 15.29 MB.
✨  Done in 3.17s.
```
Include 'MB' in cleanSavedSize message.