### PR TITLE
Add single resolved version to flattenedPatterns instead of patterns

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -85,6 +85,15 @@ test.concurrent('install file: protocol', (): Promise<void> => {
   });
 });
 
+test.concurrent('install everything when flat is enabled', (): Promise<void> => {
+  return runInstall({noLockfile: true, flat: true}, 'install-file', async (config) => {
+    assert.equal(
+      await fs.readFile(path.join(config.cwd, 'node_modules', 'foo', 'index.js')),
+      'foobar\n',
+    );
+  });
+});
+
 test.concurrent('install renamed packages', (): Promise<void> => {
   return runInstall({}, 'install-renamed-packages', async (config): Promise<void> => {
     const dir = path.join(config.cwd, 'node_modules');

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -410,7 +410,7 @@ export class Install {
       if (infos.length === 1) {
         // single version of this package
         // take out a single pattern as multiple patterns may have resolved to this package
-        patterns.push(this.resolver.patternsByPackage[name][0]);
+        flattenedPatterns.push(this.resolver.patternsByPackage[name][0]);
         continue;
       }
 


### PR DESCRIPTION
**Summary**

Fixes https://github.com/yarnpkg/yarn/issues/893

The single resolved version was accidentally being pushed to the passed in argument instead of the result. I have tested the case presented in the issue, and it works locally. 