### PR TITLE
making link command warn instead of throw an error if

### DIFF
--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -53,7 +53,7 @@ export async function run(
 
     const linkLoc = path.join(config.linkFolder, name);
     if (await fs.exists(linkLoc)) {
-      throw new MessageError(reporter.lang('linkCollision', name));
+      reporter.warn(reporter.lang('linkCollision', name));
     } else {
       await fs.mkdirp(path.dirname(linkLoc));
       await fs.symlink(config.cwd, linkLoc);


### PR DESCRIPTION
link is already registered

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes #1723 by making yarn link warn instead of throw an error if a link is already registered.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Error is thrown instead of a warning when link is registered

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
../yarn/bin/yarnpkg link
yarn link v0.17.0-0
warning There's already a module called "yarn-gh-issue-1723" registered.
✨  Done in 0.09s.
```

Some of the tests fail and I'm not really sure why. They seem unrelated and fail inconsistently. Running `npm run test` multiple times gave me different results. The test was running for nearly 10 mins too. 

Looks like the tests only failed locally.