### PR TITLE
Change all console format grey to dim

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -8,7 +8,7 @@ Object {
 exports[`test ConsoleReporter.command 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[90m$ foobar[39m",
+  "stdout": "[2K[1G[2m$ foobar[22m",
 }
 `;
 
@@ -95,7 +95,7 @@ Object {
 exports[`test ConsoleReporter.step 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[90m[1/5][39m foboar...",
+  "stdout": "[2K[1G[2m[1/5][22m foboar...",
 }
 `;
 

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -88,7 +88,7 @@ export default class ConsoleReporter extends BaseReporter {
       msg += '...';
     }
 
-    this.log(`${this.format.grey(`[${current}/${total}]`)} ${msg}`);
+    this.log(`${this.format.dim(`[${current}/${total}]`)} ${msg}`);
   }
 
   inspect(value: mixed) {
@@ -149,7 +149,7 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   command(command: string) {
-    this.log(this.format.grey(`$ ${command}`));
+    this.log(this.format.dim(`$ ${command}`));
   }
 
   warn(msg: string) {
@@ -164,7 +164,7 @@ export default class ConsoleReporter extends BaseReporter {
 
     return new Promise((resolve, reject) => {
       read({
-        prompt: `${this.format.grey('question')} ${question}: `,
+        prompt: `${this.format.dim('question')} ${question}: `,
         silent: !!options.password,
         output: this.stdout,
         input: this.stdin,
@@ -203,7 +203,7 @@ export default class ConsoleReporter extends BaseReporter {
 
       let suffix = '';
       if (hint) {
-        suffix += ` (${this.format.grey(hint)})`;
+        suffix += ` (${this.format.dim(hint)})`;
       }
       if (color) {
         name = this.format[color](name);
@@ -243,7 +243,7 @@ export default class ConsoleReporter extends BaseReporter {
       let current = 0;
       const updatePrefix = () => {
         spinner.setPrefix(
-          `${this.format.grey(`[${current === 0 ? '-' : current}/${total}]`)} `,
+          `${this.format.dim(`[${current === 0 ? '-' : current}/${total}]`)} `,
         );
       };
       const clear = () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This change fixes #1699. 

**Test plan**
Two ConsoleReporter snapshot tests failed when running the test suite. I assume that should be expected since the purpose of this change is to fix the console coloring for console reporter commands. However, let me know if I'm misunderstanding.*

In comparison with the screenshots in #1699, here is the npm-linked fix working with the correct console coloring:
![screen shot 2016-11-05 at 5 01 13 pm](https://cloud.githubusercontent.com/assets/1641390/20033877/850dd89e-a379-11e6-88a2-4f1804d92c53.png)

**Update: I realized I needed to update the `jest` snapshot for the ConsoleReporter tests.*