### PR TITLE
Add hash to cache path for non-NPM packages

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -12,6 +12,9 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 const path = require('path');
 
+// regexp which verifies that cache path contains semver + hash
+const cachePathRe = /-\d+\.\d+\.\d+-[\dabcdef]{40}$/;
+
 function addTest(pattern, registry = 'npm') {
   // concurrently network requests tend to stall
   test(`resolve ${pattern}`, async () => {
@@ -30,6 +33,11 @@ function addTest(pattern, registry = 'npm') {
     });
     const resolver = new PackageResolver(config, lockfile);
     await resolver.init([{pattern, registry}]);
+
+    const ref = resolver.getPackageReferences()[0];
+    const cachePath = config.generateHardModulePath(ref, true);
+    expect(cachePath).toMatch(cachePathRe);
+
     await reporter.close();
   });
 }

--- a/src/config.js
+++ b/src/config.js
@@ -295,11 +295,14 @@ export default class Config {
     let uid = pkg.uid;
     if (pkg.registry) {
       name = `${pkg.registry}-${name}`;
-      uid = pkg.version || uid;
     }
 
     const {hash} = pkg.remote;
-    if (hash) {
+
+    if (pkg.version && (pkg.version !== pkg.uid)) {
+      uid = `${pkg.version}-${uid}`;
+
+    } else if (hash) {
       uid += `-${hash}`;
     }
 


### PR DESCRIPTION
**Summary**

Currently, only packages resolved to NPM registry have their hash appended to cache directory name. Other packages, such as those with GitHub URL, get cached by their `name` + `version` rather than actual content. This leads to a bug where even if you update the GitHub url in `package.json` (e.g. different GitHub commit hash), it is never updated on `yarn install` unless you clean the cached folders for the package along with `node_modules`. This is a huge pain for teams that depend on GitHub urls in dependencies.

Should address #1171, #1893, #1087, #1280, #1278, #1017 #1573 #2280. I'm not sure it fully fixes all the mentioned issues, so it's a work in progress in need of a discussion and thorough testing, but it should be a step in the right direction.

**Test plan**

This is my first dive into Yarn codebase and I haven't yet figured out a way to test this — currently `npm test` fails for me locally on `master` with "process exited unexpectedly error" in `commands/remove.js` without much detail.

cc @kittens @jfirebaugh @jordanburke @ronag @wmertens @tamird @mgutz @panrafal @omnidan