### PR TITLE
Log the artifact that caused the error when a malformed request is found

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -210,7 +210,7 @@ const messages = {
   publishing: 'Publishing',
 
   infoFail: 'Received invalid response from npm.',
-  malformedRegistryResponse: 'Received malformed response from registry. The registry may be down.',
+  malformedRegistryResponse: 'Received malformed response from registry for $0. The registry may be down.',
 
   cantRequestOffline: 'Can\'t make a request in offline mode',
   requestManagerNotSetupHAR: 'RequestManager was not setup to capture HAR files',

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -26,7 +26,7 @@ export default class NpmResolver extends RegistryResolver {
 
   static async findVersionInRegistryResponse(config: Config, range: string, body: RegistryResponse): Promise<Manifest> {
     if (!body['dist-tags']) {
-      throw new MessageError(config.reporter.lang('malformedRegistryResponse'));
+      throw new MessageError(config.reporter.lang('malformedRegistryResponse', body.name));
     }
 
     if (range in body['dist-tags']) {


### PR DESCRIPTION
**Summary**

When an object downloaded from the registry doesn't have a "dist-tags" property, an error is displayed. However, it doesn't include the name of the object that caused the error, which makes it difficult to debug.

**Test plan**

No additional tests; just a text change.