### PR TITLE
Git branches can have hashes as part of their name

### DIFF
--- a/__tests__/resolvers/exotics/hosted-git-resolver.js
+++ b/__tests__/resolvers/exotics/hosted-git-resolver.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+import {explodeHostedGitFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
+import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
+import * as reporters from '../../../src/reporters/index.js';
+const reporter = new reporters.NoopReporter({});
+
+test('explodeHostedGitFragment should allow for hashes as part of the branch name', () => {
+  const fragmentString = 'jure/lens#fix-issue-#96';
+
+  const expectedFragment: ExplodedFragment = {
+    user: 'jure',
+    repo: 'lens',
+    hash: 'fix-issue-#96',
+  };
+
+  expect(explodeHostedGitFragment(fragmentString, reporter)).toEqual(expectedFragment);
+});
+
+test('explodeHostedGitFragment should work for branch names without hashes', () => {
+  const fragmentString = 'jure/lens#feature/fix-issue';
+
+  const expectedFragment: ExplodedFragment = {
+    user: 'jure',
+    repo: 'lens',
+    hash: 'feature/fix-issue',
+  };
+
+  expect(explodeHostedGitFragment(fragmentString, reporter)).toEqual(expectedFragment);
+});

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -24,9 +24,9 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
 
   if (userParts.length >= 2) {
     const user = userParts.shift();
-    const repoParts = userParts.join('/').split('#');
+    const repoParts = userParts.join('/').split(/#(.*)/);
 
-    if (repoParts.length <= 2) {
+    if (repoParts.length <= 3) {
       return {
         user,
         repo: repoParts[0],
@@ -34,6 +34,7 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
       };
     }
   }
+
 
   throw new MessageError(reporter.lang('invalidHostedGitFragment', fragment));
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Given a dependency:
```
dependencies: {
  "substance": "jure/substance#fix-lens-#96"
}
```

Yarn raises an error: 
```
error Invalid hosted git fragment "jure/substance#fix-lens-#96".
```

This is because the current code https://github.com/yarnpkg/yarn/blob/0f1db96846badbbe3b43c470c05196eb29437fb4/src/resolvers/exotics/hosted-git-resolver.js#L29 bails if there is more than one hash in the repo part.

**Test plan**

Added two tests, one for a branch with hashes and one for a `feature/fix-issue` (no hash) branch.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

