### PR TITLE
Ensure cache diretory exists before using roadrunner

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -8,6 +8,7 @@
 var mkdirp = require('mkdirp');
 var constants = require('../lib-legacy/constants');
 mkdirp.sync(constants.GLOBAL_INSTALL_DIRECTORY);
+mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
 var roadrunner = require('roadrunner');
 roadrunner.load(constants.CACHE_FILENAME);
 roadrunner.setup(constants.CACHE_FILENAME);

--- a/end_to_end_tests/data/run-yarn-test.sh
+++ b/end_to_end_tests/data/run-yarn-test.sh
@@ -16,4 +16,10 @@ cd /tmp
 mkdir yarntest
 cd yarntest
 echo {} > package.json
+
+# Create the cache directory and remove it
+# This simulates issue reported here: https://github.com/yarnpkg/yarn/issues/1724
+yarn --version || fail_with_log
+rm -rf ~/.cache/yarn
+
 yarn add react || fail_with_log


### PR DESCRIPTION
**Summary**

This solves #1724. Ensures that we always have the cache directory created so roadrunner can work successfully.

**Test plan**

Not sure what kind of tests to add for this. @Daniel15, anything you can think of that could be added to e2e tests for this?

I was able to reduce the error with:

```sh
$ rm -rf ~/Library/Caches/Yarn
$ yarn --version
```

