### PR TITLE
Verify GPG signature in installation script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -50,6 +50,7 @@ deployment:
     owner: yarnpkg
     commands:
       - ~/ghr/ghr --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) artifacts/
+      - curl https://nightly.yarnpkg.com/sign_releases?token=$SIGN_TOKEN
       - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - ./scripts/set-installation-method.js "`pwd`/package.json" npm
       - npm publish

--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -20,7 +20,7 @@ yarn_get_tarball() {
   fi
   # Get both the tarball and its GPG signature
   tarball_tmp=`mktemp`
-  curl -L -o "$tarball_tmp#1" "$url{,.asc}" >/dev/null
+  curl -L -o "$tarball_tmp#1" "$url{,.asc}"
   yarn_verify_integrity $tarball_tmp
 
   printf "$cyan> Extracting to ~/.yarn...$reset\n"
@@ -37,9 +37,14 @@ yarn_verify_integrity() {
     return
   )
 
+  if [ "$YARN_GPG" == "no" ]; then
+    printf "$cyan> WARNING: Skipping GPG integrity check!$reset\n"
+    return
+  fi
+
   printf "$cyan> Verifying integrity...$reset\n"
   # Grab the public key if it doesn't already exist
-  gpg --list-keys $gpg_key >/dev/null 2>&1 || (curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import)
+  gpg --list-keys $gpg_key >/dev/null 2>&1 || (curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import)
 
   if [ ! -f "$1.asc" ]; then
     printf "$red> Could not download GPG signature for this Yarn release. This means the release can not be verified!$reset\n"

--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -4,8 +4,10 @@ set -e
 reset="\e[0m"
 red="\e[0;31m"
 green="\e[0;32m"
+yellow="\e[0;33m"
 cyan="\e[0;36m"
 white="\e[0;37m"
+gpg_key=9D41F3C3
 
 yarn_get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"
@@ -16,12 +18,42 @@ yarn_get_tarball() {
   else
     url=https://yarnpkg.com/latest.tar.gz
   fi
-  curl -L -o yarn.tar.gz "$url" >/dev/null # get tarball
+  # Get both the tarball and its GPG signature
+  tarball_tmp=`mktemp`
+  curl -L -o "$tarball_tmp#1" "$url{,.asc}" >/dev/null
+  yarn_verify_integrity $tarball_tmp
 
   printf "$cyan> Extracting to ~/.yarn...$reset\n"
   mkdir .yarn
-  tar zxf yarn.tar.gz -C .yarn --strip 1 # extract tarball
-  rm -rf yarn.tar.gz # remove tarball
+  tar zxf $tarball_tmp -C .yarn --strip 1 # extract tarball
+  rm $tarball_tmp{,.asc}
+}
+
+# Verifies the GPG signature of the tarball
+yarn_verify_integrity() {
+  # Check if GPG is installed
+  command -v gpg >/dev/null 2>&1 || (
+    printf "$yellow> WARNING: GPG is not installed, integrity can not be verified!$reset\n"
+    return
+  )
+
+  printf "$cyan> Verifying integrity...$reset\n"
+  # Grab the public key if it doesn't already exist
+  gpg --list-keys $gpg_key >/dev/null 2>&1 || (curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import)
+
+  if [ ! -f "$1.asc" ]; then
+    printf "$red> Could not download GPG signature for this Yarn release. This means the release can not be verified!$reset\n"
+    yarn_verify_or_quit "> Do you really want to continue?"
+    return
+  fi
+
+  # Actually perform the verification
+  if gpg --verify "$1.asc" $1; then
+    printf "$green> GPG signature looks good$reset\n"
+  else
+    printf "$red> GPG signature for this Yarn release is invalid! This is BAD and may mean the release has been tampered with. It is strongly recommended that you report this to the Yarn developers.$reset\n"
+    yarn_verify_or_quit "> Do you really want to continue?"
+  fi
 }
 
 yarn_link() {
@@ -101,7 +133,7 @@ yarn_detect_profile() {
 }
 
 yarn_reset() {
-  unset -f yarn_install yarn_reset yarn_get_tarball yarn_link yarn_detect_profile
+  unset -f yarn_install yarn_reset yarn_get_tarball yarn_link yarn_detect_profile yarn_verify_integrity yarn_verify_or_quit
 }
 
 yarn_install() {
@@ -114,14 +146,14 @@ yarn_install() {
       local version_type
       if [ "$1" = '--nightly' ]; then
         latest_url=https://nightly.yarnpkg.com/latest-tar-version
-        specified_version=`curl $latest_url`
+        specified_version=`curl -sS $latest_url`
         version_type='latest'
       elif [ "$1" = '--version' ]; then
         specified_version=$2
         version_type='specified'
       else
         latest_url=https://yarnpkg.com/latest-version
-        specified_version=`curl $latest_url`
+        specified_version=`curl -sS $latest_url`
         version_type='latest'
       fi
       yarn_version=`yarn -V`
@@ -141,6 +173,16 @@ yarn_install() {
   yarn_get_tarball $1 $2
   yarn_link
   yarn_reset
+}
+
+yarn_verify_or_quit() {
+  read -p "$1 [y/N] " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    printf "$red> Aborting$reset\n"
+    exit 1
+  fi
 }
 
 cd ~


### PR DESCRIPTION
**Summary**
When installing Yarn via the install script, check the integrity of the tarball.

I'm using the same GPG key we use to sign the Debian repo, and have already signed the existing releases. The GPG signature sits alongside the tarball in the GitHub release, as an `.asc` file.

**Test plan**
Tested locally with various flags:
```
./install-latest.sh
./install-latest.sh --nightly
./install-latest.sh --version 0.17.6
```

```
daniel@Daniel-PC:/mnt/c/src/yarn/scripts$ ./install-latest.sh --nightly
Installing Yarn!
> Downloading tarball...

[1/2]: https://nightly.yarnpkg.com/latest.tar.gz --> /tmp/tmp.ghxlavTdks
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 3525k  100 3525k    0     0  1861k      0  0:00:01  0:00:01 --:--:-- 4231k

[2/2]: https://nightly.yarnpkg.com/latest.tar.gz.asc --> /tmp/tmp.ghxlavTdks.asc
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   801  100   801    0     0   6609      0 --:--:-- --:--:-- --:--:--  6609
> Verifying integrity...
gpg: Signature made Sat 19 Nov 2016 12:37:47 AM STD using RSA key ID FD2497F5
gpg: Good signature from "Yarn Packaging <yarn@dan.cx>"
Primary key fingerprint: 72EC F46A 56B4 AD39 C907  BBB7 1646 B01B 86E5 0310
     Subkey fingerprint: 6A01 0C51 6600 6599 AA17  F081 46C2 130D FD24 97F5
> GPG signature looks good
> Extracting to ~/.yarn...
> Adding to $PATH...
> We've added the following to your /home/daniel/.bashrc
> If this isn't the profile of your current shell then please add the following to your correct profile:

export PATH="$HOME/.yarn/bin:$PATH"

> Successfully installed Yarn 0.18.0-20161118.2135! Please open another terminal where the `yarn` command will now be available.
```

Closes #1923