### PR TITLE
Fix executing scripts with spaces

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -36,7 +36,7 @@ export async function run(
     if (await fs.exists(binFolder)) {
       for (const name of await fs.readdir(binFolder)) {
         binCommands.push(name);
-        scripts[name] = `${path.join(binFolder, name)}`;
+        scripts[name] = `"${path.join(binFolder, name)}"`;
       }
     }
   }
@@ -61,7 +61,7 @@ export async function run(
 
     if (cmds.length) {
       for (const [stage, cmd] of cmds) {
-        await execCommand(stage, config, `"${cmd}" ${args.join(' ')}`, config.cwd);
+        await execCommand(stage, config, `${cmd} ${args.join(' ')}`, config.cwd);
       }
     } else {
       let suggestion;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The script quoting behaviour introduced in #663 breaks package.json script entries with spaces in them on Unix.

Instead, this quotes `node_modules/.bin` executable paths, which makes sure both package.json script entries, and executables can be called.

**Test plan**

For this package.json;
```json
{
  "name": "yarntest_pr809",
  "version": "1.0.0",
  "devDependencies": {
    "jest": "^16.0.1"
  },
  "scripts": {
    "test": "jest",
    "test-help": "jest --help"
  }
}
```
with dependencies installed,

1. **In a path with no spaces** (e.g. `~/yarntest_pr809`);
  1. `yarn run test -- --help` should print jest’s help message on the current release, and with this patch.
  2. `yarn run test-help` will *fail* on the current release, and print jest’s help message with this patch.
  3. `yarn run jest -- --help` will print jest’s help message on both the current release and with this patch.
2. **In a path with spaces** (e.g. `~/yarn test pr809`);
  1. `yarn run test --help` should print jest’s help message on the current release, and with this patch.
  2. `yarn run test-help` will *fail* on the current release, and work fine with this patch.
  3. `yarn run jest -- --help` will print jest’s help message on both the current release and with this patch.

Note that the use of a help flag within a script is a contrived example, but triggers the incorrect behaviour in this case.

fixes #727, #733, #735 :smile: