### PR TITLE
Add period to `savedNewDependency` message for consistency

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -128,7 +128,7 @@ const messages = {
   unmetPeer: 'Unmet peer dependency $0.',
   incorrectPeer: 'Incorrect peer dependency $0.',
 
-  savedNewDependency: 'Saved 1 new dependency',
+  savedNewDependency: 'Saved 1 new dependency.',
   savedNewDependencies: 'Saved $0 new dependencies.',
 
   foundWarnings: 'Found $0 warnings.',


### PR DESCRIPTION
**Summary**

This adds a period to the end of the `savedNewDependency` message. This doesn't really solve a problem, but does make the output of running `yarn` more consistent. Most messages, including the very similar `savedNewDependencies`, end in a period. 

**Test plan**

I haven't actually tested this locally since it is just a change to a locale file and seems low risk. I suspect it can be tested by simply running commands such as `yarn add` or `yarn upgrade`.