### PR TITLE
fix(cache#ls): fix cache ls for scoped packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "rimraf": "^2.5.0",
     "roadrunner": "^1.1.0",
     "semver": "^5.1.0",
+    "semver-regex": "^1.0.0",
     "strip-bom": "^2.0.0",
     "tar": "^2.2.1",
     "tar-stream": "^1.5.2",

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -6,6 +6,7 @@ import buildSubCommands from './_build-sub-commands.js';
 import * as fs from '../../util/fs.js';
 
 const path = require('path');
+const semverRegex = require('semver-regex');
 
 export const {run, setFlags} = buildSubCommands('cache', {
   async ls(
@@ -18,6 +19,12 @@ export const {run, setFlags} = buildSubCommands('cache', {
     const body = [];
 
     for (const file of files) {
+      if (/^npm-@/.test(file) && !semverRegex().test(file)) {
+        const add = await fs.readdir(`${config.cacheFolder}/${file}`);
+        files.push(...add.map((f) => `${file}/${f}`));
+        continue;
+      }
+
       if (file[0] === '.') {
         continue;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4450,6 +4450,10 @@ sax@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
+semver-regex:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
+
 semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"


### PR DESCRIPTION
**Summary**

After getting scoped packages w/ bin entries working correctly I wanted to take a look in my cache. 

![ss](https://i.imgur.com/3EcXbvj.png)

`yarn` tries to find metadata files in the top-level scope directory, but the packages w/ meta information are deeper inside the tree. 

**Test plan**

I added two checks (and a dependency): 

* First, verify that the given filepath starts with `npm-@`.
* Second, verify that there is **not** a valid semver tag in the given path. 
  * uses [semver-regex](https://github.com/sindresorhus/semver-regex)

If both check out, I reckon we've found a scope dir. Get a list of all the first-level subfolders through readdir, push em back into the `files` array with the scope prefix and this is now the end of my `yarn cache ls` command: 

![ss](https://i.imgur.com/h8J4TGi.png)

ref issue: https://github.com/yarnpkg/yarn/issues/698