### PR TITLE
Add webhook for archiving CircleCI build artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,3 +47,7 @@ deployment:
       - ./ghr --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) artifacts/
       - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - npm publish
+
+notify:
+  webhooks:
+    - url: https://nightly.yarnpkg.com/api/archive_circleci


### PR DESCRIPTION
**Summary**
Archives builds from CircleCI into our directory for nightly builds. I'm using the phrase "nightly" but I really mean "unstable" as it's archived after every build, not once per night.

**Test plan**
¯\\\_(ツ)\_/¯

This probably needs more testing - The script it's calling intentionally ignores all requests that aren't for the master branch of yarnpkg/yarn repo as we don't want to archive random stuff from other repos or branches, but that means that I can't actually test it in my fork at the moment 😛 I might just create a copy of the archiving script and play with it some more in my fork.