### PR TITLE
Remove duplicate hashing utility

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -23,7 +23,7 @@ import {registries} from '../../registries/index.js';
 import {clean} from './clean.js';
 import * as constants from '../../constants.js';
 import * as fs from '../../util/fs.js';
-import * as util from '../../util/misc.js';
+import * as crypto from '../../util/crypto.js';
 import map from '../../util/map.js';
 
 const invariant = require('invariant');
@@ -663,7 +663,7 @@ export class Install {
       opts.push(`mirror:${mirror}`);
     }
 
-    return util.hash(opts.join('-'));
+    return crypto.hash(opts.join('-'), 'sha256');
   }
 }
 

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -1,11 +1,5 @@
 /* @flow */
 
-const crypto = require('crypto');
-
-export function hash(str: string): string {
-  return crypto.createHash('sha256').update(str).digest('hex');
-}
-
 export function sortAlpha(a: string, b: string): number {
   // sort alphabetically
   return a.toLowerCase().localeCompare(b.toLowerCase());


### PR DESCRIPTION
**Summary**
While trying to analyze why security checks fail (due to hash mismatches), I stumbled upon two hash utils with different default hashing strategies. My first thought was that this is why it isn't working. Turns out, that the two versions are used in different parts of the code.

This PR removes the duplicate hashing util function (for less confusion in the future).

**Test plan**
This PR removes one existing function. Tests already cover this path.