### PR TITLE
Add back eslint-plugin-react since it is a peerDep of eslint-config-fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "debug": "^2.2.0",
     "defaults": "^1.0.3",
     "diff": "^2.2.1",
+    "eslint-plugin-react": "5.2.2",
     "github": "2.5.1",
     "ini": "^1.3.4",
     "invariant": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,13 @@ eslint-plugin-no-async-without-await@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-async-without-await/-/eslint-plugin-no-async-without-await-1.1.0.tgz#2f8b058f2c97fddf912e2a44cee67be59e3794b8"
 
+eslint-plugin-react@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz#7db068e1f5487f6871e4deef36a381c303eac161"
+  dependencies:
+    doctrine "^1.2.2"
+    jsx-ast-utils "^1.2.1"
+
 "eslint-plugin-yarn-internal@file:scripts/eslint-rules":
   version "0.0.0"
 
@@ -3217,6 +3224,12 @@ jsprim@^1.2.2:
     extsprintf "1.0.2"
     json-schema "0.2.3"
     verror "1.3.6"
+
+jsx-ast-utils@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.1.tgz#14313c5c50da5b0c47020af5d1560c17e781a05a"
+  dependencies:
+    object-assign "^4.1.0"
 
 kew@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Ref https://github.com/yarnpkg/yarn/pull/669#issuecomment-253009368

```
[3/4] 🔗  Linking dependencies...
warning Unmet peer dependency "eslint-plugin-react@^5.2.2".
```

npm run test will fail on eslint because there is a missing plugin dependency in https://github.com/facebook/fbjs/blob/446badb82d7774a9d23df70b51cb04abb97e11bc/packages/eslint-config-fbjs/package.json#L24.

```
Oops! Something went wrong! :(

ESLint couldn't find the plugin "eslint-plugin-react". This can happen for a couple different reasons:
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`npm t`
