### PR TITLE
[WIP] Validating files during publish

### DIFF
--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -4,6 +4,8 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 import {ConcatStream} from '../../util/stream.js';
+import commonDirectories from '../../util/common-dir.js';
+
 import {MessageError} from '../../errors.js';
 import {setVersion, setFlags as versionSetFlags} from './version.js';
 import * as fs from '../../util/fs.js';
@@ -33,6 +35,20 @@ async function publish(
   if (access && access !== 'public' && access !== 'restricted') {
     throw new MessageError(config.reporter.lang('invalidAccess'));
   }
+  
+  commonDirectories.map((dir) => {
+    if(pkg[dir]){
+
+      for (const file in pkg[dir]) {
+          fs.access(config.cwd + '/' + pkg[dir][file].replace('./',''), ).then((res)=>{
+            // valid files
+          }).catch((err) => {
+            config.reporter.error(`file not found: ${err.path}`);
+            process.exit(1);
+          });
+      }
+    }
+  });
 
   // get tarball stream
   const stat = await fs.lstat(dir);

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -37,15 +37,14 @@ async function publish(
   }
   
   commonDirectories.map((dir) => {
-    if(pkg[dir]){
-
+    if (pkg[dir]) {
       for (const file in pkg[dir]) {
-          fs.access(config.cwd + '/' + pkg[dir][file].replace('./',''), ).then((res)=>{
-            // valid files
-          }).catch((err) => {
-            config.reporter.error(`file not found: ${err.path}`);
-            process.exit(1);
-          });
+        fs.access(config.cwd + '/' + pkg[dir][file].replace('./', '')).then((res) => {
+          // valid files
+        }).catch((err) => {
+          config.reporter.error(`file not found: ${err.path}`);
+          process.exit(1);
+        });
       }
     }
   });

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -208,6 +208,8 @@ const messages = {
   publishPrivate: 'Package marked as private, not publishing.',
   published: 'Published.',
   publishing: 'Publishing',
+  publishFileNotFound: 'File not found: ',
+
 
   infoFail: 'Received invalid response from npm.',
   malformedRegistryResponse: 'Received malformed response from registry. The registry may be down.',

--- a/src/util/common-dir.js
+++ b/src/util/common-dir.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+export default [
+  'bin',
+  'main',
+  'modules',
+  'files',   
+];


### PR DESCRIPTION
**Summary**
Fixes #1930
This is a proof of concept of validating files upon publishing. My idea is to keep a list of common directory keys, check for their existence, and then iterate over the files pre-publish.

**Test plan**
Will add tests after 👍 

Example of an package.json with a non-existent file:

<img width="394" alt="screen shot 2016-11-26 at 8 42 34 pm" src="https://cloud.githubusercontent.com/assets/1470297/20644973/e89f39fc-b418-11e6-8b98-2b8703c0cf6d.png">



And, the results of running `yarn publish` with a non-existent file:

<img width="988" alt="screen shot 2016-11-20 at 9 54 58 pm" src="https://cloud.githubusercontent.com/assets/1470297/20469192/0ea15448-af6c-11e6-9a60-6908062d07cf.png">
