### PR TITLE
Resolve GitHub http urls with hash

### DIFF
--- a/__tests__/resolvers/exotics/github-resolver.js
+++ b/__tests__/resolvers/exotics/github-resolver.js
@@ -38,15 +38,15 @@ test('getGitHTTPUrl should return the correct git github SSH url', () => {
   expect(GitHubResolver.getGitSSHUrl(fragment)).toBe(expected);
 });
 
-test('getGitHTTPUrl with hash should return the correct git github SSH url', () => {
+test('getGitHTTPUrl with hash should return the correct git url', () => {
   const fragment: ExplodedFragment = {
     user: 'foo',
     repo: 'bar',
     hash: 'hash',
   };
 
-  const expected =  'git+ssh://git@github.com/' + fragment.user + '/' + fragment.repo + '.git#hash';
-  expect(GitHubResolver.getGitSSHUrl(fragment)).toBe(expected);
+  const expected =  'https://github.com/' + fragment.user + '/' + fragment.repo + '.git#hash';
+  expect(GitHubResolver.getGitHTTPUrl(fragment)).toBe(expected);
 });
 
 test('getGitSSHUrl should return URL containing protocol', () => {

--- a/__tests__/resolvers/exotics/github-resolver.js
+++ b/__tests__/resolvers/exotics/github-resolver.js
@@ -38,6 +38,17 @@ test('getGitHTTPUrl should return the correct git github SSH url', () => {
   expect(GitHubResolver.getGitSSHUrl(fragment)).toBe(expected);
 });
 
+test('getGitHTTPUrl with hash should return the correct git github SSH url', () => {
+  const fragment: ExplodedFragment = {
+    user: 'foo',
+    repo: 'bar',
+    hash: 'hash',
+  };
+
+  const expected =  'git+ssh://git@github.com/' + fragment.user + '/' + fragment.repo + '.git#hash';
+  expect(GitHubResolver.getGitSSHUrl(fragment)).toBe(expected);
+});
+
 test('getGitSSHUrl should return URL containing protocol', () => {
   const gitSSHUrl = GitHubResolver.getGitSSHUrl({
     hash: '',

--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -31,7 +31,8 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
+    return `https://${this.hostname}/${parts.user}/${parts.repo}.git` +
+      `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

We use GitHub http urls with commit hashes. Currently, they aren't properly resolved. https://github.com/yarnpkg/yarn/pull/1393 did fix this for SSH urls only.

**Test plan**

`npm test` with a new test to check whether a hash is appended to the resolved `getGitHTTPUrl` url.