### PR TITLE
Add webhook for archive AppVeyor build artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,3 +28,12 @@ artifacts:
 cache:
  - node_modules
  - "%LOCALAPPDATA%/Yarn"
+
+notifications:
+  - provider: Webhook
+    url: https://nightly.yarnpkg.com/archive_appveyor
+    method: POST
+    headers:
+      Authorization:
+        secure: uH4c9HNDdRuL4omqqbTtBq3KgzjGTFmpvPdiNuk9391Z0YXRoRLA1Ptpa3seZ0Pt
+    on_build_failure: false


### PR DESCRIPTION
**Summary**
Basically the same as #1473 except for AppVeyor (ie. the Windows installers) instead of CircleCI.

Archives master builds from AppVeyor into our directory for nightly builds. I'm using the phrase "nightly" but I really mean "unstable" as it's archived after every build, not once per night.

**Test plan**
Tested on my fork, will also check results in AppVeyor and on the nightly site once merged.

References #1474

