### PR TITLE
use first non-flag argument as command

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -89,8 +89,8 @@ if (commandName === 'help') {
   }
 }
 
-// if no args or command name looks like a flag then default to `install`
-if (!commandName || commandName[0] === '-') {
+// if no args then default to `install`
+if (!commandName) {
   if (commandName) {
     args.unshift(commandName);
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -59,9 +59,20 @@ commander.option(
 );
 commander.allowUnknownOption();
 
-// get command name
-let commandName: string = args.shift() || '';
+// get command name, defaulting to `install`
+let commandName: string = 'install';
+
+for (let i = 0; i < args.length; i++) {
+  const token = args[i];
+  if (token[0] !== '-') {
+    commandName = token;
+    args.splice(i, 1);
+    break;
+  }
+}
+
 let command;
+
 
 //
 const hyphenate = (string) => string.replace(/[A-Z]/g, (match) => ('-' + match.charAt(0).toLowerCase()));
@@ -89,13 +100,6 @@ if (commandName === 'help') {
   }
 }
 
-// if no args then default to `install`
-if (!commandName) {
-  if (commandName) {
-    args.unshift(commandName);
-  }
-  commandName = 'install';
-}
 
 // aliases: i -> install
 // $FlowFixMe

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -73,7 +73,6 @@ for (let i = 0; i < args.length; i++) {
 
 let command;
 
-
 //
 const hyphenate = (string) => string.replace(/[A-Z]/g, (match) => ('-' + match.charAt(0).toLowerCase()));
 const getDocsLink = (name) => `http://yarnpkg.com/en/docs/cli/${name || ''}`;

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -72,6 +72,7 @@ const messages = {
   tooManyArguments: 'Too many arguments, maximum of $0.',
   tooFewArguments: 'Not enough arguments, expected at least $0.',
   noArguments: "This command doesn't require any arguments.",
+  unknownArgument: '`$0` is an unknown option for `$1`.',
 
   ownerRemoving: 'Removing owner $0 from package $1.',
   ownerRemoved: 'Owner removed.',


### PR DESCRIPTION
**Summary**

yarn does not parse the arguments correctly if a flag is passed before the first command. The patch makes the cli use the first non-flag argument instead of unconditionally using the first argument.

Also partially fixes #635.

**Test plan**

![https://i.imgur.com/RwJXs5t.png](https://i.imgur.com/RwJXs5t.png)

Previously, yarn would default to `install` if a flag was passed first. In the case
`yarn --foo add colors`, the cli would call the `install` command with a nonzero arguments array, triggering a deprecation error. Now, it correctly passes `--foo` as a flag to the `add` command.

Because `--foo` is not a valid flag, this should trigger a warning/error. I added a message to the reporter for when this is implemented.