### PR TITLE
Add public repository hint for issue creators

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,6 +6,7 @@
 **What is the current behavior?**
 
 **If the current behavior is a bug, please provide the steps to reproduce.**
+<!-- If you can, provide a link to a public repository which contains the files necessary to reproduce this. -->
 
 **What is the expected behavior?**
 


### PR DESCRIPTION
Instead of copying snippets and creating files locally, I want to only clone a provided repository when looking into an issue.
This advice will hopefully be followed by some people and thus simplify reproducing issues.

@torifat: Can we work on a small base repository with a `Dockerfile` and a `package.json` so that people could simply fork it? I saw your comment in https://github.com/yarnpkg/yarn/issues/1903 Maybe we can chat on Discord?