### PR TITLE
Resolve scoped package paths during linking on Windows

### DIFF
--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -1,30 +1,40 @@
 /* @flow */
 
-import path from 'path';
 import PackageHoister, {HoistManifest} from '../src/package-hoister.js';
+import type PackageResolver from '../src/package-resolver.js';
+import type PackageReference from '../src/package-reference.js';
+import type Config from '../src/config.js';
+import type {Manifest} from '../src/types.js';
 
-const mockConfig = {
-  cwd: __dirname,
-  getFolder(): string {
-    return 'node_modules';
-  },
-};
+const path = require('path');
 
 test('Produces valid destination paths for scoped modules', () => {
   const expected = path.join(__dirname, './node_modules/@scoped/dep');
   const scopedPackageName = '@scoped/dep';
 
+  const config = (({
+    cwd: __dirname,
+    getFolder(): string {
+      return 'node_modules';
+    },
+  }: any): Config);
+
+  const resolver = (({}: any): PackageResolver);
+
   const key = scopedPackageName;
   const parts = [scopedPackageName];
-  const pkg = {_reference: {}};
-  const loc = null;
-  const info = new HoistManifest(key, parts, pkg, loc);
+
+  const pkg = (({
+    _reference: (({}: any): PackageReference),
+  }: any): Manifest);
+
+  const info = new HoistManifest(key, parts, pkg, '');
 
   const tree = new Map([
     ['@scoped/dep', info],
   ]);
 
-  const packageHoister = new PackageHoister(mockConfig);
+  const packageHoister = new PackageHoister(config, resolver, false);
   packageHoister.tree = tree;
 
   const result = packageHoister.init();

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+import path from 'path';
+import PackageHoister, {HoistManifest} from '../src/package-hoister.js';
+
+const mockConfig = {
+  cwd: __dirname,
+  getFolder(): string {
+    return 'node_modules';
+  },
+};
+
+test('Produces valid destination paths for scoped modules', () => {
+  const expected = path.join(__dirname, './node_modules/@scoped/dep');
+  const scopedPackageName = '@scoped/dep';
+
+  const key = scopedPackageName;
+  const parts = [scopedPackageName];
+  const pkg = {_reference: {}};
+  const loc = null;
+  const info = new HoistManifest(key, parts, pkg, loc);
+
+  const tree = new Map([
+    ['@scoped/dep', info],
+  ]);
+
+  const packageHoister = new PackageHoister(mockConfig);
+  packageHoister.tree = tree;
+
+  const result = packageHoister.init();
+  const [actual] = result[0];
+
+  expect(actual).toEqual(expected);
+});

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -369,7 +369,7 @@ export default class PackageHoister {
         parts.unshift(this.config.cwd);
       }
 
-      const loc = parts.join(path.sep);
+      const loc = path.join(...parts);
       flatTree.push([loc, info]);
     }
 

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -349,7 +349,7 @@ export default class PackageHoister {
     for (const [key, info] of this.tree.entries()) {
       // decompress the location and push it to the flat tree. this path could be made
       // up of modules from different registries so we need to handle this specially
-      const parts = [];
+      const parts: Array<string> = [];
       const keyParts = key.split('#');
       for (let i = 0; i < keyParts.length; i++) {
         const key = keyParts.slice(0, i + 1).join('#');
@@ -363,10 +363,12 @@ export default class PackageHoister {
         // remove the first part which will be the folder name and replace it with a
         // hardcoded modules folder
         parts.shift();
-        parts.unshift(this.config.modulesFolder);
+        const modulesFolder = (this.config.modulesFolder == null) ? '' : this.config.modulesFolder;
+        parts.unshift(modulesFolder);
       } else {
         // first part will be the registry-specific module folder
-        parts.unshift(this.config.cwd);
+        const cwd = (this.config.cwd == null) ? '' : this.config.cwd;
+        parts.unshift(cwd);
       }
 
       const loc = path.join(...parts);

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -117,7 +117,7 @@ async function buildActionsForCopy(
     const {src, dest} = data;
     const onFresh = data.onFresh || noop;
     const onDone = data.onDone || noop;
-    files.add(dest);
+    files.add(path.normalize(dest));
 
     if (events.ignoreBasenames.indexOf(path.basename(src)) >= 0) {
       // ignored file
@@ -191,7 +191,7 @@ async function buildActionsForCopy(
     } else if (srcStat.isDirectory()) {
       await mkdirp(dest);
 
-      const destParts = dest.split(path.sep);
+      const destParts = path.normalize(dest).split(path.sep);
       while (destParts.length) {
         files.add(destParts.join(path.sep));
         destParts.pop();

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -117,7 +117,7 @@ async function buildActionsForCopy(
     const {src, dest} = data;
     const onFresh = data.onFresh || noop;
     const onDone = data.onDone || noop;
-    files.add(path.normalize(dest));
+    files.add(dest);
 
     if (events.ignoreBasenames.indexOf(path.basename(src)) >= 0) {
       // ignored file
@@ -191,7 +191,7 @@ async function buildActionsForCopy(
     } else if (srcStat.isDirectory()) {
       await mkdirp(dest);
 
-      const destParts = path.normalize(dest).split(path.sep);
+      const destParts = dest.split(path.sep);
       while (destParts.length) {
         files.add(destParts.join(path.sep));
         destParts.pop();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves #1861.

The above issue is Windows-specific. It's caused by the step that unlinks extraneous packages. This compares a Set `possibleExtraneous` against a Set of paths `files` resolved during bulk copy.

The problem is how paths are added to the `files` Set. yarn attempts to add all path segments to `files` by splitting the destination path on `path.sep`. This works as expected on Posix systems, where the path separator is the same as the scoped package name delimiter:

`project/node_modules/@scoped/dep/node_modules/subdep`

But on Windows, the destination path is constructed naively from the package name:

`project\\node_modules\\@scoped/dep\\node_modules\\subdep`

`possibleExtraneous`, having been resolved from reading directories on disk rather than from the `package.json` contains the correct Windows path:

`project\\node_modules\\@scoped\\dep\\node_modules\\subdep`

`possibleExtraneous` then checks to see if its members are present in `files`. Any that are are not considered extraneous. Because of the above difference in the path string, scoped subdirectories are wrongly seen as extraneous, and deleted.

**What changed**
~~It was difficult for me to tell what was intended behavior in other parts of the system, so I constrained this change to the two places that file paths are added to the non-extraneous `files` collection during the bulk copy operation. I'm calling `path.normalize` on each destination path before it's split by `path.sep`. This resolves the separator inconsistency caused by scoped package names.~~

My change now resolves the issue by normalizing the destination path returned by `PackageHoister.init`. As far as I can tell, this is only ever used as a filesystem path downstream, so this should be safe. 

**Test plan**

Automated:
The included unit test demonstrates the failing case when run on Windows with the change reverted.

Manual:
The repro steps in the linked issue demonstrate that this is resolved on Windows.

1. `yarn add` a scoped package (ex. `@cycle/http`)
2. `yarn add` any dependency of the scoped package, at an incompatible version (ex. `superagent@1.7.0`) (This prevents the subdependency of the scoped package from hoisting)
3. Run the same `yarn add` a second time

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->