### PR TITLE
Don't display a documentation url if actual command does not exist

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -73,7 +73,9 @@ if (commandName === 'help' || commandName === '--help' || commandName === '-h') 
   commandName = 'help';
   if (args.length) {
     const helpCommand = hyphenate(args[0]);
-    commander.on('--help', () => console.log('  ' + getDocsInfo(helpCommand) + '\n'));
+    if (commands[helpCommand]) {
+      commander.on('--help', () => console.log('  ' + getDocsInfo(helpCommand) + '\n'));
+    }
   } else {
     commander.on('--help', () => {
       console.log('  Commands:\n');
@@ -331,7 +333,7 @@ config.init({
       logError(errs);
     }
 
-    if (commandName) {
+    if (commands[commandName]) {
       reporter.info(getDocsInfo(commandName));
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This fixes issue #664, where the yarn cli was display a url for commands that don't actually exist in yarn.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
`yarn what` 
```
yarn what v0.15.1
error Command "what" not found.
```
`yarn why` (display a doc url)
```
yarn why v0.15.1
error Missing package name, folder or path to file to identify why a package has been installed
info Visit https://yarnpkg.com/en/docs/cli/why for documentation about this command.
```
`yarn what what what` (don't display doc url)
```
yarn what v0.15.1
error Command "what" not found.
```
`yarn why why why` (display a doc url)
```
yarn why v0.15.1
error Too many arguments, maximum of 1.
info Visit https://yarnpkg.com/en/docs/cli/why for documentation about this command.
```

`yarn ls no-arguments` (this will always display a doc url because the command here will always be a yarn command)
```
yarn ls v0.15.1
error This command doesn't require any arguments.
info Visit https://yarnpkg.com/en/docs/cli/ls for documentation about this command.
```

If there needs to be jest tests for this, please suggest what the best place would be to put a test like this in the `__tests__` folder.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
