### PR TITLE
Replace `.includes` with `.indexOf` for older Node 4 versions

### DIFF
--- a/src/cli/commands/ls.js
+++ b/src/cli/commands/ls.js
@@ -161,7 +161,7 @@ export function filterTree(tree: Tree, filters: Array<string>): boolean {
   }
 
   const notDim = tree.color !== 'dim';
-  const found = (filters.includes(tree.name.slice(0, tree.name.lastIndexOf('@'))) : boolean);
+  const found = filters.indexOf(tree.name.slice(0, tree.name.lastIndexOf('@'))) > -1;
   const hasChildren = tree.children == null ? false : tree.children.length > 0;
 
   return notDim && (found || hasChildren);


### PR DESCRIPTION
**Summary**

It was reported in https://github.com/yarnpkg/yarn/pull/1792#issuecomment-260364519 that this code did not work on Node v4.

**Test plan**

All tests still pass. Confirmed working on Node v4 here: https://github.com/yarnpkg/yarn/pull/1792#issuecomment-260369372
