### PR TITLE
Added short-flags for yarn add

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -155,11 +155,11 @@ export class Add extends Install {
 
 export function setFlags(commander: Object) {
   commander.usage('add [packages ...] [flags]');
-  commander.option('--dev', '-D', 'save package to your `devDependencies`');
-  commander.option('--peer', '-P', 'save package to your `peerDependencies`');
-  commander.option('--optional', '-O', 'save package to your `optionalDependencies`');
-  commander.option('--exact', 'E', 'install exact version');
-  commander.option('--tilde', '-T', 'install most recent release with the same minor version');
+  commander.option('--dev, -D', 'save package to your `devDependencies`');
+  commander.option('--peer, -P', 'save package to your `peerDependencies`');
+  commander.option('--optional, -O', 'save package to your `optionalDependencies`');
+  commander.option('--exact, E', 'install exact version');
+  commander.option('--tilde, -T', 'install most recent release with the same minor version');
 }
 
 export async function run(

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -155,11 +155,11 @@ export class Add extends Install {
 
 export function setFlags(commander: Object) {
   commander.usage('add [packages ...] [flags]');
-  commander.option('--dev', 'save package to your `devDependencies`');
-  commander.option('--peer', 'save package to your `peerDependencies`');
-  commander.option('--optional', 'save package to your `optionalDependencies`');
-  commander.option('--exact', 'install exact version');
-  commander.option('--tilde', 'install most recent release with the same minor version');
+  commander.option('--dev', '-D', 'save package to your `devDependencies`');
+  commander.option('--peer', '-P', 'save package to your `peerDependencies`');
+  commander.option('--optional', '-O', 'save package to your `optionalDependencies`');
+  commander.option('--exact', 'E', 'install exact version');
+  commander.option('--tilde', '-T', 'install most recent release with the same minor version');
 }
 
 export async function run(


### PR DESCRIPTION
Added short-flags support in `yarn add` command.

Eg. Instead of `yarn add gulp --dev`, you can use `yarn add gulp -D`.

Similarly, `--peer`, `--optional`, `--exact`, `--tilde` can be used by simply adding `-P`, `-O`, `-E`, `-T` flag with `yarn add `.

P.S. I'm a neophyte. Please guide if something is wrong.