### PR TITLE
Support unimplemented call in Windows Subsystem for Linux

### DIFF
--- a/src/util/network.js
+++ b/src/util/network.js
@@ -29,7 +29,7 @@ export function isOffline(): boolean {
     const addrs = interfaces[name];
     for (const addr of addrs) {
       if (LOCAL_IPS.indexOf(addr.address) < 0) {
-        // found a possible local ip
+        // found a possible remote ip
         return false;
       }
     }

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -6,7 +6,20 @@ const IGNORE_INTERFACES = ['lo0', 'awdl0', 'bridge0'];
 const LOCAL_IPS = ['127.0.0.1', '::1'];
 
 export function isOffline(): boolean {
-  const interfaces = os.networkInterfaces();
+  let interfaces;
+
+  try {
+    interfaces = os.networkInterfaces();
+  } catch (e) {
+    // As of October 2016, Windows Subsystem for Linux (WSL) does not support
+    // the os.networkInterfaces() call and throws instead. For this platform,
+    // assume we are online.
+    if (e.syscall === 'uv_interface_addresses') {
+      return false;
+    } else {
+      throw e;
+    }
+  }
 
   for (const name in interfaces) {
     if (IGNORE_INTERFACES.indexOf(name) >= 0) {


### PR DESCRIPTION
Yarn works fine on Windows Subsystem for Linux (WSL) apart from a single call
to enumerate network interfaces.  If this call fails on WSL, we instead assume
that the user has an internet connection and continue.

See #753 and #636 for discussion.

With this change, the test suite works better on WSL but it still has multiple failures.  I've run the test suite on Linux and it passes fine.