### PR TITLE
Return SSH URL format for getGitSSHUrl

### DIFF
--- a/__tests__/resolvers/exotics/bitbucket-resolver.js
+++ b/__tests__/resolvers/exotics/bitbucket-resolver.js
@@ -2,7 +2,9 @@
 
 import BitBucketResolver from '../../../src/resolvers/exotics/bitbucket-resolver.js';
 import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
+import Git from '../../../src/util/git.js';
 
+const url = require('url');
 const _bitBucketBase = 'https://bitbucket.org/';
 
 test('hostname should be "bitbucket.org" ', () => {
@@ -42,7 +44,7 @@ test('getGitHTTPUrl should return the correct git bitbucket SSH url', () => {
     hash: '',
   };
 
-  const expected =  'git@bitbucket.org:' + fragment.user + '/' + fragment.repo + '.git';
+  const expected =  'git+ssh://git@bitbucket.org/' + fragment.user + '/' + fragment.repo + '.git';
   expect(BitBucketResolver.getGitSSHUrl(fragment)).toBe(expected);
 });
 
@@ -58,4 +60,15 @@ test('getHTTPFileUrl should return the correct HTTP file url', () => {
 
   const expected =  _bitBucketBase + fragment.user + '/' + fragment.repo + '/raw/' + commit + '/' + filename;
   expect(BitBucketResolver.getHTTPFileUrl(fragment, filename, commit)).toBe(expected);
+});
+
+test('getGitSSHUrl should return URL containing protocol', () => {
+  const gitSSHUrl = BitBucketResolver.getGitSSHUrl({
+    hash: '',
+    repo: 'some-repo',
+    user: 'some-user',
+  });
+
+  expect(url.parse(gitSSHUrl).protocol).toEqual('git+ssh:');
+  expect(url.parse(Git.cleanUrl(gitSSHUrl)).protocol).toEqual('ssh:');
 });

--- a/__tests__/resolvers/exotics/gitlab-resolver.js
+++ b/__tests__/resolvers/exotics/gitlab-resolver.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import GitHubResolver from '../../../src/resolvers/exotics/github-resolver.js';
+import GitLabResolver from '../../../src/resolvers/exotics/gitlab-resolver.js';
 import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
 import Git from '../../../src/util/git.js';
 
 const url = require('url');
 
 test('getGitSSHUrl with hash', () => {
-  const gitSSHUrl = GitHubResolver.getGitSSHUrl({
+  const gitSSHUrl = GitLabResolver.getGitSSHUrl({
     hash: 'some-hash',
     repo: 'some-repo',
     user: 'some-user',
@@ -17,7 +17,7 @@ test('getGitSSHUrl with hash', () => {
 });
 
 test('getGitSSHUrl with no hash', () => {
-  const gitSSHUrl = GitHubResolver.getGitSSHUrl({
+  const gitSSHUrl = GitLabResolver.getGitSSHUrl({
     hash: '',
     repo: 'some-repo',
     user: 'some-user',
@@ -27,19 +27,19 @@ test('getGitSSHUrl with no hash', () => {
   expect(gitSSHUrl).toContain('some-user');
 });
 
-test('getGitHTTPUrl should return the correct git github SSH url', () => {
+test('getGitHTTPUrl should return the correct git gitlab SSH url', () => {
   const fragment: ExplodedFragment = {
     user: 'foo',
     repo: 'bar',
     hash: '',
   };
 
-  const expected =  'git+ssh://git@github.com/' + fragment.user + '/' + fragment.repo + '.git';
-  expect(GitHubResolver.getGitSSHUrl(fragment)).toBe(expected);
+  const expected =  'git+ssh://git@gitlab.com/' + fragment.user + '/' + fragment.repo + '.git';
+  expect(GitLabResolver.getGitSSHUrl(fragment)).toBe(expected);
 });
 
 test('getGitSSHUrl should return URL containing protocol', () => {
-  const gitSSHUrl = GitHubResolver.getGitSSHUrl({
+  const gitSSHUrl = GitLabResolver.getGitSSHUrl({
     hash: '',
     repo: 'some-repo',
     user: 'some-user',

--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -8,18 +8,19 @@ export default class BitbucketResolver extends HostedGitResolver {
   static protocol = 'bitbucket';
 
   static getTarballUrl(parts: ExplodedFragment, hash: string): string {
-    return `https://bitbucket.org/${parts.user}/${parts.repo}/get/${hash}.tar.gz`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}/get/${hash}.tar.gz`;
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://bitbucket.org/${parts.user}/${parts.repo}.git`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git+ssh://git@bitbucket.org/${parts.user}/${parts.repo}.git`;
+    return `git+ssh://git@${this.hostname}/${parts.user}/${parts.repo}.git` +
+      `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {
-    return `https://bitbucket.org/${parts.user}/${parts.repo}/raw/${commit}/${filename}`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}/raw/${commit}/${filename}`;
   }
 }

--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -16,7 +16,7 @@ export default class BitbucketResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git@bitbucket.org:${parts.user}/${parts.repo}.git`;
+    return `git+ssh://git@bitbucket.org/${parts.user}/${parts.repo}.git`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {

--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -26,8 +26,7 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git@${this.hostname}:${parts.user}/${parts.repo}.git` +
-      `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
+    return `git+ssh://git@github.com/${parts.user}/${parts.repo}.git`;
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {

--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -26,7 +26,8 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git+ssh://git@github.com/${parts.user}/${parts.repo}.git`;
+    return `git+ssh://git@${this.hostname}/${parts.user}/${parts.repo}.git` +
+      `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {

--- a/src/resolvers/exotics/gitlab-resolver.js
+++ b/src/resolvers/exotics/gitlab-resolver.js
@@ -8,18 +8,19 @@ export default class GitLabResolver extends HostedGitResolver {
   static protocol = 'gitlab';
 
   static getTarballUrl(parts: ExplodedFragment, hash: string): string {
-    return `https://gitlab.com/${parts.user}/${parts.repo}/repository/archive.tar.gz?ref=${hash}`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}/repository/archive.tar.gz?ref=${hash}`;
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://gitlab.com/${parts.user}/${parts.repo}.git`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git+ssh://git@gitlab.com/${parts.user}/${parts.repo}.git`;
+    return `git+ssh://git@${this.hostname}/${parts.user}/${parts.repo}.git` +
+      `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {
-    return `https://gitlab.com/${parts.user}/${parts.repo}/raw/${commit}/${filename}`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}/raw/${commit}/${filename}`;
   }
 }

--- a/src/resolvers/exotics/gitlab-resolver.js
+++ b/src/resolvers/exotics/gitlab-resolver.js
@@ -16,7 +16,7 @@ export default class GitLabResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git@gitlab.com:${parts.user}/${parts.repo}.git`;
+    return `git+ssh://git@gitlab.com/${parts.user}/${parts.repo}.git`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {


### PR DESCRIPTION
**Summary**

At this line https://github.com/diorahman/yarn/blob/master/src/fetchers/git-fetcher.js#L20 the `GitFetcher._fetch` should have a resolved URL (from hosted, private repo) that has protocol. If not the actual fetching always falls through to `fetchFromLocal`.

**Test plan**

Create a private repo on github. E.g. For my test I have https://github.com/HOOQTV/inbox and it has several releases, one of them: `v0.1.0`.

Then try to `yarn add github:hooqtv/inbox#v0.1.0`.

Before this PR: 

``` bash
▲ ev: yarn add github:hooqtv/inbox#v0.1.0
yarn add v0.1.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error git@github.com:hooqtv/inbox.git: Tarball is not in network and can not be located in cache (/Users/diorahman/Experiments/hooq/src/misc/ev/git@github.com:hooqtv/inbox.git)
info Visit http://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

After

```
  ▲ ev: yarn add github:hooqtv/inbox#v0.1.0
yarn add v0.1.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
```
