### PR TITLE
Fix mktemp usage on Mac OS, and handling of environments where GPG is not available

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -19,7 +19,7 @@ yarn_get_tarball() {
     url=https://yarnpkg.com/latest.tar.gz
   fi
   # Get both the tarball and its GPG signature
-  tarball_tmp=`mktemp`
+  tarball_tmp=`mktemp -t yarn.XXXXXXXXXX.tar.gz`
   curl -L -o "$tarball_tmp#1" "$url{,.asc}"
   yarn_verify_integrity $tarball_tmp
 
@@ -32,10 +32,10 @@ yarn_get_tarball() {
 # Verifies the GPG signature of the tarball
 yarn_verify_integrity() {
   # Check if GPG is installed
-  command -v gpg >/dev/null 2>&1 || (
+  if [[ -z "$(command -v gpg)" ]]; then
     printf "$yellow> WARNING: GPG is not installed, integrity can not be verified!$reset\n"
     return
-  )
+  fi
 
   if [ "$YARN_GPG" == "no" ]; then
     printf "$cyan> WARNING: Skipping GPG integrity check!$reset\n"


### PR DESCRIPTION
**Summary**
Fixes two issues with the install script:
 - Old versions of Mac OS (10.10 and below) require the `-t` option for `mktemp`
 - The check for GPG wasn't returning correctly, and tried to run GPG even when not available

**Test plan**
`mv /usr/bin/gpg /usr/bin/gpg-old` and run install script. Ensure output looks like:
```
> WARNING: GPG is not installed, integrity can not be verified!
> Extracting to ~/.yarn...
> Adding to $PATH...
```

Move `/usr/bin/gpg-old` back to `/usr/bin/gpg`, ensure GPG is ran:
```
> Verifying integrity...
gpg: Signature made Mon 21 Nov 2016 10:18:40 PM STD using RSA key ID FD2497F5
gpg: Good signature from "Yarn Packaging <yarn@dan.cx>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 72EC F46A 56B4 AD39 C907  BBB7 1646 B01B 86E5 0310
     Subkey fingerprint: 6A01 0C51 6600 6599 AA17  F081 46C2 130D FD24 97F5
> GPG signature looks good
> Extracting to ~/.yarn...
```

Unfortunately I don't have any Mac OS 10.10 machines available to test it out, but I think this will work as expected.

cc @BanzaiMan 

Closes #2012
Closes #1984