### PR TITLE
fix-679: empty lockfiles with no dependencies

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -162,6 +162,18 @@ test.concurrent("writes new lockfile if existing one isn't satisfied", async ():
   });
 });
 
+test.concurrent('writes a lockfile even when there are no dependencies', (): Promise<void> => {
+  // https://github.com/yarnpkg/yarn/issues/679
+  return runInstall({}, 'install-without-dependencies', async (config) => {
+    const lockfileExists = await fs.exists(path.join(config.cwd, 'yarn.lock'));
+    const installedDepFiles = await fs.walk(path.join(config.cwd, 'node_modules'));
+
+    assert(lockfileExists);
+    // 1 for integrity file (located in node_modules)
+    assert.equal(installedDepFiles.length, 1);
+  });
+});
+
 test.concurrent("throws an error if existing lockfile isn't satisfied with --frozen-lockfile", (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
 

--- a/__tests__/fixtures/install/install-without-dependencies/package.json
+++ b/__tests__/fixtures/install/install-without-dependencies/package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -311,6 +311,7 @@ export class Install {
     if (!patterns.length && !match.expected) {
       this.reporter.success(this.reporter.lang('nothingToInstall'));
       await this.createEmptyManifestFolders();
+      await this.saveLockfileAndIntegrity(patterns);
       return true;
     }
 
@@ -581,7 +582,7 @@ export class Install {
     const inSync = this.lockFileInSync(patterns);
 
     // remove is followed by install with force on which we rewrite lockfile
-    if (inSync && !this.flags.force) {
+    if (inSync && patterns.length && !this.flags.force) {
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

No lockfile is written with empty dependencies, which causes check to fail. Act the same with manifest & lockfile, so write an empty file as-well when no dependencies are going to be installed `dependencies: {}`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This will solve: https://github.com/yarnpkg/yarn/issues/679

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
$ yarn init
$ yarn install
$ yarn check
$ yarn check --integrity
$ npm run test
```
