### PR TITLE
Add package type output to `yarn outdated` command

### DIFF
--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -31,6 +31,7 @@ export async function run(
     current: string,
     wanted: string,
     latest: string,
+    packageType: string,
   }> = [];
 
   let [, patterns] = await install.fetchRequestFromCwd();
@@ -51,6 +52,7 @@ export async function run(
 
     const current = locked.version;
     let name = locked.name;
+    const packageType = install.rootPatternsToOrigin[`${name}@${current}`];
 
     let latest = '';
     let wanted = '';
@@ -77,6 +79,7 @@ export async function run(
       current,
       wanted,
       latest,
+      packageType,
     });
   }));
 
@@ -87,6 +90,7 @@ export async function run(
         info.current,
         reporter.format.green(info.wanted),
         reporter.format.magenta(info.latest),
+        info.packageType,
       ];
     });
 
@@ -94,7 +98,7 @@ export async function run(
       return sortAlpha(a[0], b[0]);
     });
 
-    reporter.table(['Package', 'Current', 'Wanted', 'Latest'], body);
+    reporter.table(['Package', 'Current', 'Wanted', 'Latest', 'Package Type'], body);
   }
 
   return Promise.resolve();


### PR DESCRIPTION
**Summary**

This fixes #1254. The `yarn outdated` command will output where the dependency is located in the `package.json` file.

**Test plan**

Displays whether the package is a `dependency` or `devDependency`.

##### Before

```sh
$ yarn outdated
Package   Current Wanted Latest
is-object 1.0.0   1.0.0  1.0.1
left-pad  1.1.0   1.1.0  1.1.3
✨  Done in 0.63s.
```

##### After

```sh
$ yarn outdated
Package   Current Wanted Latest Package Type
is-object 1.0.0   1.0.0  1.0.1  devDependencies
left-pad  1.1.0   1.1.0  1.1.3  dependencies
✨  Done in 0.35s.
```

