### PR TITLE
Add try/catch when writing yarn-error.log

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -339,7 +339,9 @@ function onUnexpectedError(err: Error) {
   log.push(`Trace: ${indent(err.stack)}`);
 
   const errorLoc = path.join(config.cwd, 'yarn-error.log');
-  fs.writeFileSync(errorLoc, log.join('\n\n') + '\n');
+  try {
+    fs.writeFileSync(errorLoc, log.join('\n\n') + '\n');
+  } catch (err) {}
 
   reporter.error(reporter.lang('unexpectedError', err.message));
   reporter.info(reporter.lang('bugReport', errorLoc));

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -341,10 +341,16 @@ function onUnexpectedError(err: Error) {
   const errorLoc = path.join(config.cwd, 'yarn-error.log');
   try {
     fs.writeFileSync(errorLoc, log.join('\n\n') + '\n');
-  } catch (err) {}
 
-  reporter.error(reporter.lang('unexpectedError', err.message));
-  reporter.info(reporter.lang('bugReport', errorLoc));
+    reporter.error(reporter.lang('unexpectedError', err.message));
+    reporter.info(reporter.lang('bugReport', errorLoc));
+  } catch (err) {
+    if (err.code === 'EACCES') {
+      reporter.error(reporter.lang('noFilePermission', err.path));
+    } else {
+      console.error(err);
+    }
+  }
 }
 
 //


### PR DESCRIPTION
**Summary**
If yarn is lacking write access, the `fs.writeFileSync()` method throws an
uncaught exception that blocks further execution.

Simply catching it and allowing further exection provides desired behaviour by
giving the user feedback and having yarn terminate.

**Test plan**
```bash
mkdir -m 500 bar && cd bar
yarn init -y
```
now results in 
```bash
node@062ea1ba7c46:~/bar$ /yarn/bin/yarn init -y
yarn init v0.18.0-0
warning The yes flag has been set. This will automatically answer yes to all questions which may have security implications.
success Saved package.json
error An unexpected error occurred: "EACCES: permission denied, open '/home/node/bar/package.json'".
info If you think this is a bug, please open a bug report with the information provided in "/home/node/bar/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/init for documentation about this command.
```
Previously it just kept hanging forever.

Fixes #2094