### PR TITLE
Gracefully quit when using unsupported node version

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -4,16 +4,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 'use strict';
 
-// init roadrunner
-var mkdirp = require('mkdirp');
-var constants = require('../lib-legacy/constants');
-mkdirp.sync(constants.GLOBAL_INSTALL_DIRECTORY);
-mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
-var roadrunner = require('roadrunner');
-roadrunner.load(constants.CACHE_FILENAME);
-roadrunner.setup(constants.CACHE_FILENAME);
-
-// get node version
+// validate that used node version is supported
 var semver = require('semver');
 var ver = process.versions.node;
 ver = ver.split('-')[0]; // explode and truncate tag from version #511
@@ -32,6 +23,15 @@ if (semver.satisfies(ver, '>=5.0.0')) {
   console.log(require('chalk').red('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.'));
   process.exit(1);
 }
+
+// init roadrunner
+var mkdirp = require('mkdirp');
+var constants = require('../lib-legacy/constants');
+mkdirp.sync(constants.GLOBAL_INSTALL_DIRECTORY);
+mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
+var roadrunner = require('roadrunner');
+roadrunner.load(constants.CACHE_FILENAME);
+roadrunner.setup(constants.CACHE_FILENAME);
 
 var i = 0;
 for (; i < possibles.length; i++) {


### PR DESCRIPTION
**Summary**
Fixes #1898

**Test plan**
I couldn't find a good way to test this. I doubt that it's worth the effort of installing an old, unsupported node version only to expect that it quits gracefully.
