### PR TITLE
init package.json repository as a string instead of an object

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -66,7 +66,7 @@ export async function run(
       default: 'index.js',
     },
     {
-      key: 'repository.url',
+      key: 'repository',
       question: 'git repository',
       default: gitUrl,
     },
@@ -127,11 +127,6 @@ export async function run(
     if (answer) {
       objectPath.set(pkg, manifestKey, answer);
     }
-  }
-
-  // if we have a git url then set the type
-  if (pkg.repository && pkg.repository.url) {
-    pkg.repository.type = 'git';
   }
 
   // save answers


### PR DESCRIPTION
**Summary**

https://github.com/npm/normalize-package-data is a tool used by the npm registry and the npm client to clean up package data. One of the things is does is:

> If repository field is a string, it will become an object with `url` set to the original string value, and type set to "git".

This means that the `package.json` file can have a simple string URL value for `repository`. This style leads to a cleaner `package.json` file and is easier for humans to read.

This PR updates the `yarn init` command to set `repository` as a string, rather than an object with `url` and `type` values.

**Example Usage**

```
$ cd example

$ git init                  
Initialized empty Git repository in /Users/zeke/Desktop/example/.git/

$ git remote add origin https://github.com/zeke/example

$ ~/forks/yarn/bin/yarn init                           
yarn init v0.16.2
question name (example): 
question version (1.0.0): 
question description: 
question entry point (index.js): 
question git repository (https://github.com/zeke/example): 
question author (Zeke Sikelianos <zeke@sikelianos.com>): 
question license (MIT): 
success Saved package.json
✨  Done in 7.15s.

$ cat package.json     
{
  "name": "example",
  "version": "1.0.0",
  "main": "index.js",
  "repository": "https://github.com/zeke/example",
  "author": "Zeke Sikelianos <zeke@sikelianos.com>",
  "license": "MIT"
}

$ cat package.json | json repository
https://github.com/zeke/example
```

**Test plan**

I can think of two ways to test this behavior, but wanted to open the PR first for input.

Option 1:

- Create a temporary `.git/config` in the test directory
- Update the existing [yarn init --yes](https://github.com/zeke/yarn/blob/38bd0a3a76d9246d3db38d71bb7cf13681524c94/__tests__/commands/init.js#L11-L23) test to look for the repository string.
- Clean up the git directory after the test.

Option 2:

- Create a new test that doesn't use `--yes`, but instead uses the `mock-stdin` dependency to simulate actual input from the user.

Either option is fine with me, but a little guidance would be appreciated!
