### PR TITLE
Fix yarn pack command for scoped packages, fixes #1714

### DIFF
--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -176,7 +176,8 @@ export async function run(
     throw new MessageError(reporter.lang('noVersion'));
   }
 
-  const filename = flags.filename || path.join(config.cwd, `${pkg.name}-v${pkg.version}.tgz`);
+  const normaliseScope = (name) => name[0] === '@' ? name.substr(1).replace('/', '-') : name;
+  const filename = flags.filename || path.join(config.cwd, `${normaliseScope(pkg.name)}-v${pkg.version}.tgz`);
 
   const stream = await pack(config, config.cwd);
 


### PR DESCRIPTION
Similar to

https://github.com/npm/npm/blob/6f34aa2d366fc9f90ae0d500ef980dd6c4ce505c/lib/pack.js#L54-L55

Verified by creating `package.json` with name `@some/scope` and running `yarn pack`. This command didn't seem to have any tests yet :-"