### PR TITLE
add depth specification to ls. Fixes #726

### DIFF
--- a/__tests__/commands/ls.js
+++ b/__tests__/commands/ls.js
@@ -1,0 +1,73 @@
+/* @flow */
+
+import * as ls from '../../src/cli/commands/ls.js';
+
+test('getParent should extract a parent object from a hash, if the parent key exists', () => {
+  const mockTreesByKey = {};
+
+  mockTreesByKey['parentPkg'] = {
+    name: 'parent@1.1.1',
+    children: [],
+  };
+  const res = ls.getParent('parentPkg#childPkg', mockTreesByKey);
+  
+  expect(res instanceof Object).toBe(true);
+  expect(res.name).toBe('parent@1.1.1');
+  expect(res.children.length).toBe(0);
+});
+
+test('getParent should return undefined if the key does not exist in hash', () => {
+  const mockTreesByKey = {};
+  mockTreesByKey['parentPkg'] = { };
+
+  const res = ls.getParent('parentPkg#childPkg', mockTreesByKey);
+  expect(res.name).not.toBeDefined();
+  expect(res.children).not.toBeDefined();
+});
+
+test('setFlags should set options for --depth', () => {
+  const flags = ['--depth'];
+  const commander = require('commander');
+  ls.setFlags(commander);
+
+  const commanderOptions = commander.options;
+  const optsLen = commanderOptions.length;
+  flags.map((flag) => {
+    let currFlagExists = false;
+    for (let i = 0; i < optsLen; i++) {
+      if (commanderOptions[i].long === flag) {
+        currFlagExists = true;
+      }
+    }
+    expect(currFlagExists).toBeTruthy();
+  });
+});
+
+test('setFlags should set options for --depth', () => {
+  const flags = ['--foo', '--bar', '--baz'];
+  const commander = require('commander');
+  ls.setFlags(commander);
+  
+  const commanderOptions = commander.options;
+  const optsLen = commanderOptions.length;
+  flags.map((flag) => {
+    let currFlagExists = false;
+    for (let i = 0; i < optsLen; i++) {
+      if (commanderOptions[i].long === flag) {
+        currFlagExists = true;
+      }
+    }
+    expect(currFlagExists).not.toBeTruthy();
+  });
+});
+
+test('getReqDepth should return a number if valid', () => {
+  expect(ls.getReqDepth('1')).toEqual(1); 
+  expect(ls.getReqDepth('01')).toEqual(1); 
+});
+
+test('getReqDepth should return -1 if invalid', () => {
+  expect(ls.getReqDepth('foo')).toEqual(-1); 
+  expect(ls.getReqDepth('bar')).toEqual(-1); 
+  expect(ls.getReqDepth('')).toEqual(-1);
+});

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -4,6 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type {InstallCwdRequest, InstallPrepared} from './install.js';
 import type {DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
+import type {LsOptions} from './ls.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import * as PackageReference from '../../package-reference.js';
 import PackageRequest from '../../package-request.js';
@@ -82,7 +83,11 @@ export class Add extends Install {
    */
 
   async maybeOutputSaveTree(patterns: Array<string>): Promise<void> {
-    const {trees, count} = await buildTree(this.resolver, this.linker, patterns, true, true);
+    // don't limit the shown tree depth
+    const opts: LsOptions = {
+      reqDepth: 0,
+    };
+    const {trees, count} = await buildTree(this.resolver, this.linker, patterns, opts, true, true);
     this.reporter.success(
       count === 1 ?
         this.reporter.lang('savedNewDependency')

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -120,7 +120,7 @@ export default class BaseReporter {
   // TODO
   list(key: string, items: Array<string>) {}
 
-  // TODO
+  // Outputs basic tree structure to console
   tree(key: string, obj: Trees) {}
 
   // called whenever we begin a step in the CLI.

--- a/src/reporters/console/helpers/tree-helper.js
+++ b/src/reporters/console/helpers/tree-helper.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+const repeat = require('repeating');
+
+// types
+import type {Trees} from '../../types.js';
+
+export type FormattedOutput = {
+  end: boolean, 
+  level: number, 
+  hint: any, 
+  color: string, 
+  name: string, 
+  formatter: any,
+};
+
+// public
+export const sortTrees = (trees: Trees): Trees => {
+  return trees.sort(function(tree1, tree2): number {
+    return tree1.name.localeCompare(tree2.name);
+  });
+};
+
+export const recurseTree = (tree: Trees, level: number, recurseFunc: Function) => {
+  const treeLen = tree.length;
+  const treeEnd = treeLen - 1;
+  for (let i = 0; i < treeLen; i++) {
+    recurseFunc(tree[i], level + 1, i === treeEnd);
+  }
+};
+
+export const getFormattedOutput = (fmt: FormattedOutput): string => {
+  const item = formatColor(fmt.color, fmt.name, fmt.formatter);
+  const indent = getIndent(fmt.end, fmt.level);
+  const suffix = getSuffix(fmt.hint, fmt.formatter);
+  return `${indent}─ ${item}${suffix}\n`;
+};
+
+// private
+const getIndentChar = (end: boolean) : string => {
+  return end ? '└' : '├';
+};
+
+const getIndent = (end: boolean, level: number) : string => {
+  const base = repeat('│  ', level);
+  const indentChar = getIndentChar(end);
+  const hasLevel =  base + indentChar;
+  return level ? hasLevel : indentChar;
+};
+
+const getSuffix = (hint: any, formatter: any) : string => {
+  return hint ? ` (${formatter.grey(hint)})` : '';
+};
+
+const formatColor = (color: string, strToFormat: string, formatter: any) : string => {
+  return color ? formatter[color](strToFormat) : strToFormat;
+};


### PR DESCRIPTION
**Summary**
Per #726, filtering the depth of children displayed should be supported.

**Test plan**
Added support for: `yarn ls depth [LEVEL]` where the first level is 1.

**Examples**:

`yarn ls depth 1`
<img width="536" alt="screen shot 2016-10-25 at 7 37 06 pm" src="https://cloud.githubusercontent.com/assets/1470297/19708199/d40dd3b4-9aea-11e6-873e-398c2b343819.png">

`yarn ls depth 2`
<img width="374" alt="screen shot 2016-10-25 at 7 37 52 pm" src="https://cloud.githubusercontent.com/assets/1470297/19708215/ebf6e8c6-9aea-11e6-9a83-7b90ad89b1a5.png">
`
