### PR TITLE
Attempt to fix failing Circle CI builds

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -2,6 +2,8 @@
 
 import Git from '../../src/util/git.js';
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
+
 test('cleanUrl', () => {
   expect(Git.cleanUrl('git+https://github.com/npm-opam/ocamlfind.git'))
     .toEqual('https://github.com/npm-opam/ocamlfind.git');


### PR DESCRIPTION
**Summary**

Bumping the timeout seemed to do the trick for me here: https://circleci.com/gh/yarnpkg/yarn/1906

**Test plan**

Circle CI builds are green again.
