### PR TITLE
Verify `dist-tags` key exists on object before querying range

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -24,8 +24,9 @@ export default class NpmResolver extends RegistryResolver {
   static registry = 'npm';
 
   static async findVersionInRegistryResponse(config: Config, range: string, body: RegistryResponse): Promise<Manifest> {
-    if (range in body['dist-tags']) {
-      range = body['dist-tags'][range];
+    const tags = body['dist-tags'];
+    if (tags && range in tags) {
+      range = tags[range];
     }
 
     const satisfied = await config.resolveConstraints(Object.keys(body.versions), range);


### PR DESCRIPTION
**Summary**

This appears to fix quite a few similar, possibly duplicate issues (#953, #1186, #1241, #1259, #1266, #1274). They all throw a similar error in `npm-resolver.js`: 

```TypeError: Cannot use 'in' operator to search for '<range>' in undefined```

This also seems like it could be a bandaid that would be masking a different problem. I unfortunately wasn't able to reproduce the issue myself. Even went as far as installing Windows 7 on VirtualBox and tried to reproduce.

**Note**

Also, it would be great to get some tests around the resolvers. I don't know much about Jest and snapshot testing and if it would be used for this. Any guidance in getting some tests in place would be awesome as well. Could even be done in a separate PR.

**Test plan**

No longer throw the `TypeError` listed above and have the `install`/`add`/`upgrade` command work as expected.

