### PR TITLE
improve Git coverage

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -10,3 +10,33 @@ test('cleanUrl', () => {
   expect(Git.cleanUrl('git://github.com/npm-opam/ocamlfind.git'))
     .toEqual('git://github.com/npm-opam/ocamlfind.git');
 });
+
+test('isCommitHash', () => {
+  expect(Git.isCommitHash('ca82a6dff817ec66f44312307202690a93763949'))
+    .toBeTruthy();
+  expect(Git.isCommitHash('abc12'))
+    .toBeTruthy();
+  expect(Git.isCommitHash(''))
+    .toBeFalsy();
+  expect(Git.isCommitHash('abc12_'))
+    .toBeFalsy();
+  expect(Git.isCommitHash('gccda'))
+    .toBeFalsy();
+  expect(Git.isCommitHash('abC12'))
+    .toBeFalsy();
+});
+
+test('assertUrl', () => {
+  expect(() => Git.assertUrl('http://random.repo', ''))
+    .toThrow();
+  expect(() => Git.assertUrl('http://random.repo', 'ab_12'))
+    .toThrow();
+  expect(() => Git.assertUrl('git://random.repo', ''))
+    .toThrow();
+  expect(() => Git.assertUrl('https://random.repo', ''))
+    .not.toThrow();
+  expect(() => Git.assertUrl('http://random.repo', 'abc12'))
+    .not.toThrow();
+  expect(() => Git.assertUrl('git://random.repo', 'abc12'))
+    .not.toThrow();
+});

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -75,7 +75,7 @@ export default class Git {
   }
 
   /**
-   * Check if the input `target` is a 40 character hex commit hash.
+   * Check if the input `target` is a 5-40 character hex commit hash.
    */
 
   static isCommitHash(target: string): boolean {
@@ -95,7 +95,7 @@ export default class Git {
 
     const parts = url.parse(ref);
 
-    if (parts.protocol === 'git') {
+    if (parts.protocol === 'git:') {
       throw new SecurityError(
         `Refusing to download the git repo ${ref} over plain git without a commit hash`,
       );


### PR DESCRIPTION
**Summary**

This pull request adds tests for util/git.js. It improves the coverage to ~67% and also fixes a bug where Git.assertUrl was not checking correctly for git:// urls (because it was expecting the protocol to be `git` but it is actually `git:`.

**Test plan**

`npm run test` now outputs ~67% statements covered and 78% functions for `util/git.js`

