### PR TITLE
Allow 'production' ENV to take precedence over NODE_ENV

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -403,6 +403,20 @@ test('install should respect NODE_ENV=production', (): Promise<void> => {
   });
 });
 
+// don't run this test in `concurrent`, it will affect other tests
+test('install should respect NPM_CONFIG_PRODUCTION=false over NODE_ENV=production', (): Promise<void> => {
+  const env = process.env.NODE_ENV;
+  const prod = process.env.NPM_CONFIG_PRODUCTION;
+  process.env.NODE_ENV = 'production';
+  process.env.NPM_CONFIG_PRODUCTION = 'false';
+  return runInstall({}, 'install-should-respect-npm_config_production', async (config) => {
+    expect(await fs.exists(path.join(config.cwd, 'node_modules/is-negative-zero/package.json'))).toBe(true);
+    // restore env
+    process.env.NODE_ENV = env;
+    process.env.NPM_CONFIG_PRODUCTION = prod;
+  });
+});
+
 test.concurrent('install should resolve circular dependencies 2', (): Promise<void> => {
   return runInstall({}, 'install-should-circumvent-circular-dependencies-2', async (config, reporter) => {
     assert.equal(

--- a/__tests__/fixtures/install/install-should-respect-npm_config_production/package.json
+++ b/__tests__/fixtures/install/install-should-respect-npm_config_production/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "left-pad": "1.0.0"
+  },
+  "devDependencies": {
+    "is-negative-zero": "1.0.0"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -210,7 +210,10 @@ export default class Config {
     await fs.mkdirp(this.cacheFolder);
     await fs.mkdirp(this.tempFolder);
 
-    if (this.getOption('production') || process.env.NODE_ENV === 'production') {
+    if (this.getOption('production') || (
+        process.env.NODE_ENV === 'production' &&
+        process.env.NPM_CONFIG_PRODUCTION !== 'false' &&
+        process.env.YARN_PRODUCTION !== 'false')) {
       this.production = true;
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

This fixes #1975.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The motivation is to fix the compatibility issue so that Yarn can be used in place of npm on Heroku ([related buildpack issue](https://github.com/heroku/heroku-buildpack-nodejs/issues/337)). In this case, when you need to install devDependencies, [as documented here](https://devcenter.heroku.com/articles/nodejs-support#devdependencies).

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

A test is included.

(I also tested locally on my setup and observed that the devDependencies were indeed installed to `node_modules` when both `NODE_ENV=production` and `NPM_CONFIG_PRODUCTION=false` were set.)
