### PR TITLE
fix(packageLinker): ensure dir before symlinking bin

### DIFF
--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -26,6 +26,7 @@ export async function linkBin(src: string, dest: string): Promise<void> {
   if (process.platform === 'win32') {
     await cmdShim(src, dest);
   } else {
+    await fs.mkdirp(path.dirname(dest));
     await fs.symlink(src, dest);
     await fs.chmod(dest, '755');
   }


### PR DESCRIPTION
**Summary**

When installing a scoped package that has a `bin` entry in its package.json, the symlink will fail because the dest dir cannot be found. 

This was fixed for the `yarn link` command in https://github.com/yarnpkg/yarn/pull/910, but not for `yarn install`. 

**Test plan**

_before_
![screenshot](https://i.imgur.com/xdRbSgF.png)

_after_
![screenshot](https://i.imgur.com/qsAnWJn.png)

--- 

I would've liked to add some tests for this, but my Jest-juju isn't up to speed so I decided against setting up a fresh test suite for the `PackageLinker`. I can give it a whirl, but for now I have to get back to my day-to-day's.

Ref issues: https://github.com/yarnpkg/yarn/issues/950, https://github.com/yarnpkg/yarn/issues/759