### PR TITLE
split aliases and affordances and enable aliases

### DIFF
--- a/src/cli/aliases.js
+++ b/src/cli/aliases.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export default {
+export const aliases = {
   // shorthands
   'run-script': 'run',
   c: 'config',
@@ -14,8 +14,9 @@ export default {
   un: 'remove',
   up: 'update',
   v: 'info',
+};
 
-  // affordances
+export const affordances = {
   'add-user': 'login',
   'dist-tag': 'tag',
   'dist-tags': 'tag',

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -6,7 +6,7 @@ import * as commands from './commands/index.js';
 import * as constants from '../constants.js';
 import * as network from '../util/network.js';
 import {MessageError} from '../errors.js';
-import aliases from './aliases.js';
+import {affordances, aliases} from './aliases.js';
 import Config from '../config.js';
 
 const camelCase = require('camelcase');
@@ -99,14 +99,18 @@ if (!commandName || commandName[0] === '-') {
   commandName = 'install';
 }
 
-// aliases: i -> install
-// $FlowFixMe
-if (commandName && typeof aliases[commandName] === 'string') {
+// affordances:  verison -> version?
+if (commandName && typeof affordances[commandName] === 'string') {
   command = {
     run(config: Config, reporter: ConsoleReporter | JSONReporter): Promise<void> {
-      throw new MessageError(`Did you mean \`yarn ${aliases[commandName]}\`?`);
+      throw new MessageError(`Did you mean \`yarn ${affordances[commandName]}\`?`);
     },
   };
+}
+
+// aliases: i -> install
+if (commandName && typeof aliases[commandName] === 'string') {
+  commandName = aliases[commandName];
 }
 
 //


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

#1035 In the interest of migration from npm and general compatibility, enabling some of the most common aliases is nice :) 

**Test plan**
before:
```
> yarn run-script install
yarn run-script v0.15.1
error Did you mean `yarn run`?
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
after:
```
> yarn run-script install
yarn run v0.15.1
$ echo 'install'
'install'
$ echo 'postinstall'
'postinstall'
Done in 0.06s.
```

What was previously the "affordances" section of the aliases object is now what errors and suggests a command.
both before and after:
```
> yarn rm
yarn rm v0.15.1
error Did you mean `yarn remove`?
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

