### PR TITLE
Fix no choice for upgrade-interactive

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -125,31 +125,34 @@ export async function run(
       (ys, y) => ys.concat(Array.isArray(y) ? flatten(y) : y), [],
   );
 
-  const choices = Object.keys(groupedDeps).map((key) => [
+  const nestedChoices = Object.keys(groupedDeps).map((key) => [
     new inquirer.Separator(reporter.format.bold.underline.green(key)),
     groupedDeps[key],
     new inquirer.Separator(' '),
   ]);
 
-  const answers = await prompt(flatten(choices));
+  const choices = flatten(nestedChoices);
+  if (choices.length) {
+    const answers = await prompt(flatten(choices));
 
-  const getName = ({name}) => name;
-  const isHint = (x) => ({hint}) => hint === x;
+    const getName = ({name}) => name;
+    const isHint = (x) => ({hint}) => hint === x;
 
-  await [null, 'dev', 'optional', 'peer'].reduce(async (promise, hint) => {
-    // Wait for previous promise to resolve
-    await promise;
-    // Reset dependency flags
-    flags.dev = hint === 'dev';
-    flags.peer = hint === 'peer';
-    flags.optional = hint === 'optional';
+    await [null, 'dev', 'optional', 'peer'].reduce(async (promise, hint) => {
+      // Wait for previous promise to resolve
+      await promise;
+      // Reset dependency flags
+      flags.dev = hint === 'dev';
+      flags.peer = hint === 'peer';
+      flags.optional = hint === 'optional';
 
-    const deps = answers.filter(isHint(hint)).map(getName);
-    if (deps.length) {
-      reporter.info(reporter.lang('updateInstalling', getNameFromHint(hint)));
-      const add = new Add(deps, flags, config, reporter, lockfile);
-      return await add.init();
-    }
-    return Promise.resolve();
-  }, Promise.resolve());
+      const deps = answers.filter(isHint(hint)).map(getName);
+      if (deps.length) {
+        reporter.info(reporter.lang('updateInstalling', getNameFromHint(hint)));
+        const add = new Add(deps, flags, config, reporter, lockfile);
+        return await add.init();
+      }
+      return Promise.resolve();
+    }, Promise.resolve());
+  }
 }


### PR DESCRIPTION
**Summary**

Currently when there's no outdated packages. `upgrade-interactive` shows the following without any options to choose from.

```
? Choose which packages to update. (Press <space> to select, <a> to toggle all, <i> to inverse selection)
```