### PR TITLE
Fix 'yarn cache dir' by using config.cacheFolder

### DIFF
--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -32,7 +32,7 @@ export const {run, setFlags} = buildSubCommands('cache', {
   },
 
   dir(config: Config) {
-    console.log(config.packagesRoot);
+    console.log(config.cacheFolder);
   },
 
   async clean(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

After PR #881 was merged, 'yarn cache dir' stopped working (was returning undefined). This PR was renaming config.packagesRoot to config.cacheFolder, but left out the dir method for the cache command.

This PR just changes the old config.packagesRoot to the new name config.cacheFolder in the cache dir method. 

**Test plan**

Output before -> undefined
Output after -> /Users/myuser/.yarn-cache

Also flow check was failing before, now it's passing.

