### PR TITLE
Delay visibility propagation until deps are known

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -224,8 +224,6 @@ export default class PackageRequest {
       invariant(ref, 'Resolved package info has no package reference');
       ref.addRequest(this);
       ref.addPattern(this.pattern, resolved);
-      ref.addOptional(this.optional);
-      ref.addVisibility(this.visibility);
       return;
     }
 
@@ -280,6 +278,12 @@ export default class PackageRequest {
 
     await Promise.all(promises);
     ref.addDependencies(deps);
+
+    // Now that we have all dependencies, it's safe to propagate optional & visibility
+    for (const otherRequest of ref.requests.slice(1)) {
+      ref.addOptional(otherRequest.optional);
+      ref.addVisibility(otherRequest.visibility);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Right now visibility is set before the dependencies are added to the package reference. This means that no visibility information propagates for other requests for the same package. Example:

1. `is-glob@^2.0.0` is encountered. Visibility for the request is "env hidden"
2. Dependencies of `is-glob@^2.0.0` are walked and inherit the visibility from their parent
3. `is-glob@^2.0.1` is encountered. Visibility for the request is "used"
4. Because there's already something compatible in flight, it's merged into the existing ref
5. `addVisibility` is called - but at this point the dependencies are not yet resolved
6. The dependencies are added - but none of them will ever learn that (one of) their parent was "used"

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I couldn't figure out a good unit test for this. What I did for manual testing in an empty directory:

```
npm init --yes
yarn add --dev chokidar@1.6.1
yarn add liftoff@2.3.0
rm -rf node_modules && ../../tools/yarn/bin/yarn.js --prod && node -e "require('is-glob')"
```

Fixes https://github.com/yarnpkg/yarn/issues/761