### PR TITLE
Fix `yarn config set` for boolean values (#1237)

### DIFF
--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -16,8 +16,15 @@ export const {run, setFlags} = buildSubCommands('config', {
       return false;
     }
 
-    const [key, val = true] = args;
+    const [key, val] = ((key, val = true) => {
+      if (typeof val === 'string' && (/^(true|false)$/i).test(val)) {
+        val = (val.toLowerCase() === 'true');
+      }
+
+      return [key, val];
+    })(...args);
     const yarnConfig = config.registries.yarn;
+
     await yarnConfig.saveHomeConfig({[key]: val});
     reporter.success(reporter.lang('configSet', key, val));
     return true;


### PR DESCRIPTION
**Summary**

All config values were treated as strings but some config keys require booleans, e.g. `strict-ssl` or `ignore-scripts`. See: #1237 

**Test plan**
1. Set `strict-ssl` to `false`
2. Run `yarn config list`
3. Verify if `strict-ssl` is set to boolean `false`

<img width="435" alt="screenshot 2016-10-20 11 39 56" src="https://cloud.githubusercontent.com/assets/1029142/19554688/f791e440-96b9-11e6-8d5e-940a0aca4b01.png">
