### PR TITLE
Don't output header and footer when json flag is passed

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -197,6 +197,9 @@ let outputWrapper = true;
 if (typeof command.hasWrapper === 'function') {
   outputWrapper = command.hasWrapper(commander, commander.args);
 }
+if (commander.json) {
+  outputWrapper = false;
+}
 if (outputWrapper) {
   reporter.header(commandName, pkg);
 }


### PR DESCRIPTION
This reduces some CLI noise when using the `--json` flag.