### PR TITLE
Add test coverage for alias commands

### DIFF
--- a/__tests__/cli/aliases.js
+++ b/__tests__/cli/aliases.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import aliases from '../../src/cli/aliases.js';
+
+test('shorthands and affordances', () => {
+  expect(aliases['run-script']).toBe('run');
+  expect(aliases['c']).toBe('config');
+  expect(aliases['i']).toBe('install');
+  expect(aliases['list']).toBe('ls');
+  expect(aliases['rb']).toBe('rebuild');
+  expect(aliases['runScript']).toBe('run');
+  expect(aliases['t']).toBe('test');
+  expect(aliases['tst']).toBe('test');
+  expect(aliases['un']).toBe('remove');
+  expect(aliases['up']).toBe('update');
+  expect(aliases['v']).toBe('info');
+  expect(aliases['add-user']).toBe('login');
+  expect(aliases['dist-tag']).toBe('tag');
+  expect(aliases['dist-tags']).toBe('tag');
+  expect(aliases['adduser']).toBe('login');
+  expect(aliases['author']).toBe('owner');
+  expect(aliases['isntall']).toBe('install');
+  expect(aliases['la']).toBe('ls');
+  expect(aliases['ll']).toBe('ls');
+  expect(aliases['r']).toBe('remove');
+  expect(aliases['rm']).toBe('remove');
+  expect(aliases['show']).toBe('info');
+  expect(aliases['uninstall']).toBe('remove');
+  expect(aliases['update']).toBe('upgrade');
+  expect(aliases['verison']).toBe('version');
+  expect(aliases['view']).toBe('info');
+});


### PR DESCRIPTION
**Summary**

Add test coverage for existing aliased commands in `src/cli/aliases.js`

**Test plan**
`npm run lint && npm run test-only`

Adds the following test output:
<img width="323" alt="screen shot 2016-10-25 at 3 22 26 am" src="https://cloud.githubusercontent.com/assets/1470297/19676452/6888a7d2-9a62-11e6-8f8b-4eb85d24a365.png">
