### PR TITLE
fix(engines): Suppress 'rhino' as invalid engine.

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -50,6 +50,7 @@ const aliases = map({
 const ignore = [
   'npm', // we'll never satisfy this for obvious reasons
   'teleport', // a module bundler used by some modules
+  'rhino', // once a target for older modules
 ];
 
 type Versions = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Older versions of lodash, among other packages, list `'rhino'` as an engine.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Printing a warning here doesn't accomplish much - best to suppress it.

Fixes #1003