### PR TITLE
Decouple Chocolatey build from Windows Installer build

### DIFF
--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -7,7 +7,7 @@
 		<version>0.0.0</version>
 		<authors>Yarn Maintainers</authors>
 		<owners>Daniel Lo Nigro</owners>
-		<tags>yarn node nodejs npm javascript packages bower</tags>
+		<tags>yarn node nodejs npm javascript packages bower admin</tags>
 		<summary>Package manager for the npm and bower package repositories</summary>
 		<description>
 Yarn is a package manager for the npm and bower registries with a few specific
@@ -38,6 +38,6 @@ utilization.
 	</metadata>
 
 	<files>
-		<file src="tools\**" target="tools" />
+		<file src="tools\chocolateyinstall.ps1" target="tools" />
 	</files>
 </package>

--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -28,9 +28,12 @@ utilization.
 		</description>
 		<projectUrl>https://yarnpkg.com/</projectUrl>
 		<packageSourceUrl>https://github.com/yarnpkg/yarn</packageSourceUrl>
+		<projectSourceUrl>https://github.com/yarnpkg/yarn</projectSourceUrl>
 		<licenseUrl>https://github.com/yarnpkg/yarn/raw/master/LICENSE</licenseUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<iconUrl>https://cdn.rawgit.com/yarnpkg/assets/master/yarn-kitten-circle.png</iconUrl>
+		<docsUrl>https://yarnpkg.com/en/docs/</docsUrl>
+		<bugTrackerUrl>https://github.com/yarnpkg/yarn/issues</bugTrackerUrl>
 
 		<dependencies>
 			<dependency id="nodejs.install" version="6.0" />


### PR DESCRIPTION
**Summary**
Previously, we required both the Windows installer and the Chocolatey package to be built on the same machine. I've updated the Chocolatey build script to be entirely standalone, similar to how we handle the Debian/Ubuntu/CentOS package repository. 

The Chocolatey build script hits https://yarnpkg.com/latest-version to get the latest version number, and also hits Chocolatey to get the latest version number on Chocolatey. If the latest version as returned by `latest-version` is newer than the latest version in Chocolatey, it downloads the latest Windows installer, hashes it, builds the Chocolatey package, then pushes it to Chocolatey. This means we can schedule it as  a cronjob or post-commit hook and new releases will be pushed to Chocolatey automatically.

Fixes #802

**Test plan**
Tested with a test Chocolatey package (changed `yarn` to `daniel15-test` in `yarn.nuspec`, hacked `$latest_version` to contain a fake version number, then ran the script)