### PR TITLE
set filename parameter to mandatory in pack -f

### DIFF
--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -159,7 +159,7 @@ export async function pack(config: Config, dir: string): Promise<stream$Duplex> 
 }
 
 export function setFlags(commander: Object) {
-  commander.option('-f, --filename [filename]', 'filename');
+  commander.option('-f, --filename <filename>', 'filename');
 }
 
 export async function run(


### PR DESCRIPTION
**Summary**
changes the filename parameter from optional to mandatory for yarn pack -f
without this change the pack -f script fails if no filename is provided


**Test plan**
before this change:
```
[tkloht@Tobias-MacBook-Air ~/Code/yarntest2:master*] ../yarn-forked/bin/yarn pack -f
yarn pack v0.16.2
error An unexpected error occurred, please open a bug report with the information provided in "/Users/tkloht/Code/yarntest2/yarn-error.log".
```
in yarn error.log:
```
Trace:
  TypeError: path must be a string or Buffer
      at TypeError (native)
      at Object.fs.open (fs.js:625:11)
      at WriteStream.open (fs.js:1874:6)
      at new WriteStream (fs.js:1860:10)
      at Object.fs.createWriteStream (fs.js:1815:10)
      at /Users/tkloht/Code/yarn-forked/lib/cli/commands/pack.js:133:23
      at Object.<anonymous> (/Users/tkloht/Code/yarn-forked/lib/cli/commands/pack.js:132:11)
      at next (native)
      at step (/Users/tkloht/Code/yarn-forked/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at /Users/tkloht/Code/yarn-forked/node_modules/babel-runtime/helpers/asyncToGenerator.js:28:20
```

after this change:
after:
```
[tkloht@Tobias-MacBook-Air ~/Code/yarntest2:master*] ../yarn-forked/bin/yarn pack -f
  error: option `-f, --filename <filename>' argument missing
```

