### PR TITLE
Fix AppVeyor deployment webhook

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 branches:
   only:
   - master
-  - /.*-stable/
+  - /v[0-9]+(\.[0-9]+)*/
 
 install:
   - ps: Install-Product node $env:node_version
@@ -44,5 +44,5 @@ deploy:
     authorization:
       secure: uH4c9HNDdRuL4omqqbTtBq3KgzjGTFmpvPdiNuk9391Z0YXRoRLA1Ptpa3seZ0Pt
     on:
-      branch: /^.*-stable$/
+      branch: /v[0-9]+(\.[0-9]+)*/
       appveyor_repo_tag: true


### PR DESCRIPTION
**Summary**
Fixes the AppVeyor deployment webhook. AppVeyor wasn't actually building the tags, it was just building the stable branch. This meant that the deployment script wasn't actually running, as `appveyor_repo_tag` was never `true`.

We don't want to deploy **every** individual commit to the stable branch, we only want to deploy tags. I've switched the branch list to only build master and tags (instead of master and stable branches), and updated the deployment webhook to be called for tags.

**Test plan**
Tested something similar on my fork: https://ci.appveyor.com/project/Daniel15/yarn/build/job/dpyvcc0p88ss9se6