### PR TITLE
Add a shasum of pkg.remote.resolved field to cache directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "detect-indent": "^4.0.0",
     "diff": "^2.2.1",
     "eslint-plugin-react": "5.2.2",
+    "hasha": "2.2.0",
     "ini": "^1.3.4",
     "invariant": "^2.2.0",
     "is-builtin-module": "^1.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ import map from './util/map.js';
 const detectIndent = require('detect-indent');
 const invariant = require('invariant');
 const path = require('path');
+const hasha = require('hasha');
 
 export type ConfigOptions = {
   cwd?: ?string,
@@ -256,6 +257,10 @@ export default class Config {
     if (pkg.registry) {
       name = `${pkg.registry}-${name}`;
       uid = pkg.version || uid;
+    }
+    if (pkg.remote && pkg.remote.resolved) {
+      const hash = hasha(pkg.remote.resolved, {algorithm: 'sha1'});
+      uid = `${uid}-${hash}`;
     }
 
     return path.join(this.cacheFolder, `${name}-${uid}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,13 @@ hash.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
+hasha:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-2.2.0.tgz#78d7cbfc1e6d66303fe79837365984517b2f6ee1"
+  dependencies:
+    is-stream "^1.0.1"
+    pinkie-promise "^2.0.0"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -2781,6 +2788,10 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Summary**

This fixes possible name clashes between hosted packages with same version numbers.

It fixes #1278, #1573, #1280, #1453

**Test plan**

By using a shasum of resolved field, we can guarantee, that every resolved url will have it's own cache entry.
Using just `remote.hash` does not have this guarantee, as:
- cache contains contents of whatever `resolved` points to - hence it'll never go out of sync
- it's empty for hosted git (https://github.com/yarnpkg/yarn/blob/master/src/resolvers/exotics/hosted-git-resolver.js#L140). Even if we update the code to use the hash, it's taken from yarn.lock. So to assure we are fetching a proper package, people would have to upgrade all dependencies.

@kittens Just when I've created this I saw you started working on using the hash. Check the rationale above as it didn't work for me. Hashing the whole resolved does.