### PR TITLE
Factory needs to be a function.

### DIFF
--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -130,7 +130,7 @@ export default class HostedGitResolver extends ExoticResolver {
       }
 
       const tarballUrl = this.constructor.getTarballUrl(this.exploded, commit);
-      const json = await config.readJson(href, JSON.parse(file));
+      const json = await config.readJson(href, () => JSON.parse(file));
       json._uid = commit;
       json._remote = {
         resolved: tarballUrl,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Let the dependencies be: 
``` 
dependencies: {
  "lens": "github:blahah/lens-1#patch-10"
}
```

Without this change, parsing package.json from this github repository results in:

```
TypeError: factory is not a function
    at /Users/juretriglav/src/yarn/lib/config.js:527:22
    at next (native)
    at step (/Users/juretriglav/src/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/juretriglav/src/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at Promise.F (/Users/juretriglav/src/yarn/node_modules/core-js/library/modules/_export.js:35:28)
    at /Users/juretriglav/src/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
    at Config.readJson (/Users/juretriglav/src/yarn/lib/config.js:536:7)
    at /Users/juretriglav/src/yarn/lib/resolvers/exotics/hosted-git-resolver.js:173:37
    at next (native)
    at step (/Users/juretriglav/src/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Running `yarn install` after this change parses the mentioned package.json successfully (but errors because of a completely separate issue).

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

See also: https://github.com/yarnpkg/yarn/blob/master/src/resolvers/exotics/git-resolver.js#L106