### PR TITLE
Update package sourc to link to Chocolatey package

### DIFF
--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -27,7 +27,7 @@ fetching in parallel. This ensures little idle time and maximum resource
 utilization.
 		</description>
 		<projectUrl>https://yarnpkg.com/</projectUrl>
-		<packageSourceUrl>https://github.com/yarnpkg/yarn</packageSourceUrl>
+		<packageSourceUrl>https://github.com/yarnpkg/yarn/tree/master/resources/win-chocolatey</packageSourceUrl>
 		<projectSourceUrl>https://github.com/yarnpkg/yarn</projectSourceUrl>
 		<licenseUrl>https://github.com/yarnpkg/yarn/raw/master/LICENSE</licenseUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
**Summary**

Update the `PackageSource` for the Chocolatey package to link directly to the Chocolatey Package inside the repository. Since `ProjectSource` already links to the Repo direct linking to the nuspec is more helpful for users on Chocolatey.

**Test plan**

Run `build-chocolatey.ps1` and tested on local Chocolatey feed.

