### PR TITLE
Fix colour codes in install script

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-reset="\e[0m"
-red="\e[0;31m"
-green="\e[0;32m"
-cyan="\e[0;36m"
-white="\e[0;37m"
+reset=`tput sgr0`
+red=`tput setaf 1`
+green=`tput setaf 2`
+cyan=`tput setaf 6`
+white=`tput setaf 7`
 
 yarn_get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"


### PR DESCRIPTION
**Summary**

The syntax the install script uses for colour coding works in some shells (including Bash, zsh and Fish), but does **not** work in dash. Debian and Ubuntu use Dash as the default implementation of `/bin/sh` (see https://wiki.ubuntu.com/DashAsBinSh), so Debian and Ubuntu users will see broken colours in the installation script if they use it (as its shebang specifies `/bin/sh`)

**Test plan**

Before:
![](http://ss.dan.cx/2016/10/ConEmu_29-23.13.26.png)

After:
![](http://ss.dan.cx/2016/10/ConEmu_29-23.12.15.png)

In `bash`, output should be identical.
