### PR TITLE
Unit tests for the command `yarn why`.

### DIFF
--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -1,0 +1,111 @@
+/* @flow */
+
+import {BufferReporter} from '../../src/reporters/index.js';
+import {run as why} from '../../src/cli/commands/why.js';
+import * as reporters from '../../src/reporters/index.js';
+import Config from '../../src/config.js';
+import assert from 'assert';
+import path from 'path';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
+
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'why');
+
+async function runWhy(
+  flags: Object,
+  args: Array<string>,
+  name: string,
+  checkSteps?: ?(config: Config, reporter: BufferReporter) => ?Promise<void>,
+): Promise<void> {
+  const cwd = path.join(fixturesLoc, name);
+  const reporter = new reporters.BufferReporter({stdout: null, stdin: null});
+
+  try {
+    const config = new Config(reporter);
+    await config.init({cwd});
+
+    await why(config, reporter, flags, args);
+
+    if (checkSteps) {
+      await checkSteps(config, reporter);
+    }
+
+  } catch (err) {
+    throw new Error(`${err && err.stack}`);
+  }
+}
+
+test.concurrent('throws error with no arguments', (): Promise<void> => {
+  const reporter = new reporters.ConsoleReporter({});
+
+  return new Promise(async (resolve): Promise<void> => {
+    try {
+      await runWhy({}, [], 'basic');
+    } catch (err) {
+      expect(err.message).toContain(reporter.lang('missingWhyDependency'));
+    } finally {
+      resolve();
+    }
+  });
+});
+
+test.concurrent('throws error with too many arguments', (): Promise<void> => {
+  const reporter = new reporters.ConsoleReporter({});
+
+  return new Promise(async (resolve): Promise<void> => {
+    try {
+      await runWhy({}, ['one', 'two'], 'basic');
+    } catch (err) {
+      expect(err.message).toContain(reporter.lang('tooManyArguments', 1));
+    } finally {
+      resolve();
+    }
+  });
+});
+
+test.concurrent('throws error if module does not exist', (): Promise<void> => {
+  const reporter = new reporters.ConsoleReporter({});
+
+  return new Promise(async (resolve): Promise<void> => {
+    try {
+      await runWhy({}, ['one'], 'basic');
+    } catch (err) {
+      console.log(err);
+      expect(err.message).toContain(reporter.lang('whyUnknownMatch'));
+    } finally {
+      resolve();
+    }
+  });
+});
+
+test.concurrent('should determine that the module installed because it is in dependencies', 
+(): Promise<void> => {
+  return runWhy({}, ['mime-types'], 'basic', (config, reporter) => {
+    const report = reporter.getBuffer(); 
+    assert.equal(report[report.length - 1].data, reporter.lang('whySpecifiedSimple', 'dependencies'));
+  });
+});
+
+test.concurrent('should determine that the module installed because it is in devDependencies', 
+(): Promise<void> => {
+  return runWhy({}, ['left-pad'], 'basic', (config, reporter) => {
+    const report = reporter.getBuffer(); 
+    assert.equal(report[report.length - 1].data, reporter.lang('whySpecifiedSimple', 'devDependencies'));
+  });
+});
+
+test.concurrent('should determine that the module installed because mime-types depend on it', 
+(): Promise<void> => {
+  return runWhy({}, ['mime-db'], 'basic', (config, reporter) => {
+    const report = reporter.getBuffer(); 
+    assert.equal(report[report.length - 1].data, reporter.lang('whyDependedOnSimple', 'mime-types'));
+  });
+});
+
+test.concurrent('should determine that the module installed because it is hoisted from glob depend on it', 
+(): Promise<void> => {
+  return runWhy({}, ['glob#minimatch'], 'basic', (config, reporter) => {
+    const report = reporter.getBuffer(); 
+    assert.equal(report[report.length - 2].data, reporter.lang('whyHoistedTo', 'glob#minimatch'));
+  });
+});

--- a/__tests__/fixtures/why/basic/package.json
+++ b/__tests__/fixtures/why/basic/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "mime-types": "2.1.12",
+    "glob": "7.1.1",
+    "uglifyify": "3.0.0"
+  },
+  "devDependencies": {
+    "left-pad": "1.1.3"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Unit tests for basic functionality of `yarn why`.
- [x] Missing initial argument `missingWhyDependency`.
- [x] Too many arguments `tooManyArguments`.
- [x] Non-existing module as argument `whyUnknownMatch`.
- [x] Determines dependencies `whySpecifiedSimple`.
- [x] Determines devDependencies `devDependencies`.
- [x] Dependant module `whyDependedOnSimple`.
- [ ] Hoisted module `whyHoistedFromSimple`. I do not know how to setup a test case for this.
- [x] Hoisted module `whyHoistedTo`.
- [ ] Check size `whyDiskSizeWithout`.
- [ ] Check size `whyDiskSizeUnique`.
- [ ] Check size `whyDiskSizeTransitive`.
- [ ] Check size `whySharedDependencies`.

And possibly later from #1524:
- [ ] Scoped packages.
