### PR TITLE
Create .npmignore on init, ignoring yarn.lock

### DIFF
--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -20,3 +20,11 @@ test.concurrent('init --yes should create package.json with defaults',  (): Prom
     assert.equal(manifest.license, String(config.getOption('init-license')));
   });
 });
+
+test.concurrent('init should create .npmignore ignoring yarn.lock',  (): Promise<void> => {
+  return runInit({yes: true}, 'init-yes', async (config): Promise<void> => {
+    const {cwd} = config;
+    const npmignoreFile = await fs.readFile(path.join(cwd, '.npmignore'));
+    assert.equal(npmignoreFile, 'yarn.lock\n');
+  });
+});

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -138,4 +138,14 @@ export async function run(
   }
 
   await install.saveRootManifests(manifests);
+
+  const npmignoreLoc = `${path.join(config.cwd, '.npmignore')}`;
+  if (!(await fs.exists(npmignoreLoc))) {
+    const npmignoreContent = [
+      'yarn.lock',
+      '',
+    ].join('\n');
+
+    await fs.writeFile(npmignoreLoc, npmignoreContent);
+  }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Essentially this: https://twitter.com/gabro27/status/786825544998481920

`yarn.lock` is a big file and shouldn't be included when publishing to npm.
This PR adds the creation of a `.npmignore` file that ignores `yarn.lock` when running `yarn init`.

The intent is to mitigate the risk of accidentally publishing that file.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I added a unit test for this.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->