### PR TITLE
Add CLI arguments to set the proxies

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -72,6 +72,8 @@ commander.option(
   '--no-emoji',
   'disable emoji in output',
 );
+commander.option('--proxy <host>', '');
+commander.option('--https-proxy <host>', '');
 
 // get command name
 let commandName: string = args.shift() || '';
@@ -339,6 +341,8 @@ config.init({
   ignoreScripts: commander.ignoreScripts,
   offline: commander.preferOffline || commander.offline,
   looseSemver: !commander.strictSemver,
+  httpProxy: commander.proxy,
+  httpsProxy: commander.httpsProxy,
 }).then(() => {
   const exit = () => {
     process.exit(0);

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,8 @@ export type ConfigOptions = {
 
   // Loosely compare semver for invalid cases like "0.01.0"
   looseSemver?: ?boolean,
+  httpProxy?: ?string,
+  httpsProxy?: ?string,
 };
 
 type PackageMetadata = {
@@ -181,8 +183,8 @@ export default class Config {
 
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
-      httpProxy: String(this.getOption('proxy') || ''),
-      httpsProxy: String(this.getOption('https-proxy') || ''),
+      httpProxy: String(opts.httpProxy || this.getOption('proxy') || ''),
+      httpsProxy: String(opts.httpsProxy || this.getOption('https-proxy') || ''),
       strictSSL: Boolean(this.getOption('strict-ssl')),
       cafile: String(opts.cafile || this.getOption('cafile') || ''),
     });


### PR DESCRIPTION
This PR adds two CLI arguments to set the http and https proxies.
A proxy set through the CLI takes precedence over any proxy set inside the .yarnrc/.npmrc files.
Fixes #655.
