### PR TITLE
fix typos: git and git-fetcher to use proper archive

### DIFF
--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -77,7 +77,7 @@ export default class GitFetcher extends BaseFetcher {
     const mirrorRootPath = this.config.getOfflineMirrorPath();
     if (tarballInMirrorPath && this.hash && mirrorRootPath) {
       tarballInMirrorPath = `${tarballInMirrorPath}-${this.hash}`;
-      const hash = await git.achive(tarballInMirrorPath);
+      const hash = await git.archive(tarballInMirrorPath);
       const relativeMirrorPath = path.relative(mirrorRootPath, tarballInMirrorPath);
       return {
         hash,

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -109,18 +109,18 @@ export default class Git {
   }
 
   /**
-   * Arhieve a repo to destination
+   * Archive a repo to destination
    */
 
-  achive(dest: string): Promise<string> {
+  archive(dest: string): Promise<string> {
     if (this.supportsArchive) {
-      return this._achiveViaRemoteArchive(dest);
+      return this._archiveViaRemoteArchive(dest);
     } else {
-      return this._achiveViaLocalFetched(dest);
+      return this._archiveViaLocalFetched(dest);
     }
   }
 
-  async _achiveViaRemoteArchive(dest: string): Promise<string> {
+  async _archiveViaRemoteArchive(dest: string): Promise<string> {
     const hashStream = new crypto.HashStream();
     await child.spawn('git', ['archive', `--remote=${this.url}`, this.ref], {
       process(proc, resolve, reject, done) {
@@ -137,7 +137,7 @@ export default class Git {
     return hashStream.getHash();
   }
 
-  async _achiveViaLocalFetched(dest: string): Promise<string> {
+  async _archiveViaLocalFetched(dest: string): Promise<string> {
     const hashStream = new crypto.HashStream();
     await child.spawn('git', ['archive', this.hash], {
       cwd: this.cwd,
@@ -338,7 +338,7 @@ export default class Git {
     // store references
     const refs = {};
 
-    // line delimetered
+    // line delimited
     const refLines = stdout.split('\n');
 
     for (const line of refLines) {


### PR DESCRIPTION

**Summary**

Fixes typos in the archive functionality


**Test plan**

Existing tests should catch this already, just variable name changes.

