### PR TITLE
Ignore optional dependency if wrong platform

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -5,6 +5,7 @@ import type PackageResolver from './package-resolver.js';
 import type {Reporter} from './reporters/index.js';
 import type Config from './config.js';
 import type {VisibilityAction} from './package-reference.js';
+import PackageCompatibility from './package-compatibility.js';
 import {cleanDependencies} from './util/normalize-manifest/validate.js';
 import Lockfile from './lockfile/wrapper.js';
 import {USED as USED_VISIBILITY, default as PackageReference} from './package-reference.js';
@@ -246,6 +247,13 @@ export default class PackageRequest {
     ref.addVisibility(this.visibility);
     info._reference = ref;
     info._remote = remote;
+
+    // Skip the dependencies if optional and not compatible
+    if (this.optional && Array.isArray(info.os)) {
+      if (!PackageCompatibility.isValidPlatform(info.os)) {
+        return;
+      }
+    }
 
     // start installation of dependencies
     const promises = [];


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/issues/1435

Expect to solve the issue where optional dependencies' dependencies are not ignored as they should be.

---

**What is the current behavior?**

I get an error while using yarn install instead of just ignoring the dependency.

**If the current behavior is a bug, please provide the steps to reproduce.**

Here is an excerpt of my `package.json`:

```
{
  // ...
  "dependencies": {
    // ...
  },
  "devDependencies": {
    // ...
  },
  "optionalDependencies": {
    "appdmg": "^0.4.5",
    // ...
  },
  // ...
}
```

Then : 
`yarn install`

Result:

```
yarn install v0.16.1
info No lockfile found.
warning airtame-packager@0.2.0: No license field
[1/4] Resolving packages...
warning electron-prebuilt > electron-download > nugget > progress-stream > through2 > xtend > object-keys@0.4.0: 
[2/4] Fetching packages...
warning appdmg@0.4.5: The platform "linux" is incompatible with this module.
info "appdmg@0.4.5" is an optional dependency and failed compatibility check. Excluding it from installation.
error macos-alias@0.2.11: The platform "linux" is incompatible with this module.
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

_As a comment, it is important to underline that **appdmg** has actually a dependency named **ds-store** that has one named **macos-alias**._

**What is the expected behavior?**

Yarn should completely ignore appdmg, therefore any dependency related to it.

**Please mention your node.js, yarn and operating system version.**
Node: 6.5.0
OS: Linux Ubuntu 16.04 (work on OSX 10.10.5 since appdmg is for Darwin).
