### PR TITLE
Remove commander's `allowUnknownOption` method call

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -57,7 +57,6 @@ commander.option(
   '--mutex [type][:specifier]',
   'use a mutex to ensure only one yarn instance is executing',
 );
-commander.allowUnknownOption();
 
 // get command name
 let commandName: string = args.shift() || '';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This solves #693 by removing the `.allowUnknownOption()` call on `commander`.

**Test plan**

##### Before

```
❯ yarn --vesrion
yarn install v0.15.1
success Already up-to-date.
✨  Done in 0.16s.
```

##### After

```
❯ yarn --vesrion
  error: unknown option `--vesrion'
```

