### PR TITLE
Add %LocalAppData%\Yarn\.bin to PATH as part of installation

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -36,6 +36,15 @@
 					Action="set"
 					System="yes"
 				/>
+				<Environment
+					Id="BinPath"
+					Name="PATH"
+					Value="[LocalAppDataFolder]Yarn\.bin"
+					Permanent="no"
+					Part="last"
+					Action="set"
+					System="yes"
+				/>
 			</Component>
 		</DirectoryRef>
 

--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -43,7 +43,7 @@
 					Permanent="no"
 					Part="last"
 					Action="set"
-					System="yes"
+					System="no"
 				/>
 			</Component>
 		</DirectoryRef>


### PR DESCRIPTION
**Summary**
Updates the Windows installer to add `%LocalAppData\Yarn\.bin` to the `PATH`, so that we can remove the "path setup" section that was added in the docs (https://yarnpkg.com/en/docs/install)

**Test plan**
Ran installer on my computer, ensured the PATH was updated correctly:
![](http://ss.dan.cx/2016/10/SystemPropertiesAdvanced_16-12.30.48.png)
Uninstalled Yarn, ensured both PATH additions were removed.
