### PR TITLE
Replace some MessageErrors string for lang  codes

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -132,7 +132,7 @@ export default class PackageRequest {
     if (Resolver) {
       return Resolver;
     } else {
-      throw new MessageError(`Unknown registry resolver ${this.registry}`);
+      throw new MessageError(this.reporter.lang('unknownRegistryResolver', this.registry));
     }
   }
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -39,11 +39,13 @@ const messages = {
 
   couldntFindMatch: "Couldn't find match for $0 in $1 for $2.",
   couldntFindPackageInCache: "Couldn't find any versions for $0 that matches $1 in our cache. Possible versions: $2",
+  couldntFindVersionThatMatchesRange: "Couldn't find any versions for $0 that matches $1. Possible versions: $2",
   moduleNotInManifest: "This module isn't specified in a manifest.",
   unknownFolderOrTarball: "Passed folder/tarball doesn't exist,",
   unknownPackage: "Couldn't find package $0.",
   unknownPackageName: "Couldn't find package name.",
   unknownUser: "Couldn't find user $0.",
+  unknownRegistryResolver: 'Unknown registry resolver $0',
   userNotAnOwner: "User $0 isn't an owner of this package.",
   invalidVersionArgument: 'Use the $0 flag to create a new version.',
   invalidVersion: 'Invalid version supplied.',
@@ -201,6 +203,10 @@ const messages = {
 
   infoFail: 'Received invalid response from npm.',
   malformedRegistryResponse: 'Received malformed response from registry. The registry may be down.',
+
+  cantRequestOffline: 'Can\'t make a request in offline mode',
+  requestManagerNotSetupHAR: 'RequestManager was not setup to capture HAR files',
+  requestError: 'Request $0 returned a $1',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -39,8 +39,12 @@ export default class NpmResolver extends RegistryResolver {
     } else {
       const versions = Object.keys(body.versions);
       throw new MessageError(
-        `Couldn't find any versions for ${body.name} that matches ${range}. ` +
-        `Possible versions: ${(versions.length > 20) ? versions.join(os.EOL) : versions.join(', ')}`,
+        config.reporter.lang(
+          'couldntFindVersionThatMatchesRange',
+          body.name,
+          range,
+          (versions.length > 20) ? versions.join(os.EOL) : versions.join(', '),
+        ),
       );
     }
   }

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -170,7 +170,7 @@ export default class RequestManager {
 
   request<T>(params: RequestParams<T>): Promise<T> {
     if (this.offlineNoRequests) {
-      return Promise.reject(new MessageError("Can't make a request in offline mode"));
+      return Promise.reject(new MessageError(this.reporter.lang('cantRequestOffline')));
     }
 
     const cached = this.cache[params.url];
@@ -182,7 +182,6 @@ export default class RequestManager {
     params.forever = true;
     params.retryAttempts = 0;
     params.strictSSL = this.strictSSL;
-    
     params.headers = Object.assign({
       'User-Agent': this.userAgent,
     }, params.headers);
@@ -283,6 +282,7 @@ export default class RequestManager {
 
   execute(opts: RequestOptions) {
     const {params} = opts;
+    const {reporter} = this;
 
     const buildNext = (fn) => (data) => {
       fn(data);
@@ -335,7 +335,7 @@ export default class RequestManager {
         }
 
         if (res.statusCode === 403) {
-          const errMsg = (body && body.message) || `Request ${params.url} returned a ${res.statusCode}`;
+          const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
           reject(new Error(errMsg));
         } else {
           if (res.statusCode === 400 || res.statusCode === 404) {
@@ -394,7 +394,7 @@ export default class RequestManager {
 
   saveHar(filename: string) {
     if (!this.captureHar) {
-      throw new Error('RequestManager was not setup to capture HAR files');
+      throw new Error(this.reporter.lang('requestManagerNotSetupHAR'));
     }
     // No request may have occurred at all.
     this._getRequestModule();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is related to the issue https://github.com/yarnpkg/yarn/issues/1387

Replace MessageError string on `package-request.js`, `npm-resolver.js` and `request-manager.js`.

Sometime Im not sure how to get the reporter so I was wondering if its not worth it that Message Error have access to a reporter and you send only the lang message?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I was able to create some test for `request-manager.js` since there was a test already in place (sry first time using Jest let me know if I should do the tests in another way)

But for the others 2 files I was not able to identify how to reach the code to test it .. so if someone could give some ideas how to test them it would be appreciated 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

