### PR TITLE
Make install pure by default

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -49,14 +49,18 @@ test.concurrent('flat arg is inherited from root manifest', async (): Promise<vo
 
 
 test.concurrent("doesn't write new lockfile if existing one satisfied", (): Promise<void> => {
-  return runInstall({}, 'install-dont-write-lockfile-if-satisfied', async (config): Promise<void> => {
-    const lockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    assert(lockfile.indexOf('foobar') >= 0);
-  });
+  return runInstall(
+    {writeLockfile: true},
+    'install-dont-write-lockfile-if-satisfied',
+    async (config): Promise<void> => {
+      const lockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+      assert(lockfile.indexOf('foobar') >= 0);
+    },
+  );
 });
 
 test.concurrent("writes new lockfile if existing one isn't satisfied", async (): Promise<void> => {
-  await runInstall({}, 'install-write-lockfile-if-not-satisfied', async (config): Promise<void> => {
+  await runInstall({writeLockfile: true}, 'install-write-lockfile-if-not-satisfied', async (config): Promise<void> => {
     const lockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     assert(lockfile.indexOf('foobar') === -1);
   });
@@ -393,7 +397,7 @@ test.concurrent(
   (): Promise<void> => {
     const mirrorPath = 'mirror-for-offline';
 
-    return runInstall({}, 'uninstall-should-clean', async (config, reporter) => {
+    return runInstall({writeLockfile: true}, 'uninstall-should-clean', async (config, reporter) => {
       assert.equal(
         await getPackageVersion(config, 'dep-a'),
         '1.0.0',
@@ -557,9 +561,9 @@ test.concurrent('install should resolve circular dependencies 2', (): Promise<vo
 });
 
 test.concurrent(
-  'install should add missing deps to yarn and mirror (PR import scenario)',
+  'install should add missing deps to yarn and mirror when given --write-lockfile (PR import scenario)',
   (): Promise<void> => {
-    return runInstall({}, 'install-import-pr', async (config) => {
+    return runInstall({writeLockfile: true}, 'install-import-pr', async (config) => {
       assert.equal(await getPackageVersion(config, 'mime-types'), '2.0.0');
       assert(semver.satisfies(await getPackageVersion(config, 'mime-db'), '~1.0.1'));
       assert.equal(await getPackageVersion(config, 'fake-yarn-dependency'), '1.0.1');
@@ -578,7 +582,6 @@ test.concurrent(
     });
   },
 );
-
 
 xit('install should update a dependency to yarn and mirror (PR import scenario 2)', (): Promise<void> => {
   // mime-types@2.0.0 is saved in local mirror and gets updated to mime-types@2.1.11 via

--- a/scripts/check-lockfile.sh
+++ b/scripts/check-lockfile.sh
@@ -15,7 +15,7 @@ cp -r scripts $DIR/scripts
 cd $DIR
 
 # install with yarn and run check
-../bin/yarn.js install --pure-lockfile
+../bin/yarn.js install
 ../bin/yarn.js check
 
 # cleanup

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -23,6 +23,7 @@ export class Add extends Install {
   ) {
     super(flags, config, reporter, lockfile);
     this.args = args;
+    this.flags.writeLockfile = true;
   }
 
   args: Array<string>;

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -76,7 +76,7 @@ export async function run(
 
   // reinstall so we can get the updated lockfile
   reporter.step(++step, totalSteps, reporter.lang('uninstallRegenerate'));
-  const reinstall = new Install({force: true, ...flags}, config, new NoopReporter(), lockfile);
+  const reinstall = new Install({force: true, writeLockfile: true, ...flags}, config, new NoopReporter(), lockfile);
   await reinstall.init();
 
   //


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This adresses the discussion found in #570, where the general consensus was that `yarn install` should not be a mutating action by default, like it is today. The argument is that a simple install should not mutate the lockfile without a flag. The PR does the following:

- `yarn install` will no longer write to the lockfile by default
- When `yarn install` is run, if a `yarn.lock`  does not already exist, one will be created
- `--pure-lockfile` is removed
- `--write-lockfile` is added to `yarn install` if you want the old behaviour
- `yarn add`, `yarn remove` and `yarn upgrade` will use `--write-lockfile` by default, as they are mutating actions, so no change to behaviour here.

Fixes #570 

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Note that the lockfile below only changes when `--write-lockfile` is provided. This is not the case with the current release. Today yarn will write the lockfile by default unless `--pure-lockfile` is provided.

```bash
fenrir :: ~/workspace/diverse % mkdir test
fenrir :: ~/workspace/diverse % cd test
fenrir :: workspace/diverse/test % yarn init --yes
fenrir :: workspace/diverse/test % yarn add left-pad@1.0.0                                                         
yarn add v0.16.1
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency
└─ left-pad@1.0.0
Done in 1.03s
fenrir :: workspace/diverse/test % sed -i 's/"left-pad": "1.0.0"/"left-pad": "^1.0.0"/' package.json
fenrir :: workspace/diverse/test % cat package.json                                                                
{
  "name": "test",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "dependencies": {
    "left-pad": "^1.0.0"
  }
}
fenrir :: workspace/diverse/test % cat yarn.lock                                                                   
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1
left-pad@1.0.0:
  version "1.0.0"
  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.0.0.tgz#c84e2417581bbb8eaf2b9e3d7a122e572ab1af37"
fenrir :: workspace/diverse/test % yarn --force                                                                    
yarn install v0.16.0
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
Done in 0.41s.
fenrir :: workspace/diverse/test % cat yarn.lock                                                                   
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


left-pad@1.0.0:
  version "1.0.0"
  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.0.0.tgz#c84e2417581bbb8eaf2b9e3d7a122e572ab1af37"

fenrir :: workspace/diverse/test % yarn --force --write-lockfile                                                   
yarn install v0.16.0
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
Done in 1.39s.
fenrir :: workspace/diverse/test % cat yarn.lock                                                                   
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


left-pad@^1.0.0:
  version "1.1.3"
  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.1.3.tgz#612f61c033f3a9e08e939f1caebeea41b6f3199a"

