### PR TITLE
CONTRIBUTING: add setup instructions [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Setup
 
-> First check that `yarn` is installed globally with `npm install yarn --global`
+> Install yarn on your system: https://yarnpkg.com/en/docs/install
 
 ```sh
 $ git clone https://github.com/yarnpkg/yarn.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,16 @@
 Contributions are always welcome, no matter how large or small. Before contributing,
 please read the [code of conduct](CODE_OF_CONDUCT.md).
 
+## Setup
+
+> First check that `yarn` is installed globally with `npm install yarn --global`
+
+```sh
+$ git clone https://github.com/yarnpkg/yarn.git
+$ cd yarn
+$ yarn
+```
+
 ## Building
 
 ```sh


### PR DESCRIPTION
Adding setup instructions similar to what we have in babel https://github.com/babel/babel/blob/master/CONTRIBUTING.md#setup