### PR TITLE
Add aliases tests

### DIFF
--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -1,0 +1,52 @@
+/* @flow */
+
+import {setAliasCmd} from '../../src/cli/index.js';
+import aliases from '../../src/cli/aliases.js';
+
+test('setAliasCmd should rewrite "yarn run-script" to "yarn run"', () => {
+  expect(setAliasCmd('run-script', aliases)).toBe('run');
+});
+
+test('setAliasCmd should rewrite "yarn c" to "yarn config"', () => {
+  expect(setAliasCmd('c', aliases)).toBe('config');
+});
+
+test('setAliasCmd should rewrite "yarn i" to "yarn install"', () => {
+  expect(setAliasCmd('i', aliases)).toBe('install');
+});
+
+test('setAliasCmd should rewrite "yarn list" to "yarn ls"', () => {
+  expect(setAliasCmd('list', aliases)).toBe('ls');
+});
+
+test('setAliasCmd should rewrite "yarn ln" to "yarn link"', () => {
+  expect(setAliasCmd('ln', aliases)).toBe('link');
+});
+
+test('setAliasCmd should rewrite "yarn rb" to "yarn rebuild"', () => {
+  expect(setAliasCmd('rb', aliases)).toBe('rebuild');
+});
+
+test('setAliasCmd should rewrite "yarn runScript" to "yarn run"', () => {
+  expect(setAliasCmd('runScript', aliases)).toBe('run');
+});
+
+test('setAliasCmd should rewrite "yarn t" to "yarn test"', () => {
+  expect(setAliasCmd('t', aliases)).toBe('test');
+});
+
+test('setAliasCmd should rewrite "yarn tst" to "yarn test"', () => {
+  expect(setAliasCmd('tst', aliases)).toBe('test');
+});
+
+test('setAliasCmd should rewrite "yarn un" to "yarn remove"', () => {
+  expect(setAliasCmd('un', aliases)).toBe('remove');
+});
+
+test('setAliasCmd should rewrite "yarn up" to "yarn update"', () => {
+  expect(setAliasCmd('up', aliases)).toBe('update');
+});
+
+test('setAliasCmd should rewrite "yarn v" to "yarn version"', () => {
+  expect(setAliasCmd('v', aliases)).toBe('version');
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -24,6 +24,11 @@ const pkg = require('../../package.json');
 
 loudRejection();
 
+// helper function to make alias rewrites easy to test
+export const setAliasCmd = (cmd: string, alias: Object): string => {
+  return aliases[cmd] ? aliases[cmd] : '';
+};
+
 //
 const startArgs = process.argv.slice(0, 2);
 let args = process.argv.slice(2);
@@ -122,7 +127,7 @@ if (!commandName || commandName[0] === '-') {
 
 // aliases: i -> install
 if (commandName && typeof aliases[commandName] === 'string') {
-  const alias = aliases[commandName];
+  const alias = setAliasCmd(commandName, aliases);
   command = {
     run(config: Config, reporter: ConsoleReporter | JSONReporter): Promise<void> {
       throw new MessageError(`Did you mean \`yarn ${alias}\`?`);


### PR DESCRIPTION
~**Summary**~
~Per a feature request in #1257, short hand aliases have been added to the yarn cli.~

~**Motivation**~
~Improve the ease of use of the yarn cli.~

Amended for addition of tests only.

