### PR TITLE
Use deterministic sort (fixes #1308)

### DIFF
--- a/__tests__/util/misc.js
+++ b/__tests__/util/misc.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import * as misc from '../../src/util/misc.js';
+
+test('sortAlpha', () => {
+  expect([
+    'foo@6.x',
+    'foo@^6.5.0',
+    'foo@~6.8.x',
+    'foo@^6.7.0',
+    'foo@~6.8.0',
+    'foo@^6.8.0',
+    'foo@6.8.0',
+  ].sort(misc.sortAlpha)).toEqual([
+    'foo@6.8.0',
+    'foo@6.x',
+    'foo@^6.5.0',
+    'foo@^6.7.0',
+    'foo@^6.8.0',
+    'foo@~6.8.0',
+    'foo@~6.8.x',
+  ]);
+});

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -8,18 +8,11 @@ export function sortAlpha(a: string, b: string): number {
   for (let i = 0; i < shortLen; i++) {
     const aChar = a.charCodeAt(i);
     const bChar = b.charCodeAt(i);
-    if (aChar < bChar) {
-      return -1;
-    } else if (aChar > bChar) {
-      return 1;
+    if (aChar !== bChar) {
+      return aChar - bChar;
     }
   }
-  if (a.length < b.length) {
-    return -1;
-  } else if (a.length > b.length) {
-    return 1;
-  }
-  return 0;
+  return a.length - b.length;
 }
 
 export function entries<T>(obj: ?{ [key: string]: T }): Array<[string, T]> {

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -3,8 +3,23 @@
 const _camelCase = require('camelcase');
 
 export function sortAlpha(a: string, b: string): number {
-  // sort alphabetically
-  return a.toLowerCase().localeCompare(b.toLowerCase());
+  // sort alphabetically in a deterministic way
+  const shortLen = Math.min(a.length, b.length);
+  for (let i = 0; i < shortLen; i++) {
+    const aChar = a.charCodeAt(i);
+    const bChar = b.charCodeAt(i);
+    if (aChar < bChar) {
+      return -1;
+    } else if (aChar > bChar) {
+      return 1;
+    }
+  }
+  if (a.length < b.length) {
+    return -1;
+  } else if (a.length > b.length) {
+    return 1;
+  }
+  return 0;
 }
 
 export function entries<T>(obj: ?{ [key: string]: T }): Array<[string, T]> {


### PR DESCRIPTION
**Summary**

The previous sort function used `localeCompare` which is dependent on the user's locale configuration (and I think node support). This resulted in non-deterministic lock files. This new approach uses unicode point code as the rank, which is consistent for everyone.

**Test plan**

Added a test.

cc: @bestander @Daniel15 