### PR TITLE
Chore - Created an .eslintrc file for the eslint configurations instead of having it in the package.json file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,39 @@
+{
+  "extends": "eslint-config-fb-strict",
+  "env": {
+    "jest": true
+  },
+  "plugins": [
+    "flowtype",
+    "no-async-without-await",
+    "yarn-internal"
+  ],
+  "rules": {
+    "yarn-internal/warn-language": 2,
+    "max-len": [
+      2,
+      120
+    ],
+    "prefer-arrow-callback": 0,
+    "babel/arrow-parens": [
+      2,
+      "always"
+    ],
+    "flowtype/require-valid-file-annotation": [
+      2,
+      "always"
+    ],
+    "flowtype/space-after-type-colon": [
+      2,
+      "always"
+    ],
+    "flowtype/require-return-type": [
+      2,
+      "always",
+      {
+        "excludeArrowFunctions": true
+      }
+    ],
+    "no-async-without-await/no-async-without-await": 2
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 fbkpm_modules
 test/fixtures/**/.fbkpm
 /tmp/
+
+# IDE
+.idea/

--- a/package.json
+++ b/package.json
@@ -92,45 +92,6 @@
     "build-chocolatey": "powershell ./scripts/build-chocolatey.ps1",
     "build-win-installer": "scripts\\build-windows-installer.bat"
   },
-  "eslintConfig": {
-    "extends": "eslint-config-fb-strict",
-    "env": {
-      "jest": true
-    },
-    "plugins": [
-      "flowtype",
-      "no-async-without-await",
-      "yarn-internal"
-    ],
-    "rules": {
-      "yarn-internal/warn-language": 2,
-      "max-len": [
-        2,
-        120
-      ],
-      "prefer-arrow-callback": 0,
-      "babel/arrow-parens": [
-        2,
-        "always"
-      ],
-      "flowtype/require-valid-file-annotation": [
-        2,
-        "always"
-      ],
-      "flowtype/space-after-type-colon": [
-        2,
-        "always"
-      ],
-      "flowtype/require-return-type": [
-        2,
-        "always",
-        {
-          "excludeArrowFunctions": true
-        }
-      ],
-      "no-async-without-await/no-async-without-await": 2
-    }
-  },
   "jest": {
     "timers": "fake",
     "testEnvironment": "node",


### PR DESCRIPTION
**Summary**

In this PR I simply extracted the `eslintConfig` out of it and placed it in a more standard way in the `.eslintrc` file.

Why?

1. The `package.json` file already have enough definitions in it and it is a big file, Let's minimize it.
* We're already using `.eslintignore` file, so why having the eslint configuration in the `package.json` file? Seems a little bit inconsistence..
* A lot of IDEs have built in plugins for eslint, having the configurations in a dedicated file for that makes that integration easier.
* Easier to find - when ever I'll need anything regarding eslint, I would just go to that file instead of searching for it in the `.package.json` file. Also, now this file and the `.eslintignore` file are one after the other.

**Test plan**

No need for tests here.. I checked the `yarn run lint` still works.