### PR TITLE
Update outdated condition in upgrade-interactive

### DIFF
--- a/__tests__/cli/aliases.js
+++ b/__tests__/cli/aliases.js
@@ -26,7 +26,7 @@ test('shorthands and affordances', () => {
   expect(aliases['rm']).toBe('remove');
   expect(aliases['show']).toBe('info');
   expect(aliases['uninstall']).toBe('remove');
-  expect(aliases['udpate']).toBe('upgrade');
+  expect(aliases['update']).toBe('upgrade');
   expect(aliases['verison']).toBe('version');
   expect(aliases['view']).toBe('info');
 });

--- a/src/cli/aliases.js
+++ b/src/cli/aliases.js
@@ -28,7 +28,7 @@ export default ({
   rm: 'remove',
   show: 'info',
   uninstall: 'remove',
-  udpate: 'upgrade',
+  update: 'upgrade',
   verison: 'version',
   view: 'info',
 }: { [key: string]: ?string });

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -10,6 +10,7 @@ import {Add} from './add.js';
 import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 
+const tty = require('tty');
 const semver = require('semver');
 
 export const requireLockfile = true;
@@ -31,14 +32,16 @@ type InquirerResponses<K, T> = {[key: K]: Array<T>};
 
 // Prompt user with Inquirer
 async function prompt(choices): Promise<Array<Dependency>> {
+  let pageSize;
+  if (process.stdout instanceof tty.WriteStream) {
+    pageSize = process.stdout.rows - 2;
+  }
   const answers: InquirerResponses<'packages', Dependency> = await inquirer.prompt([{
     name: 'packages',
     type: 'checkbox',
     message: 'Choose which packages to update.',
     choices,
-    // Couldn't make it work, I guess I'm missing something here
-    // $FlowFixMe: https://github.com/facebook/flow/blob/f41e66e27b227235750792c34f5a80f38bde6320/lib/node.js#L1197
-    pageSize: process.stdout.rows - 2,
+    pageSize,
     validate: (answer) => !!answer.length || 'You must choose at least one package.',
   }]);
   return answers.packages;

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -78,15 +78,9 @@ export async function run(
 
   const isDepOld = ({latest, current}) => latest !== 'exotic' && semver.lt(current, latest);
   const isDepExpected = ({current, wanted}) => current === wanted;
+  const orderByExpected = (depA, depB) => isDepExpected(depA) && !isDepExpected(depB) ? 1 : -1;
 
-  const outdatedDeps = allDeps
-    .filter(isDepOld)
-    .sort((depA, depB) => {
-      if (isDepExpected(depA) && !isDepExpected(depB)) {
-        return 1;
-      }
-      return -1;
-    });
+  const outdatedDeps = allDeps.filter(isDepOld).sort(orderByExpected);
 
   const getNameFromHint = (hint) => hint ? `${hint}Dependencies` : 'dependencies';
 

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -10,6 +10,8 @@ import {Add} from './add.js';
 import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 
+const semver = require('semver');
+
 export const requireLockfile = true;
 
 export function setFlags(commander: Object) {
@@ -74,7 +76,7 @@ export async function run(
     return ({name, current, wanted, latest, hint});
   })));
 
-  const isDepOld = ({latest, current}) => latest !== current;
+  const isDepOld = ({latest, current}) => latest !== 'exotic' && semver.lt(current, latest);
   const isDepExpected = ({current, wanted}) => current === wanted;
 
   const outdatedDeps = allDeps


### PR DESCRIPTION
**Summary**

Incorporate changes form #1696 to #1444 

> It would display that you weren't on latest even when your version was higher than what was determined to be latest. I also added another test in regards to dependency types here since I had to make a change that could have affected those.

Also, reverted alias back to original since we are not calling it `update`.