### PR TITLE
Use effective uid to set the userHome variable

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@
 const path = require('path');
 let userHome = require('user-home');
 
-if (process.platform === 'linux' && process.env.USER === 'root') {
+if (process.platform === 'linux' && isRootUser(getUid())) {
   userHome = path.resolve('/usr/local/share');
 }
 


### PR DESCRIPTION
**Summary**

Use the function `isRootUser` to set the `userHome` variable if root is the effective user in Linux platform. The $USER environment variable doesn't match the effective user of the process in some cases.

Related to #2123 

**Test plan**

As root, run yarn as an unpriviledged user using sudo command:
```
[root@fedora nodejs-project]# sudo -u vagrant yarn install
yarn install v0.18.0-20161202.0739
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 7.77s.
```

 * Use isRootUser function instead USER environment variable
 * Fix #2123