### PR TITLE
Enable gzip compression

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -64,6 +64,7 @@ export default class NpmRegistry extends Registry {
       auth: opts.auth,
       headers,
       json: true,
+      gzip: true,
     });
   }
 


### PR DESCRIPTION
**Summary**

Gzip compression wasn't enabled causing yarn to download twice the data npm does. Fixes #945 .

**Test plan**
`yarn add yo`

Before - 9.9MB
![before](https://cloud.githubusercontent.com/assets/985504/19405850/adbde864-927c-11e6-814a-3a10eab4f99b.png)

After - 5.3MB
![after](https://cloud.githubusercontent.com/assets/985504/19405851/adc0aca2-927c-11e6-9468-00c962d4c22c.png)
