### PR TITLE
Fix duplication of available bin commands (#1991)

### DIFF
--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -71,8 +71,7 @@ test('lists all available commands with no arguments', (): Promise<void> => {
   return runRun({}, [], 'no-args', (config, reporter): ?Promise<void> => {
     const rprtr = new reporters.BufferReporter({stdout: null, stdin: null});
     const scripts = ['build', 'prestart', 'start'];
-    // Notice `cat-names` is below twice as there is a bug with output duplication
-    const bins = ['cat-names', 'cat-names'];
+    const bins = ['cat-names'];
 
     // Emulate run output
     rprtr.error(rprtr.lang('commandNotSpecified'));

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -30,8 +30,8 @@ export async function run(
   const pkg = await config.readManifest(config.cwd);
   const scripts = map();
   const binCommands = [];
+  const visitedBinFolders = [];
   let pkgCommands = [];
-  let visitedBinFolders = [];
   for (const registry of Object.keys(registries)) {
     const binFolder = path.join(config.cwd, config.registries[registry].folder, '.bin');
     if (!visitedBinFolders.includes(binFolder)) {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -31,13 +31,17 @@ export async function run(
   const scripts = map();
   const binCommands = [];
   let pkgCommands = [];
+  let visitedBinFolders = [];
   for (const registry of Object.keys(registries)) {
     const binFolder = path.join(config.cwd, config.registries[registry].folder, '.bin');
-    if (await fs.exists(binFolder)) {
-      for (const name of await fs.readdir(binFolder)) {
-        binCommands.push(name);
-        scripts[name] = `"${path.join(binFolder, name)}"`;
+    if (!visitedBinFolders.includes(binFolder)) {
+      if (await fs.exists(binFolder)) {
+        for (const name of await fs.readdir(binFolder)) {
+          binCommands.push(name);
+          scripts[name] = `"${path.join(binFolder, name)}"`;
+        }
       }
+      visitedBinFolders.push(binFolder);
     }
   }
   if (pkg.scripts) {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -19,7 +19,6 @@ import map from '../../util/map.js';
 
 const leven = require('leven');
 const path = require('path');
-const _ = require('lodash');
 
 export async function run(
   config: Config,
@@ -31,18 +30,18 @@ export async function run(
   const pkg = await config.readManifest(config.cwd);
   const scripts = map();
   const binCommands = [];
-  let binFolders = [];
+  const visitedBinFolders = [];
   let pkgCommands = [];
   for (const registry of Object.keys(registries)) {
-    binFolders.push(path.join(config.cwd, config.registries[registry].folder, '.bin'));
-  }
-  binFolders = _.uniq(binFolders);
-  for (const binFolder of binFolders) {
-    if (await fs.exists(binFolder)) {
-      for (const name of await fs.readdir(binFolder)) {
-        binCommands.push(name);
-        scripts[name] = `"${path.join(binFolder, name)}"`;
+    const binFolder = path.join(config.cwd, config.registries[registry].folder, '.bin');
+    if (!visitedBinFolders.includes(binFolder)) {
+      if (await fs.exists(binFolder)) {
+        for (const name of await fs.readdir(binFolder)) {
+          binCommands.push(name);
+          scripts[name] = `"${path.join(binFolder, name)}"`;
+        }
       }
+      visitedBinFolders.push(binFolder);
     }
   }
   if (pkg.scripts) {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -30,18 +30,18 @@ export async function run(
   const pkg = await config.readManifest(config.cwd);
   const scripts = map();
   const binCommands = [];
-  const visitedBinFolders = [];
+  const visitedBinFolders = new Set();
   let pkgCommands = [];
   for (const registry of Object.keys(registries)) {
     const binFolder = path.join(config.cwd, config.registries[registry].folder, '.bin');
-    if (!visitedBinFolders.includes(binFolder)) {
+    if (!visitedBinFolders.has(binFolder)) {
       if (await fs.exists(binFolder)) {
         for (const name of await fs.readdir(binFolder)) {
           binCommands.push(name);
           scripts[name] = `"${path.join(binFolder, name)}"`;
         }
       }
-      visitedBinFolders.push(binFolder);
+      visitedBinFolders.add(binFolder);
     }
   }
   if (pkg.scripts) {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -19,6 +19,7 @@ import map from '../../util/map.js';
 
 const leven = require('leven');
 const path = require('path');
+const _ = require('lodash');
 
 export async function run(
   config: Config,
@@ -30,18 +31,18 @@ export async function run(
   const pkg = await config.readManifest(config.cwd);
   const scripts = map();
   const binCommands = [];
-  const visitedBinFolders = [];
+  let binFolders = [];
   let pkgCommands = [];
   for (const registry of Object.keys(registries)) {
-    const binFolder = path.join(config.cwd, config.registries[registry].folder, '.bin');
-    if (!visitedBinFolders.includes(binFolder)) {
-      if (await fs.exists(binFolder)) {
-        for (const name of await fs.readdir(binFolder)) {
-          binCommands.push(name);
-          scripts[name] = `"${path.join(binFolder, name)}"`;
-        }
+    binFolders.push(path.join(config.cwd, config.registries[registry].folder, '.bin'));
+  }
+  binFolders = _.uniq(binFolders);
+  for (const binFolder of binFolders) {
+    if (await fs.exists(binFolder)) {
+      for (const name of await fs.readdir(binFolder)) {
+        binCommands.push(name);
+        scripts[name] = `"${path.join(binFolder, name)}"`;
       }
-      visitedBinFolders.push(binFolder);
     }
   }
   if (pkg.scripts) {


### PR DESCRIPTION
**Summary**

This PR solves https://github.com/yarnpkg/yarn/issues/1991.

**Test plan**

I've modified `__tests__/commands/run.js` to reflect the fixed behavior.

Also, I ran all test suites:

```
Test Suites: 1 skipped, 36 passed, 36 of 37 total
Tests:       18 skipped, 279 passed, 297 total
Snapshots:   50 passed, 50 total
Time:        28.826s
Ran all test suites.
```