### PR TITLE
fix(config): show proper command for `yarn help config`

### DIFF
--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -5,7 +5,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import buildSubCommands from './_build-sub-commands.js';
 
-export const {run, setFlags} = buildSubCommands('access', {
+export const {run, setFlags} = buildSubCommands('config', {
   async set(
     config: Config,
     reporter: Reporter,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I noticed that `yarn help config` showed the following usage:

```console
$ yarn help config

  Usage: yarn access [set|get|delete|list] [flags]

  Options:

    -h, --help                  output usage information
    -V, --version               output the version number
    --offline                   
    --prefer-offline            
    --strict-semver             
    --json                      
    --global-folder <path>      
    --modules-folder <path>     rather than installing modules into the node_modules folder relative to the cwd, output them here
    --cache-folder <path>       specify a custom folder to store the yarn cache
    --mutex <type>[:specifier]  use a mutex to ensure only one yarn instance is executing

  Visit https://yarnpkg.com/en/docs/cli/config for documentation about this command.
```

Notice that the usage string says `yarn access`. Looks like a copy-pasta error from [this commit](https://github.com/yarnpkg/yarn/commit/86c98a62a721ec6b3cfcbb9ad745a1e6e1fafdf1#diff-e8ae27bec41dec1a053c1d1904bb85f2R8). This PR fixes that.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

After pulling/merging this branch, rerun `npm run build` and then you'll see this:

```console
$ yarn help config

  Usage: yarn config [set|get|delete|list] [flags]

  Options:

    -h, --help                  output usage information
    -V, --version               output the version number
    --offline                   
    --prefer-offline            
    --strict-semver             
    --json                      
    --global-folder <path>      
    --modules-folder <path>     rather than installing modules into the node_modules folder relative to the cwd, output them here
    --cache-folder <path>       specify a custom folder to store the yarn cache
    --mutex <type>[:specifier]  use a mutex to ensure only one yarn instance is executing

  Visit https://yarnpkg.com/en/docs/cli/config for documentation about this command.
```