### PR TITLE
Add end-to-end tests for Ubuntu 12.04, 14.04 and 16.04 using Docker

### DIFF
--- a/end_to_end_tests/README.md
+++ b/end_to_end_tests/README.md
@@ -1,0 +1,5 @@
+This directory contains end-to-end tests for Yarn. The tests perform the following steps:
+
+1. Spin up a fresh Docker container
+2. Install Yarn through the package repository
+3. Run `yarn add react` in a test directory

--- a/end_to_end_tests/data/run-ubuntu.sh
+++ b/end_to_end_tests/data/run-ubuntu.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Executed within a fresh Docker container to test installation and execution of Yarn.
+set -ex
+
+. /etc/lsb-release
+
+# Set proxy if one was passed in (eg. if caching on the host machine using apt-cacher-ng)
+if [ -n "$APT_PROXY" ]; then
+    echo 'Acquire::http::proxy "http://'$APT_PROXY'";' > /etc/apt/apt.conf.d/02proxy
+fi;
+
+# Add Yarn repo
+apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+# TODO: Use nightly repo once it's configured
+echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+apt-get update -y
+
+if [ "$DISTRIB_RELEASE" == '12.04' -o "$DISTRIB_RELEASE" == '14.04' ]; then
+  # This is an old Ubuntu version; we need to add the NodeSource repo too
+  apt-get install curl -y
+  curl -sL https://deb.nodesource.com/setup_6.x | bash -
+fi;
+
+# TODO: Remove ca-certificates from this list once https://github.com/yarnpkg/yarn/issues/1390 is fixed
+apt-get install yarn ca-certificates -y
+
+./run-yarn-test.sh

--- a/end_to_end_tests/data/run-yarn-test.sh
+++ b/end_to_end_tests/data/run-yarn-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Executed within a fresh Docker container to test execution of Yarn.
+# Should be executed after Yarn has been installed.
+set -ex
+
+fail_with_log() {
+  # Include the yarn-error.log file in the output, if available
+  exitcode=$?
+  if [ -s yarn-error.log ]; then
+    cat yarn-error.log
+  fi;
+  exit $exitcode
+}
+
+cd /tmp
+mkdir yarntest
+cd yarntest
+yarn add react || fail_with_log

--- a/end_to_end_tests/data/start-ubuntu.sh
+++ b/end_to_end_tests/data/start-ubuntu.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Starts an Ubuntu Docker container and runs the Yarn end-to-end test on it
+set -ex
+
+if [ -z "$1" ]; then
+  echo 'Ubuntu distribution was not specified'
+  exit 1
+fi;
+
+data_path=$(dirname $(readlink -f "$0"))
+docker run -v $data_path:/data -w=/data -e APT_PROXY=$APT_PROXY $1 /data/run-ubuntu.sh

--- a/end_to_end_tests/test-ubuntu-12.04.sh
+++ b/end_to_end_tests/test-ubuntu-12.04.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Starts an Ubuntu 12.04 Docker container and runs the Yarn end-to-end test on it
+set -ex
+./data/start-ubuntu.sh ubuntu:12.04

--- a/end_to_end_tests/test-ubuntu-14.04.sh
+++ b/end_to_end_tests/test-ubuntu-14.04.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Starts an Ubuntu 14.04 Docker container and runs the Yarn end-to-end test on it
+set -ex
+./data/start-ubuntu.sh ubuntu:14.04

--- a/end_to_end_tests/test-ubuntu-16.04.sh
+++ b/end_to_end_tests/test-ubuntu-16.04.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Starts an Ubuntu 16.04 Docker container and runs the Yarn end-to-end test on it
+set -ex
+./data/start-ubuntu.sh ubuntu:16.04


### PR DESCRIPTION
**Summary**
Adds some scripts for end-to-end testing of Yarn. The test script does the following:
1. Spin up a fresh Docker container
2. Install Yarn through the Debian/Ubuntu package repository
3. Run `yarn add react` in a test directory

I'm going to run these nightly. The tests will be more useful once I add a package repo for nightly builds, as it'll let us catch any regressions in the full end-to-end process.

**Test plan**

``` sh
cd end_to_end_tests
./test-ubuntu-16.04.sh # or test-ubuntu-14.04.sh or test-ubuntu-12.04.sh
```

Testing on Windows works fine if you have [Docker for Windows](https://docs.docker.com/docker-for-windows/) installed, and run the Docker command directly rather than using the shell script:

```
docker run -t -v c:/src/yarn/end_to_end_tests/data:/data -w=/data ubuntu:16.04 /data/run-ubuntu.sh
```
