### PR TITLE
Fixes race condition on yarn install mutex network

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -277,7 +277,8 @@ const runEventuallyWithNetwork = (mutexPort: ?string): Promise<void> => {
 
       socket
         .on('connect', () => {
-          socket.unref(); // let it die
+          // Allow the program to exit if this is the only active server in the event system.
+          socket.unref();
         })
         .on('close', (hadError?: boolean) => {
           // the `close` event gets always called after the `error` event

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -268,26 +268,27 @@ const runEventuallyWithNetwork = (mutexPort: ?string): Promise<void> => {
       port: +mutexPort || constants.SINGLE_INSTANCE_PORT,
     };
 
-    const clients = [];
-    const server = net.createServer((client: net$Socket) => {
-      clients.push(client);
-    });
+    const server = net.createServer();
 
     server.on('error', () => {
-      // another yarnn instance exists, let's connect to it to know when it dies.
+      // another Yarn instance exists, let's connect to it to know when it dies.
       reporter.warn(reporter.lang('waitingInstance'));
       const socket = net.createConnection(connectionOptions);
 
       socket
-        .on('data', () => {
-          // the server has informed us he's going to die soon™.
+        .on('connect', () => {
           socket.unref(); // let it die
-          process.nextTick(() => {
-            ok(runEventuallyWithNetwork(mutexPort));
-          });
+        })
+        .on('close', (hadError?: boolean) => {
+          // the `close` event gets always called after the `error` event
+          if (!hadError) {
+            process.nextTick(() => {
+              ok(runEventuallyWithNetwork(mutexPort));
+            });
+          }
         })
         .on('error', () => {
-          // No server to listen to ? :O let's retry to become the next server then.
+          // No server to listen to ? Let's retry to become the next server then.
           process.nextTick(() => {
             ok(runEventuallyWithNetwork(mutexPort));
           });
@@ -295,9 +296,6 @@ const runEventuallyWithNetwork = (mutexPort: ?string): Promise<void> => {
     });
 
     const onServerEnd = (): Promise<void> => {
-      clients.forEach((client) => {
-        client.write('closing. kthanx, bye.');
-      });
       server.close();
       return Promise.resolve();
     };
@@ -385,7 +383,7 @@ config.init({
   }
 }).catch((err: Error) => {
   reporter.verbose(err.stack);
-  
+
   if (err instanceof MessageError) {
     reporter.error(err.message);
   } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes a race condition we observed in production, to easily reproduce it, I changed the code in `onServerEnd` to wait any amount of time before resolving:
```js
const onServerEnd = (): Promise<void> => {
  clients.forEach((client) => {
    client.write('closing. kthanx, bye.');
  });
  return new Promise(ok => {
    setTimeout( () => {
      server.close();
      ok();
    }, 20);
  }
};
```

This change makes it easier to spot the issue
**Test plan**
run:
```
./bin/yarn install --mutex network& ./bin/yarn install --mutex network&./bin/yarn install --mutex network&
```

IIRC The original code was written like that because I observed some issue in relying on the `close` event on my original implementation that was using a unix socket.
Since then I changed the strategy and we use the network.
I cannot recreate the problem observed with this implementation.
I believe using the correct events is also much cleaner :)
