### PR TITLE
Fix lint warnings

### DIFF
--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -94,7 +94,7 @@ export async function setVersion(
   await config.saveRootManifests(manifests);
 
   // check if committing the new version to git is overriden
-  if (!flags.gitTagVersion || !Boolean(config.getOption('version-git-tag'))) {
+  if (!flags.gitTagVersion || !config.getOption('version-git-tag')) {
     // Don't tag the version in Git
     return function(): Promise<void> {
       return Promise.resolve();

--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,6 @@ import map from './util/map.js';
 const detectIndent = require('detect-indent');
 const invariant = require('invariant');
 const path = require('path');
-const url = require('url');
 
 export type ConfigOptions = {
   cwd?: ?string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

There were 2 lint warnings: a `no-extra-boolean-cast` on `src/cli/commands/version.js` and a `no-unused-vars` on `src/config.js`.

**Test plan**

All tests are passing.
