### PR TITLE
`yarn why`: Support scoped package query

### DIFF
--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -29,8 +29,10 @@ async function cleanQuery(config: Config, query: string): Promise<string> {
   // remove trailing hashes
   query = query.replace(/^#+/g, '');
 
-  // remove path after last hash
-  query = query.replace(/[\\/](.*?)$/g, '');
+  // remove path after last hash, except if it is scoped
+  if (query[0] !== '@') {
+    query = query.replace(/[\\/](.*?)$/g, '');
+  }
 
   return query;
 }


### PR DESCRIPTION
**Summary**

This avoids breaking scoped package names when cleaning the query of `yarn why`.

``` sh
$ yarn init -y
$ yarn add @financial-times/n-bottle
$ yarn why @financial-times/n-bottle
yarn why v0.16.1
[1/4] 🤔  Why do we have the module "@financial-times/n-bottle"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
error We couldn't find a match!
✨  Done in 0.08s.
```

**Test plan**

A scoped package name always has a slash in it, which was being unconditionally stripped (`'@foo/bar' => '@foo'`). This was ascertained by a bunch of gnarly `console.log()` statements. I regret I don't have the time to write a full test suite for this subcommand.

``` sh
yarn why @financial-times/n-bottle
yarn why v0.16.2
[1/4] 🤔  Why do we have the module "@financial-times/n-bottle"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
info Has been hoisted to "@financial-times/n-bottle"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "56kB"
info Disk size with unique dependencies: "360kB"
info Disk size with transitive dependencies: "384kB"
info Amount of shared dependencies: 5
✨  Done in 0.10s.
```
