### PR TITLE
fix publish for non default registries

### DIFF
--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -100,7 +100,7 @@ async function publish(
     body: root,
   });
 
-  if (res != null && res.success) {
+  if (res !== null && res !== false) {
     await executeLifecycleScript(config, 'publish');
     await executeLifecycleScript(config, 'postpublish');
   } else {


### PR DESCRIPTION
**Summary**

The [default registry](https://registry.npmjs.org/) returns a response body

``` json
{"success": true}
```

while other registries might not. Artifactory for example returns

```
HTTP/1.1 201 Created
Date: Tue, 25 Oct 2016 03:41:04 GMT
Connection: keep-alive
Transfer-Encoding: chunked
Content-Type: application/json

{"ok": "created new entity"}

```

This pull requests fixes publishing to non default registries.

**Test plan**

The results of the fixed version can be seen here:

https://asciinema.org/a/auvjqh4hln1ykmiuvmzy8d8ke
