### PR TITLE
Add integrity refactor

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -545,8 +545,7 @@ test.concurrent('add should store latest version in lockfile', (): Promise<void>
   });
 });
 
-// TODO disabled until https://github.com/yarnpkg/yarn/issues/1733 is fixed
-test.skip('add should generate correct integrity file', (): Promise<void> => {
+test.concurrent('add should generate correct integrity file', (): Promise<void> => {
   return runAdd({}, ['mime-db@1.24.0'], 'integrity-check', async (config, reporter) => {
     let allCorrect = true;
     try {

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -82,16 +82,16 @@ export class Add extends Install {
         version = `${String(this.config.getOption('save-prefix') || '')}${pkg.version}`;
       }
       const newPattern = `${pkg.name}@${version}`;
+      preparedPatterns.push(newPattern);
+      this.addedPatterns.push(newPattern);
       if (newPattern === pattern) {
         continue;
       }
+      // TODO move replacement into resolver
       pkg._reference.patterns = [newPattern];
       this.resolver.newPatterns.splice(this.resolver.newPatterns.indexOf(pattern), 1, newPattern);
       this.resolver.addPattern(newPattern, pkg);
       this.resolver.removePattern(pattern);
-      this.addedPatterns.push(newPattern);
-
-      preparedPatterns.push(newPattern);
     }
     return preparedPatterns;
   }

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -88,7 +88,7 @@ export class Add extends Install {
         continue;
       }
       // TODO move replacement into resolver
-      pkg._reference.patterns = [newPattern];
+      ref.patterns = [newPattern];
       this.resolver.newPatterns.splice(this.resolver.newPatterns.indexOf(pattern), 1, newPattern);
       this.resolver.addPattern(newPattern, pkg);
       this.resolver.removePattern(pattern);
@@ -98,7 +98,6 @@ export class Add extends Install {
 
   bailout(
     patterns: Array<string>,
-    match: IntegrityMatch,
   ): Promise<boolean> {
     return Promise.resolve(false);
   }

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type {Reporter} from '../../reporters/index.js';
-import type {InstallCwdRequest, InstallPrepared, IntegrityMatch} from './install.js';
+import type {InstallCwdRequest, IntegrityMatch} from './install.js';
 import type {DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
 import type {LsOptions} from './ls.js';

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type {Reporter} from '../../reporters/index.js';
-import type {InstallCwdRequest, IntegrityMatch} from './install.js';
+import type {InstallCwdRequest} from './install.js';
 import type {DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
 import type {LsOptions} from './ls.js';
@@ -63,9 +63,6 @@ export class Add extends Install {
       const pkg = this.resolver.getResolvedPattern(pattern);
       invariant(pkg, `missing package ${pattern}`);
 
-      const ref = pkg._reference;
-      invariant(ref, 'expected package reference');
-
       const parts = PackageRequest.normalizePattern(pattern);
       let version;
       if (PackageRequest.getExoticResolver(pattern)) {
@@ -87,11 +84,7 @@ export class Add extends Install {
       if (newPattern === pattern) {
         continue;
       }
-      // TODO move replacement into resolver
-      ref.patterns = [newPattern];
-      this.resolver.newPatterns.splice(this.resolver.newPatterns.indexOf(pattern), 1, newPattern);
-      this.resolver.addPattern(newPattern, pkg);
-      this.resolver.removePattern(pattern);
+      this.resolver.replacePattern(pattern, newPattern);
     }
     return preparedPatterns;
   }

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -284,7 +284,7 @@ export class Install {
 
     let patterns;
     const steps: Array<(curr: number, total: number) => Promise<{bailout: boolean} | void>> = [];
-    let [depRequests, rawPatterns] = await this.fetchRequestFromCwd();
+    const [depRequests, rawPatterns] = await this.fetchRequestFromCwd();
 
     steps.push(async (curr: number, total: number) => {
       this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -8,7 +8,7 @@ import type {RegistryNames} from '../../registries/index.js';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
 import {registryNames} from '../../registries/index.js';
 import {MessageError} from '../../errors.js';
-import Lockfile, {sortAlpha} from '../../lockfile/wrapper.js';
+import Lockfile from '../../lockfile/wrapper.js';
 import lockStringify from '../../lockfile/stringify.js';
 import * as PackageReference from '../../package-reference.js';
 import PackageFetcher from '../../package-fetcher.js';
@@ -23,6 +23,7 @@ import * as constants from '../../constants.js';
 import * as fs from '../../util/fs.js';
 import * as crypto from '../../util/crypto.js';
 import map from '../../util/map.js';
+import {sortAlpha} from '../../util/misc.js';
 
 const invariant = require('invariant');
 const emoji = require('node-emoji');

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -282,7 +282,7 @@ export class Install {
       this.reporter.error(this.reporter.lang('shrinkwrapWarning'));
     }
 
-    let patterns;
+    let patterns: Array<string> = [];
     const steps: Array<(curr: number, total: number) => Promise<{bailout: boolean} | void>> = [];
     const [depRequests, rawPatterns] = await this.fetchRequestFromCwd();
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -8,7 +8,7 @@ import type {RegistryNames} from '../../registries/index.js';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
 import {registryNames} from '../../registries/index.js';
 import {MessageError} from '../../errors.js';
-import Lockfile from '../../lockfile/wrapper.js';
+import Lockfile, {sortAlpha} from '../../lockfile/wrapper.js';
 import lockStringify from '../../lockfile/stringify.js';
 import * as PackageReference from '../../package-reference.js';
 import PackageFetcher from '../../package-fetcher.js';
@@ -27,11 +27,6 @@ import map from '../../util/map.js';
 const invariant = require('invariant');
 const emoji = require('node-emoji');
 const path = require('path');
-
-export type InstallPrepared = {
-  requests: DependencyRequestPatterns,
-  patterns: Array<string>,
-};
 
 export type InstallCwdRequest = [
   DependencyRequestPatterns,
@@ -232,17 +227,20 @@ export class Install {
    * TODO description
    */
 
-  prepare(
+  prepareRequests(requests: DependencyRequestPatterns): DependencyRequestPatterns {
+    return requests;
+  }
+
+  preparePatterns(
     patterns: Array<string>,
-    requests: DependencyRequestPatterns,
-  ): Promise<InstallPrepared> {
-    return Promise.resolve({patterns, requests});
+  ): Array<string> {
+    return patterns;
   }
 
   async bailout(
     patterns: Array<string>,
-    match: IntegrityMatch,
   ): Promise<boolean> {
+    const match = await this.matchesIntegrityHash(patterns);
     if (!this.flags.skipIntegrity && !this.flags.force && match.matches) {
       this.reporter.success(this.reporter.lang('upToDate'));
       return true;
@@ -278,26 +276,20 @@ export class Install {
    */
 
   async init(): Promise<Array<string>> {
-    let [depRequests, rawPatterns] = await this.fetchRequestFromCwd();
-
-    const prepared = await this.prepare(rawPatterns, depRequests);
-    rawPatterns = prepared.patterns;
-    depRequests = prepared.requests;
-
     // warn if we have a shrinkwrap
     if (await fs.exists(path.join(this.config.cwd, 'npm-shrinkwrap.json'))) {
       this.reporter.error(this.reporter.lang('shrinkwrapWarning'));
     }
 
-    let patterns = rawPatterns;
+    let patterns;
     const steps: Array<(curr: number, total: number) => Promise<{bailout: boolean} | void>> = [];
+    let [depRequests, rawPatterns] = await this.fetchRequestFromCwd();
 
     steps.push(async (curr: number, total: number) => {
       this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));
-      await this.resolver.init(depRequests, this.flags.flat);
-      patterns = await this.flatten(rawPatterns);
-      const match = await this.matchesIntegrityHash(rawPatterns);
-      return {bailout: await this.bailout(rawPatterns, match)};
+      await this.resolver.init(this.prepareRequests(depRequests), this.flags.flat);
+      patterns = await this.flatten(this.preparePatterns(rawPatterns));
+      return {bailout: await this.bailout(patterns)};
     });
 
 
@@ -360,7 +352,7 @@ export class Install {
     }
 
     // fin!
-    await this.saveLockfileAndIntegrity(rawPatterns);
+    await this.saveLockfileAndIntegrity(patterns);
     this.config.requestManager.clearCache();
     return patterns;
   }
@@ -596,7 +588,7 @@ export class Install {
   generateIntegrityHash(lockfile: string, patterns: Array<string>): string {
     const opts = [lockfile];
 
-    opts.push(`patterns:${patterns.join(',')}`);
+    opts.push(`patterns:${patterns.sort(sortAlpha).join(',')}`);
 
     if (this.flags.flat) {
       opts.push('flat');

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -262,6 +262,20 @@ export default class PackageResolver {
   }
 
   /**
+   * replace pattern in resolver, e.g. `name` is replaced with `name@^1.0.1`
+   */
+  replacePattern(pattern: string, newPattern: string) {
+    const pkg = this.getResolvedPattern(pattern);
+    invariant(pkg, `missing package ${pattern}`);
+    const ref = pkg._reference;
+    invariant(ref, 'expected package reference');
+    ref.patterns = [newPattern];
+    this.newPatterns.splice(this.newPatterns.indexOf(pattern), 1, newPattern);
+    this.addPattern(newPattern, pkg);
+    this.removePattern(pattern);
+  }
+
+  /**
    * Make all versions of this package resolve to it.
    */
 


### PR DESCRIPTION
Fixes #1733

**Summary**

`add` command now generates integrity hash and has correct package.js and yarn.lock 

**Test plan**
```
bestander@DESKTOP-9BB67ID:/mnt/c/Users/besta/work/temp$ ../yarn/bin/yarn add left-pad
yarn add v0.17.0-0
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency.
└─ left-pad@1.1.3
warning No license field
Done in 0.52s.
bestander@DESKTOP-9BB67ID:/mnt/c/Users/besta/work/temp$ ../yarn/bin/yarn install
yarn install v0.17.0-0
warning No license field
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.14s.
```
