### PR TITLE
Update end-to-end tests to use nightly repo

### DIFF
--- a/end_to_end_tests/data/run-ubuntu.sh
+++ b/end_to_end_tests/data/run-ubuntu.sh
@@ -11,8 +11,7 @@ fi;
 
 # Add Yarn repo
 apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
-# TODO: Use nightly repo once it's configured
-echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+echo "deb http://nightly.yarnpkg.com/debian/ nightly main" > /etc/apt/sources.list.d/yarn.list
 apt-get update -y
 
 if [ "$DISTRIB_RELEASE" == '12.04' -o "$DISTRIB_RELEASE" == '14.04' ]; then


### PR DESCRIPTION
**Summary**
Updates the end-to-end test script to use the nightly repo rather than the release repo.

**Test plan**
Tested on my build server using Jenkins + Docker.

Full build output:

```
Started by user Daniel Lo Nigro
Building in workspace /var/lib/jenkins/workspace/yarn/ubuntu-16.04
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url git://github.com/yarnpkg/yarn # timeout=10
Fetching upstream changes from git://github.com/yarnpkg/yarn
 > git --version # timeout=10
 > git fetch --tags --progress git://github.com/yarnpkg/yarn +refs/heads/*:refs/remotes/origin/*
 > git rev-parse refs/remotes/origin/master^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/master^{commit} # timeout=10
Checking out Revision c209f84b8ab160fa711916b753f2b983daa21b9c (refs/remotes/origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f c209f84b8ab160fa711916b753f2b983daa21b9c
 > git rev-list c209f84b8ab160fa711916b753f2b983daa21b9c # timeout=10
[ubuntu-16.04] $ /bin/sh -xe /tmp/hudson2398841058851874411.sh
+ cd end_to_end_tests
+ APT_PROXY=192.168.122.1:3142 ./test-ubuntu-16.04.sh
+ ./data/start-ubuntu.sh ubuntu:16.04
+ '[' -z ubuntu:16.04 ']'
+++ readlink -f ./data/start-ubuntu.sh
++ dirname /var/lib/jenkins/workspace/yarn/ubuntu-16.04/end_to_end_tests/data/start-ubuntu.sh
+ data_path=/var/lib/jenkins/workspace/yarn/ubuntu-16.04/end_to_end_tests/data
+ docker run -v /var/lib/jenkins/workspace/yarn/ubuntu-16.04/end_to_end_tests/data:/data -w=/data -e APT_PROXY=192.168.122.1:3142 ubuntu:16.04 /data/run-ubuntu.sh
+ . /etc/lsb-release
++ DISTRIB_ID=Ubuntu
++ DISTRIB_RELEASE=16.04
++ DISTRIB_CODENAME=xenial
++ DISTRIB_DESCRIPTION='Ubuntu 16.04.1 LTS'
+ '[' -n 192.168.122.1:3142 ']'
+ echo 'Acquire::http::proxy "http://192.168.122.1:3142";'
+ apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
Executing: /tmp/tmp.m791TCQED3/gpg.1.sh --keyserver
pgp.mit.edu
--recv
D101F7899D41F3C3
gpg: requesting key 9D41F3C3 from hkp server pgp.mit.edu
gpg: key 86E50310: public key "Yarn Packaging <yarn@dan.cx>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
+ echo 'deb http://nightly.yarnpkg.com/debian/ nightly main'
+ apt-get update -y
Get:1 http://nightly.yarnpkg.com/debian nightly InRelease [2464 B]
Get:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [95.7 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial-security InRelease [94.5 kB]
Get:5 http://nightly.yarnpkg.com/debian nightly/main amd64 Packages [880 B]
Get:6 http://archive.ubuntu.com/ubuntu xenial/main Sources [1103 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial/restricted Sources [5179 B]
Get:8 http://archive.ubuntu.com/ubuntu xenial/universe Sources [9802 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]
Get:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main Sources [256 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/restricted Sources [1872 B]
Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/universe Sources [134 kB]
Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [532 kB]
Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [11.7 kB]
Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [448 kB]
Get:18 http://archive.ubuntu.com/ubuntu xenial-security/main Sources [54.7 kB]
Get:19 http://archive.ubuntu.com/ubuntu xenial-security/restricted Sources [1872 B]
Get:20 http://archive.ubuntu.com/ubuntu xenial-security/universe Sources [13.8 kB]
Get:21 http://archive.ubuntu.com/ubuntu xenial-security/main amd64 Packages [200 kB]
Get:22 http://archive.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [11.7 kB]
Get:23 http://archive.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [63.2 kB]
Fetched 24.5 MB in 2s (9076 kB/s)
Reading package lists...
+ '[' 16.04 == 12.04 -o 16.04 == 14.04 ']'
+ apt-get install yarn ca-certificates -y
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libicu55 libssl1.0.0 libuv1 nodejs openssl
The following NEW packages will be installed:
  ca-certificates libicu55 libssl1.0.0 libuv1 nodejs openssl yarn
0 upgraded, 7 newly installed, 0 to remove and 11 not upgraded.
Need to get 14.1 MB of archives.
After this operation, 69.5 MB of additional disk space will be used.
Get:1 http://nightly.yarnpkg.com/debian stable/main amd64 yarn all 0.16.2-20161103.1408-1 [1472 kB]
Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libssl1.0.0 amd64 1.0.2g-1ubuntu4.5 [1082 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssl amd64 1.0.2g-1ubuntu4.5 [491 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 ca-certificates all 20160104ubuntu1 [191 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 libicu55 amd64 55.1-7 [7643 kB]
Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 libuv1 amd64 1.8.0-1 [57.4 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 nodejs amd64 4.2.6~dfsg-1ubuntu4.1 [3161 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 14.1 MB in 0s (58.6 MB/s)
Selecting previously unselected package libssl1.0.0:amd64.
(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 7256 files and directories currently installed.)
Preparing to unpack .../libssl1.0.0_1.0.2g-1ubuntu4.5_amd64.deb ...
Unpacking libssl1.0.0:amd64 (1.0.2g-1ubuntu4.5) ...
Selecting previously unselected package openssl.
Preparing to unpack .../openssl_1.0.2g-1ubuntu4.5_amd64.deb ...
Unpacking openssl (1.0.2g-1ubuntu4.5) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../ca-certificates_20160104ubuntu1_all.deb ...
Unpacking ca-certificates (20160104ubuntu1) ...
Selecting previously unselected package libicu55:amd64.
Preparing to unpack .../libicu55_55.1-7_amd64.deb ...
Unpacking libicu55:amd64 (55.1-7) ...
Selecting previously unselected package libuv1:amd64.
Preparing to unpack .../libuv1_1.8.0-1_amd64.deb ...
Unpacking libuv1:amd64 (1.8.0-1) ...
Selecting previously unselected package yarn.
Preparing to unpack .../archives/yarn_0.16.2-20161103.1408-1_all.deb ...
Unpacking yarn (0.16.2-20161103.1408-1) ...
Selecting previously unselected package nodejs.
Preparing to unpack .../nodejs_4.2.6~dfsg-1ubuntu4.1_amd64.deb ...
Unpacking nodejs (4.2.6~dfsg-1ubuntu4.1) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Setting up libssl1.0.0:amd64 (1.0.2g-1ubuntu4.5) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up openssl (1.0.2g-1ubuntu4.5) ...
Setting up ca-certificates (20160104ubuntu1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up libicu55:amd64 (55.1-7) ...
Setting up libuv1:amd64 (1.8.0-1) ...
Setting up yarn (0.16.2-20161103.1408-1) ...
Setting up nodejs (4.2.6~dfsg-1ubuntu4.1) ...
update-alternatives: using /usr/bin/nodejs to provide /usr/bin/js (js) in auto mode
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Processing triggers for ca-certificates (20160104ubuntu1) ...
Updating certificates in /etc/ssl/certs...
173 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
+ ./run-yarn-test.sh
+ cd /tmp
+ mkdir yarntest
+ cd yarntest
+ yarn add react
yarn add v0.16.2-20161103.1408-1
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 16 new dependencies.
├─ asap@2.0.5
├─ core-js@1.2.7
├─ encoding@0.1.12
├─ fbjs@0.8.5
├─ iconv-lite@0.4.13
├─ immutable@3.8.1
├─ is-stream@1.1.0
├─ isomorphic-fetch@2.2.1
├─ js-tokens@2.0.0
├─ loose-envify@1.3.0
├─ node-fetch@1.6.3
├─ object-assign@4.1.0
├─ promise@7.1.1
├─ react@15.3.2
├─ ua-parser-js@0.7.11
└─ whatwg-fetch@1.0.0
Done in 3.65s.
Finished: SUCCESS
```

