### PR TITLE
Fix --no-progress flag.

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -185,7 +185,7 @@ if (commander.json) {
 }
 const reporter = new Reporter({
   emoji: commander.emoji && process.stdout.isTTY && process.platform === 'darwin',
-  noProgress: commander.noProgress,
+  noProgress: !commander.progress,
 });
 reporter.initPeakMemoryCounter();
 


### PR DESCRIPTION
Fixes #1927. 

**Summary**

Original implementation #1190 used `commander.noProgress` but as per the documentation of commanderjs the flag `--no-progress` sets the value of `commander.progress`, not of `commander.noProgress`. This caused `undefined` to be passed around which would always bypass the check to see if noProgress was set. 



