### PR TITLE
When rendering spinners, only clear to the right of the cursor instead of the whole line

### DIFF
--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -4,8 +4,11 @@ import type {Stdout} from '../types.js';
 
 const readline = require('readline');
 
+const CLEAR_WHOLE_LINE = 0;
+const CLEAR_RIGHT_OF_CURSOR = 1;
+
 export function clearLine(stdout: Stdout) {
-  readline.clearLine(stdout, 0);
+  readline.clearLine(stdout, CLEAR_WHOLE_LINE);
   readline.cursorTo(stdout, 0);
 }
 
@@ -15,14 +18,15 @@ export function toStartOfLine(stdout: Stdout) {
 
 export function writeOnNthLine(stdout: Stdout, n: number, msg: string) {
   if (n == 0) {
-    clearLine(stdout);
+    readline.cursorTo(stdout, 0);
     stdout.write(msg);
+    readline.clearLine(stdout, CLEAR_RIGHT_OF_CURSOR);
     return;
   }
   readline.cursorTo(stdout, 0);
   readline.moveCursor(stdout, 0, -n);
-  readline.clearLine(stdout, 0);
   stdout.write(msg);
+  readline.clearLine(stdout, CLEAR_RIGHT_OF_CURSOR);
   readline.cursorTo(stdout, 0);
   readline.moveCursor(stdout, 0, n);
 }
@@ -34,6 +38,6 @@ export function clearNthLine(stdout: Stdout, n: number) {
   }
   readline.cursorTo(stdout, 0);
   readline.moveCursor(stdout, 0, -n);
-  readline.clearLine(stdout, 0);
+  readline.clearLine(stdout, CLEAR_WHOLE_LINE);
   readline.moveCursor(stdout, 0, n);
 }


### PR DESCRIPTION
**Summary**

Similar to my PR for the progress bar (#526), this improves the display of the "spinners". Previously, we were clearing the line then immediately writing to it, resulting in a lot of flashing text. I've changed it to write the new text on top of the old text, and then just clear to the right of the cursor (in case the new text is shorter than the old text)

Before:
![](http://ss.dan.cx/2016/10/12-21.20.02.gif)

After:
![](http://ss.dan.cx/2016/10/12-21.22.32.gif)

The cursor still jumps around a lot, I'm not sure if we can solve that though :(

**Test plan**

Run `yarn install` on a `package.json` that uses native modules:
```
{
  "name": "lolyarn",
  "version": "1.0.0",
  "dependencies": {
    "bcrypt": "^0.8.7",
    "leveldown": "^1.5.0"
  }
}
```