### PR TITLE
Fix support for private GitHub shortcuts deps

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -12,6 +12,7 @@ import * as fs from '../src/util/fs.js';
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 const path = require('path');
+const isCI = require('is-ci');
 
 function addTest(pattern, registry = 'npm') {
   // TODO renable these test.concurrent
@@ -35,6 +36,7 @@ function addTest(pattern, registry = 'npm') {
   });
 }
 
+// Public deps
 addTest('https://github.com/npm-ml/re'); // git url with no .git
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz'); // tarball
@@ -51,3 +53,12 @@ addTest('react-native'); // npm
 addTest('ember-cli'); // npm
 addTest('npm:gulp'); // npm
 addTest('@polymer/iron-icon'); // npm scoped package
+
+// Private deps
+
+// Only the yarn CI tools have access to this private deps. If you want to test this locally,
+// remove the if condition and change the urls to match your private deps.
+if (isCI) {
+  addTest('yarnpkg/private-dep#c6cf811'); // private github shortcut
+  addTest('github:yarnpkg/private-dep#c6cf811'); // private github shortcut, with provider
+}

--- a/__tests__/resolvers/exotics/bitbucket-resolver.js
+++ b/__tests__/resolvers/exotics/bitbucket-resolver.js
@@ -35,14 +35,25 @@ test('getGitHTTPUrl should return the correct git bitbucket url', () => {
   expect(BitBucketResolver.getGitHTTPUrl(fragment)).toBe(expected);
 });
 
-test('getGitHTTPUrl should return the correct git bitbucket SSH url', () => {
+test('getGitSSH should return the correct git bitbucket SSH url', () => {
   const fragment: ExplodedFragment = {
     user: 'foo',
     repo: 'bar',
     hash: '',
   };
 
-  const expected =  'git@bitbucket.org:' + fragment.user + '/' + fragment.repo + '.git';
+  const expected =  `git@bitbucket.org:${fragment.user}/${fragment.repo}.git`;
+  expect(BitBucketResolver.getGitSSH(fragment)).toBe(expected);
+});
+
+test('getGitSSHUrl should return the correct git bitbucket SSH url', () => {
+  const fragment: ExplodedFragment = {
+    user: 'foo',
+    repo: 'bar',
+    hash: '',
+  };
+
+  const expected =  `git+ssh://git@bitbucket.org/${fragment.user}/${fragment.repo}.git`;
   expect(BitBucketResolver.getGitSSHUrl(fragment)).toBe(expected);
 });
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ini": "^1.3.4",
     "invariant": "^2.2.0",
     "is-builtin-module": "^1.0.0",
+    "is-ci": "^1.0.9",
     "leven": "^2.0.0",
     "loud-rejection": "^1.2.0",
     "minimatch": "^3.0.3",

--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -16,6 +16,10 @@ export default class BitbucketResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
+    return `git+ssh://git@bitbucket.org/${ parts.user }/${ parts.repo }.git`;
+  }
+
+  static getGitSSH(parts: ExplodedFragment): string {
     return `git@bitbucket.org:${parts.user}/${parts.repo}.git`;
   }
 

--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -26,6 +26,11 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
+    return `git+ssh://git@github.com/${ parts.user }/${ parts.repo }.git` +
+      `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
+  }
+
+  static getGitSSH(parts: ExplodedFragment): string {
     return `git@${this.hostname}:${parts.user}/${parts.repo}.git` +
       `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }

--- a/src/resolvers/exotics/gitlab-resolver.js
+++ b/src/resolvers/exotics/gitlab-resolver.js
@@ -16,6 +16,10 @@ export default class GitLabResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
+    return `git+ssh://git@gitlab.com/${ parts.user }/${ parts.repo }.git`;
+  }
+
+  static getGitSSH(parts: ExplodedFragment): string {
     return `git@gitlab.com:${parts.user}/${parts.repo}.git`;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,7 +2671,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-ci@^1.0.9:
+is-ci, is-ci@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.9.tgz#de2c5ffe49ab3237fda38c47c8a3bbfd55bbcca7"
 


### PR DESCRIPTION
**Summary**

Fix support for private GitHub shortcuts deps. See #573

**Test plan**

![Example of commands and code](https://cloud.githubusercontent.com/assets/7464663/19340622/3ca7c65e-9100-11e6-94d5-82d1aa3226db.gif)

Only works with shortcuts:

``` json
"private-test": "github:ramasilveyra/private-test#d6c5789"
"private-test": "ramasilveyra/private-test#d6c5789"
```

I tried to follow the same name convention of [npm/hosted-git-info](https://github.com/npm/hosted-git-info) for the "urls".

I found that npm first tries the `git://` (info.git()) url then the `git@...` (info.ssh()) url then the `https://` (info.https()) url and finally the `git+ssh://...` (info.sshurl()) url: https://github.com/npm/npm/commit/6b0f58877f37df9904490ffbaaad33862bd36dce

Also what do you think about using this package to support the same repository urls for Github, Bitbucket and Gitlab as npm? It could solve a couple of incompatibility issues.

To make it work with this urls needs a little of more work on the `GitResolver`:

``` json
"private-test": "git://github.com/ramasilveyra/private-test.git#d6c5789"
"private-test": "git@github.com:ramasilveyra/private-test.git#d6c5789"
"private-test": "git+https://github.com/ramasilveyra/private-test.git#d6c5789"
"private-test": "git+ssh://git@github.com/ramasilveyra/private-test.git#d6c5789"
```

**Update**
yarn v0.16.0 actually works with:

```
"private-test": "git+ssh://git@github.com/ramasilveyra/private-test.git#d6c5789"
```
