### PR TITLE
Ensure arguments to `yarn team <cmd>` before going further

### DIFF
--- a/src/cli/commands/team.js
+++ b/src/cli/commands/team.js
@@ -45,6 +45,10 @@ function wrapRequired(callback: CLIFunctionWithParts, requireTeam: boolean): CLI
     flags: Object,
     args: Array<string>,
   ): CLIFunctionReturn {
+    if (!args.length) {
+      return false;
+    }
+
     const parts = explodeScopeTeam(args[0], requireTeam, reporter);
     if (!parts) {
       return false;


### PR DESCRIPTION
**Summary**

This fixes #1018. Previous would throw an ugly stack trace trying to split a string that doesn't exist. This fix will bail early when no arguments are given and show the command usage.

**Test plan**

##### Before:

```sh
❯ yarn team ls
yarn team v0.15.1
error TypeError: Cannot read property 'split' of undefined
    at explodeScopeTeam (/Users/neil/Projects/external/yarn/lib/cli/commands/team.js:41:23)
    at /Users/neil/Projects/external/yarn/lib/cli/commands/team.js:68:21
    at next (native)
    at step (/Users/neil/Projects/external/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/neil/Projects/external/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at Promise.F (/Users/neil/Projects/external/yarn/node_modules/core-js/library/modules/_export.js:35:28)
    at /Users/neil/Projects/external/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
    at /Users/neil/Projects/external/yarn/lib/cli/commands/team.js:87:19
    at Object.<anonymous> (/Users/neil/Projects/external/yarn/lib/cli/commands/_build-sub-commands.js:20:27)
    at next (native)
info Visit https://yarnpkg.com/en/docs/cli/team for documentation about this command.
```

##### After:

```sh
❯ yarn team ls
yarn team v0.15.1
error Usage:
error yarn team create <scope:team>
error yarn team destroy <scope:team>
error yarn team add <scope:team> <user>
error yarn team rm <scope:team> <user>
error yarn team ls <scope>|<scope:team>
error Invalid subcommand. Try "create, destroy, add, rm, ls"
info Visit https://yarnpkg.com/en/docs/cli/team for documentation about this command.
```
