### PR TITLE
Emulate `npm_config_argv` environment variable for lifecycle scripts (closes #684)

### DIFF
--- a/__tests__/fixtures/lifecycle-scripts/npm_config_argv_env_vars/log-command.js
+++ b/__tests__/fixtures/lifecycle-scripts/npm_config_argv_env_vars/log-command.js
@@ -1,0 +1,7 @@
+try {
+  const argv = JSON.parse(process.env['npm_config_argv']);
+
+  console.log(`##${argv.cooked[0]}##`);
+} catch (err) {
+  console.log(`##${err.toString()}##`);
+}

--- a/__tests__/fixtures/lifecycle-scripts/npm_config_argv_env_vars/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/npm_config_argv_env_vars/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "npm_config_argv_env_vars",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "prepublish" : "node log-command.js",
+    "pretest" : "node log-command.js"
+  }
+}

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import makeTemp from './_temp';
+import * as fs from '../src/util/fs.js';
+
+const path = require('path');
+const exec = require('child_process').exec;
+
+const fixturesLoc = path.join(__dirname, './fixtures/lifecycle-scripts');
+const yarnBin = path.join(__dirname, '../bin/yarn.js');
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+
+async function execCommand(cmd: string, packageName: string): Promise<string> {
+  const srcPackageDir = path.join(fixturesLoc, packageName);
+  const packageDir = await makeTemp(packageName);
+
+  await fs.copy(srcPackageDir, packageDir);
+
+  return new Promise((resolve, reject) => {
+    const env = Object.assign({}, process.env);
+
+    delete env.npm_config_argv;
+
+    exec(`node ${yarnBin} ${cmd}`, {cwd:packageDir, env}, (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout.toString());
+      }
+    });
+  });
+}
+
+test('should expose `npm_config_argv` environment variable to lifecycle scripts for back compatibility with npm (#684)',
+async () => {
+  let stdout = await execCommand('install', 'npm_config_argv_env_vars');
+  expect(stdout).toContain('##install##');
+
+  stdout = await execCommand('', 'npm_config_argv_env_vars');
+  expect(stdout).toContain('##install##');
+
+  stdout = await execCommand('test', 'npm_config_argv_env_vars');
+  expect(stdout).toContain('##test##');
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -328,6 +328,7 @@ config.init({
   ignoreEngines: commander.ignoreEngines,
   offline: commander.preferOffline || commander.offline,
   looseSemver: !commander.strictSemver,
+  commandName,
 }).then(() => {
   const exit = () => {
     process.exit(0);

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ export type ConfigOptions = {
 
   // Loosely compare semver for invalid cases like "0.01.0"
   looseSemver?: ?boolean,
+  commandName?: ?string
 };
 
 type PackageMetadata = {
@@ -115,6 +116,9 @@ export default class Config {
     [key: string]: ?Promise<any>
   };
 
+  //
+  commandName: string;
+
   /**
    * Execute a promise produced by factory if it doesn't exist in our cache with
    * the associated key.
@@ -193,6 +197,8 @@ export default class Config {
     this.cwd = opts.cwd || this.cwd || process.cwd();
 
     this.looseSemver = opts.looseSemver == undefined ? true : opts.looseSemver;
+
+    this.commandName = opts.commandName || '';
 
     this.preferOffline = !!opts.preferOffline;
     this.modulesFolder = opts.modulesFolder;

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -25,6 +25,10 @@ async function makeEnv(stage: string, cwd: string, config: Config): {
   env.npm_node_execpath = env.NODE || process.execPath;
   env.npm_execpath = path.join(__dirname, '..', '..', 'bin', 'yarn.js');
 
+  // Note: npm_config_argv environment variable contains output of nopt - command-line
+  // parser used by npm. Since we use other parser, we just roughly emulate it's output. (See: #684)
+  env.npm_config_argv = JSON.stringify({remain:[], cooked: [config.commandName], original: [config.commandName]});
+
   // add npm_package_*
   const manifest = await config.readManifest(cwd);
   const queue = [['', manifest]];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

npm `prepublish` script is [broken by design](https://blog.greenkeeper.io/what-is-npm-s-prepublish-and-why-is-it-so-confusing-a948373e6be1#.j9lcz8whd). yarn `prepublish` script is broken the same way for back compatibility 😆 Developers use packages like [in-publish](https://github.com/iarna/in-publish) to workaround this problem. `in-publish` relies on `npm_config_argv` environment variable to determine the actual command that is running. We can't provide exact same results as npm here, because yarn uses other command line parser, but we emulate it's output with precision that is enough to render this workaround usable.

**Test plan**

Tests are included.
