### PR TITLE
Add CLI docs for yarn add --exact and yarn add --tilde

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -159,8 +159,8 @@ export function setFlags(commander: Object) {
   commander.option('--dev', 'save package to your `devDependencies`');
   commander.option('--peer', 'save package to your `peerDependencies`');
   commander.option('--optional', 'save package to your `optionalDependencies`');
-  commander.option('--exact', '');
-  commander.option('--tilde', '');
+  commander.option('--exact', 'install exact version');
+  commander.option('--tilde', 'install most recent release with the same minor version');
 }
 
 export async function run(


### PR DESCRIPTION
**Summary**

yarn add --exact and yarn add --tilde had no CLI docs when running `yarn help add`.

I added this documentation.

**Test plan**

Tested manually with ./bin/yarn help add

Descriptions were based on official docs:
https://yarnpkg.com/en/docs/cli/add