### PR TITLE
Fixes issue #639

### DIFF
--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -50,7 +50,11 @@ export default class TarballResolver extends ExoticResolver {
       return shrunk;
     }
 
-    const {url} = this;
+    let {url} = this;
+    if (url.startsWith('file:')) {
+      url = url.substring(5);
+    }
+    
     let {hash, registry} = this;
     let pkgJson;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Yarn install fails when "file:" prefix is specified in the package target in the dependency.
eg: "dependencies": {
    "blabla":"file:folder/blabla.tar.gz"
  }

**Fix**
yarn was failing because it was not able to resolve the pattern with 'file:' in it. Also, as noted in #639 yarn works if the 'file:' prefix is not provided. Hence the best solution was to extract a substring of the pattern without the 'file:' prefix. 

IT WORKS!!!

**Test plan**
![pkgjson](https://cloud.githubusercontent.com/assets/13907699/19834934/1d7efdc6-9e9b-11e6-8db8-b266ab18844c.png)

The output

![term](https://cloud.githubusercontent.com/assets/13907699/19834938/2f667c44-9e9b-11e6-993d-c1c8f47983c9.png)

Also, i tested it with other paths containing folders in the path and it worked.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
