### PR TITLE
Fixes #1382

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -36,9 +36,8 @@ export async function run(
       // Ignore - Git repo may not have an origin URL yet (eg. if it only exists locally)
     }
 
-    // get author default based on git config
-    author.name = author.name || await child.spawn('git', ['config', 'user.name']);
-    author.email = author.email || await child.spawn('git', ['config', 'user.email']);
+    author.name = author.name || await getAuthorData(reporter, 'user.name');
+    author.email = author.email || await getAuthorData(reporter, 'user.email');
   }
 
   const keys = [
@@ -134,4 +133,17 @@ export async function run(
   }
 
   await config.saveRootManifests(manifests);
+}
+
+
+async function getAuthorData(
+  reporter: Reporter,
+  credential: String,
+): string {
+  try {
+    // try to get author default based on git config
+    return await child.spawn('git', ['config', credential]);
+  } catch (e) {
+    return await reporter.question(credential.replace('user.', 'author '));
+  }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -36,8 +36,8 @@ export async function run(
       // Ignore - Git repo may not have an origin URL yet (eg. if it only exists locally)
     }
 
-    author.name = author.name || await getAuthorData(reporter, 'user.name');
-    author.email = author.email || await getAuthorData(reporter, 'user.email');
+    author.name = author.name || await getAuthorData('user.name');
+    author.email = author.email || await getAuthorData('user.email');
   }
 
   const keys = [
@@ -137,13 +137,12 @@ export async function run(
 
 
 async function getAuthorData(
-  reporter: Reporter,
   credential: string,
 ): Promise<string> {
   try {
     // try to get author default based on git config
     return await child.spawn('git', ['config', credential]);
   } catch (e) {
-    return await reporter.question(credential.replace('user.', "author's"));
+    return '';
   }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -138,12 +138,12 @@ export async function run(
 
 async function getAuthorData(
   reporter: Reporter,
-  credential: String,
-): string {
+  credential: string,
+): Promise<string> {
   try {
     // try to get author default based on git config
     return await child.spawn('git', ['config', credential]);
   } catch (e) {
-    return await reporter.question(credential.replace('user.', 'author '));
+    return await reporter.question(credential.replace('user.', 'author\'s '));
   }
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -144,6 +144,6 @@ async function getAuthorData(
     // try to get author default based on git config
     return await child.spawn('git', ['config', credential]);
   } catch (e) {
-    return await reporter.question(credential.replace('user.', 'author\'s '));
+    return await reporter.question(credential.replace('user.', "author's"));
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+ Added solution to fix #1382 . When the user doesn't have user in the `gitconfig` `yarn init` was crashing. 


**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

1. Remove the `user` property from your `gitconfig`. 
2. Run `yarn init`.
3. You'll be prompted with questions to add the `Author's name` & `Author's email`. (Both are optional)
4. The init process should be completed successfully.

**Before**

<img width="782" alt="yarninitfailing" src="https://cloud.githubusercontent.com/assets/5958030/19667128/0fdc38aa-9a1d-11e6-9973-c2c4877de201.png">


**After**

<img width="477" alt="success" src="https://cloud.githubusercontent.com/assets/5958030/19667147/31ad5a0e-9a1d-11e6-9b36-b535db158843.png">

Feedback to improve this implementation is more than welcome 😄 
