### PR TITLE
Document --force

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -679,7 +679,7 @@ export function _setFlags(commander: Object) {
   commander.option('--ignore-engines', 'ignore engines check');
   commander.option('--ignore-scripts', '');
   commander.option('--ignore-optional', '');
-  commander.option('--force', 'refetch all packages');
+  commander.option('--force', 'ignore all caches');
   commander.option('--flat', 'only allow one version of a package');
   commander.option('--prod, --production', '');
   commander.option('--no-lockfile', "don't read or generate a lockfile");

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -679,7 +679,7 @@ export function _setFlags(commander: Object) {
   commander.option('--ignore-engines', 'ignore engines check');
   commander.option('--ignore-scripts', '');
   commander.option('--ignore-optional', '');
-  commander.option('--force', '');
+  commander.option('--force', 'refetch all packages');
   commander.option('--flat', 'only allow one version of a package');
   commander.option('--prod, --production', '');
   commander.option('--no-lockfile', "don't read or generate a lockfile");


### PR DESCRIPTION
**Summary**

Documents `install/add --force`, which does what #858 asks for.

**Test plan**

Run `yarn add --help` or `yarn install --help` and `--force` should be documented as `refetch all packages`
