### PR TITLE
When tarball fetches fail, report the status code instead of "invalid…

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -215,6 +215,7 @@ const messages = {
   cantRequestOffline: 'Can\'t make a request in offline mode',
   requestManagerNotSetupHAR: 'RequestManager was not setup to capture HAR files',
   requestError: 'Request $0 returned a $1',
+  requestFailed: 'Request failed $0',
   tarballNotInNetworkOrCache: '$0: Tarball is not in network and can not be located in cache ($1)',
   fetchBadHash: 'Bad hash. Expected $0 but got $1 ',
   fetchErrorCorrupt: '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  $ rm -rf $1\n  $ yarn install',


### PR DESCRIPTION
Output before:

```
inrainbows:issue-1619 karolis$ ../../yarn/bin/yarn add appdynamics
yarn add v0.18.0-0
info No lockfile found.
[1/4] 🔍  Resolving packages...
warning appdynamics > node-uuid@1.4.7: use uuid module instead
warning appdynamics > set-immediate@0.1.1: Use `setimmediate` instead
error An unexpected error occurred: "http://packages.appdynamics.com/nodejs/4.2.9.0/appdynamics-zmq.tgz: invalid tar file".
info If you think this is a bug, please open a bug report with the information provided in "/Users/karolis/Documents/workspace/yarn-issues/issue-1619/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

Output after:

```
inrainbows:issue-1619 karolis$ ../../yarn/bin/yarn add appdynamics
yarn add v0.18.0-0
info No lockfile found.
[1/4] 🔍  Resolving packages...
warning appdynamics > node-uuid@1.4.7: use uuid module instead
warning appdynamics > set-immediate@0.1.1: Use `setimmediate` instead
error An unexpected error occurred: "http://packages.appdynamics.com/nodejs/4.2.9.0/appdynamics-zmq.tgz: Request failed \"403 Forbidden\"".
info If you think this is a bug, please open a bug report with the information provided in "/Users/karolis/Documents/workspace/yarn-issues/issue-1619/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

Now instead of saying **"invalid tar file"** we report **Request failed "403 Forbidden"**. This could help triage the incoming issues better, because "invalid tar" could be hiding a variety of issues where requests simply fail. E.g. as seen in #1619.

Some pending questions:

- [ ] is this the best way to handle failed requests, `request` docs are a bit mysterious on this
- [ ] why are the quotes escaped in the terminal for `report.lang`s...
- [ ] should we stream in the body and in case it fails to untar, try to JSON.parse it to get more details on the error?