### PR TITLE
fix(.gitignore): ignore fixtures/.bin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.nyc_output
 /coverage
 /__tests__/fixtures/**/_*
+/__tests__/fixtures/**/*.bin
 /dist
 /artifacts
 /updates


### PR DESCRIPTION
**Summary**

When running the test suite for `yarn`, git status changes something drastically to >150 changed files. All of which seem to point to `__test/fixtures/**/*.bin`.

**Test plan**
```sh
❯ nr test-only; git status
❯ .......
❯ Test Suites: 2 skipped, 18 passed, 18 of 20 total
Tests:       20 skipped, 174 passed, 194 total
Snapshots:   49 passed, 49 total
Time:        69.768s, estimated 71s
Ran all test suites.
On branch ignore-test-fixture-bins
Your branch is up-to-date with 'origin/ignore-test-fixture-bins'.
nothing to commit, working tree clean
```
