### PR TITLE
Remove optional install error logging

### DIFF
--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -109,10 +109,7 @@ export default class PackageInstallScripts {
       const ref = pkg._reference;
       invariant(ref, 'expected reference');
 
-      if (ref.optional) {
-        this.reporter.error(this.reporter.lang('optionalModuleScriptFail', err.message));
-        this.reporter.info(this.reporter.lang('optionalModuleFail'));
-      } else {
+      if (!ref.optional) {
         throw err;
       }
     }


### PR DESCRIPTION
**Summary**

When installing a project with optional dependencies, the install for those dependencies are run, and if they fail, the error message is quite overwhelming.

After some digging it looks to me like the error is harmless, but it can be very off-putting.
It also appears that the message output by this `this.reporter.info(this.reporter.lang('optionalModuleFail'));` is somehow swallowed. This would print the following to the user `This module is OPTIONAL, you can safely ignore this error` but it never happens.

The user is already informed earlier in the install process that the package is optional, and will be skipped.

```
warning fsevents@1.0.15: The platform "win32" is incompatible with this module.
info "fsevents@1.0.15" is an optional dependency and failed compatibility check. Excluding it from installation.
```

Fixes #1059

**Test plan**

Created a very simple package with an optional dependency of `fsevents`.

```json
{
  "name": "test",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "optionalDependencies": {
    "fsevents": "1.0.15"
  }
}
```

Before change:
![error](https://cloud.githubusercontent.com/assets/2027834/20459213/d38f4c6e-aeb9-11e6-9187-808c2a1099b7.PNG)

After change:
![no-error](https://cloud.githubusercontent.com/assets/2027834/20459214/d9b4b552-aeb9-11e6-8486-470699806acc.PNG)
