### PR TITLE
Automate release of Windows installer.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,3 +37,12 @@ notifications:
       Authorization:
         secure: uH4c9HNDdRuL4omqqbTtBq3KgzjGTFmpvPdiNuk9391Z0YXRoRLA1Ptpa3seZ0Pt
     on_build_failure: false
+
+deploy:
+  - provider: Webhook
+    url: https://nightly.yarnpkg.com/release_appveyor
+    authorization:
+      secure: uH4c9HNDdRuL4omqqbTtBq3KgzjGTFmpvPdiNuk9391Z0YXRoRLA1Ptpa3seZ0Pt
+    on:
+      branch: /^.*-stable$/
+      appveyor_repo_tag: true

--- a/resources/winsetup/YarnSetup.wixproj
+++ b/resources/winsetup/YarnSetup.wixproj
@@ -79,10 +79,10 @@
     />
   </Target>
   <Target Name="AfterBuild">
-    <!-- Rename installer to yarn-[version].msi -->
+    <!-- Rename installer to yarn-[version]-unsigned.msi -->
     <Copy
       SourceFiles="$(OutputPath)\Yarn.msi"
-      DestinationFiles="$(YarnDistPath)\..\artifacts\yarn-$(YarnVersion).msi"
+      DestinationFiles="$(YarnDistPath)\..\artifacts\yarn-$(YarnVersion)-unsigned.msi"
     />
   </Target>
 </Project>


### PR DESCRIPTION
**Summary**

This automates signing the Windows installer and attaching it to the releases. Windows installers built via AppVeyor will now have an `-unsigned` suffix in their filenames, and the code that signs the installer will remove the suffix after signing it. This signing code is running on the same server that's handling hosting the nightly builds.

This might need a bit of hand-holding / monitoring for the very next release we do, to ensure that everything works as expected. cc @bestander 

Once we ensure this is working, we can automate bumping the `latest_release` config field on the website, and the release process will be fully automated! 🎉 

**Test plan**

Played around with it in my fork, manually called the webhook with a valid AppVeyor payload and ensured it worked (https://github.com/Daniel15/yarn/releases/tag/v0.18.0-0)

Closes #1977