### PR TITLE
Normalize scripts object in manifest with relative bin path

### DIFF
--- a/__tests__/fixtures/normalize-manifest/normalize scripts object/actual.json
+++ b/__tests__/fixtures/normalize-manifest/normalize scripts object/actual.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "scripts": {
+    "test": "./node_modules/.bin/karma",
+    "build": "./node_modules/.bin/webpack -d --no-color",
+    "watch": "node_modules\\.bin\\webpack --watch"
+  }
+}

--- a/__tests__/fixtures/normalize-manifest/normalize scripts object/expected.json
+++ b/__tests__/fixtures/normalize-manifest/normalize scripts object/expected.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "scripts": {
+    "test": "karma",
+    "build": "webpack -d --no-color",
+    "watch": "webpack --watch"
+  }
+}

--- a/__tests__/fixtures/normalize-manifest/normalize scripts object/warnings.json
+++ b/__tests__/fixtures/normalize-manifest/normalize scripts object/warnings.json
@@ -1,0 +1,1 @@
+["No license field"]

--- a/__tests__/normalize-manifest.js
+++ b/__tests__/normalize-manifest.js
@@ -95,6 +95,26 @@ test('util.extractDescription', () => {
   expect(util.extractDescription(undefined)).toEqual(undefined);
 });
 
+test('util.parseScript', () => {
+  expect(util.parseScript('karma')).toEqual('karma');
+  expect(util.parseScript('webpack -d --no-color')).toEqual('webpack -d --no-color');
+  expect(util.parseScript('./node_modules/.bin/webpack -d --no-color')).toEqual('webpack -d --no-color');
+  expect(util.parseScript('node_modules\\.bin\\webpack -d --no-color')).toEqual('webpack -d --no-color');
+  expect(util.parseScript('node_modules/.bin/webpack --watch')).toEqual('webpack --watch');
+});
+
+test('util.normalizeScripts', () => {
+  expect(util.normalizeScripts({
+    'test': 'node_modules/.bin/karma',
+    'build': './node_modules/.bin/webpack -d --no-color',
+    'watch': 'node_modules\\.bin\\webpack --watch',
+  })).toEqual({
+    'test': 'karma',
+    'build': 'webpack -d --no-color',
+    'watch': 'webpack --watch',
+  });
+});
+
 // fill out expected and normalize paths
 function expand<T>(expected: T): T {
   if (expected.man && Array.isArray(expected.man)) {

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -2,7 +2,7 @@
 
 import type {Reporter} from '../../reporters/index.js';
 import {isValidLicense} from './util.js';
-import {normalizePerson, extractDescription} from './util.js';
+import {normalizePerson, extractDescription, normalizeScripts} from './util.js';
 import {hostedGitFragmentToGitUrl} from '../../resolvers/index.js';
 import inferLicense from './infer-license.js';
 import * as fs from '../fs.js';
@@ -157,7 +157,7 @@ export default async function (
 
   // dummy script object to shove file inferred scripts onto
   if (info.scripts && typeof info.scripts === 'object') {
-    scripts = info.scripts;
+    scripts = normalizeScripts(info.scripts);
   } else {
     scripts = {};
   }

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -74,9 +74,9 @@ export function parseScript(script: string): string {
 
 export function normalizeScripts(scripts: Object): Object {
   const normalizedScripts = {};
-  Object.keys(scripts).forEach((scriptName) => {
+  for (const scriptName in scripts) {
     normalizedScripts[scriptName] = parseScript(scripts[scriptName]);
-  });
+  }
   return normalizedScripts;
 }
 

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -64,6 +64,22 @@ export function normalizePerson(person: mixed): mixed | PersonObject {
   return parsePerson(stringifyPerson(person));
 }
 
+export function parseScript(script: string): string {
+  const relativeBinPath = /^(\.[\/\\])?node_modules[\/\\].bin[\\\/]/;
+  if (script.match(relativeBinPath)) {
+    script = script.replace(relativeBinPath, '');
+  }
+  return script;
+}
+
+export function normalizeScripts(scripts: Object): Object {
+  const normalizedScripts = {};
+  Object.keys(scripts).forEach((scriptName) => {
+    normalizedScripts[scriptName] = parseScript(scripts[scriptName]);
+  });
+  return normalizedScripts;
+}
+
 export function extractDescription(readme: mixed): ?string {
   if (typeof readme !== 'string' || readme === '') {
     return undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The scripts object in the package.json is not normalized as with npm. The path `./node_modules/.bin/script` is causing issues on Windows. Strip of the relative path with regex as it's not explicitly needed.

Fixes: 
* https://github.com/yarnpkg/yarn/issues/1657
* https://github.com/yarnpkg/yarn/issues/1606

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

* Automated: New tests for normalizing scripts have been added
* Manual:

Use a package.json with a relative bin script (can be done on any OS)

```
{
    "name": "",
    "version": "",
    "scripts": {
        "test": "./node_modules/.bin/webpack --watch"
    }
}
```

Notice that the executed command in the output has been normalized:

```
$ yarn run test
yarn run v0.17.0-0
$ webpack --watch
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

