### PR TITLE
Properly save dependency with `yarn upgrade [dependency]` command

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -120,6 +120,22 @@ export class Add extends Install {
 
       // build up list of objects to put ourselves into from the cli args
       const targetKeys: Array<string> = [];
+      if (this.config.commandName === 'upgrade') {
+        // use prototype to avoid passing args as `excludePatterns` parameter
+        await Install.prototype.fetchRequestFromCwd.call(this);
+
+        const keys = Object.keys(this.rootPatternsToOrigin);
+        const depType = keys.reduce((acc, prev) => {
+          // lookup the package to determine dependency type
+          if (prev.indexOf(`${pkg.name}@`) === 0) {
+            return this.rootPatternsToOrigin[prev];
+          }
+
+          return acc;
+        }, null);
+
+        targetKeys.push(depType);
+      }
       if (dev) {
         targetKeys.push('devDependencies');
       }


### PR DESCRIPTION
**Summary**

This fixes #1458. Now the logic will properly update the `package.json` whether the package was a dependency or devDependency.

**Test plan**

```js
{
  "name": "yarn-example",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "devDependencies": {
    "is-negative-zero": "^0.1.0",
    "left-pad": "^1.0.0"
  },
  "dependencies": {
    "max-safe-integer": "^1.0.0"
  }
}
```

```sh
$ yarn upgrade max-safe-integer left-pad
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 2 new dependencies.
├─ left-pad@1.1.3
└─ max-safe-integer@1.0.1
✨  Done in 0.49s.
```

##### Before

```diff
     "left-pad": "^1.0.0"
   },
   "dependencies": {
-    "max-safe-integer": "^1.0.0"
+    "left-pad": "^1.1.3",
+    "max-safe-integer": "^1.0.1"
   }
 }
```

##### After

```diff
   "license": "MIT",
   "devDependencies": {
     "is-negative-zero": "^0.1.0",
-    "left-pad": "^1.0.0"
+    "left-pad": "^1.1.3"
   },
   "dependencies": {
-    "max-safe-integer": "^1.0.0"
+    "max-safe-integer": "^1.0.1"
   }
 }
```

*Note: I will add tests to this in the afternoon.*

