### PR TITLE
Remove duplicate --production flag from licenses

### DIFF
--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -14,11 +14,6 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] != 'generate-disclaimer';
 }
 
-export function setFlags(commander: Object) {
-  setUsage(commander);
-  commander.option('--production', '');
-}
-
 async function getManifests(config: Config, flags: Object): Promise<Array<Manifest>> {
   const lockfile = await Lockfile.fromDirectory(config.cwd);
   const install = new Install({skipIntegrity: true, ...flags}, config, new NoopReporter(), lockfile);
@@ -52,7 +47,7 @@ async function getManifests(config: Config, flags: Object): Promise<Array<Manife
   return manifests;
 }
 
-const {setFlags: setUsage, run} = buildSubCommands('licenses', {
+export const {run, setFlags} = buildSubCommands('licenses', {
   async ls(
     config: Config,
     reporter: Reporter,
@@ -162,5 +157,3 @@ const {setFlags: setUsage, run} = buildSubCommands('licenses', {
     }
   },
 });
-
-export {run};


### PR DESCRIPTION
**Summary**

There is code currently that explicitly adds a `--production` flag option to the `licenses` command. This is unneeded and results in duplicate output of the flag when running `yarn help licenses`

**Test plan**

Running `bin\yarn.cmd licenses ls` and `bin\yarn.cmd licenses ls --production` result in the same results using the latest yarn. There currently are no tests around `licenses.js` and removing code seems like the wrong time to add them.