### PR TITLE
Fix `yarn info` failing on single character packages (#1219)

### DIFF
--- a/__tests__/util/parse-package-name.js
+++ b/__tests__/util/parse-package-name.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+import parsePackageName from '../../src/util/parse-package-name.js';
+
+test('parsePackageName', () => {
+  expect(parsePackageName('foo@1.2.3'))
+    .toEqual({
+      name: 'foo',
+      version: '1.2.3',
+    });
+
+  expect(parsePackageName('foo'))
+    .toEqual({
+      name: 'foo',
+    });
+
+  expect(parsePackageName('q'))
+    .toEqual({
+      name: 'q',
+    });
+
+  expect(parsePackageName('q@1.2.3'))
+    .toEqual({
+      name: 'q',
+      version: '1.2.3',
+    });
+});

--- a/src/util/parse-package-name.js
+++ b/src/util/parse-package-name.js
@@ -5,7 +5,7 @@ type PackageInput = {
   version: ?string,
 };
 
-const PKG_INPUT = /(^\S[^\s@]+)(?:@(\S+))?$/;
+const PKG_INPUT = /(^\S?[^\s@]+)(?:@(\S+))?$/;
 
 export default function parsePackageName(input: string): PackageInput {
   const [, name, version] = PKG_INPUT.exec(input);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes https://github.com/yarnpkg/yarn/issues/1219

`yarn info $PACKAGE` failed when $PACKAGE is a single character. This is due to an overly restrictive regex in `parse-package-name.js`.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I've included a test for `parsePackageName`, which failed before the regex change and passes after.

`bin/yarn info q` now works:

```
└> bin/yarn info q | head
yarn info v0.16.0
{ name: 'q',
  description: 'A library for promises (CommonJS/Promises/A,B,D)',
  'dist-tags':
   { latest: '1.4.1',
     future: '2.0.3' },
  versions:
   [ '0.0.0',
     '0.0.1',
     '0.0.2',
```