### PR TITLE
Fix flags for `yarn add` command

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -169,11 +169,11 @@ export class Add extends Install {
 
 export function setFlags(commander: Object) {
   commander.usage('add [packages ...] [flags]');
-  commander.option('--dev, -D', 'save package to your `devDependencies`');
-  commander.option('--peer, -P', 'save package to your `peerDependencies`');
-  commander.option('--optional, -O', 'save package to your `optionalDependencies`');
-  commander.option('--exact, -E', 'install exact version');
-  commander.option('--tilde, -T', 'install most recent release with the same minor version');
+  commander.option('-D, --dev', 'save package to your `devDependencies`');
+  commander.option('-P, --peer', 'save package to your `peerDependencies`');
+  commander.option('-O, --optional', 'save package to your `optionalDependencies`');
+  commander.option('-E, --exact', 'install exact version');
+  commander.option('-T, --tilde', 'install most recent release with the same minor version');
 }
 
 export async function run(


### PR DESCRIPTION
**Summary**

This fixes #1700. The shorthand/alias commands should come before the long command name in the `commander.option` function. The last one defined in the list is the name of the flag that is set. So, previously when passing `--dev` and we look for `flags.dev`, it wouldn't be set, but `flags.D` would be set to `true`.

**Test plan**

All tests pass and flags are respected.

