### PR TITLE
Convert "yarn" executable to a shell script that runs either "node" or "nodejs"

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,2 +1,27 @@
-#!/usr/bin/env node
-require('./yarn.js');
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+  *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1;
+}
+
+if command_exists node; then
+  node "$basedir/yarn.js" "$@"
+  ret=$?
+# Debian and Ubuntu use "nodejs" as the name of the binary, not "node", so we
+# search for that too. See:
+# https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907
+elif command_exists nodejs; then
+  nodejs "$basedir/yarn.js" "$@"
+  ret=$?
+else
+  echo 'Yarn requires Node.js 4.0 or higher to be installed.'
+  ret=1
+fi
+
+exit $ret

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Ensure all the tools we need are available
 ensureAvailable() {
-  eval $1 --version >/dev/null || (echo "You need to install $1" && exit 2)
+  command -v "$1" >/dev/null 2>&1 || (echo "You need to install $1" && exit 2)
 }
 ensureAvailable dpkg-deb
 ensureAvailable fpm
@@ -13,7 +13,7 @@ ensureAvailable lintian
 ensureAvailable rpmbuild
 
 PACKAGE_TMPDIR=tmp/debian_pkg
-VERSION=`node dist/bin/yarn --version`
+VERSION=`dist/bin/yarn --version`
 TARBALL_NAME=dist/yarn-v$VERSION.tar.gz
 DEB_PACKAGE_NAME=yarn_$VERSION'_all.deb'
 OUTPUT_DIR=artifacts
@@ -50,11 +50,16 @@ find $PACKAGE_TMPDIR/usr/share/yarn \( -name '*.md' -o  -name '*.md~' -o -name '
 # Assume everything else is junk we don't need
 rm -rf $PACKAGE_TMPDIR/dist
 
-# Currently the "binaries" are JavaScript files that expect to be in the same
-# directory as the libraries, so we can't just copy them directly to /usr/bin.
-# Symlink them instead.
+# Swap out the basedir calculation code with a hard-coded path, as the default
+# way we do this doesn't follow symlinks.
+sed -i 's/basedir\=\$.*/basedir=\/usr\/share\/yarn\/bin/' $PACKAGE_TMPDIR/usr/share/yarn/bin/yarn
+
+# The Yarn executable expects to be in the same directory as the libraries, so
+# we can't just copy it directly to /usr/bin. Symlink them instead.
 mkdir -p $PACKAGE_TMPDIR/usr/bin/
-ln -s ../share/yarn/bin/yarn.js $PACKAGE_TMPDIR/usr/bin/yarn
+ln -s ../share/yarn/bin/yarn $PACKAGE_TMPDIR/usr/bin/yarn
+# Alias as "yarnpkg" too.
+ln -s ../share/yarn/bin/yarn $PACKAGE_TMPDIR/usr/bin/yarnpkg
 
 # Common FPM parameters for all packages we'll build using FPM
 FPM="fpm --input-type dir --chdir $PACKAGE_TMPDIR --name yarn --version $VERSION "`
@@ -69,9 +74,6 @@ mv *.rpm $OUTPUT_DIR
 mkdir -p $PACKAGE_TMPDIR/DEBIAN
 mkdir -p $PACKAGE_TMPDIR/usr/share/lintian/overrides/
 cp resources/debian/lintian-overrides $PACKAGE_TMPDIR/usr/share/lintian/overrides/yarn
-
-# Debian/Ubuntu call the Node.js binary "nodejs", not "node".
-sed -i 's/env node/env nodejs/' $PACKAGE_TMPDIR/usr/share/yarn/bin/yarn.js
 
 # Replace variables in Debian package control file
 INSTALLED_SIZE=`du -sk $PACKAGE_TMPDIR | cut -f 1`

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -17,5 +17,5 @@ npm install --production
 rm -rf node_modules/*/test node_modules/*/dist
 cd ..
 
-tar -cvzf dist/yarn-v`node dist/bin/yarn --version`.tar.gz dist/*
+tar -cvzf dist/yarn-v`dist/bin/yarn --version`.tar.gz dist/*
 shasum -a 256 dist/yarn-*.tar.gz


### PR DESCRIPTION
**Summary**
Converted `yarn` to be a shell script that checks for both `node` or `nodejs`. If neither is found, shows an error stating that Node.js needs to be installed.

**Test plan**
Tested in the following environments:
 - Ubuntu 16.04, Node.js v6.7.0 installed from NodeSource repo
 - Debian Testing, Node.js v4.3.1 installed from Debian repo
 - Cygwin on Windows 10
 - WSL (Bash on Ubuntu on Windows) on Windows 10

Built Debian package with `./scripts/build-deb.sh` and tested it on Ubuntu.

**Background**
Yarn always executes `node` (due to the shebang of `#!/usr/bin/env node`), and always executes `nodejs` on Debian/Ubuntu (we `sed` the shebang when building the package: https://github.com/yarnpkg/yarn/blob/master/scripts/build-deb.sh#L74).

The tricky/unfortunate thing with Node.js on Debian is that `/usr/bin/node` conflicted with another package. See:
https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907

In the end, both packages that used the `node` binary name were renamed - Node.js became `nodejs`, and the other Node (some ham radio app) became `ax25-node`. This means that when installing Node.js via Debian package, the binary is called `nodejs`. However, for other installation methods (such as `nvm`), the binary is called `node`. 

Installing both Yarn and Node.js via Debian package is generally the preferred method, and works fine. However, this  naming does have several implications when mixing and matching different installation styles:
 - Yarn installed via `npm` will fail with Node.js installed via Debian package (it'll try to run `node` which doesn't exist)
 - Yarn installed via Debian package will fail with Node.js installed via nvm (it'll try to run `nodejs` which doesn't exist)

Often people work around this by symlinking `/usr/bin/node` to `/usr/bin/nodejs` or vice-versa, but that's hacky. 

Closes #1142
Closes #819