### PR TITLE
Return registry from URL when requesting a file

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -142,7 +142,11 @@ export default class NpmRegistry extends Registry {
   getRegistry(packageName: string): string {
     // If this is a request for a file, return the registry from the URL
     if (HTTPS_EXPRESSION.test(packageName)) {
-      return packageName.match(/https?:\/\/[^\/]+\//i)[0];
+      const registryProtocolHost = packageName.match(/^https?:\/\/[^\/]+\//i);
+
+      if (registryProtocolHost) {
+        return registryProtocolHost[0];
+      }
     }
 
     // Try scoped registry, and default registry


### PR DESCRIPTION
This ensures authentication options are passed to these requests.

Fixes #1318
