### PR TITLE
Use commit hash for icon url

### DIFF
--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -31,7 +31,7 @@ utilization.
 		<projectSourceUrl>https://github.com/yarnpkg/yarn</projectSourceUrl>
 		<licenseUrl>https://github.com/yarnpkg/yarn/raw/master/LICENSE</licenseUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<iconUrl>https://cdn.rawgit.com/yarnpkg/assets/master/yarn-kitten-circle.png</iconUrl>
+		<iconUrl>https://cdn.rawgit.com/yarnpkg/assets/b28fd5a09430a7b7701dbebe1765fe166c389cc6/yarn-kitten-circle.png</iconUrl>
 		<docsUrl>https://yarnpkg.com/en/docs/</docsUrl>
 		<bugTrackerUrl>https://github.com/yarnpkg/yarn/issues</bugTrackerUrl>
 


### PR DESCRIPTION
**Summary**

Use commit hash for linking to the icon in the Chocolatey package. This solves the issue that the Chocolatey package still has a valid icon, even if the file is renamed or moved once (on the downside the hash needs to be updated if icon is changed).

**Test plan**

Ran `build-chocolatey.ps1` and tested on local Chocolatey feed.

