### PR TITLE
Add support for usernames in git resolver (Take 2)

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -41,6 +41,7 @@ addTest('https://github.com/npm-ml/re'); // git url with no .git
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz'); // tarball
 addTest('https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // hash
+addTest('https://git@github.com/babel/babylon.git'); // git url, with username
 addTest('https://github.com/babel/babel-loader.git#feature/sourcemaps'); // hash with slashes
 addTest('git+https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // git+hash
 addTest('gitlab:leanlabsio/kanban'); // gitlab

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -30,13 +30,13 @@ export default class GitResolver extends ExoticResolver {
   hash: string;
 
   static isVersion(pattern: string): boolean {
+    const parts = urlParse(pattern);
+
     // this pattern hasn't been exploded yet, we'll hit this code path again later once
     // we've been normalized #59
-    if (pattern.indexOf('@') >= 0) {
+    if (!parts.protocol) {
       return false;
     }
-
-    const parts = urlParse(pattern);
 
     const pathname = parts.pathname;
     if (pathname && pathname.endsWith('.git')) {
@@ -44,10 +44,8 @@ export default class GitResolver extends ExoticResolver {
       return true;
     }
 
-    if (parts.protocol) {
-      if (GIT_PROTOCOLS.indexOf(parts.protocol) >= 0) {
-        return true;
-      }
+    if (GIT_PROTOCOLS.indexOf(parts.protocol) >= 0) {
+      return true;
     }
 
     if (parts.hostname && parts.path) {


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The Git resolver did not understand usernames in URLs, e.g. `git+ssh://git@github.com/...` due to it treating any pattern containing `@` as being "un-exploded". See https://github.com/yarnpkg/yarn/commit/411205015b7d4f4af3c344062c1f85c64a32365c, #513.

For me it was falling through, and calling the npm resolver instead. The package wasn't published on the registry, so it was erroring there. For others, it would error due to version mismatches if it was on the registry.

Instead, it's now simply treating any `pattern` with no protocol as being invalid. [There's no valid npm git URL without a protocol.](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies)

Example failing pattern from before:

```
eslint-config-radweb@git+https://git@github.com/radweb/eslint-config-radweb.git
                    ^               ^
```

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added test, they pass.

Btw I've noticed `https://github.com/npm-ml/ocaml.git#npm-4.02.3` times out a _lot_.