### PR TITLE
Validate name upon init fixes #1268

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -6,6 +6,7 @@ import {stringifyPerson} from '../../util/normalize-manifest/util.js';
 import {registryNames} from '../../registries/index.js';
 import * as child from '../../util/child.js';
 import * as fs from '../../util/fs.js';
+import * as validate from '../../util/normalize-manifest/validate.js';
 
 const objectPath = require('object-path');
 const path = require('path');
@@ -46,6 +47,7 @@ export async function run(
       key: 'name',
       question: 'name',
       default: path.basename(config.cwd),
+      validation: validate.isValidPackageName,
     },
     {
       key: 'version',
@@ -100,11 +102,25 @@ export async function run(
     }
 
     let answer;
+    let validAnswer = false;
 
     if (yes) {
       answer = def;
-    } else {
-      answer = (await reporter.question(question)) || def;
+    } else { 
+      //loop until a valid answer is provided, if validation is on entry
+      if (entry.validation) {
+        while (!validAnswer) {
+          answer = (await reporter.question(question)) || def;
+          //validate answer
+          if (entry.validation(String(answer))) {
+            validAnswer = true;
+          } else {
+            reporter.error(reporter.lang('invalidPackageName'));
+          }
+        }
+      } else {
+        answer = (await reporter.question(question)) || def;
+      }        
     }
 
     if (answer) {


### PR DESCRIPTION
**Summary**
I made use of the existing package name validation and put this inside a loop to enforce valid names, i.e. no spaces.
Fixes #1268

**Test plan**
Tests for validating user input will need to be added. Guidance, best practices, advice is welcome.

<img width="611" alt="screen shot 2016-10-20 at 5 51 19 am" src="https://cloud.githubusercontent.com/assets/1470297/19555097/63ca3cf6-9689-11e6-89bb-ecad5b14453d.png">


