### PR TITLE
When saving build artifacts, rather than copying, save list of files to ignore

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -25,26 +25,28 @@ test.concurrent('properly find and save build artifacts', async () => {
     const cacheFolder = path.join(config.cacheFolder, 'npm-dummy-0.0.0');
     assert.deepEqual(
       (await fs.readJson(path.join(cacheFolder, constants.METADATA_FILENAME))).artifacts,
-      ['dummy.txt']
+      ['dummy', 'dummy/dummy.txt', 'dummy.txt'],
     );
 
     // retains artifact
     const moduleFolder = path.join(config.cwd, 'node_modules', 'dummy');
     assert.equal(await fs.readFile(path.join(moduleFolder, 'dummy.txt')), 'foobar');
+    assert.equal(await fs.readFile(path.join(moduleFolder, 'dummy', 'dummy.txt')), 'foobar');
   });
 });
 
 test.concurrent("removes extraneous files that aren't in module or artifacts", async () => {
-  async function check(cwd: string) {
+  async function check(cwd: string): Promise<void> {
     // retains artifact
     const moduleFolder = path.join(cwd, 'node_modules', 'dummy');
     assert.equal(await fs.readFile(path.join(moduleFolder, 'dummy.txt')), 'foobar');
+    assert.equal(await fs.readFile(path.join(moduleFolder, 'dummy', 'dummy.txt')), 'foobar');
 
     // removes extraneous
     assert.ok(!(await fs.exists(path.join(moduleFolder, 'dummy2.txt'))));
   }
 
-  async function create(cwd: string) {
+  async function create(cwd: string): Promise<void> {
     // create an extraneous file
     const moduleFolder = path.join(cwd, 'node_modules', 'dummy');
     await fs.mkdirp(moduleFolder);
@@ -644,7 +646,7 @@ if (process.platform !== 'win32') {
     return runInstall({}, 'cache-symlinks', async (config, reporter) => {
       const symlink = path.resolve(config.cwd, 'node_modules', 'dep-a', 'link-index.js');
       expect(await fs.exists(symlink)).toBe(true);
-      await fs.unlink(path.resolve(config.cwd, 'node_modules'));
+      await fs.unlink(path.join(config.cwd, 'node_modules'));
 
       const lockfile = await createLockfile(config.cwd);
       const install = new Install({}, config, reporter, lockfile);

--- a/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/install.js
+++ b/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/install.js
@@ -1,4 +1,6 @@
 var fs = require('fs');
 fs.writeFileSync('dummy.txt', 'foobar');
-fs.mkdirSync('dummy');
+if (!fs.existsSync('dummy')) {
+  fs.mkdirSync('dummy');
+}
 fs.writeFileSync('dummy/dummy.txt', 'foobar');

--- a/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/install.js
+++ b/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/install.js
@@ -1,0 +1,1 @@
+require('fs').writeFileSync('dummy.txt', 'foobar');

--- a/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/install.js
+++ b/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/install.js
@@ -1,1 +1,4 @@
-require('fs').writeFileSync('dummy.txt', 'foobar');
+var fs = require('fs');
+fs.writeFileSync('dummy.txt', 'foobar');
+fs.mkdirSync('dummy');
+fs.writeFileSync('dummy/dummy.txt', 'foobar');

--- a/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/package.json
+++ b/__tests__/fixtures/install/artifacts-finds-and-saves/dummy/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dummy",
+  "version": "0.0.0",
+  "scripts": {
+    "install": "node install.js"
+  }
+}

--- a/__tests__/fixtures/install/artifacts-finds-and-saves/package.json
+++ b/__tests__/fixtures/install/artifacts-finds-and-saves/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "dummy": "file:dummy"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,7 @@ export type ConfigOptions = {
 };
 
 type PackageMetadata = {
+  artifacts: Array<string>,
   registry: RegistryNames,
   hash: string,
   remote: ?PackageRemote,
@@ -353,6 +354,7 @@ export default class Config {
 
       return {
         package: pkg,
+        artifacts: metadata.artifacts || [],
         hash: metadata.hash,
         remote: metadata.remote,
         registry: metadata.registry,

--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -49,6 +49,7 @@ export default class BaseFetcher {
       const pkg = await this.config.readManifest(dest, this.registry);
 
       await fs.writeFile(path.join(dest, constants.METADATA_FILENAME), JSON.stringify({
+        artifacts: [],
         remote: this.remote,
         registry: this.registry,
         hash,

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -96,10 +96,6 @@ export default class PackageFetcher {
         if (res.resolved) {
           ref.remote.resolved = res.resolved;
         }
-
-        if (res.cached) {
-          ref.cached = true;
-        }
       }
 
       if (newPkg) {

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -98,11 +98,7 @@ export default class PackageInstallScripts {
     const ref = pkg._reference;
     invariant(ref, 'expected reference');
     const loc = this.config.generateHardModulePath(ref);
-    if (ref.cached) {
-      // This package is fetched directly from installed cache with build artifacts
-      // No need to rebuild
-      return;
-    }
+
     try {
       for (const [stage, cmd] of cmds) {
         await executeLifecycleScript(stage, this.config, loc, cmd, spinner);

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -56,7 +56,7 @@ export default class PackageInstallScripts {
     return mtimes;
   }
 
-  async copyBuildArtifacts(
+  async saveBuildArtifacts(
     loc: string,
     pkg: Manifest,
     beforeFiles: Map<string, number>,
@@ -72,16 +72,8 @@ export default class PackageInstallScripts {
       }
     }
 
-    // install script may have removed files, remove them from the cache too
-    const removedFiles = [];
-    for (const [file] of beforeFiles) {
-      if (!afterFiles.has(file)) {
-        removedFiles.push(file);
-      }
-    }
-
-    if (!removedFiles.length && !buildArtifacts.length) {
-      // nothing else to do here since we have no build side effects
+    if (!buildArtifacts.length) {
+      // nothing else to do here since we have no build artifacts
       return;
     }
 
@@ -89,34 +81,17 @@ export default class PackageInstallScripts {
     // the cache in a bad state. remove the metadata file and add it back once we've
     // done our copies to ensure cache integrity.
     const cachedLoc = this.config.generateHardModulePath(pkg._reference, true);
-    const cachedMetadataLoc = path.join(cachedLoc, constants.METADATA_FILENAME);
-    const cachedMetadata = await fs.readFile(cachedMetadataLoc);
-    await fs.unlink(cachedMetadataLoc);
+    const metadata = await this.config.readPackageMetadata(cachedLoc);
+    metadata.artifacts = buildArtifacts;
 
-    // remove files that install script removed
-    if (removedFiles.length) {
-      for (const file of removedFiles) {
-        await fs.unlink(path.join(cachedLoc, file));
-      }
-    }
+    const metadataLoc = path.join(cachedLoc, constants.METADATA_FILENAME);
+    await fs.writeFile(metadataLoc, JSON.stringify({
+      ...metadata,
 
-    // copy over build artifacts to cache directory
-    if (buildArtifacts.length) {
-      const copyRequests = [];
-      for (const file of buildArtifacts) {
-        copyRequests.push({
-          src: path.join(loc, file),
-          dest: path.join(cachedLoc, file),
-          onDone() {
-            spinner.tick(`Cached build artifact ${file}`);
-          },
-        });
-      }
-      await fs.copyBulk(copyRequests, {
-        possibleExtraneous: false,
-      });
-      await fs.writeFile(cachedMetadataLoc, cachedMetadata);
-    }
+      // config.readPackageMetadata also returns the package manifest but that's not in the original
+      // metadata json
+      package: undefined,
+    }, null, '  '));
   }
 
   async install(cmds: Array<[string, string]>, pkg: Manifest, spinner: ReporterSetSpinner): Promise<void> {
@@ -299,7 +274,7 @@ export default class PackageInstallScripts {
         const loc = this.config.generateHardModulePath(ref);
         const beforeFiles = beforeFilesMap.get(loc);
         invariant(beforeFiles, 'files before installation should always be recorded');
-        await this.copyBuildArtifacts(loc, pkg, beforeFiles, set.spinners[0]);
+        await this.saveBuildArtifacts(loc, pkg, beforeFiles, set.spinners[0]);
       }
     }
 

--- a/src/package-reference.js
+++ b/src/package-reference.js
@@ -44,7 +44,6 @@ export default class PackageReference {
     this.ignore = false;
     this.fresh = false;
     this.location = null;
-    this.cached = false;
     this.addRequest(request);
   }
 
@@ -59,8 +58,6 @@ export default class PackageReference {
   optional: ?boolean;
   visibility: {[action: string]: number};
   ignore: boolean;
-  // whether or not this package is fetched from cache
-  cached: boolean;
   fresh: boolean;
   dependencies: Array<string>;
   patterns: Array<string>;

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -104,7 +104,7 @@ async function buildActionsForCopy(
   }
 
   // simulate the existence of some files to prevent considering them extraenous
-  for (let file of phantomFiles) {
+  for (const file of phantomFiles) {
     possibleExtraneous.delete(file);
   }
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -68,6 +68,7 @@ type CopyOptions = {
   onStart: (num: number) => void,
   possibleExtraneous: PossibleExtraneous,
   ignoreBasenames: Array<string>,
+  phantomFiles: Array<string>,
 };
 
 async function buildActionsForCopy(
@@ -76,6 +77,7 @@ async function buildActionsForCopy(
   possibleExtraneousSeed: PossibleExtraneous,
 ): Promise<CopyActions> {
   const possibleExtraneous: Set<string> = new Set(possibleExtraneousSeed || []);
+  const phantomFiles: Set<string> = new Set(events.phantomFiles || []);
   const noExtraneous = possibleExtraneousSeed === false;
   const files: Set<string> = new Set();
 
@@ -99,6 +101,11 @@ async function buildActionsForCopy(
   while (queue.length) {
     const items = queue.splice(0, 4);
     await Promise.all(items.map(build));
+  }
+
+  // simulate the existence of some files to prevent considering them extraenous
+  for (let file of phantomFiles) {
+    possibleExtraneous.delete(file);
   }
 
   // remove all extraneous files that weren't in the tree
@@ -243,6 +250,7 @@ export async function copyBulk(
     onStart?: ?(num: number) => void,
     possibleExtraneous?: PossibleExtraneous,
     ignoreBasenames?: Array<string>,
+    phantomFiles?: Array<string>,
   },
 ): Promise<void> {
   const events: CopyOptions = {
@@ -250,6 +258,7 @@ export async function copyBulk(
     onProgress: (_events && _events.onProgress) || noop,
     possibleExtraneous: _events ? _events.possibleExtraneous : [],
     ignoreBasenames: (_events && _events.ignoreBasenames) || [],
+    phantomFiles: (_events && _events.phantomFiles) || [],
   };
 
   const actions: CopyActions = await buildActionsForCopy(queue, events, events.possibleExtraneous);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR removes the build artifact copying to our cache and instead saves a list of the build artifact files so we ignore them when considering files extraneous inside modules. We need to save this list to distinguish build artifacts (which we should keep) and other extraneous files.

If we consider build artifacts to be extraneous then it'd require running all install scripts, even if they weren't touched, on every single install which is excessively expensive.

**Test plan**

Tests were added. `$ jest`.