### PR TITLE
Normalize permissions when extracting tarfiles

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -65,6 +65,13 @@ export default class TarballFetcher extends BaseFetcher {
 
     extractorStream
       .pipe(untarStream)
+      .on('entry', (entry) => {
+        if (entry.type == 'Directory' || entry.props.mode & 0o100) { // eslint-disable-line no-bitwise
+          entry.props.mode = 0o775;
+        } else {
+          entry.props.mode = 0o664;
+        }
+      })
       .on('error', reject)
       .on('end', () => {
         const expectHash = this.hash;


### PR DESCRIPTION
**Summary**

Tar-files from the registry might have unwanted file permissions, for example:
- files and directories the user can't read
- world-writable files
- inconsistent permissions

This addresses the issues by ignoring the permissions in the input file. It will leave group writable files/directories if the users umask allows that (such as umask 0002 or 0007), but it will never leave them world writable even with umask 0000.

Fixes #1143, #961, #872, and #713

 For example, in #961 a tarball is missing access rights for a directory:

```
dir$ rm -Rf node_modules/ package.json ~/.yarn-cache/npm-@types/; yarn init --yes; yarn add @types/react-router@2.0.37
yarn init v0.16.2
...
[2/4] Fetching packages...
error An unexpected error occurred, please open a bug report with the information provided in "/home/chlunde/tmp/dir/yarn-error.log".
...
dir$ tail -n3 yarn-error.log 
Trace: 
  Error: https://registry.yarnpkg.com/@types/react-router/-/react-router-2.0.37.tgz: EACCES: permission denied, open '/home/chlunde/.yarn-cache/npm-@types/react-router-2.0.37/lib/History.d.ts'
      at Error (native)
```

This is caused by incorrect permissions in the tarfile:

```
dir$ tar -tvzf react-router-2.0.37.tgz  | grep /$
drw-rw-rw- 0/0               0 2016-10-03 17:23 react-router/lib/
```

**Test plan**

I have verified that I can install @types/react-router@2.0.37 after the change:

```
$ mkdir dir; cd dir
$ rm -Rf ~/.yarn-cache/npm-@types/; yarn init --yes; yarn add @types/react-router@2.0.37
yarn init v0.16.2
warning The yes flag has been set. This will automatically answer yes to all questions which may have security implications.
success Saved package.json
Done in 0.06s.
yarn add v0.16.2
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 3 new dependencies.
├─ @types/history@2.0.39
├─ @types/react-router@2.0.37
└─ @types/react@0.14.43
Done in 3.01s.
```

I have also verified that umask is applied:

```
dir$ umask
0022
dir$ ls -l node_modules/@types/react-router
total 20
drwxr-xr-x. 2 chlunde chlunde 4096 Oct 26 23:05 lib/
-rw-r--r--. 1 chlunde chlunde  815 Oct  3 17:23 package.json
...
chlunde@localhost.localdomain dir$ umask 0002
chlunde@localhost.localdomain dir$ rm -Rf node_modules/ package.json ~/.yarn-cache/npm-\@types/; yarn init --yes; yarn add @types/react-router@2.0.37
...
Done in 1.13s.
chlunde@localhost.localdomain dir$ ls -l node_modules/@types/react-router
total 20
drwxrwxr-x. 2 chlunde chlunde 4096 Oct 26 23:07 lib/
-rw-rw-r--. 1 chlunde chlunde  815 Oct  3 17:23 package.json
...
```

**TODO**
- Are there other file types in tarballs that need special handling
- Do you think this code needs integration tests?
