### PR TITLE
Fix `which` check during yarn install (#2061)

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -145,7 +145,7 @@ yarn_install() {
   printf "${white}Installing Yarn!$reset\n"
 
   if [ -d "$HOME/.yarn" ]; then
-    if [ -n `which yarn` ]; then
+    if which yarn; then
       local latest_url
       local specified_version
       local version_type
@@ -169,8 +169,8 @@ yarn_install() {
         rm -rf "$HOME/.yarn"
       fi
     else
-      printf "$red> ~/.yarn already exists, possibly from a past Yarn install.$reset\n"
-      printf "$red> Remove it (rm -rf ~/.yarn) and run this script again.$reset\n"
+      printf "$red> $HOME/.yarn already exists, possibly from a past Yarn install.$reset\n"
+      printf "$red> Remove it (rm -rf $HOME/.yarn) and run this script again.$reset\n"
       exit 0
     fi
   fi


### PR DESCRIPTION
**Summary**

This PR fixes #2061. Since the `if` construct by design [tests the exit value of commands](http://mywiki.wooledge.org/BashPitfalls?highlight=%28is+a+command%29#if_.5Bgrep_foo_myfile.5D), it’s better to test the `which yarn` command directly.

**Test plan**

```
rm -rf ~/.yarn
mkdir ~/.yarn
./scripts/install-latest.sh
```