### PR TITLE
Prevent `yarn install` from getting in an infinite loop

### DIFF
--- a/src/cli/commands/_execute-lifecycle-script.js
+++ b/src/cli/commands/_execute-lifecycle-script.js
@@ -15,9 +15,19 @@ export async function execFromManifest(config: Config, commandName: string, pkg:
   }
 
   const cmd: ?string = pkg.scripts[commandName];
-  if (cmd) {
+  if (cmd && isValidCommand(commandName, cmd)) {
     await execCommand(commandName, config, cmd, cwd);
   }
+}
+
+function isValidCommand(commandName: string, cmd: string): boolean {
+  // prevent infinite loop (see: https://github.com/yarnpkg/yarn/issues/1227)
+  // blocks `yarn`, `yarn i`, `yarn install`, with any flags as well
+  if (commandName.endsWith('install') && /^yarn(\si(nstall)?)?(\s\-.*)?$/.test(cmd)) {
+    return false;
+  }
+
+  return true;
 }
 
 export async function execCommand(stage: string, config: Config, cmd: string, cwd: string): Promise<void> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This fixes #1227. It adds a check before executing the (pre/post)install lifecycle methods to make sure it won't get into an infinite loop. Not sure if this is the best way to handle it, so feedback is welcome.

**Test plan**

The lifecycle methods (pre/post)install can no longer get in a `yarn install` infinite loop.

