### PR TITLE
fix todo message when url not found on hosted git

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -220,6 +220,7 @@ const messages = {
   fetchErrorCorrupt: '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  $ rm -rf $1\n  $ yarn install',
   errorDecompressingTarball: '$0. Error decompressing $1, it appears to be corrupt.',
   updateInstalling: 'Installing $0...',
+  hostedGitResolveError: 'Error connecting to repository. Please, check the url.',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -102,7 +102,7 @@ export default class HostedGitResolver extends ExoticResolver {
 
       out = lines.join('\n');
     } else {
-      throw new Error('TODO');
+      throw new Error(this.reporter.lang('hostedGitResolveError'));
     }
 
     const refs = Git.parseRefs(out);


### PR DESCRIPTION
**Summary**
When a hosted git url cannot be resolved, currently "TODO" is returned to the user. Reference #1921 

** Motivation ** 
Better error message.

