### PR TITLE
show version number of a package in package.json and yarn.lock inplace of  dist-tag

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -58,6 +58,7 @@ export class Add extends Install {
     const patterns = await Install.prototype.init.call(this);
     await this.maybeOutputSaveTree(patterns);
     await this.savePackages();
+    await Install.prototype.saveLockfileAndIntegrity.call(this, patterns);
     return patterns;
   }
 
@@ -106,7 +107,11 @@ export class Add extends Install {
       let version;
       if (parts.hasVersion && parts.range) {
         // if the user specified a range then use it verbatim
-        version = parts.range;
+        if (parts.range.match(/^[a-zA-Z]+.*/) != null) {
+          version = pkg.version;
+        } else {
+          version = parts.range;
+        }
       } else if (PackageRequest.getExoticResolver(pattern)) {
         // wasn't a name/range tuple so this is just a raw exotic pattern
         version = pattern;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Changed the logic in savePackages function of add.js to replace the dist-tag with its version number.
Also since the lockfile is written before the patterns can be changed in the savePackages(), the lockfile should be written again with the modified pattern.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR addresses issue #1306 
