### PR TITLE
Support auth for private npm packages

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -7,7 +7,7 @@ import type {ConfigRegistries} from './index.js';
 import * as fs from '../util/fs.js';
 import NpmResolver from '../resolvers/registries/npm-resolver.js';
 import Registry from './base-registry.js';
-import {addSuffix} from '../util/misc';
+import {addSuffix, removePrefix} from '../util/misc';
 
 const defaults = require('defaults');
 const userHome = require('user-home');
@@ -53,7 +53,8 @@ export default class NpmRegistry extends Registry {
     const registry = addSuffix(this.getRegistry(pathname), '/');
     const requestUrl = url.resolve(registry, pathname);
     const alwaysAuth = this.getScopedOption(registry.replace(/^https?:/, ''), 'always-auth')
-                    || this.getOption('always-auth');
+      || this.getOption('always-auth')
+      || removePrefix(requestUrl, registry)[0] === '@';
 
     const headers = {};
     if (this.token || (alwaysAuth && requestUrl.startsWith(registry))) {

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -159,7 +159,7 @@ export default class NpmResolver extends RegistryResolver {
       info._remote = {
         resolved: `${this.cleanRegistry(dist.tarball)}#${dist.shasum}`,
         type: 'tarball',
-        reference: dist.tarball,
+        reference: this.cleanRegistry(dist.tarball),
         hash: dist.shasum,
         registry: 'npm',
       };


### PR DESCRIPTION
**Summary**

Sends the auth token for scoped packages, which may be private. Fixes #1134 and #521.

**Test plan**

Tested installing a private package on the public registry without `always-auth` in .npmrc.