### PR TITLE
Create blank package.json during end-to-end tests to work around #1747

### DIFF
--- a/end_to_end_tests/data/run-ubuntu.sh
+++ b/end_to_end_tests/data/run-ubuntu.sh
@@ -10,7 +10,7 @@ if [ -n "$APT_PROXY" ]; then
 fi;
 
 # Add Yarn repo
-apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://nightly.yarnpkg.com/debian/ nightly main" > /etc/apt/sources.list.d/yarn.list
 apt-get update -y
 

--- a/end_to_end_tests/data/run-yarn-test.sh
+++ b/end_to_end_tests/data/run-yarn-test.sh
@@ -15,4 +15,5 @@ fail_with_log() {
 cd /tmp
 mkdir yarntest
 cd yarntest
+echo {} > package.json
 yarn add react || fail_with_log

--- a/end_to_end_tests/data/start-ubuntu.sh
+++ b/end_to_end_tests/data/start-ubuntu.sh
@@ -8,4 +8,4 @@ if [ -z "$1" ]; then
 fi;
 
 data_path=$(dirname $(readlink -f "$0"))
-docker run -v $data_path:/data -w=/data -e APT_PROXY=$APT_PROXY $1 /data/run-ubuntu.sh
+docker run -v $data_path:/data -w=/data -e APT_PROXY=$APT_PROXY -e DEBIAN_FRONTEND=noninteractive $1 /data/run-ubuntu.sh


### PR DESCRIPTION
**Summary**

Latest released version of Yarn handles `yarn add` in directories that don't yet have a `package.json` file, whereas the latest master version fails. I updated the end-to-end test to create a blank package.json to work around this change. See #1747 for more details.

Also other miscellaneous improvements:
 - Set `DEBIAN_FRONTEND=noninteractive` so apt-get doesn't complain about not having a tty
 - Grab GPG key via HTTP instead of keyserver to avoid flaky keyservers

**Test plan**
Tested on my computer:
```
docker run -t -v c:/src/yarn/end_to_end_tests/data:/data -w=/data -e DEBIAN_FRONTEND=noninteractive ubuntu:16.04 /data/run-ubuntu.sh
```