### PR TITLE
Fix test for `yarn init --yes`

### DIFF
--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import {runInit} from './_init.js';
-import {DEFAULTS} from '../../src/registries/yarn-registry.js';
 import * as fs from '../../src/util/fs.js';
 import assert from 'assert';
 
@@ -17,7 +16,7 @@ test.concurrent('init --yes should create package.json with defaults',  (): Prom
 
     assert.equal(manifest.name, path.basename(cwd));
     assert.equal(manifest.main, 'index.js');
-    assert.equal(manifest.version, DEFAULTS['init-version']);
-    assert.equal(manifest.license, DEFAULTS['init-license']);
+    assert.equal(manifest.version, String(config.getOption('init-version')));
+    assert.equal(manifest.license, String(config.getOption('init-license')));
   });
 });


### PR DESCRIPTION
**Summary**

Fixed test to use default values from config.

**Test plan**

```bash
👉  jest --verbose __tests__/commands/init.js
 PASS  __tests__/commands/init.js
  ✓ init --yes should create package.json with defaults (162ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.102s, estimated 5s
Ran all test suites matching "__tests__/commands/init.js".
```

cc @bestander 