### PR TITLE
Fix installing from private registry.npmjs.org

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -719,6 +719,20 @@ test('install a scoped module from authed private registry with a missing traili
   });
 });
 
+test('install a private scoped module from the official npm registry', (): Promise<void> => {
+  return runInstall({noLockfile: true}, 'install-private-pkg-from-npm', async (config) => {
+    const authedRequests = request.__getAuthedRequests();
+    assert.equal(authedRequests[0].url, 'https://registry.yarnpkg.com/@types%2flodash');
+    assert.equal(authedRequests[0].headers.authorization, 'Bearer abc123');
+    assert.equal(authedRequests[1].url, 'https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.37.tgz');
+    assert.equal(authedRequests[1].headers.authorization, 'Bearer abc123');
+    assert.equal(
+      (await fs.readFile(path.join(config.cwd, 'node_modules', '@types', 'lodash', 'index.d.ts'))).split('\n')[0],
+      '// Type definitions for Lo-Dash 4.14',
+    );
+  });
+});
+
 test.concurrent('install will not overwrite files in symlinked scoped directories', async (): Promise<void> => {
   await runInstall({}, 'install-dont-overwrite-linked-scoped', async (config): Promise<void> => {
     const dependencyPath = path.join(config.cwd, 'node_modules', '@fakescope', 'fake-dependency');
@@ -778,3 +792,4 @@ test.concurrent('a subdependency of an optional dependency that fails should be 
       assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'sub-dep')));
     });
   });
+

--- a/__tests__/fixtures/install/install-private-pkg-from-npm/.npmrc
+++ b/__tests__/fixtures/install/install-private-pkg-from-npm/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=abc123
+@types:registry=https://registry.npmjs.org/

--- a/__tests__/fixtures/install/install-private-pkg-from-npm/package.json
+++ b/__tests__/fixtures/install/install-private-pkg-from-npm/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@types/lodash": "4.14.37"
+  }
+}

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -9,6 +9,10 @@ import NpmResolver from '../resolvers/registries/npm-resolver.js';
 import envReplace from '../util/env-replace.js';
 import Registry from './base-registry.js';
 import {addSuffix, removePrefix} from '../util/misc';
+import {YARN_REGISTRY} from '../constants.js';
+
+const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 
 const defaults = require('defaults');
 const userHome = require('user-home');
@@ -16,7 +20,6 @@ const path = require('path');
 const url = require('url');
 const ini = require('ini');
 
-const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 
 function getGlobalPrefix(): string {
   if (process.env.PREFIX) {
@@ -66,7 +69,7 @@ export default class NpmRegistry extends Registry {
     }
 
     return this.requestManager.request({
-      url: requestUrl,
+      url: this.cleanRegistry(requestUrl),
       method: opts.method,
       body: opts.body,
       auth: opts.auth,
@@ -201,5 +204,9 @@ export default class NpmRegistry extends Registry {
 
   getScopedOption(scope: string, option: string): mixed {
     return this.getOption(scope + (scope ? ':' : '') + option);
+  }
+
+  cleanRegistry(url: string): string {
+    return url.replace(NPM_REGISTRY, YARN_REGISTRY);
   }
 }

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -7,13 +7,10 @@ import RegistryResolver from './registry-resolver.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 import map from '../../util/map.js';
 import * as fs from '../../util/fs.js';
-import {YARN_REGISTRY} from '../../constants.js';
 
 const invariant = require('invariant');
 const path = require('path');
 const os = require('os');
-
-const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
 
 type RegistryResponse = {
   name: string,
@@ -135,14 +132,6 @@ export default class NpmResolver extends RegistryResolver {
     }
   }
 
-  cleanRegistry(url: string): string {
-    if (this.config.getOption('registry') === YARN_REGISTRY) {
-      return url.replace(NPM_REGISTRY, YARN_REGISTRY);
-    } else {
-      return url;
-    }
-  }
-
   async resolve(): Promise<Manifest> {
     // lockfile
     const shrunk = this.request.getLocked('tarball');
@@ -167,9 +156,9 @@ export default class NpmResolver extends RegistryResolver {
 
     if (dist != null && dist.tarball) {
       info._remote = {
-        resolved: `${this.cleanRegistry(dist.tarball)}#${dist.shasum}`,
+        resolved: `${dist.tarball}#${dist.shasum}`,
         type: 'tarball',
-        reference: this.cleanRegistry(dist.tarball),
+        reference: dist.tarball,
         hash: dist.shasum,
         registry: 'npm',
       };


### PR DESCRIPTION
First attempt at fixing #1895. Discussed in more detail in #1666.

The issue this tries to fix is that rewriting npmjs.org > yarnpkg.com will confuse any logic that relies on reading per registry configuration from the .npmrc file, such as reading authTokens.

I thinks this PR might affect how the lock files get generated, not sure if that's a problem.