### PR TITLE
Remove warning about depending on packages with the same name as Node built-ins

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -29,7 +29,6 @@ const messages = {
   manifestLicenseInvalid: 'License should be a valid SPDX license expression',
   manifestLicenseNone: 'No license field',
   manifestStringExpected: '$0 is not a string',
-  manifestDependencyBuiltin: 'Dependency $0 listed in $1 is the name of a built-in module',
   manifestDependencyCollision: '$0 has dependency $1 with range $2 that collides with a dependency in $3 of the same name with version $4',
 
   configSet: 'Set $0 to $1.',

--- a/src/util/normalize-manifest/validate.js
+++ b/src/util/normalize-manifest/validate.js
@@ -111,17 +111,6 @@ export function cleanDependencies(info: Object, isRoot: boolean, reporter: Repor
     depTypes.push([type, deps]);
   }
 
-  // check root dependencies for builtin module names
-  if (isRoot) {
-    for (const [type, deps] of depTypes) {
-      for (const name in deps) {
-        if (isBuiltinModule(name)) {
-          warn(reporter.lang('manifestDependencyBuiltin', name, type));
-        }
-      }
-    }
-  }
-
   // ensure that dependencies don't have ones that can collide
   for (const [type, deps] of depTypes) {
     for (const name in deps) {


### PR DESCRIPTION
**Summary**

The reason for this is that Yarn is useful in many JS environments such as browsers and React Native, which don't provide the Node built-ins. Depending on polyfills is the right thing to do in that scenario and the reality is that people intentionally publish these polyfills under the same name as the Node built-ins (e.g. url and buffer).

Fixes #917

**Test plan**

`npm test`