### PR TITLE
Make `.git` suffix optional for hosted git

### DIFF
--- a/__tests__/resolvers/exotics/hosted-git-resolver.js
+++ b/__tests__/resolvers/exotics/hosted-git-resolver.js
@@ -28,3 +28,17 @@ test('explodeHostedGitFragment should work for branch names without hashes', () 
 
   expect(explodeHostedGitFragment(fragmentString, reporter)).toEqual(expectedFragment);
 });
+
+test('explodeHostedGitFragment should work identical with and without .git suffix', () => {
+  const fragmentWithGit = 'jure/lens.git#feature/fix-issue';
+  const fragmentWithoutGit = 'jure/lens#feature/fix-issue';
+
+  const expectedFragment: ExplodedFragment = {
+    user: 'jure',
+    repo: 'lens',
+    hash: 'feature/fix-issue',
+  };
+
+  expect(explodeHostedGitFragment(fragmentWithoutGit, reporter)).toEqual(expectedFragment);
+  expect(explodeHostedGitFragment(fragmentWithGit, reporter)).toEqual(expectedFragment);
+});

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -24,7 +24,7 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
 
   if (userParts.length >= 2) {
     const user = userParts.shift();
-    const repoParts = userParts.join('/').split(/#(.*)/);
+    const repoParts = userParts.join('/').split(/(?:[.]git)?#(.*)/);
 
     if (repoParts.length <= 3) {
       return {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #1287

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When a github URL is used in a `package.json` file which has a `.git`
suffix attached to its repository name, resolution fails with an error:

```
TypeError: Cannot read property 'split' of undefined
 at Function.parseRefs (/usr/local/Cellar/yarn/0.16.0/libexec/lib/node_modules/yarn/lib/util/git.js:439:20)
 at /usr/local/Cellar/yarn/0.16.0/libexec/lib/node_modules/yarn/lib/resolvers/exotics/hosted-git-resolver.js:138:50
 ...
```

for e.g. `https://github.com/gulpjs/gulp.git`.

This was caused by an extraneous `.git` suffix appended to the URL by
the resolver.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added a unit test which checks a github URL with and w/o .git suffix.
