### PR TITLE
Move `babel-plugin-transform-inline-imports-commonjs` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "dependencies": {
-    "babel-plugin-transform-inline-imports-commonjs": "^1.0.0",
     "babel-runtime": "^6.0.0",
     "bytes": "^2.4.0",
     "camelcase": "^3.0.0",
@@ -47,6 +46,7 @@
     "babel-jest": "^14.0.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-typeof-symbol": "^6.8.0",
+    "babel-plugin-transform-inline-imports-commonjs": "^1.0.0",
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-es2015-node4": "^2.1.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Babel plugin was in `dependencies` rather than `devDependencies`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

