### PR TITLE
Directly add NodeSource repo in end-to-end tests, rather than using their shell script

### DIFF
--- a/end_to_end_tests/data/run-ubuntu.sh
+++ b/end_to_end_tests/data/run-ubuntu.sh
@@ -12,14 +12,17 @@ fi;
 # Add Yarn repo
 apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://nightly.yarnpkg.com/debian/ nightly main" > /etc/apt/sources.list.d/yarn.list
-apt-get update -y
 
-if [ "$DISTRIB_RELEASE" == '12.04' -o "$DISTRIB_RELEASE" == '14.04' ]; then
-  # This is an old Ubuntu version; we need to add the NodeSource repo too
-  apt-get install curl -y
-  curl -sL https://deb.nodesource.com/setup_6.x | bash -
+# Check if this is an old Ubuntu version that needs the NodeSource repo
+if [ "$DISTRIB_RELEASE" == '14.04' ]; then
+  apt-key adv --fetch-keys http://deb.nodesource.com/gpgkey/nodesource.gpg.key
+  echo 'deb http://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
+elif [ "$DISTRIB_RELEASE" == '12.04' ]; then
+  apt-key adv --fetch-keys http://deb.nodesource.com/gpgkey/nodesource.gpg.key
+  echo 'deb http://deb.nodesource.com/node_6.x precise main' > /etc/apt/sources.list.d/nodesource.list
 fi;
 
+apt-get update -y
 # TODO: Remove ca-certificates from this list once https://github.com/yarnpkg/yarn/issues/1390 is fixed
 apt-get install yarn ca-certificates -y
 


### PR DESCRIPTION
**Summary**
Old approach had a few issues:
 - It required cURL to be installed, when it's otherwise unnecessary
 - Packages can't be cached (eg. by [apt-cacher-ng](https://www.unix-ag.uni-kl.de/~bloch/acng/)) as they're being loaded over HTTPS. I'm caching the packages to speed up the test runs.

Directly adding their repo (rather than using their shell script) seems like a better idea.

**Test plan**
Tested on my computer:
```
docker run -t -v c:/src/yarn/end_to_end_tests/data:/data -w=/data -e DEBIAN_FRONTEND=noninteractive ubuntu:12.04 /data/run-ubuntu.sh
```