### PR TITLE
Only write escape sequences to a TTY

### DIFF
--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -3,20 +3,33 @@
 import type {Stdout} from '../types.js';
 
 const readline = require('readline');
+const {supportsColor} = require('chalk');
 
 const CLEAR_WHOLE_LINE = 0;
 const CLEAR_RIGHT_OF_CURSOR = 1;
 
 export function clearLine(stdout: Stdout) {
+  if (!supportsColor) {
+    return;
+  }
+
   readline.clearLine(stdout, CLEAR_WHOLE_LINE);
   readline.cursorTo(stdout, 0);
 }
 
 export function toStartOfLine(stdout: Stdout) {
+  if (!supportsColor) {
+    return;
+  }
+
   readline.cursorTo(stdout, 0);
 }
 
 export function writeOnNthLine(stdout: Stdout, n: number, msg: string) {
+  if (!supportsColor) {
+    return;
+  }
+
   if (n == 0) {
     readline.cursorTo(stdout, 0);
     stdout.write(msg);
@@ -32,6 +45,10 @@ export function writeOnNthLine(stdout: Stdout, n: number, msg: string) {
 }
 
 export function clearNthLine(stdout: Stdout, n: number) {
+  if (!supportsColor) {
+    return;
+  }
+
   if (n == 0) {
     clearLine(stdout);
     return;


### PR DESCRIPTION
**Summary**

This solves #728 which is to make yarn a nice unix citizen by not emitting escape sequences outside TTYs.

**Test plan**

The only thing I noticed was that flow doesn't seem to support `process.stdout.isTTY`, see https://github.com/facebook/flow/issues/1825. And since I don't really use flow, so I'm not sure how to fix this.

![skarmavbild 2016-10-12 kl 01 31 02](https://cloud.githubusercontent.com/assets/664779/19292329/97941f58-901b-11e6-9bfa-2161e38170ed.png)
