### PR TITLE
Rename 'manifestPotentialType' to 'manifestPotentialTypo'

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -21,7 +21,7 @@ const messages = {
   clearedCache: 'Cleared cache.',
   packWroteTarball: 'Wrote tarball to $0.',
 
-  manifestPotentialType: 'Potential typo $0, did you mean $1?',
+  manifestPotentialTypo: 'Potential typo $0, did you mean $1?',
   manifestBuiltinModule: '$0 is also the name of a node core module',
   manifestNameDot: "Name can't start with a dot",
   manifestNameIllegalChars: 'Name contains illegal characters',

--- a/src/util/normalize-manifest/validate.js
+++ b/src/util/normalize-manifest/validate.js
@@ -48,7 +48,7 @@ export default function(info: Object, isRoot: boolean, reporter: Reporter, warn:
   if (isRoot) {
     for (const key in typos) {
       if (key in info) {
-        warn(reporter.lang('manifestPotentialType', key, typos[key]));
+        warn(reporter.lang('manifestPotentialTypo', key, typos[key]));
       }
     }
   }


### PR DESCRIPTION
**Summary**

Renamed `manifestPotentialType` in `en.js` to clearer `manifestPotentialTypo`.

**Test plan**

No tests needed I think.

