### PR TITLE
fix-1158: resolve dep verions by ranges, not exact versions (#1158) (#1272) (#1404)

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -290,30 +290,27 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 7', (): P
 
 test.concurrent('install should dedupe dependencies avoiding conflicts 8', (): Promise<void> => {
   // revealed in https://github.com/yarnpkg/yarn/issues/112
+  // adapted for https://github.com/yarnpkg/yarn/issues/1158
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-8', async (config) => {
     assert.equal(await getPackageVersion(config, 'glob'), '5.0.15');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/globby/glob'), '6.0.4');
+    assert.equal(await getPackageVersion(config, 'findup-sync/glob'), '4.3.5');
     assert.equal(await getPackageVersion(config, 'inquirer'), '0.8.5');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/yeoman-environment/inquirer'), '1.1.3');
     assert.equal(await getPackageVersion(config, 'lodash'), '3.10.1');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/yeoman-environment/lodash'), '4.15.0');
+    assert.equal(await getPackageVersion(config, 'ast-query/lodash'), '4.15.0');
     assert.equal(await getPackageVersion(config, 'run-async'), '0.1.0');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/yeoman-environment/run-async'), '2.2.0');
   });
 });
 
-
 test.concurrent('install should dedupe dependencies avoiding conflicts 9', (): Promise<void> => {
   // revealed in https://github.com/yarnpkg/yarn/issues/112
+  // adapted for https://github.com/yarnpkg/yarn/issues/1158
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-9', async (config) => {
     assert.equal(await getPackageVersion(config, 'glob'), '5.0.15');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/globby/glob'), '6.0.4');
+    assert.equal(await getPackageVersion(config, 'findup-sync/glob'), '4.3.5');
     assert.equal(await getPackageVersion(config, 'inquirer'), '0.8.5');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/yeoman-environment/inquirer'), '1.1.3');
     assert.equal(await getPackageVersion(config, 'lodash'), '3.10.1');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/yeoman-environment/lodash'), '4.15.0');
+    assert.equal(await getPackageVersion(config, 'ast-query/lodash'), '4.15.0');
     assert.equal(await getPackageVersion(config, 'run-async'), '0.1.0');
-    assert.equal(await getPackageVersion(config, 'yeoman-generator/yeoman-environment/run-async'), '2.2.0');
   });
 });
 

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -217,7 +217,8 @@ export default class PackageRequest {
 
     // check if while we were resolving this dep we've already resolved one that satisfies
     // the same range
-    const resolved: ?Manifest = this.resolver.getExactVersionMatch(info.name, info.version);
+    const {range, name} = PackageRequest.normalizePattern(this.pattern);
+    const resolved: ?Manifest = this.resolver.getHighestRangeVersionMatch(name, range);
     if (resolved) {
       const ref = resolved._reference;
       invariant(ref, 'Resolved package info has no package reference');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Smarter/looser dep version number resolving -- by range instead of exact version. ([comment and code disagree](https://github.com/yarnpkg/yarn/blob/master/src/package-request.js#L218-L220))

`package-request` will resolve a package to the **highest** available version, and check if that package version has already been resolved with `package-resolver`'s **exact version match** `getExactVersionMatch`. 

Instead of matching the exact highest version: match satisfying resolved ranges of the requested package, and pick the highest available one, *if* possible. *If not* possible, continue and resolve to the highest possible version as before.

https://github.com/yarnpkg/yarn/issues/112 originally says and tests the opposite of this. The concerns in this issue have been tested as-well and are succeeding: `npm shrinkwrap` && `yarn check`. Tests have been adapted, since the setup was largely the same.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves:
* https://github.com/yarnpkg/yarn/issues/1158
* https://github.com/yarnpkg/yarn/issues/1272
* https://github.com/yarnpkg/yarn/issues/1404

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
{
  "dependencies": {
    "devbridge-autocomplete": "^1.2.26",
    "jquery": "2.1.2"
  }
}
```

```
$ yarn install
$ npm shrinkwrap --dev
$ yarn check
```

Open `yarn.lock` and see that range-matching dependencies are shared.

