### PR TITLE
install sh script: Do not "exit 1" if yarn already installed

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -98,7 +98,7 @@ yarn_install() {
   if [ -d "$HOME/.yarn" ]; then
     printf "$red> ~/.yarn already exists, possibly from a past Yarn install.$reset\n"
     printf "$red> Remove it (rm -rf ~/.yarn) and run this script again.$reset\n"
-    exit 1
+    exit 0
   fi
 
   yarn_get_tarball


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I think it's bad idea to exit 1 in this case - because this script can't be used in pipeline or in ansible. Throwing exception breaks next movements. If Yarn already installed this script - it will warn and normally exited with exit code 0.
What do you think?