### PR TITLE
make sure the cache folder would been created in temp 'cwd ' folder during the tests

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -106,6 +106,11 @@ export async function run<T, R>(
   await fs.mkdirp(path.join(cwd, '.yarn-cache'));
   await fs.mkdirp(path.join(cwd, 'node_modules'));
 
+  // make sure the cache folder been created in temp folder
+  if (flags.cacheFolder) {
+    flags.cacheFolder = path.join(cwd, flags.cacheFolder);
+  }
+
   try {
     const config = new Config(reporter);
     await config.init({


### PR DESCRIPTION
This is a hot fix for #2144 which fully resolved the issue of cache folder been created in current directory every time running tests.

It's related to #2046 and #2140 as well.

@mvestergaard , @bestander