### PR TITLE
[WIP] add: Fix option conflicts with the add command for the first package.

### DIFF
--- a/__tests__/cli/add.js
+++ b/__tests__/cli/add.js
@@ -1,0 +1,79 @@
+/* @flow */
+
+import NoopReporter from '../../src/reporters/base-reporter.js';
+import makeTemp from '../_temp';
+import * as fs from '../../src/util/fs.js';
+
+const path = require('path');
+const exec = require('child_process').exec;
+
+const fixturesLoc = path.join(__dirname, '../fixtures/cli');
+const yarnBin = path.join(__dirname, '../../bin/yarn.js');
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+
+async function execCommand(cmd: string, packageName: string): Promise<string> {
+  const srcPackageDir = path.join(fixturesLoc, packageName);
+  const packageDir = await makeTemp(packageName);
+
+  await fs.copy(srcPackageDir, packageDir, new NoopReporter());
+
+  return new Promise((resolve, reject) => {
+    exec(`node ${yarnBin} ${cmd}`, {cwd:packageDir}, (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout.toString());
+      }
+    });
+  });
+}
+
+test('should add `assert` package', async () => {
+  const stdout = await execCommand('add assert', 'add');
+  expect(stdout).toContain('success');
+  expect(stdout).toContain('assert');
+});
+
+describe('should add packages that share a name with a CLI option', () => {
+  const packages = [
+    'json',
+    'force',
+    'flat',
+    'prod',
+    'production',
+    'mutex',
+    'proxy',
+    'https-proxy',
+    'dev',
+    'peer',
+    'optional',
+    'exact',
+    'tilde',
+  ];
+
+  packages.forEach((pkg) => {
+    test(`should add '${pkg}' package`, async () => {
+      const stdout = await execCommand(`add ${pkg}`, 'add');
+      expect(stdout).toContain('success');
+      expect(stdout).toContain(pkg);
+    });
+  });
+
+  packages.forEach((pkg) => {
+    test(`should add --dev '${pkg}' package`, async () => {
+      const stdout = await execCommand(`add --dev ${pkg}`, 'add');
+      expect(stdout).toContain('success');
+      expect(stdout).toContain(pkg);
+    });
+  });
+
+  packages.forEach((pkg) => {
+    test(`should add assert and '${pkg}' packages`, async () => {
+      const stdout = await execCommand(`add ${pkg} assert`, 'add');
+      expect(stdout).toContain('success');
+      expect(stdout).toContain('assert');
+      expect(stdout).toContain(pkg);
+    });
+  });
+});

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -602,3 +602,16 @@ test.concurrent('add infers line endings from existing unix manifest file', asyn
       await promisify(fsNode.writeFile)(path.join(cwd, 'package.json'), existingLockfile, 'utf8');
     });
 });
+
+test.concurrent('install package "flat"', (): Promise<void> => {
+  return runAdd(['flat'], {}, 'install-with-save-offline-mirror', async (config, reporter) => {
+    const lockfile = await createLockfile(config.cwd);
+    const install = new Add(['flat'], {}, config, reporter, lockfile);
+    await install.init();
+    assert.ok(JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies.flat);
+
+    const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileWritten);
+    assert.ok(lockFileLines[0].includes('flat'));
+  });
+});

--- a/__tests__/fixtures/cli/add/package.json
+++ b/__tests__/fixtures/cli/add/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "yarn-cli-add-fixture",
+  "version": "1.0.0",
+  "description": "Fixture for CLI add."
+}

--- a/__tests__/fixtures/request-cache/GET/localhost/.bin
+++ b/__tests__/fixtures/request-cache/GET/localhost/.bin
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Date: Wed, 02 Nov 2016 01:47:42 GMT
+Connection: close
+Content-Length: 2
+
+ok

--- a/__tests__/fixtures/request-cache/GET/localhost/.bin
+++ b/__tests__/fixtures/request-cache/GET/localhost/.bin
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Date: Wed, 02 Nov 2016 01:47:42 GMT
+Date: Wed, 02 Nov 2016 18:31:12 GMT
 Connection: close
 Content-Length: 2
 

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -196,15 +196,19 @@ export async function run(
   reporter: Reporter,
   flags: Object,
   args: Array<string>,
+  rawArgs: Array<string>,
 ): Promise<void> {
-  if (!args.length) {
+  const extraDeps = rawArgs.filter((dep) => dep.indexOf('--') !== 0 && !args.includes(dep));
+  const deps = args.concat(extraDeps);
+
+  if (!deps.length) {
     throw new MessageError(reporter.lang('missingAddDependencies'));
   }
 
   const lockfile = await Lockfile.fromDirectory(config.cwd, reporter);
 
   await wrapLifecycle(config, flags, async () => {
-    const install = new Add(args, flags, config, reporter, lockfile);
+    const install = new Add(deps, flags, config, reporter, lockfile);
     await install.init();
   });
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -231,7 +231,7 @@ if (command.requireLockfile && !fs.existsSync(path.join(config.cwd, constants.LO
 //
 const run = (): Promise<void> => {
   invariant(command, 'missing command');
-  return command.run(config, reporter, commander, commander.args).then(() => {
+  return command.run(config, reporter, commander, commander.args, args).then(() => {
     reporter.close();
     if (outputWrapper) {
       reporter.footer(false);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

First reported in #1609, if you try to `add` a package that shares a name with an option flag, yarn is unable to parse the package name if it is the first one on the list.

While people can work around this by running `yarn add -- <package>`, and while it is a small list of relatively unpopular packages, it does fail to keep parity with `npm`. It might also be indicative of a lack of testing around the CLI as a whole.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I added a test for installing `flat` via unit testing (i.e. using the `src/cli/commands/Add` class directly). It doesn't replicate the issue, but it ensures that the problem is not in the class itself.

I then added testing of executing `yarn add` as it's built in `./bin`. I used the `lifecycle-scripts.js` test as a template. It currently tests adding a common package, `assert`, and then tests all existing packages that conflict with current option flags.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

~~**To do**~~

~~I've done a bit of digging, but I haven't been able to fix the problem yet. It definitely has something to do with `commander` because removing the `setFlags` function from the `Add` class fixes those specific conflicts. Also interestingly, `yarn remove` does not suffer from this issue.~~

~~I'll continue to look into it, but if anyone sees a fix, feel free to comment or make a PR to my branch.~~