### PR TITLE
Don't install Node.js via Chocolatey on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ branches:
 
 install:
   - ps: Install-Product node $env:node_version
-  - choco install yarn
+  - choco install -i yarn
   - refreshenv
   - yarn install
 


### PR DESCRIPTION
May fix #1232 as per the discussion in http://help.appveyor.com/discussions/problems/5425-nodejs-690-seems-broken. Node.js is already installed via MSI so we don't need to install it again via Chocolatey.