### PR TITLE
ignore cache files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.nyc_output
 /coverage
 /__tests__/fixtures/**/_*
+/__tests__/fixtures/request-cache
 /dist
 /artifacts
 /updates


### PR DESCRIPTION
**Summary**

Whenever the tests fail, the files in the request-cache are not
cleaned up.

**Test plan**

NA