### PR TITLE
Add mkdirp to create a @<scope> folder before doing symlink so that yarn link works

### DIFF
--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -55,6 +55,7 @@ export async function run(
     if (await fs.exists(linkLoc)) {
       throw new MessageError(reporter.lang('linkCollision', name));
     } else {
+      await fs.mkdirp(path.parse(linkLoc).dir);
       await fs.symlink(config.cwd, linkLoc);
       reporter.success(reporter.lang('linkRegistered', name));
       reporter.info(reporter.lang('linkInstallMessage', name));

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -55,7 +55,7 @@ export async function run(
     if (await fs.exists(linkLoc)) {
       throw new MessageError(reporter.lang('linkCollision', name));
     } else {
-      await fs.mkdirp(path.parse(linkLoc).dir);
+      await fs.mkdirp(path.dirname(linkLoc));
       await fs.symlink(config.cwd, linkLoc);
       reporter.success(reporter.lang('linkRegistered', name));
       reporter.info(reporter.lang('linkInstallMessage', name));


### PR DESCRIPTION
**Summary**

I was getting an error each time I did `yarn link` on a scoped module because the symlink can't create a folder the `@<scope>` folder inside 

```
$ yarn link
yarn link v0.15.1
warning package.json: No license field
info /Users/ofunes/.yarn-config/link/@<scope>/<module_name>
error ENOENT: no such file or directory, symlink '../../../path/to/<module_name>' -> '/Users/ofunes/.yarn-config/link/@<scope>/<module_name>'
    at Error (native)
info Visit https://yarnpkg.com/en/docs/cli/link for documentation about this command.
```

**Test plan**

Now when I run `yarn link` it creates the link. 

Since I'm using `mkdirp` available through `utils/fs`, then I (`path.dirname`) parse the `linkLoc` variable and get the `.dir` property which can be either `/Users/ofunes/.yarn-config/link` or `/Users/ofunes/.yarn-config/link/@<scope>`  just before calling `symlink` since the `/link` folder already exists then `mkdirp` does nothing and when it has an `@scope` it will create it. :)

```
$ yarn link
yarn link v0.15.1
warning package.json: No license field
success Registered "@<scope>/<module_name>".
info You can now run `yarn link "@<scope>/<module_name>"` in the projects where you want to use this module and it will be used instead.
✨  Done in 0.07s.
```