### PR TITLE
Remove NodeSource repo from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ matrix:
       os: osx
 
 before_install:
-  # Repo for newer Node.js versions
-  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - ./scripts/bootstrap-env-ubuntu.sh
 
 install:


### PR DESCRIPTION
**Summary**
Removes the NodeSource repo from the TravisCI build - I don't think we need it any more

**Test plan**
Will check Travis on the PR