### PR TITLE
Fix self-update

### DIFF
--- a/__tests__/commands/self-update.js
+++ b/__tests__/commands/self-update.js
@@ -53,10 +53,10 @@ function run(checks: (reporter: reporters.Reporter, config: Config) => Promise<v
       await config.init({cwd});
       roadrunner.reset(CACHE_FILENAME);
       await checks(reporter, config);
-      roadrunner.reset(CACHE_FILENAME);
     } catch (err) {
       throw new Error(`${err} \nConsole output:\n ${out}`);
     } finally {
+      roadrunner.reset(CACHE_FILENAME);
       await fs.unlink(updatesFolder);
     }
   });
@@ -64,13 +64,14 @@ function run(checks: (reporter: reporters.Reporter, config: Config) => Promise<v
 
 it('Self-update should download a release and symlink it as "current"', (): Promise<void> => {
   return run(async (reporter, config) => {
-    await selfUpdate(config, reporter, {}, ['v0.14.1']);
-    expect(await fs.exists(path.resolve(updatesFolder, 'current')));
-    expect(await fs.exists(path.resolve(updatesFolder, 'v0.14.1')));
+    await selfUpdate(config, reporter, {version: () => '0.0.1'}, []);
+
+    expect(await fs.exists(path.resolve(updatesFolder, 'current'))).toBe(true);
     const packageJson = await fs.readJson(path.resolve(updatesFolder, 'current', 'package.json'));
-    expect(packageJson.version === '0.14.1');
+
+    expect(await fs.exists(path.resolve(updatesFolder, packageJson.version))).toBe(true);
     const version = await child.exec('node bin/yarn.js -V');
-    expect(version[0].trim(), '0.14.1');
+    expect(version[0].trim()).toBe(packageJson.version);
   });
 });
 
@@ -78,34 +79,36 @@ it('Self-update should download a release and symlink it as "current"', (): Prom
 it('Self-update should work from self-updated location', (): Promise<void> => {
   return run(async (reporter, config) => {
     // mock an existing self-update
-    await child.exec('npm run build');
-    await fs.copy(path.resolve(updatesFolder, '..'), path.resolve(updatesFolder, 'v0.99.0'));
-    await fs.symlink(path.resolve(updatesFolder, 'v0.99.0'), path.resolve(updatesFolder, 'current'));
+    await child.exec('yarn run build');
+    await fs.copy(path.resolve(updatesFolder, '..'), path.resolve(updatesFolder, '0.2.0'));
+    await fs.symlink(path.resolve(updatesFolder, '0.2.0'), path.resolve(updatesFolder, 'current'));
     let packageJson = await fs.readJson(path.resolve(updatesFolder, 'current', 'package.json'));
-    packageJson.version = '0.99.0';
+    packageJson.version = '0.2.0';
     await fs.writeFile(path.resolve(updatesFolder, 'current', 'package.json'),
       JSON.stringify(packageJson, null, 4));
     let version = await child.exec('node bin/yarn.js -V');
-    expect(version[0].trim(), '0.99.0');
+    expect(version[0].trim()).toBe('0.2.0');
 
     // mock a to_clean folder
-    packageJson.version = '0.98.0';
-    fs.mkdirp(path.resolve(updatesFolder, 'v0.98.0'));
-    await fs.symlink(path.resolve(updatesFolder, 'v0.98.0'), path.resolve(updatesFolder, 'to_clean'));
-    await fs.writeFile(path.resolve(updatesFolder, 'v0.98.0', 'package.json'),
+    packageJson.version = '0.1.0';
+    fs.mkdirp(path.resolve(updatesFolder, '0.1.0'));
+    await fs.symlink(path.resolve(updatesFolder, '0.1.0'), path.resolve(updatesFolder, 'to_clean'));
+    await fs.writeFile(path.resolve(updatesFolder, '0.1.0', 'package.json'),
       JSON.stringify(packageJson, null, 4));
 
-    await child.exec('node bin/yarn.js self-update v0.15.0');
+    await child.exec('node bin/yarn.js self-update');
 
     // new version is current
     version = await child.exec('node bin/yarn.js -V');
-    expect(version[0].trim(), '0.15.0');
+    expect(await fs.exists(path.resolve(updatesFolder, 'current'))).toBe(true);
+    packageJson = await fs.readJson(path.resolve(updatesFolder, 'current', 'package.json'));
+    expect(version[0].trim()).toBe(packageJson.version);
 
-    expect(await fs.exists(path.resolve(updatesFolder, 'v0.98.0'))).toBe(false);
-    expect(await fs.exists(path.resolve(updatesFolder, 'v0.99.0'))).toBe(true);
-    expect(await fs.exists(path.resolve(updatesFolder, 'v0.15.0'))).toBe(true);
+    expect(await fs.exists(path.resolve(updatesFolder, '0.1.0'))).toBe(false);
+    expect(await fs.exists(path.resolve(updatesFolder, '0.2.0'))).toBe(true);
+    expect(await fs.exists(path.resolve(updatesFolder, packageJson.version))).toBe(true);
 
     packageJson = await fs.readJson(path.resolve(updatesFolder, 'to_clean', 'package.json'));
-    expect(packageJson.version).toBe('0.99.0');
+    expect(packageJson.version).toBe('0.2.0');
   });
 });

--- a/__tests__/commands/self-update.js
+++ b/__tests__/commands/self-update.js
@@ -78,7 +78,7 @@ xit('Self-update should download a release and symlink it as "current"', (): Pro
 });
 
 
-it('Self-update should work from self-updated location', (): Promise<void> => {
+xit('Self-update should work from self-updated location', (): Promise<void> => {
   return run(async (reporter, config) => {
     // mock an existing self-update
     await child.exec('npm run build');

--- a/__tests__/commands/self-update.js
+++ b/__tests__/commands/self-update.js
@@ -81,9 +81,10 @@ it('Self-update should download a release and symlink it as "current"', (): Prom
 it('Self-update should work from self-updated location', (): Promise<void> => {
   return run(async (reporter, config) => {
     // mock an existing self-update
-    await child.exec('yarn run build');
-    await fs.copy(path.resolve(updatesFolder, '..'), path.resolve(updatesFolder, '0.2.0'));
-    await fs.symlink(path.resolve(updatesFolder, '0.2.0'), path.resolve(updatesFolder, 'current'));
+    await child.exec('npm run build');
+    const versionFolder = path.resolve(updatesFolder, '0.2.0');
+    await fs.copy(path.resolve(updatesFolder, '..'), versionFolder);
+    await fs.symlink(versionFolder, path.resolve(updatesFolder, 'current'));
     let packageJson = await fs.readJson(path.resolve(updatesFolder, 'current', 'package.json'));
     packageJson.version = '0.2.0';
     await fs.writeFile(path.resolve(updatesFolder, 'current', 'package.json'),

--- a/__tests__/commands/self-update.js
+++ b/__tests__/commands/self-update.js
@@ -62,7 +62,7 @@ function run(checks: (reporter: reporters.Reporter, config: Config) => Promise<v
   });
 }
 
-it('Self-update should download a release and symlink it as "current"', (): Promise<void> => {
+xit('Self-update should download a release and symlink it as "current"', (): Promise<void> => {
   return run(async (reporter, config) => {
     await selfUpdate(config, reporter, {version: () => '0.0.1'}, []);
 
@@ -115,4 +115,4 @@ it('Self-update should work from self-updated location', (): Promise<void> => {
     packageJson = await fs.readJson(path.resolve(updatesFolder, 'to_clean', 'package.json'));
     expect(packageJson.version).toBe('0.2.0');
   });
-});
+}, 180000); // 3 minutes

--- a/__tests__/commands/self-update.js
+++ b/__tests__/commands/self-update.js
@@ -66,11 +66,13 @@ it('Self-update should download a release and symlink it as "current"', (): Prom
   return run(async (reporter, config) => {
     await selfUpdate(config, reporter, {version: () => '0.0.1'}, []);
 
-    expect(await fs.exists(path.resolve(updatesFolder, 'current'))).toBe(true);
+    const currentFolder = path.resolve(updatesFolder, 'current');
+    expect(await fs.exists(currentFolder)).toBe(true);
     const packageJson = await fs.readJson(path.resolve(updatesFolder, 'current', 'package.json'));
 
-    expect(await fs.exists(path.resolve(updatesFolder, packageJson.version))).toBe(true);
+    expect(await fs.exists(await fs.realpath(currentFolder))).toBe(true);
     const version = await child.exec('node bin/yarn.js -V');
+
     expect(version[0].trim()).toBe(packageJson.version);
   });
 });
@@ -100,13 +102,14 @@ it('Self-update should work from self-updated location', (): Promise<void> => {
 
     // new version is current
     version = await child.exec('node bin/yarn.js -V');
-    expect(await fs.exists(path.resolve(updatesFolder, 'current'))).toBe(true);
+    const currentFolder = path.resolve(updatesFolder, 'current');
+    expect(await fs.exists(currentFolder)).toBe(true);
     packageJson = await fs.readJson(path.resolve(updatesFolder, 'current', 'package.json'));
     expect(version[0].trim()).toBe(packageJson.version);
 
     expect(await fs.exists(path.resolve(updatesFolder, '0.1.0'))).toBe(false);
     expect(await fs.exists(path.resolve(updatesFolder, '0.2.0'))).toBe(true);
-    expect(await fs.exists(path.resolve(updatesFolder, packageJson.version))).toBe(true);
+    expect(await fs.exists(await fs.realpath(currentFolder))).toBe(true);
 
     packageJson = await fs.readJson(path.resolve(updatesFolder, 'to_clean', 'package.json'));
     expect(packageJson.version).toBe('0.2.0');

--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -5,14 +5,12 @@
 'use strict';
 
 // init roadrunner
-var userHome = require('user-home');
 var mkdirp = require('mkdirp');
-var path = require('path');
-var CACHE_FILENAME = path.join(userHome, '.yarn', '.roadrunner.json');
-mkdirp.sync(path.dirname(CACHE_FILENAME));
+var constants = require('../lib-legacy/constants');
+mkdirp.sync(constants.GLOBAL_INSTALL_DIRECTORY);
 var roadrunner = require('roadrunner');
-roadrunner.load(CACHE_FILENAME);
-roadrunner.setup(CACHE_FILENAME);
+roadrunner.load(constants.CACHE_FILENAME);
+roadrunner.setup(constants.CACHE_FILENAME);
 
 // get node version
 var semver = require('semver');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "detect-indent": "^4.0.0",
     "diff": "^2.2.1",
     "eslint-plugin-react": "5.2.2",
-    "github": "2.5.1",
     "ini": "^1.3.4",
     "invariant": "^2.2.0",
     "is-builtin-module": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "request": "^2.75.0",
     "request-capture-har": "^1.1.4",
     "rimraf": "^2.5.0",
-    "roadrunner": "danez/roadrunner#patch-1",
+    "roadrunner": "^1.1.0",
     "semver": "^5.1.0",
     "strip-bom": "^2.0.0",
     "tar": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "request": "^2.75.0",
     "request-capture-har": "^1.1.4",
     "rimraf": "^2.5.0",
-    "roadrunner": "^1.0.6",
+    "roadrunner": "danez/roadrunner#patch-1",
     "semver": "^5.1.0",
     "strip-bom": "^2.0.0",
     "tar": "^2.2.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -38,6 +38,7 @@ function getDirectory(type: string): string {
 export const MODULE_CACHE_DIRECTORY = getDirectory('cache');
 export const LINK_REGISTRY_DIRECTORY = getDirectory('config/link');
 export const GLOBAL_MODULE_DIRECTORY = getDirectory('config/global');
+export const CACHE_FILENAME = path.join(userHome, '.yarn', '.roadrunner.json');
 
 export const INTEGRITY_FILENAME = '.yarn-integrity';
 export const LOCKFILE_FILENAME = 'yarn.lock';

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,10 +35,11 @@ function getDirectory(type: string): string {
   return path.join(userHome, `.yarn-${type}`);
 }
 
+export const GLOBAL_INSTALL_DIRECTORY = path.join(userHome, '.yarn');
 export const MODULE_CACHE_DIRECTORY = getDirectory('cache');
 export const LINK_REGISTRY_DIRECTORY = getDirectory('config/link');
 export const GLOBAL_MODULE_DIRECTORY = getDirectory('config/global');
-export const CACHE_FILENAME = path.join(userHome, '.yarn', '.roadrunner.json');
+export const CACHE_FILENAME = path.join(GLOBAL_INSTALL_DIRECTORY, '.roadrunner.json');
 
 export const INTEGRITY_FILENAME = '.yarn-integrity';
 export const LOCKFILE_FILENAME = 'yarn.lock';
@@ -50,8 +51,8 @@ export const DEFAULT_INDENT = '  ';
 export const SINGLE_INSTANCE_PORT = 31997;
 export const SINGLE_INSTANCE_FILENAME = '.yarn-single-instance';
 
-export const GITHUB_USER = 'yarnpkg';
-export const GITHUB_REPO = 'yarn';
+export const SELF_UPDATE_VERSION_URL = 'https://yarnpkg.com/latest-version';
+export const SELF_UPDATE_TARBALL_URL = 'https://yarnpkg.com/latest.tar.gz';
 export const SELF_UPDATE_DOWNLOAD_FOLDER = 'updates';
 
 export const ENV_PATH_KEY = getPathKey(process.platform, process.env);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -116,6 +116,7 @@ const messages = {
 
   selfUpdateReleased: 'Replaced current release with $0.',
   selfUpdateDownloading: `Downloading asset $0 from release $1`,
+  selfUpdateFailed: `Failed to retrieve asset from release $0`,
 
   optionalCompatibilityExcluded: '$0 is an optional dependency and failed compatibility check. Excluding it from installation.',
   optionalModuleFail: 'This module is OPTIONAL, you can safely ignore this error',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -109,14 +109,14 @@ const messages = {
   commandFailed: 'Command failed with exit code $0.',
 
   foundIncompatible: 'Found incompatible module',
-  incompatibleEngine: `The engine $0 is incompatible with this module. Expected version $1.`,
-  incompatibleCPU: `The CPU architecture $0 is incompatible with this module.`,
+  incompatibleEngine: 'The engine $0 is incompatible with this module. Expected version $1.',
+  incompatibleCPU: 'The CPU architecture $0 is incompatible with this module.',
   incompatibleOS: 'The platform $0 is incompatible with this module.',
   invalidEngine: 'The engine $0 appears to be invalid.',
 
   selfUpdateReleased: 'Replaced current release with $0.',
-  selfUpdateDownloading: `Downloading asset $0 from release $1`,
-  selfUpdateFailed: `Failed to retrieve asset from release $0`,
+  selfUpdateDownloading: 'Downloading yarn version $0.',
+  selfUpdateNoNewer: 'Yarn is already using the latest version.',
 
   optionalCompatibilityExcluded: '$0 is an optional dependency and failed compatibility check. Excluding it from installation.',
   optionalModuleFail: 'This module is OPTIONAL, you can safely ignore this error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,13 +40,6 @@ acorn@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.3.tgz#1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1"
 
-agent-base@2:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.0.1.tgz#bd8f9e86a8eb221fffa07bd14befd55df142815e"
-  dependencies:
-    extend "~3.0.0"
-    semver "~5.0.1"
-
 ajv-keywords@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.1.1.tgz#02550bc605a3e576041565628af972e06c549d50"
@@ -1573,7 +1566,7 @@ death@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/death/-/death-1.0.0.tgz#4d46e15488d4b636b699f0671b04632d752fd2de"
 
-debug@^2.1.1, debug@^2.2.0, debug@~2.2.0, debug@2:
+debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -2009,7 +2002,7 @@ expand-tilde@^1.2.1, expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.0, extend@3:
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -2134,13 +2127,6 @@ flow-bin@0.33.0:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.33.0.tgz#ef011eace7a6100f1ae08b852db78279032b8750"
 
-follow-redirects@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-0.0.7.tgz#34b90bab2a911aa347571da90f22bd36ecd8a919"
-  dependencies:
-    debug "^2.2.0"
-    stream-consume "^0.1.0"
-
 for-in@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.6.tgz#c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
@@ -2242,14 +2228,6 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
   dependencies:
     assert-plus "^1.0.0"
-
-github@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/github/-/github-2.5.1.tgz#5adf2b3012af7505b1f2177aae3ff3963143b428"
-  dependencies:
-    follow-redirects "0.0.7"
-    https-proxy-agent "^1.0.0"
-    mime "^1.2.11"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2584,14 +2562,6 @@ http-signature@~1.1.0:
 https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
-
-https-proxy-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
-  dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
 
 iconv-lite@^0.4.13, iconv-lite@^0.4.5:
   version "0.4.13"
@@ -3634,10 +3604,6 @@ mime-types@^2.1.11, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.24.0"
 
-mime@^1.2.11:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
-
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -4455,9 +4421,9 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-roadrunner@^1.0.6:
+roadrunner@danez/roadrunner#patch-1:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/roadrunner/-/roadrunner-1.0.6.tgz#e466a15f9844289413d09943ad263574623ec1c9"
+  resolved "https://codeload.github.com/danez/roadrunner/tar.gz/2ead9501e3681fa7584b79e6e6546fb046a83f54"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -4491,10 +4457,6 @@ semver@^4.1.0:
 semver@^5.1.0, semver@~5.3.0, "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
 sequencify@~0.0.7:
   version "0.0.7"
@@ -4642,7 +4604,7 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-consume@^0.1.0, stream-consume@~0.1.0:
+stream-consume@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.0.tgz#a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4421,9 +4421,9 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-roadrunner@danez/roadrunner#patch-1:
-  version "1.0.6"
-  resolved "https://codeload.github.com/danez/roadrunner/tar.gz/2ead9501e3681fa7584b79e6e6546fb046a83f54"
+roadrunner@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/roadrunner/-/roadrunner-1.1.0.tgz#1180a30d64e1970d8f55dd8cb0da8ffccecad71e"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This fixes self-update by doing:

* enable the tests
* use npm run build in the test instad of make build
* invalidated roadrunner cache, so that the symlink to `current` gets reevaluated
* do not do the request to github for the assets as they are already included in the release response
* pick the correct asset from the asset list by doing a name-check (content-type is sometimes set to octet-stream for the tar file, so we can't use that)

The roadrunner change is necessary as the tests need to invalidate the path cache so that the next test can reevaluate the symlinks. Same for the actual self-update command which also changes the symlink. This depends on kittens/roadrunner#1

Fixes #612 

Docs: https://github.com/yarnpkg/website/pull/173
