### PR TITLE
Fixing global add in linux root folder #1029

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,10 +2,12 @@
 const path = require('path');
 let userHome = require('user-home');
 if (process.platform === 'linux' && process.env.USER === 'root') {
-  userHome = path.resolve(process.execPath, '..', '..', 'lib');
+  userHome = path.resolve('/usr/local/share');
 }
 
-type Env = {[key: string]: ?string};
+type Env = {
+  [key: string]: ? string
+};
 
 export const DEPENDENCY_TYPES = [
   'devDependencies',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,9 @@
 /* @flow */
-
-const userHome = require('user-home');
 const path = require('path');
+let userHome = require('user-home');
+if (process.platform === 'linux' && process.env.USER === 'root') {
+  userHome = path.resolve(process.execPath, '..', '..', 'lib');
+}
 
 type Env = {[key: string]: ?string};
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixing `yarn global add` being installed in root folder described in [issue #1029](https://github.com/yarnpkg/yarn/issues/1029)
.
Users can't access `/root/.yarn-*` .
Using `/usr/local/lib`instead like npm modules (`/usr/local/lib/node_modules`)
eg:

```
yarn global add react-native-cli
/usr/local/bin/react-native -> ../lib/.yarn-config/global/node_modules/.bin/react-native*
```

**Reference**
- [Issue #1029](https://github.com/yarnpkg/yarn/issues/1029)
