### PR TITLE
increase the timeout for long running tests

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -14,7 +14,7 @@ import {runInstall} from './_install.js';
 import assert from 'assert';
 import semver from 'semver';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
 const path = require('path');
 

--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -11,7 +11,7 @@ import assert from 'assert';
 import semver from 'semver';
 import {getPackageVersion, explodeLockfile, runInstall, createLockfile} from './_install.js';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
 const path = require('path');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Increases the timeouts for the `commands/add.js` and `commands/install.js` tests
#903 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
These tests are passing but occasionally timing out on mac os because they take so long to run

**Test plan**
Run the test suite several times on mac os