### PR TITLE
fix #1684 prefer --modules-folder

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -590,19 +590,19 @@ export class Install {
     const possibleFolders = [];
     if (this.config.modulesFolder) {
       possibleFolders.push(this.config.modulesFolder);
-    }
+    } else {
+      // get a list of registry names to check existence in
+      let checkRegistryNames = this.resolver.usedRegistries;
+      if (!checkRegistryNames.length) {
+        // we haven't used any registries yet
+        checkRegistryNames = registryNames;
+      }
 
-    // get a list of registry names to check existence in
-    let checkRegistryNames = this.resolver.usedRegistries;
-    if (!checkRegistryNames.length) {
-      // we haven't used any registries yet
-      checkRegistryNames = registryNames;
-    }
-
-    // ensure we only write to a registry folder that was used
-    for (const name of checkRegistryNames) {
-      const loc = path.join(this.config.cwd, this.config.registries[name].folder);
-      possibleFolders.push(loc);
+      // ensure we only write to a registry folder that was used
+      for (const name of checkRegistryNames) {
+        const loc = path.join(this.config.cwd, this.config.registries[name].folder);
+        possibleFolders.push(loc);
+      }
     }
 
     // if we already have an integrity hash in one of these folders then use it's location otherwise use the


### PR DESCRIPTION
**Summary**

This change fixes #1684: --modules-folder does not  not work if current folder already has node_modules

**Test plan**

These commands can be used in any test repo to compare results before and after (same commands as used to bisect #1684)

`rm -rf vendor node_modules/ && node ../yarn/lib-legacy/cli/index.js install && node ../yarn/lib-legacy/cli/index.js install --modules-folder vendor && ls vendor
`
