### PR TITLE
Support npmrc for private registries and auth

### DIFF
--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -33,9 +33,18 @@ async function getCredentials(config: Config, reporter: Reporter): Promise<?{
   return {username, email};
 }
 
-export async function getToken(config: Config, reporter: Reporter): Promise<
+export async function getToken(config: Config, reporter: Reporter, name: ?string): Promise<
   () => Promise<void>
 > {
+  const auth = config.registries.npm.getAuth(name);
+  if (auth) {
+    config.registries.npm.setToken(auth);
+    return function revoke(): Promise<void> {
+      reporter.info(reporter.lang('notRevokingConfigToken'));
+      return Promise.resolve();
+    };
+  }
+
   const env = process.env.YARN_AUTH_TOKEN || process.env.KPM_AUTH_TOKEN || process.env.NPM_AUTH_TOKEN;
   if (env) {
     config.registries.npm.setToken(env);

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -33,7 +33,7 @@ async function getCredentials(config: Config, reporter: Reporter): Promise<?{
   return {username, email};
 }
 
-export async function getToken(config: Config, reporter: Reporter, name: ?string): Promise<
+export async function getToken(config: Config, reporter: Reporter, name: string = ''): Promise<
   () => Promise<void>
 > {
   const auth = config.registries.npm.getAuth(name);

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -47,7 +47,7 @@ export async function getToken(config: Config, reporter: Reporter, name: ?string
 
   const env = process.env.YARN_AUTH_TOKEN || process.env.KPM_AUTH_TOKEN || process.env.NPM_AUTH_TOKEN;
   if (env) {
-    config.registries.npm.setToken(env);
+    config.registries.npm.setToken(`Bearer ${env}`);
     return function revoke(): Promise<void> {
       reporter.info(reporter.lang('notRevokingEnvToken'));
       return Promise.resolve();
@@ -89,7 +89,7 @@ export async function getToken(config: Config, reporter: Reporter, name: ?string
     reporter.success(reporter.lang('loggedIn'));
 
     const token = res.token;
-    config.registries.npm.setToken(token);
+    config.registries.npm.setToken(`Bearer ${token}`);
 
     return async function revoke(): Promise<void> {
       reporter.success(reporter.lang('revokedToken'));

--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -34,7 +34,7 @@ export async function mutate(
 
   const msgs = buildMessages(username, name);
   reporter.step(1, 3, reporter.lang('loggingIn'));
-  const revoke = await getToken(config, reporter);
+  const revoke = await getToken(config, reporter, name);
 
   reporter.step(2, 3, msgs.info);
   const user = await config.registries.npm.request(`-/user/org.couchdb.user:${username}`);
@@ -160,7 +160,7 @@ export const {run, setFlags} = buildSubCommands('owner', {
     const name = await getName(args, config);
 
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    const revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter, name);
 
     reporter.step(2, 3, reporter.lang('ownerGetting', name));
     const pkg = await config.registries.npm.request(name);

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -138,7 +138,7 @@ export async function run(
 
   //
   reporter.step(2, 4, reporter.lang('loggingIn'));
-  const revoke = await getToken(config, reporter);
+  const revoke = await getToken(config, reporter, pkg.name);
 
   //
   reporter.step(3, 4, reporter.lang('publishing'));

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -120,11 +120,12 @@ export const {run, setFlags, examples} = buildSubCommands('tag', {
     flags: Object,
     args: Array<string>,
   ): Promise<void> {
+    const name = await getName(args, config);
+
     reporter.step(1, 3, reporter.lang('loggingIn'));
     const revoke = await getToken(config, reporter, name);
 
     reporter.step(2, 3, reporter.lang('gettingTags'));
-    const name = await getName(args, config);
     const tags = await config.registries.npm.request(`-/package/${name}/dist-tags`);
 
     if (tags) {

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -50,7 +50,7 @@ export const {run, setFlags, examples} = buildSubCommands('tag', {
     const tag = args.shift();
 
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    const revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter, name);
 
     reporter.step(2, 3, reporter.lang('creatingTag', tag, range));
     const result = await config.registries.npm.request(
@@ -91,7 +91,7 @@ export const {run, setFlags, examples} = buildSubCommands('tag', {
     const tag = args.shift();
 
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    const revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter, name);
 
     reporter.step(2, 3, reporter.lang('deletingTags'));
     const result = await config.registries.npm.request(`-/package/${name}/dist-tags/${encodeURI(tag)}`, {
@@ -121,7 +121,7 @@ export const {run, setFlags, examples} = buildSubCommands('tag', {
     args: Array<string>,
   ): Promise<void> {
     reporter.step(1, 3, reporter.lang('loggingIn'));
-    const revoke = await getToken(config, reporter);
+    const revoke = await getToken(config, reporter, name);
 
     reporter.step(2, 3, reporter.lang('gettingTags'));
     const name = await getName(args, config);

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-import type {RegistryNames} from './registries/index.js';
+import type {RegistryNames, ConfigRegistries} from './registries/index.js';
 import type {Reporter} from './reporters/index.js';
-import type Registry from './registries/base-registry.js';
 import type {Manifest, PackageRemote} from './types.js';
 import normalizeManifest from './util/normalize-manifest/index.js';
 import {MessageError} from './errors.js';
@@ -42,7 +41,6 @@ type PackageMetadata = {
   package: Manifest
 };
 
-
 type RootManifests = {
   [registryName: RegistryNames]: {
     loc: string,
@@ -59,10 +57,6 @@ function sortObject(object: Object): Object {
   });
   return sortedObject;
 }
-
-export type ConfigRegistries = {
-  [name: RegistryNames]: Registry
-};
 
 export default class Config {
   constructor(reporter: Reporter) {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -130,9 +130,9 @@ export default class TarballFetcher extends BaseFetcher {
 
   fetchFromExternal(): Promise<FetchedOverride> {
     const {reference: ref} = this;
+    const registry = this.config.registries[this.registry];
 
-    return this.config.requestManager.request({
-      url: ref,
+    return registry.request(ref, {
       headers: {
         'Accept-Encoding': 'gzip',
         'Accept': 'application/octet-stream',

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -1,7 +1,8 @@
 /* @flow */
 
 import type RequestManager, {RequestMethods} from '../util/request-manager.js';
-import type Config, {ConfigRegistries} from '../config.js';
+import type Config from '../config.js';
+import type {ConfigRegistries} from './index.js';
 import {removePrefix} from '../util/misc.js';
 
 const objectPath = require('object-path');
@@ -11,6 +12,8 @@ export type RegistryRequestOptions = {
   method?: RequestMethods,
   auth?: Object,
   body?: mixed,
+  buffer?: bool,
+  process?: Function
 };
 
 export type CheckOutdatedReturn = Promise<{

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -76,8 +76,11 @@ export default class BaseRegistry {
     return Promise.reject(new Error('unimplemented'));
   }
 
-  request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<?Object> {
-    return Promise.reject(new Error('unimplemented'));
+  request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<*> {
+    return this.requestManager.request({
+      url: pathname,
+      ...opts,
+    });
   }
 
   async init(): Promise<void> {

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -13,3 +13,8 @@ export const registries = {
 export const registryNames = Object.keys(registries);
 
 export type RegistryNames = $Keys<typeof registries>;
+export type ConfigRegistries = {
+  npm: NpmRegistry,
+  yarn: YarnRegistry,
+  bower: BowerRegistry
+};

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -7,6 +7,7 @@ import type {ConfigRegistries} from './index.js';
 import * as fs from '../util/fs.js';
 import NpmResolver from '../resolvers/registries/npm-resolver.js';
 import Registry from './base-registry.js';
+import {addSuffix} from '../util/misc';
 
 const defaults = require('defaults');
 const userHome = require('user-home');
@@ -49,15 +50,13 @@ export default class NpmRegistry extends Registry {
   }
 
   request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<*> {
-    const registry = this.getRegistry(pathname);
+    const registry = addSuffix(this.getRegistry(pathname), '/');
+    const requestUrl = url.resolve(registry, pathname);
 
     const headers = {};
-    if (this.token || this.getOption('always-auth')) {
+    if (this.token || (this.getOption('always-auth') && requestUrl.startsWith(registry))) {
       headers.authorization = this.getAuth(pathname);
     }
-
-    // $FlowFixMe : https://github.com/facebook/flow/issues/908
-    const requestUrl = url.format(`${registry}/${pathname}`);
 
     return this.requestManager.request({
       url: requestUrl,

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -157,14 +157,15 @@ export default class NpmRegistry extends Registry {
     }
 
     for (let registry of [this.getRegistry(packageName), '', DEFAULT_REGISTRY]) {
-      // Check for auth token.
       registry = registry.replace(/^https?:/, '');
 
+      // Check for bearer token.
       let auth = this.getScopedOption(registry, '_authToken');
       if (auth) {
         return `Bearer ${String(auth)}`;
       }
 
+      // Check for basic auth token.
       auth = this.getScopedOption(registry, '_auth');
       if (auth) {
         return `Basic ${String(auth)}`;

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -2,11 +2,11 @@
 
 import type RequestManager from '../util/request-manager.js';
 import type {RegistryRequestOptions, CheckOutdatedReturn} from './base-registry.js';
-import type Config, {ConfigRegistries} from '../config.js';
+import type Config from '../config.js';
+import type {ConfigRegistries} from './index.js';
 import * as fs from '../util/fs.js';
 import NpmResolver from '../resolvers/registries/npm-resolver.js';
 import Registry from './base-registry.js';
-import {removeSuffix} from '../util/misc.js';
 
 const defaults = require('defaults');
 const userHome = require('user-home');
@@ -48,7 +48,7 @@ export default class NpmRegistry extends Registry {
     return name.replace('/', '%2f');
   }
 
-  request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<?Object> {
+  request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<*> {
     const registry = this.getRegistry(pathname);
 
     const headers = {};
@@ -138,10 +138,11 @@ export default class NpmRegistry extends Registry {
     return !packageName || packageName[0] !== '@' ? '' : packageName.split(/\/|%2f/)[0];
   }
 
-  getRegistry(packageName: ?string): string {
+  getRegistry(packageName: string): string {
     // Try scoped registry, and default registry
     for (const scope of [this.getScope(packageName), '']) {
-      const registry = this.getScopedOption(scope, 'registry') || this.registries.yarn.getScopedOption(scope, 'registry');
+      const registry = this.getScopedOption(scope, 'registry')
+                    || this.registries.yarn.getScopedOption(scope, 'registry');
       if (registry) {
         return registry;
       }
@@ -150,7 +151,7 @@ export default class NpmRegistry extends Registry {
     return DEFAULT_REGISTRY;
   }
 
-  getAuth(packageName: ?string): ?string {
+  getAuth(packageName: string): string {
     if (this.token) {
       return this.token;
     }
@@ -173,14 +174,14 @@ export default class NpmRegistry extends Registry {
       const username = this.getScopedOption(registry, 'username');
       const password = this.getScopedOption(registry, '_password');
       if (username && password) {
-        return 'Basic ' + new Buffer(username + ':' + new Buffer(password, 'base64')).toString('base64');
+        return 'Basic ' + new Buffer(username + ':' + new Buffer(password, 'base64').toString()).toString('base64');
       }
     }
 
-    return null;
+    return '';
   }
 
-  getScopedOption(scope: ?string, option: string): string {
-    return this.getOption(scope + (scope ? ':' : '') + option);
+  getScopedOption(scope: string, option: string): string {
+    return String(this.getOption(scope + (scope ? ':' : '') + option));
   }
 }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -52,9 +52,11 @@ export default class NpmRegistry extends Registry {
   request(pathname: string, opts?: RegistryRequestOptions = {}): Promise<*> {
     const registry = addSuffix(this.getRegistry(pathname), '/');
     const requestUrl = url.resolve(registry, pathname);
+    const alwaysAuth = this.getScopedOption(registry.replace(/^https?:/, ''), 'always-auth')
+                    || this.getOption('always-auth');
 
     const headers = {};
-    if (this.token || (this.getOption('always-auth') && requestUrl.startsWith(registry))) {
+    if (this.token || (alwaysAuth && requestUrl.startsWith(registry))) {
       headers.authorization = this.getAuth(pathname);
     }
 

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -144,7 +144,7 @@ export default class NpmRegistry extends Registry {
       const registry = this.getScopedOption(scope, 'registry')
                     || this.registries.yarn.getScopedOption(scope, 'registry');
       if (registry) {
-        return registry;
+        return String(registry);
       }
     }
 
@@ -162,26 +162,27 @@ export default class NpmRegistry extends Registry {
 
       let auth = this.getScopedOption(registry, '_authToken');
       if (auth) {
-        return `Bearer ${auth}`;
+        return `Bearer ${String(auth)}`;
       }
 
       auth = this.getScopedOption(registry, '_auth');
       if (auth) {
-        return `Basic ${auth}`;
+        return `Basic ${String(auth)}`;
       }
 
       // Check for basic username/password auth.
       const username = this.getScopedOption(registry, 'username');
       const password = this.getScopedOption(registry, '_password');
       if (username && password) {
-        return 'Basic ' + new Buffer(username + ':' + new Buffer(password, 'base64').toString()).toString('base64');
+        const pw = new Buffer(String(password), 'base64').toString();
+        return 'Basic ' + new Buffer(String(username) + ':' + pw).toString('base64');
       }
     }
 
     return '';
   }
 
-  getScopedOption(scope: string, option: string): string {
-    return String(this.getOption(scope + (scope ? ':' : '') + option));
+  getScopedOption(scope: string, option: string): mixed {
+    return this.getOption(scope + (scope ? ':' : '') + option);
   }
 }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -53,7 +53,7 @@ export default class NpmRegistry extends Registry {
 
     const headers = {};
     if (this.token || this.getOption('always-auth')) {
-      headers.authorization = `Bearer ${this.getAuth(pathname)}`;
+      headers.authorization = this.getAuth(pathname);
     }
 
     // $FlowFixMe : https://github.com/facebook/flow/issues/908
@@ -158,16 +158,22 @@ export default class NpmRegistry extends Registry {
     for (let registry of [this.getRegistry(packageName), '', DEFAULT_REGISTRY]) {
       // Check for auth token.
       registry = registry.replace(/^https?:/, '');
-      const auth = this.getScopedOption(registry, '_auth') || this.getScopedOption(registry, '_authToken');
+
+      let auth = this.getScopedOption(registry, '_authToken');
       if (auth) {
-        return auth;
+        return `Bearer ${auth}`;
+      }
+
+      auth = this.getScopedOption(registry, '_auth');
+      if (auth) {
+        return `Basic ${auth}`;
       }
 
       // Check for basic username/password auth.
       const username = this.getScopedOption(registry, 'username');
       const password = this.getScopedOption(registry, '_password');
       if (username && password) {
-        return new Buffer(username + ':' + new Buffer(password, 'base64')).toString('base64');
+        return 'Basic ' + new Buffer(username + ':' + new Buffer(password, 'base64')).toString('base64');
       }
     }
 

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type RequestManager from '../util/request-manager.js';
-import type {ConfigRegistries} from '../config.js';
+import type {ConfigRegistries} from './index.js';
 import {YARN_REGISTRY} from '../constants.js';
 import NpmRegistry from './npm-registry.js';
 import stringify from '../lockfile/stringify.js';

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -182,6 +182,7 @@ const messages = {
   loggingIn: 'Logging in',
   loggedIn: 'Logged in.',
   notRevokingEnvToken: 'Not revoking login token, specified via environment variable.',
+  notRevokingConfigToken: 'Not revoking login token, specified via config file.',
   noTokenToRevoke: 'No login token to revoke.',
   revokingToken: 'Revoking token',
   revokedToken: 'Revoked login token.',

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -30,3 +30,15 @@ export function removeSuffix(pattern: string, suffix: string): string {
 
   return pattern;
 }
+
+export function addSuffix(pattern: string, suffix: string): string {
+  if (!pattern.endsWith(suffix)) {
+    return pattern + suffix;
+  }
+
+  return pattern;
+}
+
+export function stringify(obj: Object): string {
+  return JSON.stringify(obj, null, '  ');
+}

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -38,7 +38,3 @@ export function addSuffix(pattern: string, suffix: string): string {
 
   return pattern;
 }
-
-export function stringify(obj: Object): string {
-  return JSON.stringify(obj, null, '  ');
-}


### PR DESCRIPTION
**Summary**

This implements support for private registries configured in `.npmrc` files. It extracts the registry to use and the auth token info. Supports bearer tokens and basic auth, scoped registries, and the `always-auth` option. Should fix #606.

My flow experience is minimal, so if I messed something up or did something silly please let me know. 😀

**Test plan**

I tested with several npm configs against real live Sonatype Nexus, and Artifactory instances. Here are some cases:

```
# Default registry bearer token from npm
//registry.npmjs.org/:_authToken=TOKEN

# Default registry, basic auth token, always-auth turned on
registry=https://my-registry.com/
_auth=TOKEN
email=test@example.com
always-auth=true

# Scoped registry
@coralui:registry=https://my-registry.com/
//my-registry.com/:_password=PASSWORD
//my-registry.com/:username=USERNAME
//my-registry.com/:email=test@example.com
//my-registry.com/:always-auth=true
```