### PR TITLE
Increase git clone depth to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 git:
-  depth: 1
+  depth: 10
 language: generic
 
 sudo: false


### PR DESCRIPTION
**Summary**

This PR increases the `git` clone depth, so that builds can proceed when multiple commits are pushed before a build runs.

See, for example, https://travis-ci.org/yarnpkg/yarn/jobs/167023508#L121 for an example of the build failure.

**Test plan**

Not applicable.

---

Since this repository has a lot of commits, cloning with
depth 1 can cause builds to fail erroneously when the commit
to test is not available in the shallow clone.