### PR TITLE
Don't let the authorization header be empty

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -58,7 +58,10 @@ export default class NpmRegistry extends Registry {
 
     const headers = {};
     if (this.token || (alwaysAuth && requestUrl.startsWith(registry))) {
-      headers.authorization = this.getAuth(pathname);
+      const authorization = this.getAuth(pathname);
+      if (authorization) {
+        headers.authorization = authorization;
+      }
     }
 
     return this.requestManager.request({
@@ -148,7 +151,7 @@ export default class NpmRegistry extends Registry {
     return DEFAULT_REGISTRY;
   }
 
-  getAuth(packageName: string): string {
+  getAuth(packageName: string): ?string {
     if (this.token) {
       return this.token;
     }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -151,7 +151,7 @@ export default class NpmRegistry extends Registry {
     return DEFAULT_REGISTRY;
   }
 
-  getAuth(packageName: string): ?string {
+  getAuth(packageName: string): string {
     if (this.token) {
       return this.token;
     }
@@ -180,7 +180,7 @@ export default class NpmRegistry extends Registry {
       }
     }
 
-    return undefined;
+    return '';
   }
 
   getScopedOption(scope: string, option: string): mixed {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -177,7 +177,7 @@ export default class NpmRegistry extends Registry {
       }
     }
 
-    return '';
+    return undefined;
   }
 
   getScopedOption(scope: string, option: string): mixed {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is aimed at solving problems with `@types` (And I guess other public scopes) that can be seen in #825 and #1260 where even with the latest version yarn fails to restore packages where npm succeed. The case is specific to enterprise caches as the yarn or npm default repositories aren't affected.

In my case I had the problem and tested the resolution on ProGet ( http://inedo.com/proget ) configured with an NPM connector..

The issue is that `always-auth` is assumed for scoped packages, and `always-auth` forces the creation of an `authorization:` http header, even when no authentication can be found. The header is created empty in this case. As ProGet is an ASP.Net application and this platform consider an empty authorization header to be something that can never be met, it refuses the connection.

This PR doesn't change the behavior of `always-auth` being assumed for scoped packages but it remove the empty header if no authentication can be found.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

* I ran `yarn` to restore packages in a previously non-working repository and checked that It worked, creating the lock file and was usable after. Tested `yarn add` with a new packages in `@types`
* I tested the same commands while targeting the default repository instead of the cache to ensure that it worked.

I don't have access to a repository that require authentication for scoped packages but the change is minimal and doesn't affect any case where authentication was sent before so it shouldn't affect them (Also npm doesn't send the header in such cases)