### PR TITLE
cli: fix help for misspelled command

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -333,8 +333,9 @@ config.init({
       logError(errs);
     }
 
-    if (commands[commandName]) {
-      reporter.info(getDocsInfo(commandName));
+    const actualCommandForHelp = commands[commandName] ? commandName : aliases[commandName];
+    if (actualCommandForHelp) {
+      reporter.info(getDocsInfo(actualCommandForHelp));
     }
   }
 


### PR DESCRIPTION
**Summary**

If the command is misspelled, the help message should point to
the URL with properly spelled command name.

**Test plan**

Commands to reproduce is in https://github.com/yarnpkg/yarn/pull/803#issuecomment-253134849

----

cc @cpojer 
