### PR TITLE
Don't create .yarnclean if it already exists

### DIFF
--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -120,7 +120,7 @@ export async function run(
   args: Array<string>,
 ): Promise<void> {
   reporter.step(1, 2, reporter.lang('cleanCreatingFile', CLEAN_FILENAME));
-  await fs.writeFile(path.join(config.cwd, CLEAN_FILENAME), '\n');
+  await fs.writeFile(path.join(config.cwd, CLEAN_FILENAME), '\n', {flag: 'wx'});
 
   reporter.step(2, 2, reporter.lang('cleaning'));
   const {removedFiles, removedSize} = await clean(config, reporter);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The file `.yarnclean`should not be created if it exists. Otherwise filter rules are not usable.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Related issues:

- [1008](https://github.com/yarnpkg/yarn/issues/1008)
- [1051](https://github.com/yarnpkg/yarn/issues/1051)

**Test plan**

Tests and linting passed.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

