### PR TITLE
Improvements on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,12 @@ env:
   - NODE_VERSION="4" TEST_TYPE="test-ci"
 
 matrix:
-  include:
-    - env: NODE_VERSION="6" TEST_TYPE="test-ci"
+  exclude:
+    - env: TEST_TYPE="build-dist"
       os: osx
-    - env: NODE_VERSION="4" TEST_TYPE="test-ci"
+    - env: TEST_TYPE="check-lockfile"
+      os: osx
+    - env: TEST_TYPE="lint"
       os: osx
 
 install:
@@ -42,6 +44,10 @@ install:
  - node --version
  - npm install -g npm@3
  - npm install
+
+os:
+  - osx
+  - linux
 
 script: npm run $TEST_TYPE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ install:
  - git --version
 
  # install proper node version
- - rm -rf ~/.nvm
- - git clone https://github.com/creationix/nvm.git ~/.nvm
- - source ~/.nvm/nvm.sh
  - nvm install ${NODE_VERSION:=6}
  - node --version
  - npm install -g npm@3

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,17 @@ cache:
 env:
   matrix:
   - TEST_TYPE="build-dist"
-  - TEST_TYPE="lockfile"
+  - TEST_TYPE="check-lockfile"
   - TEST_TYPE="lint"
-  - NODE_VERSION="6" TEST_TYPE="js"
-  - NODE_VERSION="4" TEST_TYPE="js"
+  - NODE_VERSION="6" TEST_TYPE="test-ci"
+  - NODE_VERSION="4" TEST_TYPE="test-ci"
 
 matrix:
-  exclude:
-  - env: TEST_TYPE="build-dist"
-    os: osx
-  - env: TEST_TYPE="lockfile"
-    os: osx
-  - env: TEST_TYPE="lint"
-    os: osx
+  include:
+    - env: NODE_VERSION="6" TEST_TYPE="test-ci"
+      os: osx
+    - env: NODE_VERSION="4" TEST_TYPE="test-ci"
+      os: osx
 
 install:
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink git; brew install git; fi
@@ -48,12 +46,5 @@ install:
  - npm install -g npm@3
  - npm install
 
-os:
- - osx
- - linux
+script: npm run $TEST_TYPE
 
-script:
- - if [[ "$TEST_TYPE" == "js" ]]; then npm run test-ci; fi
- - if [[ "$TEST_TYPE" == "build-dist" ]]; then npm run build-dist; fi
- - if [[ "$TEST_TYPE" == "lockfile" ]]; then npm run check-lockfile; fi
- - if [[ "$TEST_TYPE" == "lint" ]]; then npm run lint; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 ---
 git:
   depth: 1
-sudo: true # can't use this due to git upgrade requirement
 language: generic
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - git
 
 branches:
   only:
@@ -33,9 +39,7 @@ matrix:
     os: osx
 
 install:
- # install latest git
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink git; brew install git; fi
- - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/update-linux-git.sh; fi
  - git --version
 
  # install proper node version

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ matrix:
       os: osx
 
 install:
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink git; brew install git; fi
- - git --version
-
  # install proper node version
  - nvm install ${NODE_VERSION:=6}
  - node --version

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -6,7 +6,7 @@ npm run build
 npm pack
 rm -rf dist
 mkdir dist
-mv yarnpkg-*.tgz dist/pack.tgz
+mv yarn-*.tgz dist/pack.tgz
 
 cd dist
 tar -xzf pack.tgz --strip 1

--- a/scripts/update-linux-git.sh
+++ b/scripts/update-linux-git.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-sudo add-apt-repository ppa:git-core/ppa -y
-sudo apt-get update
-sudo apt-get install git -y


### PR DESCRIPTION
**Summary**

This PR improves Travis CI builds in the following ways:

1. Runs on containers, so Linux jobs start faster
1. Cleans up `git`-related tasks
  1. Uses `apt` addon to update `git`. Strictly speaking, this may be unnecessary (depending on what version of `git` is available on the image).
  1. Skips updating `git` on the Mac. This also appears unnecessary, and adds some time to the build, since Homebrew now runs `brew update` in the background, which can be quite slow on an old package index.
1. Tweak `$TEST_TYPE` values, so that `script` section is easier to understand.

**Test plan**

Not applicable.