### PR TITLE
Use auth tokens for NPM registry requests

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -131,12 +131,18 @@ export default class TarballFetcher extends BaseFetcher {
   fetchFromExternal(): Promise<FetchedOverride> {
     const {reference: ref} = this;
 
+    const headers: Object = {
+      'Accept-Encoding': 'gzip',
+      'Accept': 'application/octet-stream',
+    };
+
+    if (this.remote.auth && this.remote.auth.token) {
+      headers.authorization = `Bearer ${this.remote.auth.token}`;
+    }
+
     return this.config.requestManager.request({
       url: ref,
-      headers: {
-        'Accept-Encoding': 'gzip',
-        'Accept': 'application/octet-stream',
-      },
+      headers,
       buffer: true,
       process: (req, resolve, reject) => {
         // should we save this to the offline cache?

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -126,6 +126,10 @@ export default class NpmRegistry extends Registry {
         await fs.mkdirp(mirrorLoc);
       }
 
+      if (config['_auth']) {
+        this.token = config['_auth'];
+      }
+
       defaults(this.config, config);
     }
   }

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -162,6 +162,9 @@ export default class NpmResolver extends RegistryResolver {
         reference: dist.tarball,
         hash: dist.shasum,
         registry: 'npm',
+        auth: {
+          token: this.config.registries.npm.token,
+        },
       };
     }
 

--- a/src/types.js
+++ b/src/types.js
@@ -44,6 +44,12 @@ export type PackageRemote = {
   reference: string,
   resolved?: ?string,
   hash?: ?string,
+  auth?: {
+    email?: string,
+    username?: string,
+    password?: string,
+    token?: string,
+  }
 };
 
 // `dependencies` field in package info


### PR DESCRIPTION
**Summary**
The NPM registry and NPM compatible registries support privately hosted
modules. To access meta data for these modules and the modules' tarballs
themselves, bearer tokens can be used.

To support this, NPM's `_auth` property need to be raed from the config
and this option must be used for meta data and tarball requests as the
bearer token.

**Test plan**
I did not add tests for this as I am interested in general design feedback and intent of support first.

