### PR TITLE
Remove duplicate team display

### DIFF
--- a/src/cli/commands/team.js
+++ b/src/cli/commands/team.js
@@ -186,9 +186,9 @@ export const {run, setFlags} = buildSubCommands('team', {
     return true;
   }, false),
 }, [
-  'team create <scope:team>',
-  'team destroy <scope:team>',
-  'team add <scope:team> <user>',
-  'team rm <scope:team> <user>',
-  'team ls <scope>|<scope:team>',
+  'create <scope:team>',
+  'destroy <scope:team>',
+  'add <scope:team> <user>',
+  'rm <scope:team> <user>',
+  'ls <scope>|<scope:team>',
 ]);


### PR DESCRIPTION
**Summary**

When running the `yarn team` command without arguments, the display would output each command with "team" duplicated, which shows an invalid command. See test plan below for comparison.

**Test plan**

##### Before:

```sh
❯ yarn team
yarn team v0.15.1
error Usage:
error yarn team team create <scope:team>
error yarn team team destroy <scope:team>
error yarn team team add <scope:team> <user>
error yarn team team rm <scope:team> <user>
error yarn team team ls <scope>|<scope:team>
error Invalid subcommand. Try "create, destroy, add, rm, ls"
info Visit http://yarnpkg.com/en/docs/cli/team for documentation about this command.
```

##### After:

```sh
❯ yarn team
yarn team v0.15.1
error Usage:
error yarn team create <scope:team>
error yarn team destroy <scope:team>
error yarn team add <scope:team> <user>
error yarn team rm <scope:team> <user>
error yarn team ls <scope>|<scope:team>
error Invalid subcommand. Try "create, destroy, add, rm, ls"
info Visit https://yarnpkg.com/en/docs/cli/team for documentation about this command.
```