### PR TITLE
Add configuration options for the yarn cache path.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -36,7 +36,7 @@ function getDirectory(type: string): string {
 }
 
 export const GLOBAL_INSTALL_DIRECTORY = path.join(userHome, '.yarn');
-export const MODULE_CACHE_DIRECTORY = getDirectory('cache');
+export const MODULE_CACHE_DIRECTORY = process.env.YARN_CACHE_PATH || getDirectory('cache');
 export const LINK_REGISTRY_DIRECTORY = getDirectory('config/link');
 export const GLOBAL_MODULE_DIRECTORY = getDirectory('config/global');
 export const CACHE_FILENAME = path.join(GLOBAL_INSTALL_DIRECTORY, '.roadrunner.json');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The generic cache path doesn't work for all scenarios.  For me, it was a little bit of a blocker for docker containers.  Allowing a configurable path lets me set the cache path to be stored on specific volume which can then be shared between hosts, or can specify a more permanent storage path in an otherwise ephemeral container. 

**Test plan**

**_ENV VAR**_

```
export YARN_CACHE_PATH=~/test-cache

yarn config list #=> contains the cache-path of ~/test-cache

yarn # install modules and see that files are stored in the specified cache
```

**_ENV VAR can be removed to fallback on default behaviors**_

```
unset YARN_CACHE_PATH

rm -rf node_modules/

yarn # install modules to the default cache location
```
