### PR TITLE
Fix all variations of generateDisclaimer command to not have wrapper

### DIFF
--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -8,10 +8,11 @@ import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import buildSubCommands from './_build-sub-commands.js';
 
+const camelCase = require('camelcase');
 const invariant = require('invariant');
 
 export function hasWrapper(flags: Object, args: Array<string>): boolean {
-  return args[0] != 'generate-disclaimer';
+  return camelCase(args[0]) != 'generateDisclaimer';
 }
 
 export function setFlags(commander: Object) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes #1191.

Previously `yarn licenses generate-disclaimer` would not include the output wrapper header and footer but other valid variations of the same command such as `yarn licenses generateDisclaimer` would.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Previous behavior:
`yarn licenses generate-disclaimer` outputs disclaimers without wrapper
`yarn licenses generateDisclaimer` outputs disclaimers with wrapper

New behavior:
`yarn licenses generate-disclaimer` and `yarn licenses generateDisclaimer` have the same output without wrapper.
