### PR TITLE
Support private registries (non-auth) and fix git resolver

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -13,6 +13,7 @@ import * as fs from '../../src/util/fs.js';
 import {runInstall} from './_install.js';
 import assert from 'assert';
 import semver from 'semver';
+import {removeSuffix} from '../../src/util/misc.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
@@ -265,7 +266,6 @@ test.concurrent('install with --save and without offline mirror', (): Promise<vo
   return runAdd({}, ['is-array@^1.0.1'], 'install-with-save-no-offline-mirror', async (config) => {
 
     const allFiles = await fs.walk(config.cwd);
-
     assert(allFiles.findIndex((file): boolean => {
       return file.relative === `${mirrorPath}/is-array-1.0.1.tgz`;
     }) === -1);

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -68,6 +68,19 @@ test('GitFetcher.fetch', async () => {
   expect(name).toBe('font-roboto');
 });
 
+test('GitFetcher.fetch with git+https', async () => {
+  const dir = await mkdir('git-fetcher');
+  const fetcher = new GitFetcher(dir, {
+    type: 'git',
+    reference: 'git+https://github.com/PolymerElements/font-roboto',
+    hash: '2fd5c7bd715a24fb5b250298a140a3ba1b71fe46',
+    registry: 'bower',
+  }, await createConfig());
+  await fetcher.fetch();
+  const name = (await fs.readJson(path.join(dir, 'bower.json'))).name;
+  expect(name).toBe('font-roboto');
+});
+
 test('TarballFetcher.fetch', async () => {
   const dir = await mkdir('tarball-fetcher');
   const fetcher = new TarballFetcher(dir, {

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -42,6 +42,7 @@ addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git u
 addTest('https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz'); // tarball
 addTest('https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // hash
 addTest('https://github.com/babel/babel-loader.git#feature/sourcemaps'); // hash with slashes
+addTest('git+https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // git+hash
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -47,7 +47,11 @@ export default class NpmRegistry extends Registry {
   }
 
   request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<?Object> {
-    const registry = removeSuffix(String(this.registries.yarn.getOption('registry')), '/');
+    let registry = removeSuffix(String(this.registries.yarn.getOption('registry')), '/');
+
+    if (this.config.registry) {
+      registry = this.config.registry;
+    }
 
     const headers = {};
     if (this.token) {
@@ -112,7 +116,6 @@ export default class NpmRegistry extends Registry {
 
     for (const [, loc, file] of await this.getPossibleConfigLocations('.npmrc')) {
       const config = ini.parse(file);
-
       // normalize offline mirror path relative to the current npmrc
       let offlineLoc = config['yarn-offline-mirror'];
       // old kpm compatibility

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -47,11 +47,9 @@ export default class NpmRegistry extends Registry {
   }
 
   request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<?Object> {
-    let registry = removeSuffix(String(this.registries.yarn.getOption('registry')), '/');
-
-    if (this.config.registry) {
-      registry = this.config.registry;
-    }
+    const registry = this.config.registry ?
+      removeSuffix(this.config.registry, '/') :
+      removeSuffix(String(this.registries.yarn.getOption('registry')), '/');
 
     const headers = {};
     if (this.token) {

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -13,7 +13,7 @@ import Git from '../../util/git.js';
 const urlParse = require('url').parse;
 
 // we purposefully omit https and http as those are only valid if they end in the .git extension
-const GIT_PROTOCOLS = ['git', 'git+ssh', 'git+https', 'ssh'];
+const GIT_PROTOCOLS = ['git:', 'git+ssh:', 'git+https:', 'ssh:'];
 
 const GIT_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.com'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@ acorn-globals@^1.0.4:
   dependencies:
     acorn "^2.1.0"
 
-acorn-jsx@^3.0.0:
+acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
@@ -236,8 +236,8 @@ aws-sign2@~0.6.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
 aws4@^1.2.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
 babel-code-frame@^6.16.0:
   version "6.16.0"
@@ -3222,9 +3222,10 @@ jsprim@^1.2.2:
     verror "1.3.6"
 
 jsx-ast-utils@^1.2.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.1.tgz#14313c5c50da5b0c47020af5d1560c17e781a05a"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.2.tgz#dff658782705352111f9865d40471bc4a955961e"
   dependencies:
+    acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
 
 kew@^0.7.0:


### PR DESCRIPTION
* Basic support for private registries defined in .npmrc.
* Fix git resolver so it properly matches non-github git+https, etc packages.

I want to use Yarn at work and this lets me do that. We utilize a private registry and github enterprise.

**Test plan**
There are currently no tests for npm-registry to begin with so I didn't add anything there.
For git+https I added a test to package-resolver and fetchers.js.
