### PR TITLE
Improve the console output if a package version cannot be resolved

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -43,7 +43,7 @@ export default class NpmResolver extends RegistryResolver {
           'couldntFindVersionThatMatchesRange',
           body.name,
           range,
-          (versions.length > 20) ? versions.join(os.EOL) : versions.join(', '),
+          versions.join(', '),
         ),
       );
     }


### PR DESCRIPTION
The base-reporter.js turns its parameters into JSON strings. There's
probably a good reason for this, but when you pass a string with
newlines on it, the reporter literally prints the `\n` characters.

```
$ yarn add webpack@2
yarn add v0.17.10
[1/4] 🔍  Resolving packages...
error Couldn't find any versions for "webpack" that matches "2".
Possible versions:
"0.1.0\n0.1.1\n0.1.2\n0.1.3\n0.1.4\n0.1.5\n0.1.6\n0.2.0\n0.2.1\n0.2.2\n0.2.3\n0.2.4\n0.2.6\n0.2.7\n0.2.8\n0.3.0\n0.3.1\n0.3.2\n..."
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about
this command.
```

Here we cleanup the output, by removing the condition that put each
package version in it's own line. I think for long lists ("webpack" has
+400 releases) having each version in its own line is overkill, and
hides the original error message up in the terminal scrollback.

```
$ bin/yarn add webpack@2
yarn add v0.19.0-0
[1/4] 🔍  Resolving packages...
error Couldn't find any versions for "webpack" that matches "2". Possible versions: "0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.6, 0.2.7, 0.2.8, 0.3.0, 0.3.1, 0.3.2..."
```

Fixes #2136