### PR TITLE
Do not follow redirect for HostedGitResolver#hasHTTPCapability

### DIFF
--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -166,6 +166,7 @@ export default class HostedGitResolver extends ExoticResolver {
       url,
       method: 'HEAD',
       queue: this.resolver.fetchingQueue,
+      followRedirect: false,
     })) !== false;
   }
 

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -52,7 +52,8 @@ type RequestParams<T> = {
     reject: (err: Error) => void
   ) => void,
   callback?: (err: ?Error, res: any, body: any) => void,
-  retryAttempts?: number
+  retryAttempts?: number,
+  followRedirect?: boolean
 };
 
 type RequestOptions = {
@@ -338,7 +339,7 @@ export default class RequestManager {
           const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
           reject(new Error(errMsg));
         } else {
-          if (res.statusCode === 400 || res.statusCode === 404) {
+          if (res.statusCode === 400 || res.statusCode === 404 || res.statusCode === 401) {
             body = false;
           }
           resolve(body);


### PR DESCRIPTION
**Summary**

For hosted git resolver, e.g. for BitBucket, the HEAD https://bitbucket.org/someuser/private.git inside the `hasHTTPCapability` gives 302 redirecting user to sign in. However, in such condition we need to fallback to `git+ssh`.

**Test plan**

Create a private git repo on bitbucket, e.g. https://bitbucket.org/someuser/private.git then do:

```
$ yarn add bitbucket:someuser/private
```

Currently, it gives:

```
error An unexpected error occurred, please open a bug report with the information provided in "/Users/diorahman/Experiments/misc/ev/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

After this patch and if this one (https://github.com/yarnpkg/yarn/pull/1081) merged. It will give successful result. 
