### PR TITLE
vscode ignore settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /resources/winsetup/bin
 /resources/win-chocolatey/tools/chocolateyinstall.ps1
 .vs
+/.vscode
 *.msi
 *.nupkg
 fbkpm_modules


### PR DESCRIPTION
vscode creates a [settings file](https://code.visualstudio.com/Docs/customization/userandworkspace) for user workspace settings. To get vscode linting flow and not defaulting to Typescript, there are a [couple of steps](https://github.com/Microsoft/vscode/issues/5214#issuecomment-209357738). 

Perhaps, ignoring the created `.vscode` directory could solve some small headaches?

