### PR TITLE
Set umask to 0022 when building dist, so file permissions are correct

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -30,6 +30,7 @@ rm -f dist/*.deb $OUTPUT_DIR/*.deb $OUTPUT_DIR/*.rpm
 # Extract to a temporary directory
 rm -rf $PACKAGE_TMPDIR
 mkdir -p $PACKAGE_TMPDIR/
+umask 0022 # Ensure permissions are correct (0755 for dirs, 0644 for files)
 tar zxf $TARBALL_NAME -C $PACKAGE_TMPDIR/
 
 # Create Linux package structure

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -9,6 +9,7 @@ mkdir dist
 mv yarn-*.tgz dist/pack.tgz
 
 cd dist
+umask 0022 # Ensure permissions are correct (0755 for dirs, 0644 for files)
 tar -xzf pack.tgz --strip 1
 rm -rf pack.tgz
 npm install --production


### PR DESCRIPTION
**Summary**
CircleCI has a default umask of `0002`, which results in files having their mode set to `0664` and directories having their mode set to `0775`. These should really be `0644` and `0755` respectively, which is accomplished by using the umask of `0022` (which is the default on most systems anyways). Lintian in particular complains about the file permissions being incorrect when the `.deb` package ls linted.

**Test plan**
Built my branch on CircleCI: https://circleci.com/gh/yarnpkg/yarn/1361