### PR TITLE
Build tarball and standalone JS files into artifacts directory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,9 +41,5 @@ deployment:
     owner: yarnpkg
     commands:
       - ./ghr --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) artifacts/
-      # TODO(#548): All artifacts should come from artifacts/ directory
-      - ./ghr --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) dist/yarn-v*.tar.gz
-      - ./ghr --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) dist/yarn-$(dist/bin/yarn --version).js
-      - ./ghr --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) dist/yarn-legacy-$(dist/bin/yarn --version).js
       - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - npm publish

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -14,9 +14,9 @@ ensureAvailable rpmbuild
 
 PACKAGE_TMPDIR=tmp/debian_pkg
 VERSION=`dist/bin/yarn --version`
-TARBALL_NAME=dist/yarn-v$VERSION.tar.gz
-DEB_PACKAGE_NAME=yarn_$VERSION'_all.deb'
 OUTPUT_DIR=artifacts
+TARBALL_NAME=$OUTPUT_DIR/yarn-v$VERSION.tar.gz
+DEB_PACKAGE_NAME=yarn_$VERSION'_all.deb'
 
 if [ ! -e $TARBALL_NAME ]; then
   echo "Hey! Listen! You need to run build-dist.sh first."
@@ -25,7 +25,7 @@ fi;
 
 mkdir -p $OUTPUT_DIR
 # Remove old packages
-rm -f dist/*.deb $OUTPUT_DIR/*.deb $OUTPUT_DIR/*.rpm
+rm -f $OUTPUT_DIR/*.deb $OUTPUT_DIR/*.rpm
 
 # Extract to a temporary directory
 rm -rf $PACKAGE_TMPDIR

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -6,6 +6,7 @@ npm run build
 npm pack
 rm -rf dist
 mkdir dist
+mkdir -p artifacts
 mv yarn-*.tgz dist/pack.tgz
 
 cd dist
@@ -17,5 +18,5 @@ npm install --production
 rm -rf node_modules/*/test node_modules/*/dist
 cd ..
 
-tar -cvzf dist/yarn-v`dist/bin/yarn --version`.tar.gz dist/*
-shasum -a 256 dist/yarn-*.tar.gz
+tar -cvzf artifacts/yarn-v`dist/bin/yarn --version`.tar.gz dist/*
+shasum -a 256 artifacts/yarn-*.tar.gz

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -35,7 +35,7 @@ const compiler = webpack({
   ],
   output: {
     filename: `yarn-${version}.js`,
-    path: path.join(basedir, 'dist'),
+    path: path.join(basedir, 'artifacts'),
   },
   target: 'node',
 });
@@ -72,7 +72,7 @@ const compilerLegacy = webpack({
   ],
   output: {
     filename: `yarn-legacy-${version}.js`,
-    path: path.join(basedir, 'dist'),
+    path: path.join(basedir, 'artifacts'),
   },
   target: 'node',
 });


### PR DESCRIPTION
Builds the tarball and standalone JS files into the `artifacts` directory rather than the `dist` directory. The Debian package, RPM package and Windows installer are all already built into `artifacts`. This keeps the `dist` directory clean (see #548 for motivation)

Confirmed that all the artifacts appear correctly in CircleCI:
![](http://ss.dan.cx/2016/10/chrome_18-23.16.41.png)

Closes #548