### PR TITLE
AppVeyor now has Yarn preinstalled, don't install it manually

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ branches:
 
 install:
   - ps: Install-Product node $env:node_version
-  - choco install -i yarn
-  - refreshenv
   - yarn install
 
 build_script:


### PR DESCRIPTION
**Summary**
https://www.appveyor.com/updates/2016/11/01/ mentions that Yarn is preinstalled now (thanks @FeodorFitsner!), so we shouldn't need to install it manually.

**Test plan**
It works! https://ci.appveyor.com/project/kittens/yarn/build/1.0.577