### PR TITLE
Don't remove compiled files in `yarn clean`

### DIFF
--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -52,10 +52,6 @@ const DEFAULT_FILTERS = ignoreLinesToRegex([
   '.*.yml',
   '*.yml',
 
-  // compiled files
-  '*.min.js',
-  '*-min.js',
-
   //
   '*.gz',
   '*.md',


### PR DESCRIPTION
**Summary**

Some packages (like 'timepicker') use minified files as the main entrypoint. This makes them incompatible with `yarn clean`.

I want to use a custom `.yarnclean` while still being able to use this package, and it seems there is no way to do this without modifying yarn itself.