### PR TITLE
Fix slashes handling in registry name

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -55,7 +55,7 @@ export default class NpmRegistry extends Registry {
     }
 
     return this.requestManager.request({
-      url: url.resolve(registry, pathname),
+      url: `${registry}/${pathname}`,
       method: opts.method,
       body: opts.body,
       auth: opts.auth,


### PR DESCRIPTION
**Summary**

Some registry names need trailing slash. So this PR fixes issue described in https://github.com/yarnpkg/yarn/issues/606#issuecomment-253070677

**Test plan**

`yarn`
