### PR TITLE
reverted Nested executables #1210 to fix #1823

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -521,7 +521,8 @@ test.concurrent(
   },
 );
 
-test.concurrent('install should hoist nested bin scripts', (): Promise<void> => {
+// disabled to resolve https://github.com/yarnpkg/yarn/pull/1210
+test.skip('install should hoist nested bin scripts', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-nested-bin', async (config) => {
     const binScripts = await fs.walk(path.join(config.cwd, 'node_modules', '.bin'));
     // need to double the amount as windows makes 2 entries for each dependency

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -187,7 +187,7 @@ export default class PackageLinker {
     if (this.config.binLinks) {
       const tickBin = this.reporter.progress(flatTree.length);
       await promise.queue(flatTree, async ([dest, {pkg}]) => {
-        const binLoc = path.join(this.config.cwd, this.config.getFolder(pkg));
+        const binLoc = path.join(dest, this.config.getFolder(pkg));
         await this.linkBinDependencies(pkg, binLoc);
         tickBin(dest);
       }, 4);


### PR DESCRIPTION
Fixes #1823.
Looks like nested dependencies binaries can conflict with each other and I reverted #1210 for now.

In a fix we need to expect tests that prevent duplicate bins overwriting