### PR TITLE
cli: make mutex's type a mandatory argument

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -54,8 +54,9 @@ commander.option(
   'rather than storing modules into a global packages root, store them here',
 );
 commander.option(
-  '--mutex [type][:specifier]',
+  '--mutex <type>[:specifier]',
   'use a mutex to ensure only one yarn instance is executing',
+  ''
 );
 commander.allowUnknownOption();
 
@@ -300,7 +301,7 @@ config.init({
   };
 
   const mutex = commander.mutex;
-  if (mutex) {
+  if (mutex && typeof mutex === 'string') {
     const parts = mutex.split(':');
     const mutexType = parts.shift();
     const mutexSpecifier = parts.join(':');


### PR DESCRIPTION
**Summary**

Without making `mutex`'s `type` argument a mandatory one, by default,
`true` is assumed and it fails with the following error.

    ➜  yarn git:(master) ./bin/yarn --mutex
    yarn install v0.15.1
    error TypeError: mutex.split is not a function
        at config.init.then (yarn/lib/cli/index.js:336:25)
        info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

And if just `mutex` is specified, commander treats that as an array and
fails like this

    ➜  yarn git:(master) ./bin/yarn mutex
    yarn mutex v0.15.1
    error TypeError: mutex.split is not a function
        at config.init.then (yarn/lib/cli/index.js:336:25)

This patch makes the `type` a mandatory parameter. So, now

    ➜  yarn git:(fix-mutex-cmd-args) ./bin/yarn --mutex

      error: option `--mutex <type>[:specifier]' argument missing

Also, simply typing `mutex` will be ignored.

    ➜  yarn git:(fix-mutex-cmd-args) ./bin/yarn --mutex
    yarn mutex v0.15.1
    error No command specified.
    ...
    question Which command would you like to run?:

**Test plan**

Included in summary itself