### PR TITLE
Making sure to parse boolean when setting config, fixed 1237

### DIFF
--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -72,7 +72,7 @@ export default class YarnRegistry extends NpmRegistry {
     if (typeof val === 'undefined') {
       val = DEFAULTS[key];
     }
-    
+
     return val;
   }
 
@@ -102,7 +102,7 @@ export default class YarnRegistry extends NpmRegistry {
       }
 
       // update just the home config
-      this.homeConfig[key] = config[key];
+      this.homeConfig[key] = JSON.parse(config[key]);
     }
 
     await fs.writeFile(this.homeConfigLoc, `${stringify(this.homeConfig)}\n`);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR fixes an issue with parsing boolean before setting them into the config files


**Issue**
[issue #1237](https://github.com/yarnpkg/yarn/issues/1237)
