### PR TITLE
fix(optionalDependency): reset ignore-optional default flag

### DIFF
--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -24,7 +24,7 @@ export const DEFAULTS = {
 
   'save-prefix': '^',
   'ignore-scripts': false,
-  'ignore-optional': true,
+  'ignore-optional': false,
   registry: YARN_REGISTRY,
   'user-agent': [
     `yarn/${pkg.version}`,


### PR DESCRIPTION
**Summary**
Currently optional dependencies are not installed since the default flag is true, with or with out flag it sets to true

fixes #628 
