### PR TITLE
add symlink link: dependency type (fixes #884)

### DIFF
--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -5,6 +5,7 @@ import TarballFetcher, {LocalTarballFetcher} from '../src/fetchers/tarball-fetch
 import BaseFetcher from '../src/fetchers/base-fetcher.js';
 import CopyFetcher from '../src/fetchers/copy-fetcher.js';
 import GitFetcher from '../src/fetchers/git-fetcher.js';
+import LinkFetcher from '../src/fetchers/link-fetcher.js';
 import {NoopReporter} from '../src/reporters/index.js';
 import Config from '../src/config.js';
 import mkdir from './_temp.js';
@@ -53,6 +54,22 @@ test('CopyFetcher.fetch', async () => {
   expect(content).toBe('{}');
   const contentFoo = await fs.readFile(path.join(b, 'foo'));
   expect(contentFoo).toBe('bar');
+});
+
+test('LinkFetcher.fetch', async () => {
+  const a = await mkdir('link-fetcher-a');
+  await fs.writeFile(path.join(a, 'package.json'), '{}');
+  await fs.writeFile(path.join(a, 'foo'), 'bar');
+
+  const b = await mkdir('link-fetcher-b');
+  const fetcher = new LinkFetcher(b, {
+    type: 'link',
+    reference: a,
+    registry: 'npm',
+  }, await createConfig());
+  await fetcher.fetch();
+  const stat = await fs.lstat(b);
+  expect(stat.isDirectory()).toEqual(true);
 });
 
 test('GitFetcher.fetch fetchFromLocal not in network or cache', async () => {

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -51,3 +51,6 @@ addTest('react-native'); // npm
 addTest('ember-cli'); // npm
 addTest('npm:gulp'); // npm
 addTest('@polymer/iron-icon'); // npm scoped package
+addTest(`file:${__dirname}/../node_modules/babel-core`); // file
+addTest(`link:${__dirname}/../node_modules/eslint`); // existing link
+addTest(`link:./../not-created-yet`); // not existing link

--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint no-unused-vars: 0 */
 
-import type {PackageRemote, FetchedMetadata, FetchedOverride} from '../types.js';
+import type {PackageRemote, FetchedMetadata, FetchedOverride, Manifest} from '../types.js';
 import type {RegistryNames} from '../registries/index.js';
 import type Config from '../config.js';
 import * as constants from '../constants.js';
@@ -44,6 +44,12 @@ export default class BaseFetcher {
 
       // fetch package and get the hash
       const {hash, resolved} = await this._fetch();
+
+      // skip any readManifest operation for link type as dest might not exist yet
+      if (this.remote.type === 'link') {
+        const mockPkg: Manifest = {_uid: '', name: '', version: '0.0.0', _registry: this.registry};
+        return Promise.resolve({resolved, hash, dest, package: mockPkg, cached: false});
+      }
 
       // load the new normalized manifest
       const pkg = await this.config.readManifest(dest, this.registry);

--- a/src/fetchers/index.js
+++ b/src/fetchers/index.js
@@ -3,21 +3,25 @@
 import BaseFetcher from './base-fetcher.js';
 import CopyFetcher from './copy-fetcher.js';
 import GitFetcher from './git-fetcher.js';
+import LinkFetcher from './link-fetcher.js';
 import TarballFetcher from './tarball-fetcher.js';
 
 export {BaseFetcher as base};
 export {CopyFetcher as copy};
 export {GitFetcher as git};
+export {LinkFetcher as link};
 export {TarballFetcher as tarball};
 
 export type Fetchers =
   | BaseFetcher
   | CopyFetcher
   | GitFetcher
+  | LinkFetcher
   | TarballFetcher;
 
 export type FetcherNames =
   | 'base'
   | 'copy'
   | 'git'
+  | 'link'
   | 'tarball';

--- a/src/fetchers/link-fetcher.js
+++ b/src/fetchers/link-fetcher.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+import type {FetchedOverride} from '../types.js';
+import BaseFetcher from './base-fetcher.js';
+
+export default class LinkFetcher extends BaseFetcher {
+  _fetch(): Promise<FetchedOverride> {
+    // nothing to fetch
+    return Promise.resolve({
+      hash: this.hash || '',
+      resolved: null,
+    });
+  }
+}

--- a/src/resolvers/exotics/link-resolver.js
+++ b/src/resolvers/exotics/link-resolver.js
@@ -1,0 +1,40 @@
+/* @flow */
+
+import type {Manifest} from '../../types.js';
+import type {RegistryNames} from '../../registries/index.js';
+import type PackageRequest from '../../package-request.js';
+import ExoticResolver from './exotic-resolver.js';
+import * as util from '../../util/misc.js';
+
+const path = require('path');
+
+export default class FileResolver extends ExoticResolver {
+  constructor(request: PackageRequest, fragment: string) {
+    super(request, fragment);
+    this.loc = util.removePrefix(fragment, 'link:');
+  }
+
+  loc: string;
+
+  static protocol = 'link';
+
+  resolve(): Promise<Manifest> {
+    let loc = this.loc;
+    if (!path.isAbsolute(loc)) {
+      loc = path.join(this.config.cwd, loc);
+    }
+
+    const registry: RegistryNames = 'npm';
+    const manifest: Manifest = {_uid: '', name: '', version: '0.0.0', _registry: registry};
+
+    manifest._remote = {
+      type: 'link',
+      registry,
+      reference: loc,
+    };
+
+    manifest._uid = manifest.version;
+
+    return Promise.resolve(manifest);
+  }
+}

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -14,6 +14,7 @@ import ExoticGit from './exotics/git-resolver.js';
 import ExoticTarball from './exotics/tarball-resolver.js';
 import ExoticGitHub from './exotics/github-resolver.js';
 import ExoticFile from './exotics/file-resolver.js';
+import ExoticLink from './exotics/link-resolver.js';
 import ExoticGitLab from './exotics/gitlab-resolver.js';
 import ExoticGist from './exotics/gist-resolver.js';
 import ExoticBitbucket from './exotics/bitbucket-resolver.js';
@@ -23,6 +24,7 @@ export const exotics = {
   tarball: ExoticTarball,
   github: ExoticGitHub,
   file: ExoticFile,
+  link: ExoticLink,
   gitlab: ExoticGitLab,
   gist: ExoticGist,
   bitbucket: ExoticBitbucket,

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -37,6 +37,7 @@ const noop = () => {};
 export type CopyQueueItem = {
   src: string,
   dest: string,
+  type?: string,
   onFresh?: ?() => void,
   onDone?: ?() => void,
 };
@@ -113,10 +114,22 @@ async function buildActionsForCopy(
 
   //
   async function build(data): Promise<void> {
-    const {src, dest} = data;
+    const {src, dest, type} = data;
     const onFresh = data.onFresh || noop;
     const onDone = data.onDone || noop;
     files.add(dest);
+
+    if (type === 'link') {
+      await mkdirp(path.dirname(dest));
+      onFresh();
+      actions.push({
+        type: 'symlink',
+        dest,
+        linkname: src,
+      });
+      onDone();
+      return;
+    }
 
     if (events.ignoreBasenames.indexOf(path.basename(src)) >= 0) {
       // ignored file


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Implements the `link:` dependency type, see #884 for reasons.

I tried to integrate it as smoothly as possible in the existing code base, I chose to implement a noop `LinkFetcher` class instead of forking away the default resolving/fetching process.

Will gladly refactor if needed.

**Test plan**

With the following `package.json`:

```
{
  "name": "@mgcrea/test-yarn-link",
  "version": "1.0.0",
  "dependencies": {
    "@mgcrea/core-users": "link:./../core-users",
    "express-restify": "link:./../express-restify"
  },
  "devDependencies": {}
}
```

```
$ rm -rf node_modules; yarn
yarn install v0.15.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
✨  Done in 0.14s.
```

```
$ ll node_modules/
total 4.0K
drwxr-xr-x 3 olivier staff 102 Oct 16 00:46 '@mgcrea'/
lrwxr-xr-x 1 olivier staff  21 Oct 16 00:46 express-restify -> ../../express-restify/
```

Had to improve the `possibleExtraneous` logic to handle scoped packages as well (scope folder would be removed on `yarn add`).
