### PR TITLE
Use https protocol in docs link

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -65,7 +65,7 @@ let command;
 
 //
 const hyphenate = (string) => string.replace(/[A-Z]/g, (match) => ('-' + match.charAt(0).toLowerCase()));
-const getDocsLink = (name) => `http://yarnpkg.com/en/docs/cli/${name || ''}`;
+const getDocsLink = (name) => `https://yarnpkg.com/en/docs/cli/${name || ''}`;
 const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
 
 //


### PR DESCRIPTION
**Summary**

The docs URL is displayed as `http` which redirects to `https`. Linking directly to the `https` removes the unnecessary redirect.