### PR TITLE
Fix scripts cmd slashes for windows

### DIFF
--- a/__tests__/util/fix-cmd-win-slashes.js
+++ b/__tests__/util/fix-cmd-win-slashes.js
@@ -1,0 +1,60 @@
+/* @flow */
+import {fixCmdWinSlashes} from '../../src/util/fix-cmd-win-slashes.js';
+
+const cmdCases = [
+  [
+    'fixes just slashed command',
+    'some/command',
+    'some\\command',
+  ],
+  [
+    'fixes slashed command in double quotes',
+    '"./some/command/more"',
+    '".\\some\\command\\more"',
+  ],
+  [
+    'slashed command in single quotes',
+    '\'./some/command/more\'',
+    '\'.\\some\\command\\more\'',
+  ],
+  [
+    'fixes slashed command with slashed param',
+    './some/command/more slashed/param',
+    '.\\some\\command\\more slashed/param',
+  ],
+  [
+    'fixes slashed command in single quotes with two slashed params',
+    '\'./some/command/more\' justparam slashed/param --param slashed/param2',
+    '\'.\\some\\command\\more\' justparam slashed/param --param slashed/param2',
+  ],
+  [
+    'fixes two slashed commands (&&) with two slashed params',
+    '\'./some/command/more\' justparam slashed/param &&  ../another/command with/slashed/param',
+    '\'.\\some\\command\\more\' justparam slashed/param &&  ..\\another\\command with/slashed/param',
+  ],
+  [
+    'fixes three slashed commands (&&) with two slashed params',
+    '\'./some/command/more\' justparam slashed/param &&' + 
+      '  "../another/command" with/slashed/param | ./another/more/command with/slashed/param',
+    '\'.\\some\\command\\more\' justparam slashed/param &&' + 
+      '  "..\\another\\command" with/slashed/param | .\\another\\more\\command with/slashed/param',
+  ],
+  [
+    'does not change nested command (inside the quotes)',
+    'command -c bash \"slashed/nested/cmd && nested/bin/some\"',
+    'command -c bash \"slashed/nested/cmd && nested/bin/some\"',
+  ],
+];
+
+describe('fixCmdWinSlashes', () => {
+  cmdCases.forEach((cmdCase) => {
+    const name = cmdCase[0];
+    const original = cmdCase[1];
+    const fixed = cmdCase[2];
+    it(name, () => {
+      expect(fixCmdWinSlashes(original)).toEqual(fixed);
+    });        
+  });   
+});
+
+

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -16,6 +16,7 @@ import {MessageError} from '../../errors.js';
 import {registries} from '../../resolvers/index.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
+import {fixCmdWinSlashes} from '../../util/fix-cmd-win-slashes.js';
 
 const leven = require('leven');
 const path = require('path');
@@ -55,7 +56,8 @@ export async function run(
     for (const action of actions) {
       const cmd = scripts[action];
       if (cmd) {
-        cmds.push([action, cmd]);
+        const isWin = /win/.test(process.platform);
+        cmds.push([action, isWin ? fixCmdWinSlashes(cmd) : cmd]);
       }
     }
 

--- a/src/util/fix-cmd-win-slashes.js
+++ b/src/util/fix-cmd-win-slashes.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+export function fixCmdWinSlashes(cmd: string): string {
+  function findQuotes(quoteSymbol: string): {from: number, to: number}[] {
+    const quotes = [];
+    const addQuote = (_, index) => {
+      quotes.push({from: index, to: index + _.length});
+      return _;
+    };
+    const regEx = new RegExp(quoteSymbol + '.*' + quoteSymbol);    
+    cmd.replace(regEx, addQuote);
+    return quotes;
+  }
+  const quotes = findQuotes('"').concat(findQuotes('\''));
+
+  function isInsideQuotes(index: number): boolean {    
+    return quotes.reduce((result, quote) => {
+      return result || (quote.from <= index && index <= quote.to);
+    }, false);
+  }
+
+  const cmdPrePattern = '((?:^|&&|&|\\|\\||\\|)\\s*)';
+  const cmdPattern = '(".*?"|\'.*?\'|\\S*)';
+  const regExp = new RegExp(`${cmdPrePattern}${cmdPattern}`, 'g');
+  return cmd.replace(regExp, (whole, pre, cmd, index) => {
+    if ((pre[0] === '&' || pre[0] === '|') && isInsideQuotes(index)) {
+      return whole;
+    }
+    return pre + cmd.replace(/\//g, '\\');
+  });
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This address the issue https://github.com/yarnpkg/yarn/issues/1729 which as about that on windows yarn fails to execute scripts that contain commands with unix-style slashes, for example this will fail on windows:
```json
"scripts": {
  "compile": "../node_modules/.bin/tsc"
}
```

So to run such script on windows machine successfully we need to replace slashes from `/` to `\`, 

```json
  "compile": "..\\node_modules\\.bin\\tsc"
```

For we need to find all the executable commands in the script line, so we assume that exec commands that need to be fixed:
- Are located in the beginning of the line
- Or located after symbols: `&&` or `&` or `||` or `|`
- `&&` or `&` or `||` or `|` symbols after which command go may not be inside the quotes. In opposite case this will mean that it is inside the nested command like:
	`docker run container bash -c "cat some.thing | some/bin/here"`
- Can be inside of single or double quotes (may contain spaces)
- Can be without quotes (no spaces)
- In the substrings that satisfies upper criteria all backslashes `/` are replaced with windows slashes `\`

**Test plan**

Added test that check correct transformation for different command cases.

So this need some triage and opinions.