### PR TITLE
Revert #1553 and instead just use Bash explicitly

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-reset=`tput sgr0`
-red=`tput setaf 1`
-green=`tput setaf 2`
-cyan=`tput setaf 6`
-white=`tput setaf 7`
+reset="\e[0m"
+red="\e[0;31m"
+green="\e[0;32m"
+cyan="\e[0;36m"
+white="\e[0;37m"
 
 yarn_get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"


### PR DESCRIPTION
**Summary**
Terminals are terrible. Literally the worst. `tput` fails if the terminal is `vt100`. I'm reverting my change and instead making the script execute Bash directly.

**Test plan**
Ensure output still has colours:
![](http://ss.dan.cx/2016/10/ConEmu_29-23.12.15.png)


Reverts #1553 
Fixes #1574