### PR TITLE
Use Yarn package/installer on Travis/AppVeyor/CircleCI rather than npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 ---
 git:
   depth: 10
-language: generic
+language: node_js
 
-sudo: false
+node_js:
+  - "6"
+
+sudo: required # Until Yarn repo is added to apt-source-whitelist
 
 addons:
   apt:
@@ -39,13 +42,13 @@ matrix:
     - env: TEST_TYPE="lint"
       os: osx
 
-install:
- # install proper node version
- - nvm install ${NODE_VERSION:=6}
- - node --version
+before_install:
+  # Repo for newer Node.js versions
+  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+  - ./scripts/bootstrap-env-ubuntu.sh
 
- # install deps
- - npm install -g yarn
+install:
+ - node --version
  - yarn install
 
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ branches:
 
 install:
   - ps: Install-Product node $env:node_version
-  - npm install -g yarn
+  - choco install yarn
+  - refreshenv
   - yarn install
 
 build_script:

--- a/circle.yml
+++ b/circle.yml
@@ -5,25 +5,23 @@ general:
   artifacts:
     - "artifacts/"
 
+machine:
+  node:
+    version: 6
+
 dependencies:
   cache_directories:
     - "~/.yarn-cache"
 
   override:
-    # install node
-    - nvm install 6
-    - nvm use 6 && nvm alias default 6
     - which node
 
     # install dependencies
-    - npm install -g yarn
-    - yarn install
+    - ./scripts/bootstrap-env-ubuntu.sh
 
     # setup ghr
     - curl -L -o ghr.zip https://github.com/tcnksm/ghr/releases/download/v0.5.0/ghr_v0.5.0_linux_amd64.zip
     - unzip ghr.zip
-
-    - ./scripts/bootstrap-env-ubuntu.sh
 
 test:
   override:

--- a/scripts/bootstrap-env-ubuntu.sh
+++ b/scripts/bootstrap-env-ubuntu.sh
@@ -2,5 +2,10 @@
 # Bootstraps a Yarn development environment on Ubuntu.
 set -ex
 
-sudo apt-get install -y rpm lintian
+# Add Yarn package repo - We require Yarn to build Yarn itself :D
+sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
+sudo apt-get update -qq
+sudo apt-get install -y rpm lintian yarn
 gem install fpm

--- a/scripts/build-dist.ps1
+++ b/scripts/build-dist.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 npm run build
+# Change this to "yarn pack" once #1114 is fixed
 npm pack
 if (Test-Path dist) {
   rm dist -Recurse
@@ -11,6 +12,7 @@ mv yarn-*.tgz dist/pack.tgz
 cd dist
 tar -xzf pack.tgz --strip 1
 rm pack.tgz
+# Change this to "yarn install --production" once #1115 is fixed
 npm install --production
 rm node_modules/*/test -Recurse
 rm node_modules/*/dist -Recurse

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -12,6 +12,7 @@ cd dist
 umask 0022 # Ensure permissions are correct (0755 for dirs, 0644 for files)
 tar -xzf pack.tgz --strip 1
 rm -rf pack.tgz
+# Change this to "yarn install --production" once #1115 is fixed
 npm install --production
 rm -rf node_modules/*/test node_modules/*/dist
 cd ..


### PR DESCRIPTION
**Summary**
On Linux:
- Install Yarn from Ubuntu package rather than `npm`
- Moved installation of Yarn to `bootstrap-env-ubuntu.sh` script. The more of the environment configuration we have in here, the better (as it'll make it easier to have Docker/Vagrant images for Yarn dev/build in the future)
- Use Travis and CircleCI's built-in method to choose Node.js v6 rather than nvm

On Windows (AppVeyor):
- Install Yarn from Chocolatey package

**Test plan**
Will check on Travis/AppVeyor/CircleCI once PR is submitted and the build is kicked off