### PR TITLE
Add --yes flag to yarn init

### DIFF
--- a/__tests__/commands/_init.js
+++ b/__tests__/commands/_init.js
@@ -1,0 +1,81 @@
+/* @flow */
+
+import {Reporter} from '../../src/reporters/index.js';
+import * as reporters from '../../src/reporters/index.js';
+import * as fs from '../../src/util/fs.js';
+import {run as init} from '../../src/cli/commands/init.js';
+import Config from '../../src/config.js';
+
+const stream = require('stream');
+const path = require('path');
+const os = require('os');
+
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'init');
+
+export function runInit(
+  flags: Object,
+  name: string,
+  checkInitialized?: ?(config: Config) => ?Promise<void>,
+): Promise<void> {
+  return run(() => {
+    return init;
+  }, flags, path.join(fixturesLoc, name), checkInitialized);
+}
+
+export async function run(
+  factory: () => (config: Config, reporter: Reporter, flags: Object, args: Array<string>) => Promise<void>,
+  flags: Object,
+  dir: string,
+  checkInitialized: ?(config: Config) => ?Promise<void>,
+): Promise<void> {
+  const cwd = path.join(
+    os.tmpdir(),
+    `yarn-${path.basename(dir)}-${Math.random()}`,
+  );
+  await fs.unlink(cwd);
+  await fs.copy(dir, cwd);
+
+  for (const {basename, absolute} of await fs.walk(cwd)) {
+    if (basename.toLowerCase() === '.ds_store') {
+      await fs.unlink(absolute);
+    }
+  }
+
+  let out = '';
+  const stdout = new stream.Writable({
+    decodeStrings: false,
+    write(data, encoding, cb) {
+      out += data;
+      cb();
+    },
+  });
+
+  const reporter = new reporters.ConsoleReporter({stdout, stderr: stdout});
+
+  // create directories
+  await fs.mkdirp(path.join(cwd, '.yarn'));
+  await fs.mkdirp(path.join(cwd, 'node_modules'));
+
+  try {
+    const config = new Config(reporter);
+    await config.init({
+      cwd,
+      globalFolder: path.join(cwd, '.yarn/.global'),
+      packagesRoot: path.join(cwd, '.yarn'),
+      linkFolder: path.join(cwd, '.yarn/.link'),
+    });
+
+    await init(config, reporter, flags, []);
+
+    try {
+      if (checkInitialized) {
+        await checkInitialized(config);
+      }
+    } finally {
+      // clean up
+      await fs.unlink(cwd);
+    }
+  } catch (err) {
+    throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
+  }
+}

--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import {runInit} from './_init.js';
+import {DEFAULTS} from '../../src/registries/yarn-registry.js';
+import * as fs from '../../src/util/fs.js';
+import assert from 'assert';
+
+const path = require('path');
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+
+test.concurrent('init --yes should create package.json with defaults',  (): Promise<void> => {
+  return runInit({yes: true}, 'init-yes', async (config): Promise<void> => {
+    const {cwd} = config;
+    const manifestFile = await fs.readFile(path.join(cwd, 'package.json'));
+    const manifest = JSON.parse(manifestFile);
+
+    assert.equal(manifest.name, path.basename(cwd));
+    assert.equal(manifest.main, 'index.js');
+    assert.equal(manifest.version, DEFAULTS['init-version']);
+    assert.equal(manifest.license, DEFAULTS['init-license']);
+  });
+});

--- a/__tests__/fixtures/init/init-yes/.npmrc
+++ b/__tests__/fixtures/init/init-yes/.npmrc
@@ -1,0 +1,1 @@
+yarn-offline-mirror=./mirror-for-offline

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "testPathIgnorePatterns": [
       "__tests__/(fixtures|__mocks__)/",
       "updates/",
-      "/_(temp|mock|install).js$"
+      "/_(temp|mock|install|init).js$"
     ]
   }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -12,7 +12,9 @@ import * as fs from '../../util/fs.js';
 const objectPath = require('object-path');
 const path = require('path');
 
-export const noArguments = true;
+export function setFlags(commander: Object) {
+  commander.option('-y, --yes', 'use default options');
+}
 
 export async function run(
   config: Config,
@@ -84,6 +86,7 @@ export async function run(
   // get answers
   const pkg = {};
   for (const entry of keys) {
+    const {yes} = flags;
     const {key: manifestKey} = entry;
     let {question, default: def} = entry;
 
@@ -100,7 +103,14 @@ export async function run(
       question += ` (${def})`;
     }
 
-    const answer = (await reporter.question(question)) || def;
+    let answer;
+
+    if (yes) {
+      answer = def;
+    } else {
+      answer = (await reporter.question(question)) || def;
+    }
+
     if (answer) {
       objectPath.set(pkg, manifestKey, answer);
     }


### PR DESCRIPTION
**Summary**

Added `-y, --yes` flag to `yarn init` to create `package.json` with default values.

Fixes #637.

**Test plan**

```bash
👉  yarn init -y
yarn init v0.15.1
warning The yes flag has been set. This will automatically answer yes to all questions which may have security implications.
success Saved package.json
✨  Done in 0.09s.
```

```bash
👉  cat package.json
{
  "name": "test",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT"
}
```