### PR TITLE
hide verbose error message when no manifest found

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -327,7 +327,8 @@ export default class Config {
         }
       }
 
-      throw new Error(`Couldn't find a package.json (or bower.json) file in ${dir}`);
+      this.reporter.error(this.reporter.lang('noManifestFound', dir));
+      return {};
     });
   }
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -132,6 +132,7 @@ const messages = {
   savedLockfile: 'Saved lockfile.',
   noRequiredLockfile: 'No lockfile in this directory. Run `yarn install` to generate one.',
   noLockfileFound: 'No lockfile found.',
+  noManifestFound: 'Couldn\'t find a package.json (or bower.json) file in $0',
 
   invalidSemver: 'Invalid semver version',
   newVersion: 'New version',


### PR DESCRIPTION
yarn command will not show verbose message when no package.json or
bower is found

fixes #824