### PR TITLE
Add node shebang to single JS builds

### DIFF
--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -27,6 +27,12 @@ const compiler = webpack({
       loader: 'json',
     }],
   },
+  plugins: [
+    new webpack.BannerPlugin({
+      banner: "#!/usr/bin/env node",
+      raw: true
+    })
+  ],
   output: {
     filename: `yarn-${version}.js`,
     path: path.join(basedir, 'dist'),
@@ -58,6 +64,12 @@ const compilerLegacy = webpack({
       loader: 'json',
     }],
   },
+  plugins: [
+    new webpack.BannerPlugin({
+      banner: "#!/usr/bin/env node",
+      raw: true
+    })
+  ],
   output: {
     filename: `yarn-legacy-${version}.js`,
     path: path.join(basedir, 'dist'),


### PR DESCRIPTION
**Summary**

Adds `#!/usr/bin/env node` at the top of single JS builds so they can be run directly if execute permissions are set. Fixes #888 

**Test plan**

`npm run test` has no changes.
