### PR TITLE
Join available versions with newline if more than 20

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -11,6 +11,7 @@ import {YARN_REGISTRY} from '../../constants.js';
 
 const invariant = require('invariant');
 const path = require('path');
+const os = require('os');
 
 const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
 
@@ -36,9 +37,10 @@ export default class NpmResolver extends RegistryResolver {
     if (satisfied) {
       return body.versions[satisfied];
     } else {
+      const versions = Object.keys(body.versions);
       throw new MessageError(
         `Couldn't find any versions for ${body.name} that matches ${range}. ` +
-        `Possible versions: ${Object.keys(body.versions).join(', ')}`,
+        `Possible versions: ${(versions.length > 20) ? versions.join(os.EOL) : versions.join(', ')}`,
       );
     }
   }


### PR DESCRIPTION
**Summary**

When trying to add a unexistant version of a package, yarn warn user and list available version, separated by a comma and a space : 

```
[1/4] Resolving packages...
error Couldn't find any versions for typescript that matches 2.1.0. Possible versions: 0.8.0, 0.8.1, 0.8.1-1, 0.8.2, 0.8.3, 0.9.0, 0.9.0-1, 0.9.1, 0.9.1-1, 0.9.5, 0.9.7, 1.0.0, 1.0.1, 1.1.0-1, 1.3.0, 1.4.1, 1.5.0-alpha, 1.5.0-beta, 1.5.3, 1.6.0-dev.20150722.1, 1.6.0-dev.20150723, 1.6.0-dev.20150724, 1.6.0-dev.20150725, 1.6.0-dev.20150726, 1.6.0-dev.20150727, 1.6.0-dev.20150728, 1.6.0-dev.20150729, 1.6.0-dev.20150730, 1.6.0-dev.20150731, 1.6.0-dev.20150801, 1.6.0-dev.20150802 [...]
```

The output can be really hard to read on packages with numerous versions.
This PR proposes to use new lines as separator when there are more than 20 versions available : 

```
[1/4] Resolving packages...
error Couldn't find any versions for typescript that matches 2.1.0. Possible versions: 0.8.0
0.8.1
0.8.1-1
0.8.2
0.8.3
0.9.0
0.9.0-1
0.9.1
0.9.1-1
0.9.5
0.9.7
1.0.0
1.0.1
[...]
```

**Test plan**

Try to add an unexistant version of a depedency, eg : `yarn add typescript@2.1.0`

