### PR TITLE
Fix `yarn upgrade <package>` command to store version in lockfile

### DIFF
--- a/__tests__/fixtures/add/latest-version-in-lockfile/package.json
+++ b/__tests__/fixtures/add/latest-version-in-lockfile/package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/__tests__/fixtures/upgrade/fixed-to-latest/package.json
+++ b/__tests__/fixtures/upgrade/fixed-to-latest/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "max-safe-integer": "1.0.0"
+  }
+}

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -98,6 +98,8 @@ export class Add extends Install {
 
   async savePackages(): Promise<void> {
     const {exact, tilde} = this.flags;
+    // hold only patterns for lockfile
+    const patterns = [];
 
     // fill rootPatternsToOrigin without `excludePatterns`
     await Install.prototype.fetchRequestFromCwd.call(this);
@@ -155,9 +157,13 @@ export class Add extends Install {
       }
       this.resolver.addPattern(newPattern, pkg);
       this.resolver.removePattern(pattern);
+
+      // push new pattern to the lockfile
+      patterns.push(newPattern);
     }
 
     await this.config.saveRootManifests(manifests);
+    await this.saveLockfileAndIntegrity(patterns);
   }
 }
 


### PR DESCRIPTION
**Summary**

This fixes #1685. The command would not store the latest version in the lockfile and would drop the version altogether. This change will resave the lockfile when it formats the patterns for the manifest.

**Test plan**

```js
{
  "dependencies": {
    "lodash": "4.15.0"
  }
}
```

```sh
$ yarn upgrade lodash
```

##### Before

```
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1
lodash:
  version "4.16.6"
  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
````

##### After

```
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1
lodash@^4.16.6:
  version "4.16.6"
  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
```

