### PR TITLE
Fix git resolver so isVersion matches git+https and the like

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -42,6 +42,7 @@ addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git u
 addTest('https://github.com/PolymerElements/font-roboto/archive/2fd5c7bd715a24fb5b250298a140a3ba1b71fe46.tar.gz'); // tarball
 addTest('https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // hash
 addTest('https://github.com/babel/babel-loader.git#feature/sourcemaps'); // hash with slashes
+addTest('git+https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // git+hash
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -13,7 +13,7 @@ import Git from '../../util/git.js';
 const urlParse = require('url').parse;
 
 // we purposefully omit https and http as those are only valid if they end in the .git extension
-const GIT_PROTOCOLS = ['git', 'git+ssh', 'git+https', 'ssh'];
+const GIT_PROTOCOLS = ['git:', 'git+ssh:', 'git+https:', 'ssh:'];
 
 const GIT_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.com'];
 


### PR DESCRIPTION
**Summary**

Fixes git-resolver so it takes the proper code path for git+https, etc packages.

This is the last bit that's required for me to use yarn at work.

**Test plan**

Added a test to __tests__/package-resolver.js

