### PR TITLE
Match CircleCI badge visually to the other badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://travis-ci.org/yarnpkg/yarn"><img alt="Travis Status" src="https://travis-ci.org/yarnpkg/yarn.svg"></a>
-  <a href="https://circleci.com/gh/yarnpkg/yarn"><img alt="Circle Status" src="https://circleci.com/gh/yarnpkg/yarn.svg?style=svg&circle-token=5f0a78473b0f440afb218bf2b82323cc6b3cb43f"></a>
+  <a href="https://circleci.com/gh/yarnpkg/yarn"><img alt="Circle Status" src="https://circleci.com/gh/yarnpkg/yarn.svg?style=shield&circle-token=5f0a78473b0f440afb218bf2b82323cc6b3cb43f"></a>
   <a href="https://ci.appveyor.com/project/kittens/yarn/branch/master"><img alt="Appveyor Status" src="https://ci.appveyor.com/api/projects/status/0xdv8chwe2kmk463?svg=true"></a>
   <a href="https://discord.gg/yarnpkg"><img alt="Discord Chat" src="https://discordapp.com/api/guilds/226791405589233664/widget.png"></a>
 </p>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Makes the badge for CircleCI in the readme look more like the other badges next to it.
This improves the consistency and polish of Yarn's developer-facing documentation.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

No functional changes, only aesthetics.

Before: 
<img width="430" alt="yarnpkg_yarn__ _fast__reliable__and_secure_dependency_management_" src="https://cloud.githubusercontent.com/assets/268934/20860972/5a7e8558-b939-11e6-9b60-675471b79fc5.png">

After:
<img width="465" alt="yarn_readme_md_at_06d873cd905b9a7ceb1e5bfcd712074f5afe9a0b_ _kevgo_yarn" src="https://cloud.githubusercontent.com/assets/268934/20860983/6f617c0a-b939-11e6-9dfa-2734a1d1e984.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

