### PR TITLE
Duplicate upgrade-engines fix. Fixes #2139

### DIFF
--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -8,8 +8,6 @@ import Lockfile from '../../lockfile/wrapper.js';
 export function setFlags(commander: Object) {
   // TODO: support some flags that install command has
   commander.usage('upgrade [flags]');
-
-  commander.option('--ignore-engines', 'ignore engines check');
 }
 
 export const requireLockfile = true;


### PR DESCRIPTION
**Summary**
Remove engine option from upgrade help as it's supported globally.

Fixes #2139


