### PR TITLE
Enable ability to run `yarn upgrade [package]`

### DIFF
--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -10,7 +10,6 @@ export function setFlags(commander: Object) {
   commander;
 }
 
-export const noArguments = true;
 export const requireLockfile = true;
 
 export async function run(


### PR DESCRIPTION
**Summary**

This solves #598. This doesn't affect the ability to run `yarn upgrade` to upgrade all packages.

**Test plan**

```sh
❯ yarn outdated
yarn outdated v0.15.1
Package   Current Wanted Latest
react-dom 15.1.0  15.3.2 15.3.2
react     15.1.0  15.3.2 15.3.2
✨  Done in 0.37s.
```

##### Before:

```sh
❯ yarn upgrade react
yarn upgrade v0.15.1
error This command doesn't require any arguments.
info Visit http://yarnpkg.com/en/docs/cli/upgrade for documentation about this command.
```

##### After:

```sh
❯ yarn upgrade react
yarn upgrade v0.15.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 2 new dependencies.
├─ fbjs@0.8.5
└─ react@15.3.2
✨  Done in 0.79s.
```

```sh
❯ yarn ls
yarn ls v0.15.1
├─ asap@2.0.5
├─ core-js@1.2.7
├─ encoding@0.1.12
│  └─ iconv-lite@~0.4.13
├─ fbjs@0.8.5
│  ├─ core-js@^1.0.0
│  ├─ immutable@^3.7.6
│  ├─ isomorphic-fetch@^2.1.1
│  ├─ loose-envify@^1.0.0
│  ├─ object-assign@^4.1.0
│  ├─ promise@^7.1.1
│  └─ ua-parser-js@^0.7.9
├─ iconv-lite@0.4.13
├─ immutable@3.8.1
├─ is-stream@1.1.0
├─ isomorphic-fetch@2.2.1
│  ├─ node-fetch@^1.0.1
│  └─ whatwg-fetch@>=0.10.0
├─ js-tokens@1.0.3
├─ loose-envify@1.2.0
│  └─ js-tokens@^1.0.1
├─ node-fetch@1.6.3
│  ├─ encoding@^0.1.11
│  └─ is-stream@^1.0.1
├─ object-assign@4.1.0
├─ promise@7.1.1
│  └─ asap@~2.0.3
├─ react-dom@15.1.0
├─ react@15.3.2
│  ├─ fbjs@^0.8.4
│  ├─ loose-envify@^1.1.0
│  └─ object-assign@^4.1.0
├─ ua-parser-js@0.7.10
└─ whatwg-fetch@1.0.0
✨  Done in 0.09s.
```
