### PR TITLE
Warn when man or bin directory not found but don't crash

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -31,6 +31,7 @@ const messages = {
   manifestStringExpected: '$0 is not a string',
   manifestDependencyBuiltin: 'Dependency $0 listed in $1 is the name of a built-in module',
   manifestDependencyCollision: '$0 has dependency $1 with range $2 that collides with a dependency in $3 of the same name with version $4',
+  manifestDirectoryNotFound: 'Unable to read $0 directory of module $1',
 
   configSet: 'Set $0 to $1.',
   configDelete: 'Deleted $0.',

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -196,7 +196,7 @@ export default async function (
           bin[scriptName] = path.join('.', binDir, scriptName);
         }
       } catch (err) {
-        if (err.code && err.code === 'ENOTENT') {
+        if (err.code && err.code === 'ENOENT') {
           warn(reporter.lang('manifestDirectoryNotFound', binDir, info.name));
         }
       }
@@ -214,7 +214,7 @@ export default async function (
           }
         }
       } catch (err) {
-        if (err.code && err.code === 'ENOTENT') {
+        if (err.code && err.code === 'ENOENT') {
           warn(reporter.lang('manifestDirectoryNotFound', manDir, info.name));
         }
       }

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -187,18 +187,17 @@ export default async function (
 
     if (!info.bin && binDir && typeof binDir === 'string') {
       const bin = info.bin = {};
+      const fullBinDir = path.join(moduleLoc, binDir);
 
-      try {
-        for (const scriptName of await fs.readdir(path.join(moduleLoc, binDir))) {
+      if (await fs.exists(fullBinDir)) {
+        for (const scriptName of await fs.readdir(fullBinDir)) {
           if (scriptName[0] === '.') {
             continue;
           }
           bin[scriptName] = path.join('.', binDir, scriptName);
         }
-      } catch (err) {
-        if (err.code && err.code === 'ENOENT') {
-          warn(reporter.lang('manifestDirectoryNotFound', binDir, info.name));
-        }
+      } else {
+        warn(reporter.lang('manifestDirectoryNotFound', binDir, info.name));
       }
     }
 
@@ -206,17 +205,16 @@ export default async function (
 
     if  (!info.man && typeof manDir === 'string') {
       const man = info.man = [];
+      const fullManDir = path.join(moduleLoc, manDir);
 
-      try {
-        for (const filename of await fs.readdir(path.join(moduleLoc, manDir))) {
+      if (await fs.exists(fullManDir)) {
+        for (const filename of await fs.readdir(fullManDir)) {
           if (/^(.*?)\.[0-9]$/.test(filename)) {
             man.push(path.join('.', manDir, filename));
           }
         }
-      } catch (err) {
-        if (err.code && err.code === 'ENOENT') {
-          warn(reporter.lang('manifestDirectoryNotFound', manDir, info.name));
-        }
+      } else {
+        warn(reporter.lang('manifestDirectoryNotFound', manDir, info.name));
       }
     }
   }

--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -13,8 +13,6 @@ export default async function (
   config: Config,
   isRoot: boolean,
 ): Promise<Manifest> {
-  await fix(info, moduleLoc, config.reporter, warn, config.looseSemver);
-
   // create human readable name
   const {name, version} = info;
   let human: ?string;
@@ -35,6 +33,7 @@ export default async function (
     config.reporter.warn(msg);
   }
 
+  await fix(info, moduleLoc, config.reporter, warn, config.looseSemver);
   try {
     validate(info, isRoot, config.reporter, warn);
   } catch (err) {

--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -13,7 +13,7 @@ export default async function (
   config: Config,
   isRoot: boolean,
 ): Promise<Manifest> {
-  await fix(info, moduleLoc, config.reporter, config.looseSemver);
+  await fix(info, moduleLoc, config.reporter, warn, config.looseSemver);
 
   // create human readable name
   const {name, version} = info;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes situation where the bin or man directory is specified in the package.json but does not really exist.  This change is to address issues like #739
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
yarn add newman@3.2.0 succeeds to install.  Previously when installing dependency postman-collection@0.5.5 yarn would crash with an ENOENT trying to read the bin directory that doesn't exist.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

