### PR TITLE
Improve 'Usage' docs for upgrade command.

### DIFF
--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -7,7 +7,7 @@ import Lockfile from '../../lockfile/wrapper.js';
 
 export function setFlags(commander: Object) {
   // TODO: support some flags that install command has
-  commander;
+  commander.usage('upgrade [flags]');
 }
 
 export const requireLockfile = true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The `upgrade` command was updated to provide similar "usage" docs to most other subcommand, which include the name of the subcommand in the output.

**Test plan**

Before: Usage: [command] [flags]
After:  Usage: upgrade [flags]

 * Tested that `./bin/yarn help upgrade` has changed output as expected
 * Tested that `./bin/yarn upgrade` still works as expected and isn't broken.