### PR TITLE
fix --ignore-scripts flag not working

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -705,15 +705,18 @@ export async function run(
     }
     throw new MessageError(reporter.lang('installCommandRenamed', `yarn ${command} ${exampleArgs.join(' ')}`));
   }
-
-  await executeLifecycleScript(config, 'preinstall');
+  if (!flags.ignoreScripts) {
+    await executeLifecycleScript(config, 'preinstall');
+  }
 
   const install = new Install(flags, config, reporter, lockfile);
   await install.init();
 
   // npm behaviour, seems kinda funky but yay compatibility
   await executeLifecycleScript(config, 'install');
-  await executeLifecycleScript(config, 'postinstall');
+  if (!flags.ignoreScripts) {
+    await executeLifecycleScript(config, 'postinstall');
+  }
   if (!flags.production) {
     await executeLifecycleScript(config, 'prepublish');
   }


### PR DESCRIPTION
**Summary**

Fixes the ```--ignore-scripts``` flag not working.

**Test plan**

Build and run it with and without the flag.  Observe that postinstall and preinstall scripts are now working properly.