### PR TITLE
Fixes #1408

### DIFF
--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -44,7 +44,7 @@ export async function run(
 
       for (const type of constants.DEPENDENCY_TYPES) {
         const deps = object[type];
-        if (deps) {
+        if (deps && deps[name]) {
           found = true;
           delete deps[name];
         }


### PR DESCRIPTION
This Fix for #1408 will change `yarn remove [package]` (where package is not in package.json) to error on invalid package name:

```
[1/2] Removing module fassdfsdf...
error This module isn't specified in a manifest.
```