### PR TITLE
Remove Node.js check from Windows installer for now

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -7,11 +7,11 @@
 		<MediaTemplate EmbedCab="yes" />
 
 		<!-- Ensure Node.js is installed. Can be either 32-bit or 64-bit, we don't particularly care -->
-		<Property Id="NODEVERSION">
+		<!--<Property Id="NODEVERSION">
 			<RegistrySearch Id="NodeVersionReg32bit" Root="HKLM" Key="SOFTWARE\Node.js" Name="Version" Type="raw" Win64="no" />
 			<RegistrySearch Id="NodeVersionReg64bit" Root="HKLM" Key="SOFTWARE\Node.js" Name="Version" Type="raw" Win64="yes" />
 		</Property>
-		<Condition Message="Yarn requires Node.js 4.0 or higher to be installed">NODEVERSION</Condition>
+		<Condition Message="Yarn requires Node.js 4.0 or higher to be installed">NODEVERSION</Condition>-->
 
 		<Feature Id="MainFeature" Title="Yarn" Level="1">
 			<ComponentGroupRef Id="YarnFiles" />


### PR DESCRIPTION
**Summary**
Remove Node.js check from Windows installer for now. It doesn't handle systems such as `nvm` or `nodemon` that install Node.js without updating the registry.

**Test plan**
Built Windows installer (`npm run build-win-installer`), installed it, it worked.

References #626