### PR TITLE
Quote command so paths with whitespace work

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -61,7 +61,7 @@ export async function run(
 
     if (cmds.length) {
       for (const [stage, cmd] of cmds) {
-        await execCommand(stage, config, `${cmd} ${args.join(' ')}`, config.cwd);
+        await execCommand(stage, config, `"${cmd}" ${args.join(' ')}`, config.cwd);
       }
     } else {
       let suggestion;


### PR DESCRIPTION
**Summary**

If the project is in a path with whitespace (`/Users/bleh/My Stuff/project/`), running binaries (`yarn run eslint`) doesn't work. I quoted `cmd` to solve this issue.

A better way to solve this could be passing cmd and args separately down to `child.js`s `spawn()` and quoting or escaping there, but that would require too much API change.

Comments?

**Test plan**

Reproduce:
```bash
mkdir "some dir"
cd "some dir"
git clone git@github.com:yarnpkg/yarn.git
cd yarn
yarn
yarn run eslint
```