### PR TITLE
shorthands execute commands

### DIFF
--- a/src/cli/aliases.js
+++ b/src/cli/aliases.js
@@ -1,20 +1,6 @@
 /* @flow */
 
 export default {
-  // shorthands
-  'run-script': 'run',
-  c: 'config',
-  i: 'install',
-  list: 'ls',
-  ln: 'link',
-  rb: 'rebuild',
-  runScript: 'run',
-  t: 'test',
-  tst: 'test',
-  un: 'remove',
-  up: 'update',
-  v: 'info',
-
   // affordances
   'add-user': 'login',
   'dist-tag': 'tag',

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -7,6 +7,7 @@ import * as constants from '../constants.js';
 import * as network from '../util/network.js';
 import {MessageError} from '../errors.js';
 import aliases from './aliases.js';
+import shortHands from './shortHands.js';
 import Config from '../config.js';
 
 const camelCase = require('camelcase');
@@ -97,7 +98,6 @@ if (!commandName || commandName[0] === '-') {
   commandName = 'install';
 }
 
-// aliases: i -> install
 // $FlowFixMe
 if (commandName && typeof aliases[commandName] === 'string') {
   command = {
@@ -105,6 +105,12 @@ if (commandName && typeof aliases[commandName] === 'string') {
       throw new MessageError(`Did you mean \`yarn ${aliases[commandName]}\`?`);
     },
   };
+}
+
+// shorthands - e.g. i -> install
+// $FlowFixMe
+if (commandName && typeof shortHands[commandName] === 'string') {
+  commandName = shortHands[commandName];
 }
 
 //

--- a/src/cli/shortHands.js
+++ b/src/cli/shortHands.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+export default {
+  // shorthands
+  'run-script': 'run',
+  c: 'config',
+  i: 'install',
+  list: 'ls',
+  ln: 'link',
+  rb: 'rebuild',
+  runScript: 'run',
+  t: 'test',
+  tst: 'test',
+  un: 'remove',
+  up: 'update',
+  v: 'info',
+};


### PR DESCRIPTION
**Summary**
Allow support for shorthands to actually execute commands.
`yarn i` will now execute `install` instead of giving an error.
This is the same behavior as npm where `npm install` and `npm i` are equivalent.
I really like that feature of npm and I would like to have it in yarn.

**Test plan**
![screenshot from 2016-10-11 23-32-29](https://cloud.githubusercontent.com/assets/5586960/19289443/1233915a-900b-11e6-9631-7ffd026406eb.png)
