### PR TITLE
honor github commit hash

### DIFF
--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -26,7 +26,7 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
-    return `git@github.com:${parts.user}/${parts.repo}.git`;
+    return `git@github.com:${parts.user}/${parts.repo}.git${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {


### PR DESCRIPTION
**Summary**

This small commit honors the commit hash for packages hosted on github. This allows references in `package.json` to use a commit hash like this:

```json
    "cool-util": "niceguy/cool-util#5ea08cb76619f78e17b988ee3acfeba10ce12160"
```

**Test plan**

Verified that this small addition pulls in the correct version from github.