### PR TITLE
Add support for --exact & --tilde in upgrade-interactive

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -16,8 +16,9 @@ const semver = require('semver');
 export const requireLockfile = true;
 
 export function setFlags(commander: Object) {
-  // TODO: support some flags that install command has
-  commander.usage('update');
+  commander.usage('upgrade-interactive');
+  commander.option('-E, --exact', 'install exact version');
+  commander.option('-T, --tilde', 'install most recent release with the same minor version');
 }
 
 type Dependency = {


### PR DESCRIPTION
**Summary**

The way `upgrade-interactive` works, it already support both `--exact` & `--tilde`. So, I have just enabled them.

**Test Plan**
```
$ cat package.json
{
  "dependencies": {
    "react": "15.3.0"
  }
}
$ yarn upgrade-interactive --exact
```

**After**
```
$ cat package.json
{
  "dependencies": {
    "react": "15.3.2"
  }
}
```
---

- [ ] Add `test`