### PR TITLE
Add `--version` flag to install script

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -109,6 +109,7 @@ yarn_install() {
 
   if [ -d "$HOME/.yarn" ]; then
     if [ -n `which yarn` ]; then
+      local latest_url
       local specified_version
       local version_type
       if [ "$1" = '--nightly' ]; then

--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -11,6 +11,8 @@ yarn_get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"
   if [ "$1" = '--nightly' ]; then
     url=https://nightly.yarnpkg.com/latest.tar.gz
+  elif [ "$1" = '--version' ]; then
+    url="https://yarnpkg.com/downloads/$2/yarn-v$2.tar.gz"
   else
     url=https://yarnpkg.com/latest.tar.gz
   fi
@@ -107,16 +109,24 @@ yarn_install() {
 
   if [ -d "$HOME/.yarn" ]; then
     if [ -n `which yarn` ]; then
+      local SPECIFIED_VERSION
+      local VERSION_TYPE
       if [ "$1" = '--nightly' ]; then
         latest_url=https://nightly.yarnpkg.com/latest-tar-version
+        SPECIFIED_VERSION=`curl $latest_url`
+        VERSION_TYPE='latest'
+      elif [ "$1" = '--version' ]; then
+        SPECIFIED_VERSION=$2
+        VERSION_TYPE='specified'
       else
         latest_url=https://yarnpkg.com/latest-version
+        SPECIFIED_VERSION=`curl $latest_url`
+        VERSION_TYPE='latest'
       fi
-      LATEST_VERSION=`curl $latest_url`
       YARN_VERSION=`yarn -V`
-
-      if [ "$LATEST_VERSION" -eq "$YARN_VERSION" ]; then
-        printf "$green> Yarn is already at the latest version.$reset\n"
+      YARN_ALT_VERSION=`yarn --version`
+      if [ "$SPECIFIED_VERSION" = "$YARN_VERSION" -o "$SPECIFIED_VERSION" = "$YARN_ALT_VERSION" ]; then
+        printf "$green> Yarn is already at the $SPECIFIED_VERSION version.$reset\n"
       else
         rm -rf "$HOME/.yarn"
       fi
@@ -127,10 +137,10 @@ yarn_install() {
     fi
   fi
 
-  yarn_get_tarball $1
+  yarn_get_tarball $1 $2
   yarn_link
   yarn_reset
 }
 
 cd ~
-yarn_install $1
+yarn_install $1 $2

--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -109,24 +109,24 @@ yarn_install() {
 
   if [ -d "$HOME/.yarn" ]; then
     if [ -n `which yarn` ]; then
-      local SPECIFIED_VERSION
-      local VERSION_TYPE
+      local specified_version
+      local version_type
       if [ "$1" = '--nightly' ]; then
         latest_url=https://nightly.yarnpkg.com/latest-tar-version
-        SPECIFIED_VERSION=`curl $latest_url`
-        VERSION_TYPE='latest'
+        specified_version=`curl $latest_url`
+        version_type='latest'
       elif [ "$1" = '--version' ]; then
-        SPECIFIED_VERSION=$2
-        VERSION_TYPE='specified'
+        specified_version=$2
+        version_type='specified'
       else
         latest_url=https://yarnpkg.com/latest-version
-        SPECIFIED_VERSION=`curl $latest_url`
-        VERSION_TYPE='latest'
+        specified_version=`curl $latest_url`
+        version_type='latest'
       fi
-      YARN_VERSION=`yarn -V`
-      YARN_ALT_VERSION=`yarn --version`
-      if [ "$SPECIFIED_VERSION" = "$YARN_VERSION" -o "$SPECIFIED_VERSION" = "$YARN_ALT_VERSION" ]; then
-        printf "$green> Yarn is already at the $SPECIFIED_VERSION version.$reset\n"
+      yarn_version=`yarn -V`
+      yarn_alt_version=`yarn --version`
+      if [ "$specified_version" = "$yarn_version" -o "$specified_version" = "$yarn_alt_version" ]; then
+        printf "$green> Yarn is already at the $specified_version version.$reset\n"
       else
         rm -rf "$HOME/.yarn"
       fi


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds a --version flag to the installation script, expanding on the nightly flag added in https://github.com/yarnpkg/yarn/pull/1554. When provided, the script will download the specified build of Yarn, rather than the stable released version. It grabs them from the downloads directory as specified in https://github.com/yarnpkg/yarn/issues/1724#issuecomment-260568698 and updates the version check to reflect if the user has installed the same version (regardless of flags provided) in the user's home directory. The speed of this script is ~1 minute faster compared to using `npm` and provides an alternative to switching versions to help with https://github.com/yarnpkg/yarn/issues/1724 as well.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`./install-latest.sh` gets latest release version (`0.16.1`), `./install-latest.sh --nightly` gets latest nightly build (0.18.0-20161117.1624 right now), `./install-latest.sh --version 0.17.4` installs `0.17.4`.
