### PR TITLE
Add ied as prior art

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Yarn wouldn't exist if it wasn't for excellent prior art. Yarn has been inspired
  - [Bundler](https://github.com/bundler/bundler)
  - [Cargo](https://github.com/rust-lang/cargo)
  - [npm](https://github.com/npm/npm)
+ - [ied](https://github.com/alexanderGugel/ied)
 
 ## Credits
 


### PR DESCRIPTION
Per HN comment from @kittens 

> We initially used a method similar to ied when we first started experimenting with internal usage at Facebook.

https://news.ycombinator.com/item?id=12685936