### PR TITLE
Execute pre/post install lifecycle scripts for `yarn add` command

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -7,6 +7,7 @@ import type Config from '../../config.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import * as PackageReference from '../../package-reference.js';
 import PackageRequest from '../../package-request.js';
+import executeLifecycleScript from './_execute-lifecycle-script.js';
 import {buildTree} from './ls.js';
 import {Install, _setFlags} from './install.js';
 import {MessageError} from '../../errors.js';
@@ -174,6 +175,11 @@ export async function run(
   }
 
   const lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
+
+  await executeLifecycleScript(config, 'preinstall');
+
   const install = new Add(args, flags, config, reporter, lockfile);
   await install.init();
+
+  await executeLifecycleScript(config, 'postinstall');
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This resolves #1238. Now will execute `preinstall` and `postinstall` during the `yarn install` command.

**Test plan**

```js
{
  "name": "yarn-example",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "scripts": {
    "preinstall": "echo 'Hello'"
  }
}
```

##### Before

```sh
$ yarn add left-pad
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency
└─ left-pad@1.1.3
✨  Done in 0.43s.
```

```sh
$ yarn add left-pad
info No lockfile found.
$ echo 'Hello'
Hello
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency
└─ left-pad@1.1.3
✨  Done in 0.45s.
```
