### PR TITLE
fix path to constants

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -6,7 +6,7 @@
 
 // init roadrunner
 var mkdirp = require('mkdirp');
-var constants = require('../lib-legacy/constants');
+var constants = require('../src/constants');
 mkdirp.sync(constants.GLOBAL_INSTALL_DIRECTORY);
 var roadrunner = require('roadrunner');
 roadrunner.load(constants.CACHE_FILENAME);


### PR DESCRIPTION


**Summary**

I'm currently seeing this error when running `yarn install` off of master

![screen shot 2016-10-18 at 9 55 51 am](https://cloud.githubusercontent.com/assets/21967/19483267/64422930-9519-11e6-9772-666485794b65.png)

This fix corrects the path to the `constants.js` file under `src`.
