### PR TITLE
Fix yarn check --integrity behavior not aligning with yarn install's integrity checking

### DIFF
--- a/__tests__/commands/install.js
+++ b/__tests__/commands/install.js
@@ -213,6 +213,13 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 1', (): P
   });
 });
 
+test.concurrent('check and install should verify integrity in the same way when flat', (): Promise<void> => {
+  return runInstall({flat: true}, 'install-should-dedupe-avoiding-conflicts-1', async (config, reporter) => {
+    // Will raise if check doesn't flatten the patterns
+    await check(config, reporter, {flat: true, integrity: true}, []);
+  });
+});
+
 test.concurrent('install should dedupe dependencies avoiding conflicts 2', (): Promise<void> => {
   // A@2 -> B@2 -> C@2
   //            -> D@1

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -41,9 +41,10 @@ export async function run(
 
   // get patterns that are installed when running `yarn install`
   const [, rawPatterns] = await install.hydrate(true);
+  const patterns = await install.flatten(rawPatterns);
 
   // check if patterns exist in lockfile
-  for (const pattern of rawPatterns) {
+  for (const pattern of patterns) {
     if (!lockfile.getLocked(pattern)) {
       reportError(`Lockfile does not contain pattern: ${pattern}`);
     }
@@ -54,7 +55,7 @@ export async function run(
     const integrityLoc = await install.getIntegrityHashLocation();
 
     if (integrityLoc && await fs.exists(integrityLoc)) {
-      const match = await install.matchesIntegrityHash(rawPatterns);
+      const match = await install.matchesIntegrityHash(patterns);
       if (match.matches === false) {
         reportError(`Integrity hashes don't match, expected ${match.expected} but got ${match.actual}`);
       }
@@ -63,7 +64,7 @@ export async function run(
     }
   } else {
     // check if any of the node_modules are out of sync
-    const res = await install.linker.getFlatHoistedTree(rawPatterns);
+    const res = await install.linker.getFlatHoistedTree(patterns);
     for (const [loc, {originalKey, pkg}] of res) {
       const parts = humaniseLocation(loc);
 


### PR DESCRIPTION
**Summary**

There's a mismatch between what `yarn install` does for integrity checking and what `yarn check` does. `yarn check` [flattens the patterns](https://github.com/yarnpkg/yarn/blob/099e76dc075763427605a6a63906127402370bb2/src/cli/commands/install.js#L342), while `yarn check` doesn't, as it just uses Install.hydrate (which doesn't return the patterns flattened)

We ran into some issues where `yarn install` would say everything was file while `yarn check --integrity` would say there's a mismatch. This patch fixes it
