### PR TITLE
Hostname check inside isPossibleOfflineError()

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -191,7 +191,7 @@ export default class RequestManager {
 
   isPossibleOfflineError(err: RequestError): boolean {
     const {code, hostname} = err;
-    if (code == null || hostname == null) {
+    if (!code) {
       return false;
     }
 
@@ -203,7 +203,7 @@ export default class RequestManager {
     }
 
     // used to be able to resolve this domain! something is wrong
-    if (code === 'ENOTFOUND' && successHosts[hostname]) {
+    if (code === 'ENOTFOUND' && hostname && successHosts[hostname]) {
       // can't resolve this domain but we've successfully resolved it before
       return true;
     }


### PR DESCRIPTION
**Summary**
`hostname` is not always available on network `error` objects when checking that object inside `lib/util.js:isPossibleOfflineError()` function this will always `return false;` so **INSTALL BREAKS ON ANY TYPE OF ERROR** and doesn't attempts to retry and recover from that network error.

**UPDATE** PR Re-based  and used a cleaner solution for this problem :)