### PR TITLE
Meaningful error message on malformed registry response

### DIFF
--- a/__tests__/fixtures/request-cache/GET/localhost/.bin
+++ b/__tests__/fixtures/request-cache/GET/localhost/.bin
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Date: Wed, 19 Oct 2016 13:30:48 GMT
+Date: Mon, 24 Oct 2016 13:03:20 GMT
 Connection: close
 Content-Length: 2
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -199,6 +199,7 @@ const messages = {
   publishing: 'Publishing',
 
   infoFail: 'Received invalid response from npm.',
+  malformedRegistryResponse: 'Received malformed response from registry. The registry may be down.',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -25,9 +25,9 @@ export default class NpmResolver extends RegistryResolver {
 
   static async findVersionInRegistryResponse(config: Config, range: string, body: RegistryResponse): Promise<Manifest> {
     if (!body['dist-tags']) {
-      throw new MessageError(`Received malformed response from registry. The registry may be down.`);
+      throw new MessageError(config.reporter.lang('malformedRegistryResponse'));
     }
-    
+
     if (range in body['dist-tags']) {
       range = body['dist-tags'][range];
     }

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -24,6 +24,10 @@ export default class NpmResolver extends RegistryResolver {
   static registry = 'npm';
 
   static async findVersionInRegistryResponse(config: Config, range: string, body: RegistryResponse): Promise<Manifest> {
+    if (!body['dist-tags']) {
+      throw new MessageError(`Received malformed response from registry. The registry may be down.`);
+    }
+    
     if (range in body['dist-tags']) {
       range = body['dist-tags'][range];
     }


### PR DESCRIPTION
**Summary**

When the yarn DNS failed to resolve today, a malformed response from the registry caused a cryptic error (see #1348) rather than a meaningful message. 

Sorry for no test plan; this is a simple commit, but I wouldn't know how to reproduce it. `npm test` still works, so it doesn't break anything. =)