### PR TITLE
`yarn --help` now equivalent to `yarn help`

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -69,7 +69,8 @@ const getDocsLink = (name) => `https://yarnpkg.com/en/docs/cli/${name || ''}`;
 const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
 
 //
-if (commandName === 'help') {
+if (commandName === 'help' || commandName === '--help' || commandName === '-h') {
+  commandName = 'help';
   if (args.length) {
     const helpCommand = hyphenate(args[0]);
     commander.on('--help', () => console.log('  ' + getDocsInfo(helpCommand) + '\n'));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
- `yarn --help` no longer shows help instructions just for the `install` command
- Fixes #740

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- Run `yarn help`, `yarn -h`, `yarn --help`. All have the same behavior
- `yarn help install`, `yarn --help install`, etc. still show help instructions for install

