### PR TITLE
Flag to ignore platform compatibility

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -59,6 +59,7 @@ type IntegrityMatch = {
 
 type Flags = {
   // install
+  ignorePlatform: boolean,
   ignoreEngines: boolean,
   ignoreScripts: boolean,
   ignoreOptional: boolean,
@@ -82,6 +83,7 @@ function normalizeFlags(config: Config, rawFlags: Object): Flags {
   const flags = {
     // install
     har: !!rawFlags.har,
+    ignorePlatform: !!rawFlags.ignorePlatform,
     ignoreEngines: !!rawFlags.ignoreEngines,
     ignoreScripts: !!rawFlags.ignoreScripts,
     ignoreOptional: !!rawFlags.ignoreOptional,
@@ -102,6 +104,10 @@ function normalizeFlags(config: Config, rawFlags: Object): Flags {
 
   if (config.getOption('ignore-scripts')) {
     flags.ignoreScripts = true;
+  }
+
+  if (config.getOption('ignore-platform')) {
+    flags.ignorePlatform = true;
   }
 
   if (config.getOption('ignore-engines')) {
@@ -669,6 +675,7 @@ export class Install {
 
 export function _setFlags(commander: Object) {
   commander.option('--har', 'save HAR output of network traffic');
+  commander.option('--ignore-platform', 'ignore platform checks');
   commander.option('--ignore-engines', 'ignore engines check');
   commander.option('--ignore-scripts', '');
   commander.option('--ignore-optional', '');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -288,6 +288,7 @@ config.init({
   packagesRoot: commander.packagesRoot,
   preferOffline: commander.preferOffline,
   captureHar: commander.har,
+  ignorePlatform: commander.ignorePlatform,
   ignoreEngines: commander.ignoreEngines,
   offline: commander.preferOffline || commander.offline,
   looseSemver: !commander.strictSemver,

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ type ConfigOptions = {
   offline?: boolean,
   preferOffline?: boolean,
   captureHar?: boolean,
+  ignorePlatform?: boolean,
   ignoreEngines?: boolean,
 
   // Loosely compare semver for invalid cases like "0.01.0"
@@ -55,6 +56,7 @@ export default class Config {
   looseSemver: boolean;
   offline: boolean;
   preferOffline: boolean;
+  ignorePlatform: boolean;
 
   //
   linkedModules: Array<string>;
@@ -182,6 +184,7 @@ export default class Config {
     this.linkFolder = opts.linkFolder || constants.LINK_REGISTRY_DIRECTORY;
     this.tempFolder = opts.tempFolder || path.join(this.packagesRoot, '.tmp');
     this.offline = !!opts.offline;
+    this.ignorePlatform = !!opts.ignorePlatform;
 
     this.requestManager.setOptions({
       offline: !!opts.offline && !opts.preferOffline,

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -138,13 +138,13 @@ export default class PackageCompatibility {
       }
     };
 
-    if (Array.isArray(info.os)) {
+    if (!this.config.ignorePlatform && Array.isArray(info.os)) {
       if (!PackageCompatibility.isValidPlatform(info.os)) {
         pushError(this.reporter.lang('incompatibleOS', process.platform));
       }
     }
 
-    if (Array.isArray(info.cpu)) {
+    if (!this.config.ignorePlatform && Array.isArray(info.cpu)) {
       if (!PackageCompatibility.isValidArch(info.cpu)) {
         pushError(this.reporter.lang('incompatibleCPU', process.arch));
       }


### PR DESCRIPTION
**Summary**

Hi everyone,

I had an issue with some packages with _not quite correct_ platform properties in `package.json`, blocking completely an install process that was working well with _npm_.

So the output was:
```
❯ yarn
yarn install v0.15.1
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error babel-plugin-react-require@2.1.0: The platform "darwin" is incompatible with this module.
error babel-plugin-react-require@2.1.0: The CPU architecture "x64" is incompatible with this module.
error Found incompatible module
info Visit http://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
This is caused by packages having the `os` & `cpu` properties set to the empty array value:
```json
{
  "name": "foo",
  "version": "1.0.0",
  "os": [],
  "cpu": []
}
```

This PR adds a new `--ignore-platform` flag to permit the installation (as a temporary workaround while the change lands upstream). I think this could also helps when packaging some project for another platform type.

I not quite sure about the semantics of `config` vs `flags` in a command, so the implementation may not be like it should be. Some insights would be welcome on this.

**Test plan**

```
❯ yarn --ignore-platform
yarn install v0.15.1
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
✨  Done in 30.00s.
```
