### PR TITLE
Add `--nightly` flag to install script

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -9,7 +9,12 @@ white="\e[0;37m"
 
 yarn_get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"
-  curl -L -o yarn.tar.gz "https://yarnpkg.com/latest.tar.gz" >/dev/null # get tarball
+  if [ "$1" = '--nightly' ]; then
+    url=https://nightly.yarnpkg.com/latest.tar.gz
+  else
+    url=https://yarnpkg.com/latest.tar.gz
+  fi
+  curl -L -o yarn.tar.gz "$url" >/dev/null # get tarball
 
   printf "$cyan> Extracting to ~/.yarn...$reset\n"
   mkdir .yarn
@@ -42,7 +47,12 @@ yarn_link() {
     echo "> If this isn't the profile of your current shell then please add the following to your correct profile:"
     printf "   $SOURCE_STR$reset\n"
 
-    printf "$green> Successfully installed! Please open another terminal where the \`yarn\` command will now be available.$reset\n"
+    version=`./.yarn/bin/yarn --version` || (
+      printf "$red> Yarn was installed, but doesn't seem to be working :(.$reset\n"
+      exit 1;
+    )
+
+    printf "$green> Successfully installed Yarn $version! Please open another terminal where the \`yarn\` command will now be available.$reset\n"
   fi
 }
 
@@ -101,10 +111,10 @@ yarn_install() {
     exit 0
   fi
 
-  yarn_get_tarball
+  yarn_get_tarball $1
   yarn_link
   yarn_reset
 }
 
 cd ~
-yarn_install
+yarn_install $1


### PR DESCRIPTION
**Summary**

Adds a `--nightly` flag to the installation script. When provided, the script will download the latest nightly build of Yarn, rather than the stable released version

**Test plan**
`./install-latest.sh` gets latest release version (0.16.1), `./install-latest.sh --nightly` gets latest nightly build (0.16.2-20161030.0336 right now)
