### PR TITLE
Load GPG key from URL rather than keyserver

### DIFF
--- a/scripts/bootstrap-env-ubuntu.sh
+++ b/scripts/bootstrap-env-ubuntu.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Add Yarn package repo - We require Yarn to build Yarn itself :D
-sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
 sudo apt-get update -qq


### PR DESCRIPTION
**Summary**
Loads GPG key from a URL we host, rather than a keyserver. This will hopefully make builds less flaky (they won't fail when the keyserver has issues)

I tried `https` but it didn't work:
> gpgkeys: protocol 'https' not supported
> gpg: no handler for keyserver scheme 'https'
> gpg: WARNING: unable to fetch URI https://dl.yarnpkg.com/debian/pubkey.gpg: keyserver error

**Test plan**

Tested the command locally. Will check CircleCI build.