### PR TITLE
[git] Upgrade to secure url

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -26,17 +26,50 @@ test('isCommitHash', () => {
     .toBeFalsy();
 });
 
-test('assertUrl', () => {
-  expect(() => Git.assertUrl('http://random.repo', ''))
-    .toThrow();
-  expect(() => Git.assertUrl('http://random.repo', 'ab_12'))
-    .toThrow();
-  expect(() => Git.assertUrl('git://random.repo', ''))
-    .toThrow();
-  expect(() => Git.assertUrl('https://random.repo', ''))
-    .not.toThrow();
-  expect(() => Git.assertUrl('http://random.repo', 'abc12'))
-    .not.toThrow();
-  expect(() => Git.assertUrl('git://random.repo', 'abc12'))
-    .not.toThrow();
-});
+async function toThrow(f): Promise <boolean> {
+  try {
+    await f();
+    return false;
+  } catch (e) {
+    return true;
+  }
+}
+
+test('secureUrl', async function (): Promise<void> {
+  expect(await
+         toThrow(() => {
+           return Git.secureUrl('http://random.repo', '');
+         }),
+        ).toEqual(true);
+
+  expect(await
+         toThrow(() => {
+           return Git.secureUrl('http://random.repo', 'ab_12');
+         }),
+        ).toEqual(true);
+
+  expect(await
+         toThrow(() => {
+           return Git.secureUrl('git://random.repo', '');
+         }),
+        ).toEqual(true);
+
+  expect(await
+         toThrow(() => {
+           return Git.secureUrl('https://random.repo', '');
+         }),
+        ).toEqual(false);
+
+  expect(await
+         toThrow(() => {
+           return Git.secureUrl('http://random.repo', 'abc12');
+         }),
+        ).toEqual(false);
+
+  expect(await
+         toThrow(() => {
+           return Git.secureUrl('git://random.repo', 'abc12');
+         }),
+        ).toEqual(false);
+},
+);

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -70,7 +70,7 @@ export default class GitFetcher extends BaseFetcher {
     invariant(hash, 'Commit hash required');
 
     const git = new Git(this.config, this.reference, hash);
-    await git.initRemote();
+    await git.init();
     await git.clone(this.dest);
 
     // Get the tarball filename from the url

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -93,7 +93,7 @@ export default class GitResolver extends ExoticResolver {
 
     const {config} = this;
     const client = new Git(config, url, this.hash);
-    const commit = await client.initRemote();
+    const commit = await client.init();
 
     async function tryRegistry(registry): Promise<?Manifest> {
       const {filename} = registries[registry];

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -188,7 +188,7 @@ export default class HostedGitResolver extends ExoticResolver {
     // if you have write permissions
     if (await Git.hasArchiveCapability(sshUrl)) {
       const archiveClient = new Git(this.config, sshUrl, this.hash);
-      const commit = await archiveClient.initRemote();
+      const commit = await archiveClient.init();
       return await this.fork(GitResolver, true, `${sshUrl}#${commit}`);
     }
 


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/pull/1365/files introduced a fix to enforce secure protocols. This unfortunately broke a lot of packages we have which depend on 'git' protocol (e.g., 'npm show @opam-alpha/core').

Instead of refusing to work when a unsecure protocol is provided, maybe a better way here is to automatically upgrade to a secure url.
