### PR TITLE
Change DEB nodejs relation from Depends to Recommends

### DIFF
--- a/resources/debian/control.in
+++ b/resources/debian/control.in
@@ -1,6 +1,7 @@
 Package: yarn
 Version: $VERSION-1
-Recommends: nodejs (>= 4.0.0)
+Recommends: nodejs
+Conflicts: nodejs (< 4.0.0)
 Section: devel
 Priority: optional
 Architecture: all

--- a/resources/debian/control.in
+++ b/resources/debian/control.in
@@ -1,6 +1,6 @@
 Package: yarn
 Version: $VERSION-1
-Depends: nodejs (>= 4.0.0)
+Recommends: nodejs (>= 4.0.0)
 Section: devel
 Priority: optional
 Architecture: all


### PR DESCRIPTION
**Summary**

A "Recommends" relation preserves the out-of-the-box experience for most people, as recommended packages are installed by default on modern Debian / Ubuntu distros. But it allows people who install Node.js using a different method to opt out of the nodejs DEB package.

**Test plan**

`$ bash scripts/build-deb.sh`
...
`$ sudo dpkg -i artifacts/yarn_0.15.1_all.deb`

^ the above commands execute successfully.

```
$ which yarn 
/usr/bin/yarn
```

```
$ yarn version
yarn version v0.15.1
info Current version: 0.15.1
```