### PR TITLE
Make registry environment variables case agnostic

### DIFF
--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -119,18 +119,18 @@ export default class BaseRegistry {
 
   mergeEnv(prefix: string) {
     // try environment variables
-    for (let key in process.env) {
-      key = key.toLowerCase();
+    for (const envKey in process.env) {
+      let key = envKey.toLowerCase();
 
       // only accept keys prefixed with the prefix
-      if (key.indexOf(prefix) < 0) {
+      if (key.indexOf(prefix.toLowerCase()) < 0) {
         continue;
       }
 
-      const val = BaseRegistry.normalizeConfigOption(process.env[key]);
+      const val = BaseRegistry.normalizeConfigOption(process.env[envKey]);
 
       // remove config prefix
-      key = removePrefix(key, prefix);
+      key = removePrefix(key, prefix.toLowerCase());
 
       // replace dunders with dots
       key = key.replace(/__/g, '.');


### PR DESCRIPTION
**Summary**
To ignore the case of environment variable keys, eg use of `NPM_CONFIG_REGISTRY` instead of `npm_config_registry`

As exists, yarn only uses environment variables with lowercased keys
For npm, [environment variables are case insensitive](https://docs.npmjs.com/misc/config#environment-variables)

**Test plan**
Before:

```
> export NPM_CONFIG_REGISTRY=https://custom.npm.registry
> yarn install
yarn install v0.16.0
info No lockfile found.
[1/4] 🔍  Resolving packages...
error Couldn't find package "privately-hosted-package" on the "npm" registry.
> export npm_config_registry=https://custom.npm.registry
> yarn install
...
success Saved lockfile.
```

After:

```
> export NPM_CONFIG_REGISTRY=https://custom.npm.registry
> yarn install
yarn install v0.16.0
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
```
