### PR TITLE
Make `yarn why` more accurate

### DIFF
--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -43,8 +43,7 @@ async function getPackageSize(info: HoistManifest): Promise<number> {
   ]));
   const sizes = await Promise.all(
     files.map(
-      (walkFile) => fs.stat(walkFile.absolute)
-        .then((stat) => stat.size),
+      (walkFile) => fs.fileSizeOnDisk(walkFile.absolute),
     ),
   );
   return sum(sizes);

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import type {HoistManifest} from '../../package-hoister.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 
@@ -36,8 +35,8 @@ async function cleanQuery(config: Config, query: string): Promise<string> {
   return query;
 }
 
-async function getPackageSize(info: HoistManifest): Promise<number> {
-  const files = await fs.walk(info.loc, null, new Set([
+async function getPackageSize([loc, info]): Promise<number> {
+  const files = await fs.walk(loc, null, new Set([
     METADATA_FILENAME,
     TARBALL_FILENAME,
   ]));
@@ -46,23 +45,29 @@ async function getPackageSize(info: HoistManifest): Promise<number> {
       (walkFile) => fs.fileSizeOnDisk(walkFile.absolute),
     ),
   );
+
   return sum(sizes);
 }
 
 
 const sum = (array) => array.length ? array.reduce((a, b) => a + b, 0) : 0;
 const collect = (hoistManifests, allDependencies, dependency, {recursive} = {recursive: false}) => {
-  const deps = dependency.pkg.dependencies;
+  const [, depInfo] = dependency;
+  const deps = depInfo.pkg.dependencies;
+
   if (!deps) {
     return allDependencies;
   }
 
   const dependencyKeys = new Set(Object.keys(deps));
   const directDependencies = [];
-  for (const [, info] of hoistManifests) {
-    if (!allDependencies.has(info) && dependencyKeys.has(info.key)) {
-      allDependencies.add(info);
-      directDependencies.push(info);
+
+  for (const dep of hoistManifests) {
+    const [, info] = dep;
+
+    if (!allDependencies.has(dep) && dependencyKeys.has(info.key)) {
+      allDependencies.add(dep);
+      directDependencies.push(dep);
     }
   }
 
@@ -117,9 +122,9 @@ export async function run(
   reporter.step(3, 4, reporter.lang('whyFinding'), emoji.get('mag'));
 
   let match;
-  for (const [, info] of hoisted) {
+  for (const [loc, info] of hoisted) {
     if (info.key === query || info.previousKeys.indexOf(query) >= 0) {
-      match = info;
+      match = [loc, info];
       break;
     }
   }
@@ -129,7 +134,8 @@ export async function run(
     return;
   }
 
-  const matchRef = match.pkg._reference;
+  const [, matchInfo] = match;
+  const matchRef = matchInfo.pkg._reference;
   invariant(matchRef, 'expected reference');
 
   const matchPatterns = matchRef.patterns;
@@ -176,8 +182,8 @@ export async function run(
   }
 
   // reason: this is hoisted from these modules
-  for (const pattern of match.previousKeys) {
-    if (pattern !== match.key) {
+  for (const pattern of matchInfo.previousKeys) {
+    if (pattern !== matchInfo.key) {
       reasons.push({
         type: 'whyHoistedFrom',
         typeSimple: 'whyHoistedFromSimple',
@@ -204,13 +210,13 @@ export async function run(
     transitiveSizes = await Promise.all(transitiveDependencies.map(getPackageSize));
   } catch (e) {}
 
-  const transitiveKeys = new Set(transitiveDependencies.map((info) => info.key));
+  const transitiveKeys = new Set(transitiveDependencies.map(([, info]) => info.key));
   const sharedDependencies = getSharedDependencies(hoisted, transitiveKeys);
 
   //
   // reason: hoisted
-  if (query === match.originalKey) {
-    reporter.info(reporter.lang('whyHoistedTo', match.key));
+  if (query === matchInfo.originalKey) {
+    reporter.info(reporter.lang('whyHoistedTo', matchInfo.key));
   }
 
   if (reasons.length === 1) {

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -42,7 +42,7 @@ async function getPackageSize([loc, info]): Promise<number> {
   ]));
   const sizes = await Promise.all(
     files.map(
-      (walkFile) => fs.fileSizeOnDisk(walkFile.absolute),
+      (walkFile) => fs.getFileSizeOnDisk(walkFile.absolute),
     ),
   );
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -412,6 +412,18 @@ export async function walk(
   return files;
 }
 
+export async function fileSizeOnDisk(loc: string): Promise<number> {
+  const stat = await lstat(loc);
+
+  return _fileSizeOnDisk(stat);
+}
+
+export function _fileSizeOnDisk(fileStat: Object): number {
+  const {size, blksize: blockSize} = fileStat;
+
+  return (Math.ceil(size / blockSize) * blockSize);
+}
+
 export function normalizeOS(body: string): string {
   return body.replace(/\r\n/g, '\n');
 }

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -412,14 +412,9 @@ export async function walk(
   return files;
 }
 
-export async function fileSizeOnDisk(loc: string): Promise<number> {
+export async function getFileSizeOnDisk(loc: string): Promise<number> {
   const stat = await lstat(loc);
-
-  return _fileSizeOnDisk(stat);
-}
-
-export function _fileSizeOnDisk(fileStat: Object): number {
-  const {size, blksize: blockSize} = fileStat;
+  const {size, blksize: blockSize} = stat;
 
   return (Math.ceil(size / blockSize) * blockSize);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Added calculating `size on disk` for dependencies and counting the size of real packages from `node_modules` instead of packages from cache (see #578). I'm new to this stuff so feel free to suggest some improvements to this.

**Test plan**
The same scenario as in #578:
```
mkdir test && cd test
yarn init -y && yarn add jest

du -sh node_modules
 42M	node_modules

yarn why jest
yarn why v0.15.1
[1/4] 🤔  Why do we have the module "jest"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
info Has been hoisted to "jest"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "36kB"
info Disk size with unique dependencies: "252kB"
info Disk size with transitive dependencies: "43MB"
info Amount of shared dependencies: 18
✨  Done in 1.27s.
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

cc @cpojer, would love to hear some feedback from you on this!