### PR TITLE
Custom Registry url.resolve Issue

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -54,8 +54,11 @@ export default class NpmRegistry extends Registry {
       headers.authorization = `Bearer ${this.token}`;
     }
 
+    // $FlowFixMe : https://github.com/facebook/flow/issues/908
+    const requestUrl = url.format(`${registry}/${pathname}`);
+
     return this.requestManager.request({
-      url: url.resolve(registry, pathname),
+      url: requestUrl,
       method: opts.method,
       body: opts.body,
       auth: opts.auth,


### PR DESCRIPTION
**Summary**
Ensures with and without trailing / registry url is correct and resolvable.

Currently if you set a npm registry via config to be:

1. `yarn config set registry https://mycustom.registry.com/dev/registry`
2. `yarn add redux` (not in cache / fresh install)

The `url.resolve` will turn the url to be `https://mycustom.registry.com/dev/redux` (no `registry` as part of the path due to `/` being removed `removeSuffix`.)

**Test plan(s)**

******
1. `yarn config set registry https://mycustom.registry.com/dev/registry`
2. `yarn add react`

******
1. `yarn config set registry https://mycustom.registry.com/dev/registry/`
2. `yarn add redux`

******
1. `yarn config set registry https://registry.npmjs.org/`
2. `yarn add react-router`


### Note:
There appears to be a flow issue with `url.format` currently:

https://github.com/facebook/flow/issues/908
https://nodejs.org/api/url.html#url_url_format_urlobject
