### PR TITLE
Implement npm@4's prepublish behavior

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -693,6 +693,10 @@ export async function run(
   await wrapLifecycle(config, flags, async () => {
     const install = new Install(flags, config, reporter, lockfile);
     await install.init();
+
+    if (await config.hasLifecycleScript('prepublish')) {
+      reporter.warn(reporter.lang('prepublishOnInstall'));
+    }
   });
 }
 
@@ -707,5 +711,6 @@ export async function wrapLifecycle(config: Config, flags: Object, factory: () =
 
   if (!flags.production) {
     await config.executeLifecycleScript('prepublish');
+    await config.executeLifecycleScript('prepare');
   }
 }

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -63,6 +63,8 @@ async function publish(
 
   // TODO this might modify package.json, do we need to reload it?
   await config.executeLifecycleScript('prepublish');
+  await config.executeLifecycleScript('prepublishOnly');
+  await config.executeLifecycleScript('prepare');
 
   // create body
   const root = {

--- a/src/config.js
+++ b/src/config.js
@@ -280,6 +280,23 @@ export default class Config {
   }
 
   /**
+   * Returns whether the given lifecycle script is defined in the manifest.
+   * Always false when --ignore-scripts has been passed.
+   */
+
+  async hasLifecycleScript(commandName: string, cwd?: string): Promise<bool> {
+    if (this.ignoreScripts) {
+      return false;
+    } else {
+      const pkg = await this.readManifest(cwd || this.cwd);
+      if (!pkg.scripts) {
+        return false;
+      }
+      return commandName in pkg.scripts;
+    }
+  }
+
+  /**
    * Generate an absolute temporary filename location based on the input filename.
    */
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -215,6 +215,8 @@ const messages = {
   fetchBadHash: 'Bad hash. Expected $0 but got $1 ',
   fetchErrorCorrupt: '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  $ rm -rf $1\n  $ yarn install',
   errorDecompressingTarball: '$0. Error decompressing $1, it appears to be corrupt.',
+
+  prepublishOnInstall: '`prepublish` on install is deprecated and will stop running in the future.',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
Fixes #1323, motivation is explained there.

Lifecycle calls were written in the same order as npm runs them. A deprecation warning for `prepublish` was also added. npm@5 intends to stop running `prepublish`, and a later npm version will rename `prepublishOnly` to `prepublish`.

One notable difference is that `npm pack` is also supposed to run `prepare` and (old) `prepublish`, but `yarn pack` does neither. Not sure where that should go.

I also tried looking into writing tests, but as the lifecycle scripts are run by a wrapper rather than by the `Install` class itself, it can't be tested with the helpers used by `__tests__/commands/install.js` (?).

Sample output for `install`:

```
$ cat package.json
{
  "scripts": {
    "preinstall": "echo preinstall",
    "install": "echo install",
    "postinstall": "echo postinstall",
    "prepare": "echo prepare",
    "prepublish": "echo prepublish",
    "prepublishOnly": "echo prepublishOnly"
  }
}
```

```
$ ~/src/yarn/bin/yarn
yarn install v0.16.2
info No lockfile found.
$ echo preinstall
preinstall
warning No license field
success Nothing to install.
warning `prepublish` on install is deprecated and will stop running in the future.
$ echo install
install
$ echo postinstall
postinstall
$ echo prepublish
prepublish
$ echo prepare
prepare
✨  Done in 0.08s.
```

I don't know how to test `yarn publish` as there is no way to do a dry-run with it AFAICT.
