### PR TITLE
Mark master branch as "prerelease"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn",
   "installationMethod": "unknown",
-  "version": "0.16.2",
+  "version": "0.17.0-0",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "dependencies": {

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -7,5 +7,7 @@ VERSION=$(node -p -e "require('./package.json').version")
 BRANCH=$(echo "$VERSION" | (IFS="."; read a b c && echo $a.$b-stable))
 echo "$BRANCH"
 git checkout -b "$BRANCH"
-git push origin master --follow-tags
 git push origin "$BRANCH" --follow-tags
+git checkout master
+npm version preminor
+git push origin master --follow-tags

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -2,12 +2,12 @@
 
 set -ex
 
-npm version minor
+yarn version --new-version minor
 VERSION=$(node -p -e "require('./package.json').version")
 BRANCH=$(echo "$VERSION" | (IFS="."; read a b c && echo $a.$b-stable))
 echo "$BRANCH"
 git checkout -b "$BRANCH"
 git push origin "$BRANCH" --follow-tags
 git checkout master
-npm version preminor
+yarn version --new-version preminor
 git push origin master --follow-tags


### PR DESCRIPTION
For example, you are on version 0.16 and call `scripts/release-branch.sh` it will:

- change package.json version to 0.17.0 and tag change with v0.17.0
- make new branch 0.17-stable and push it to origin
- switch back to master
- change package.json version to preminor 0.18.0-0 and tag change with v0.18.0-0
- push master to origin

This way when people report bugs from master branch it will not be confused with released versions of Yarn

cc @Daniel15 

Test Plan:
(locally with commit commands suppressed)
```
bestander-mbp:yarn bestander$ ./scripts/release-branch.sh
+ yarn version --new-version minor
yarn version v0.16.1
info Current version: 0.19.0
info New version: 0.20.0
✨  Done in 0.14s.
++ node -p -e 'require('\''./package.json'\'').version'
+ VERSION=0.20.0
++ echo 0.20.0
++ IFS=.
++ read a b c
++ echo 0.20-stable
+ BRANCH=0.20-stable
+ echo 0.20-stable
0.20-stable
+ git checkout -b 0.20-stable
Switched to a new branch '0.20-stable'
+ git checkout master
Switched to branch 'master'
+ yarn version --new-version preminor
yarn version v0.16.1
info Current version: 0.20.0
info New version: 0.21.0-0
✨  Done in 0.14s.

./scripts/release-branch.sh
+ yarn version --new-version minor
yarn version v0.16.1
info Current version: 0.21.0-0
info New version: 0.21.0
✨  Done in 0.16s.
++ node -p -e 'require('\''./package.json'\'').version'
+ VERSION=0.21.0
++ echo 0.21.0
++ IFS=.
++ read a b c
++ echo 0.21-stable
+ BRANCH=0.21-stable
+ echo 0.21-stable
0.21-stable
+ git checkout -b 0.21-stable
Switched to a new branch '0.21-stable'
+ git checkout master
Switched to branch 'master'
+ yarn version --new-version preminor
yarn version v0.16.1
info Current version: 0.21.0
info New version: 0.22.0-0
✨  Done in 0.15s.
```
