### PR TITLE
Use regex rather than Convert[To|From]-Json to update installation method

### DIFF
--- a/resources/win-chocolatey/tools/chocolateyinstall.ps1.in
+++ b/resources/win-chocolatey/tools/chocolateyinstall.ps1.in
@@ -21,8 +21,8 @@ if (Test-Path "${env:ProgramFiles(x86)}\Yarn\package.json") {
   $path = "$env:ProgramFiles\Yarn\package.json"
 }
 $script = @"
-  `$package_manifest = Get-Content -Path '$path' | ConvertFrom-Json
-  `$package_manifest.installationMethod = 'choco'
-  ConvertTo-Json -InputObject `$package_manifest | Set-Content -Path '$path'
+  (Get-Content -Path '$path') ``
+    -replace 'installationMethod":.+', 'installationMethod": "choco",' ``
+    | Set-Content '$path'
 "@
 Start-ChocolateyProcessAsAdmin -Statements $script


### PR DESCRIPTION
**Summary**
Updates the build script of the Chocolatey package to just use a regular expression to update the installation method in `package.json`, rather than using `ConvertFrom-Json`. We were encountering odd issues with the JSON parsing, and it's not available in older PowerShell versions.

**Test plan**
Pushed an updated Yarn package, it passed verification: https://chocolatey.org/packages/yarn

Closes #2065