### PR TITLE
Fix git dependencies with slashes inside branch name

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -40,6 +40,7 @@ addTest('https://github.com/npm-ml/re'); // git url with no .git
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz'); // tarball
 addTest('https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // hash
+addTest('https://github.com/babel/babel-loader.git#feature/sourcemaps'); // hash with slashes
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -344,7 +344,7 @@ export default class Git {
     for (const line of refLines) {
       // line example: 64b2c0cee9e829f73c5ad32b8cc8cb6f3bec65bb refs/tags/v4.2.2
       const [sha, id] = line.split(/\s+/g);
-      let [,, name] = id.split('/');
+      let name = id.split('/').slice(2).join('/');
 
       // TODO: find out why this is necessary. idk it makes it work...
       name = removeSuffix(name, '^{}');


### PR DESCRIPTION
**Summary**

Previously, branches with slashes such as `features/feature-branch` would not be recognized by the package resolver. This happened because ref names (e.g. `refs/heads/features/feature-branch`) were not parsed correctly. Instead of looking at everything after the second slash, it only looked at the string after the second slash and before the third. This resulted in `refs/heads/features/feature-branch` being parsed to `features` instead of `features/feature-branch`.

**Test plan**

I have added a test case to `__tests__/package-resolver.js` that tries to parse `https://github.com/babel/babel-loader.git#feature/sourcemaps`. Previously, this caused an error. This has been fixed now.

There is one more failing test though, but I'm sure it's not related to my change. Tests seem to be always failing for this project right now.