### PR TITLE
Fix .tar.gz pattern matching

### DIFF
--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -37,7 +37,7 @@ export default class TarballResolver extends ExoticResolver {
 
     // local file reference - ignore patterns with names
     if (pattern.indexOf('@') < 0) {
-      if (pattern.endsWith('.tgz') || pattern.endsWith('tar.gz')) {
+      if (pattern.endsWith('.tgz') || pattern.endsWith('.tar.gz')) {
         return true;
       }
     }


### PR DESCRIPTION
Closes #1973 
"tar.gz" actually [is a node module itself](https://www.npmjs.com/package/tar.gz)
Any real .tar.gz will have the preceding dot in the file extension.

**Test plan**

I searched for existing tests for the resolvers but couldn't find any. The tarball resolver apparently has no test at all. I think a coverage service would help to make that visible (see https://github.com/yarnpkg/yarn/issues/510). This way, people can easily start to contribute to yarn by adding tests for untested branches. I'd set this up but I'm not a member of the organisation. Can some member do it? @wyze, @torifat @kittens ?
