### PR TITLE
Add support for 'ca' config file option

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -197,6 +197,7 @@ export default class Config {
       httpProxy: String(opts.httpProxy || this.getOption('proxy') || ''),
       httpsProxy: String(opts.httpsProxy || this.getOption('https-proxy') || ''),
       strictSSL: Boolean(this.getOption('strict-ssl')),
+      ca: Array.prototype.concat(opts.ca || this.getOption('ca') || []).map(String),
       cafile: String(opts.cafile || this.getOption('cafile') || ''),
       cert: String(opts.cert || this.getOption('cert') || ''),
       key: String(opts.key || this.getOption('key') || ''),

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -111,6 +111,7 @@ export default class RequestManager {
     httpProxy?: string,
     httpsProxy?: string,
     strictSSL?: boolean,
+    ca?: Array<string>,
     cafile?: string,
     cert?: string,
     key?: string,
@@ -139,6 +140,10 @@ export default class RequestManager {
       this.strictSSL = opts.strictSSL;
     }
 
+    if (opts.ca != null && opts.ca.length > 0) {
+      this.ca = opts.ca;
+    }
+
     if (opts.cafile != null && opts.cafile != '') {
       // The CA bundle file can contain one or more certificates with comments/text between each PEM block.
       // tls.connect wants an array of certificates without any comments/text, so we need to split the string
@@ -146,6 +151,7 @@ export default class RequestManager {
       try {
         const bundle = fs.readFileSync(opts.cafile).toString();
         const hasPemPrefix = (block) => block.startsWith('-----BEGIN ');
+        // opts.cafile overrides opts.ca, this matches with npm behavior
         this.ca = bundle.split(/(-----BEGIN .*\r?\n[^-]+\r?\n--.*)/).filter(hasPemPrefix);
       } catch (err) {
         this.reporter.error(`Could not open cafile: ${err.message}`);


### PR DESCRIPTION
**Summary**
npm supports specifying CA contents directly in the `.npmrc` file, using `ca` option.
yarn does not currently support this, as mentioned in several comments, e.g.:
* https://github.com/yarnpkg/website/issues/128#issue-182372920
* https://github.com/yarnpkg/yarn/issues/606#issuecomment-252977248

**Test plan**
Localhost is running Sinopia with cert signed by self-signed root CA.
Below is `.npmrc` file contents (root CA cert is removed for brevity):

    registry=https://localhost:4873
    ca[]="-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"

npm output:

    $ npm install leftpad
    leftpad@0.0.0 node_modules/leftpad

yarn output:

    $ yarn add leftpad
    yarn add v0.16.1
    [1/4] Resolving packages...
    error An unexpected error occured, please open a bug report with the information provided in "/home/yarn/bin/yarn-error.log".
    info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.

    $ cat yarn-error.log 
    ...
      leftpad@^0.0.0:
        version "0.0.0"
        resolved "https://localhost:4873/leftpad/-/leftpad-0.0.0.tgz#020c9ad0787216ba0f30d79d479b4b355d7d39c3"

    Trace: 
      Error: unable to verify the first certificate
      at Error (native)
      at TLSSocket.<anonymous> (_tls_wrap.js:1017:38)
      at emitNone (events.js:67:13)
      at TLSSocket.emit (events.js:166:7)
      at TLSSocket._init.ssl.onclienthello.ssl.oncertcb.TLSSocket._finishInit (_tls_wrap.js:582:8)
      at TLSWrap.ssl.onclienthello.ssl.oncertcb.ssl.onnewsession.ssl.onhandshakedone (_tls_wrap.js:424:38)

yarn output after the fix:

    $ ./yarn add leftpad
    yarn add v0.17.0-0
    [1/4] Resolving packages...
    [2/4] Fetching packages...
    [3/4] Linking dependencies...
    [4/4] Building fresh packages...
    success Saved lockfile.
    success Saved 1 new dependency.
    └─ leftpad@0.0.0
    Done in 0.77s.

