### PR TITLE
Add usage section to README.me with link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@
 
 Read the [Installation Guide](https://yarnpkg.com/en/docs/install) on our website for detailed instructions on how to install Yarn.
 
+## Using Yarn
+
+Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for detailed instructions on how to use Yarn.
+
 ## Contributing to Yarn
 
 Contributions are always welcome, no matter how large or small. Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
**Summary**

Upon looking for basic usage commands I discovered that there is no mention of this in the official README.md, just an indirect link in the form of a link to the installation guide in the official documentation (where you can navigate to the usage documentation, if you know to look for it from here). I therefore propose to add a separate usage section, and/or a documentation section with url to the official documentation for further reading.

**Test plan**

N/A.