### PR TITLE
Update build script so that it can be run from any directory

### DIFF
--- a/scripts/build-chocolatey.ps1
+++ b/scripts/build-chocolatey.ps1
@@ -33,12 +33,12 @@ Invoke-WebRequest -Uri $url -OutFile $installer_file
 $hash = (Get-FileHash -Path $installer_file -Algorithm SHA256).Hash
 
 # Replace placeholders in chocolateyInstall.ps1
-(Get-Content .\resources\win-chocolatey\tools\chocolateyinstall.ps1.in) `
+(Get-Content $PSScriptRoot\..\resources\win-chocolatey\tools\chocolateyinstall.ps1.in) `
   -replace '{VERSION}', $latest_version `
   -replace '{CHECKSUM}', $hash | 
-  Set-Content .\resources\win-chocolatey\tools\chocolateyinstall.ps1
+  Set-Content $PSScriptRoot\..\resources\win-chocolatey\tools\chocolateyinstall.ps1
   
-choco pack .\resources\win-chocolatey\yarn.nuspec --version $latest_version
+choco pack $PSScriptRoot\..\resources\win-chocolatey\yarn.nuspec --version $latest_version
 mv *.nupkg artifacts
 
 if (!$Publish) {


### PR DESCRIPTION
**Summary**

Updates the `build-chocolatey.ps1` package so that it can be run from any directory and not only from the root directory.

**Test plan**

Ran `build-chocolatey.ps1` from root and scripts directory
