### PR TITLE
Do not output wrapper for cache dir command (#2158)

### DIFF
--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -8,6 +8,10 @@ import {METADATA_FILENAME} from '../../constants';
 
 const path = require('path');
 
+export function hasWrapper(flags: Object, args: Array<string>): boolean {
+  return args[0] !== 'dir';
+}
+
 export const {run, setFlags} = buildSubCommands('cache', {
   async ls(
     config: Config,

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -5,6 +5,10 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import buildSubCommands from './_build-sub-commands.js';
 
+export function hasWrapper(flags: Object, args: Array<string>): boolean {
+  return args[0] !== 'get';
+}
+
 export const {run, setFlags} = buildSubCommands('config', {
   async set(
     config: Config,
@@ -73,7 +77,3 @@ export const {run, setFlags} = buildSubCommands('config', {
     return true;
   },
 });
-
-export function hasWrapper(flags: Object, args: Array<string>): boolean {
-  return args[0] !== 'get';
-}

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -31,6 +31,10 @@ class GlobalAdd extends Add {
 
 const path = require('path');
 
+export function hasWrapper(flags: Object, args: Array<string>): boolean {
+  return args[0] !== 'bin';
+}
+
 async function updateCwd(config: Config): Promise<void> {
   await config.init({
     cwd: config.globalFolder,
@@ -159,10 +163,6 @@ function ls(manifest: Manifest, reporter: Reporter, saved: boolean) {
   } else if (saved) {
     reporter.warn(`${human} has no binaries`);
   }
-}
-
-export function hasWrapper(flags: Object, args: Array<string>): boolean {
-  return args[0] !== 'bin';
 }
 
 const {run, setFlags: _setFlags} = buildSubCommands('global', {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

`yarn cache dir` command should not output header and footer, but only the cache directory path.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves issue #2158.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<code>$ yarn cache dir</code>

Expected output should look like:
<code>/root/.cache/yarn</code>
