### PR TITLE
Fix an issue with cache config tests modifying actual config

### DIFF
--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -6,6 +6,8 @@ import * as configCmd from '../../src/cli/commands/config.js';
 import {run as buildRun} from './_helpers.js';
 import * as fs from '../../src/util/fs.js';
 
+const path = require('path');
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 const runConfig = buildRun.bind(
@@ -13,6 +15,7 @@ const runConfig = buildRun.bind(
   reporters.ConsoleReporter,
   '',
   (args, flags, config, reporter): CLIFunctionReturn => {
+    config.registries.yarn.homeConfigLoc = path.join(config.cwd, '.yarnrc');
     return configCmd.run(config, reporter, flags, args);
   },
 );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The tests from #2046 modify the config in ~/.yarnrc which results in cache folders being created in weird places after having run the tests.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

