### PR TITLE
limited number of cores to be used in test runner

### DIFF
--- a/__tests__/fixtures/request-cache/GET/localhost/.bin
+++ b/__tests__/fixtures/request-cache/GET/localhost/.bin
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Date: Sat, 05 Nov 2016 05:55:07 GMT
+Date: Mon, 14 Nov 2016 16:46:07 GMT
 Connection: close
 Content-Length: 2
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "check-lockfile": "./scripts/check-lockfile.sh",
     "build": "gulp build",
     "watch": "gulp watch",
-    "test-only": "jest --coverage --verbose",
+    "test-only": "jest --coverage --verbose --maxWorkers 3",
     "lint": "eslint . && flow check",
     "release-branch": "./scripts/release-branch.sh",
     "build-dist": "./scripts/build-dist.sh",


### PR DESCRIPTION
CI systems sometimes don't report number of available cores correctly.
Jest is trying to use all JS cores and this may cause too much memory to be allocated which causes a build to fail. (see tests running in ~16 threads https://2093-49970642-gh.circle-artifacts.com/0/tmp/memory-usage.txt)

**Test plan**

Locally test runtime is not slowed down any significant way
```
Test Suites: 2 skipped, 34 passed, 34 of 36 total
Tests:       19 skipped, 265 passed, 284 total
Snapshots:   50 passed, 50 total
Time:        66.623s, estimated 68s
```