### PR TITLE
Adding 'yarn global upgrade'(Issue #776)

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -11,6 +11,7 @@ import Lockfile from '../../lockfile/wrapper.js';
 import {Install} from './install.js';
 import {Add} from './add.js';
 import {run as runRemove} from './remove.js';
+import {run as runUpgrade} from './upgrade.js';
 import {linkBin} from '../../package-linker.js';
 import * as fs from '../../util/fs.js';
 
@@ -217,6 +218,23 @@ export const {run, setFlags} = buildSubCommands('global', {
     await runRemove(config, reporter, flags, args);
 
     // remove binaries
+    await updateBins();
+  },
+
+  async upgrade(
+    config: Config,
+    reporter: Reporter,
+    flags: Object,
+    args: Array<string>,
+  ): Promise<void> {
+    await updateCwd(config);
+
+    const updateBins = await initUpdateBins(config, reporter);
+    
+    // upgrade module
+    await runUpgrade(config, reporter, flags, args);
+
+    // update binaries
     await updateBins();
   },
 });


### PR DESCRIPTION
**Summary**

Needed to upgrade global packages. Fixes #776 .

**Test plan**

```

$ yarn global ls|grep how-to
warning No license field
warning fsevents@1.0.14: The platform "linux" is incompatible with this module.
info how-to-npm@2.0.0 has binaries:
   - how-to-npm

$ yarn global add how-to-npm@1.2.0
yarn global v0.16.1
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
warning fsevents@1.0.14: The platform "linux" is incompatible with this module.
info "fsevents@1.0.14" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed how-to-npm@1.2.0 with binaries:
      - how-to-npm
Done in 7.25s.

$ Workspace/yarn/bin/yarn global upgrade how-to-npm
yarn global v0.16.2
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
warning fsevents@1.0.14: The platform "linux" is incompatible with this module.
info "fsevents@1.0.14" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency.
└─ how-to-npm@2.0.0
Done in 3.38s.

$ yarn global ls|grep how-to
warning No license field
warning fsevents@1.0.14: The platform "linux" is incompatible with this module.
info how-to-npm@2.0.0 has binaries:
   - how-to-npm


```
