### PR TITLE
Fix Discord server ID in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://travis-ci.org/yarnpkg/yarn"><img alt="Travis Status" src="https://travis-ci.com/yarnpkg/yarn.svg?token=DxqWAqRqs3zWAF8EhBHy"></a>
   <a href="https://circleci.com/gh/yarnpkg/yarn"><img alt="Circle Status" src="https://circleci.com/gh/yarnpkg/yarn.svg?style=svg&circle-token=5f0a78473b0f440afb218bf2b82323cc6b3cb43f"></a>
   <a href="https://ci.appveyor.com/project/yarnpkg/yarn/branch/master"><img alt="Appveyor Status" src="https://ci.appveyor.com/api/projects/status/rhcdj4980ccy7su3/branch/master?svg=true"></a>
-  <a href="https://discord.gg/yarnpkg"><img alt="Discord Status" src="https://discordapp.com/api/guilds/41771983423143937/widget.png"></a>
+  <a href="https://discord.gg/yarnpkg"><img alt="Discord Status" src="https://discordapp.com/api/guilds/226791405589233664/widget.png"></a>
 </p>
 
 ---


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR fixes the server ID in the discord badge. The server ID in it was pointing another server that was not yarnpkg's. Merging this PR also means going into server settings & enabling the Widget so that it functions properly.

![_general](https://cloud.githubusercontent.com/assets/5489149/19288141/8194271e-8fb9-11e6-9a30-5a6c5dc71ed0.png)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

