### PR TITLE
Fix authentication when @scope:registry does not specify trailing slash

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -668,6 +668,20 @@ test('install a scoped module from authed private registry', (): Promise<void> =
   });
 });
 
+test('install a scoped module from authed private registry with a missing trailing slash', (): Promise<void> => {
+  return runInstall({noLockfile: true}, 'install-from-authed-private-registry-no-slash', async (config) => {
+    const authedRequests = request.__getAuthedRequests();
+    assert.equal(authedRequests[0].url, 'https://registry.yarnpkg.com/@types%2flodash');
+    assert.equal(authedRequests[0].headers.authorization, 'Bearer abc123');
+    assert.equal(authedRequests[1].url, 'https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.37.tgz');
+    assert.equal(authedRequests[1].headers.authorization, 'Bearer abc123');
+    assert.equal(
+      (await fs.readFile(path.join(config.cwd, 'node_modules', '@types', 'lodash', 'index.d.ts'))).split('\n')[0],
+      '// Type definitions for Lo-Dash 4.14',
+    );
+  });
+});
+
 test.concurrent('install a module with incompatible optional dependency should skip dependency',
   (): Promise<void> => {
     return runInstall({}, 'install-should-skip-incompatible-optional-dep', async (config) => {

--- a/__tests__/fixtures/install/install-from-authed-private-registry-no-slash/.npmrc
+++ b/__tests__/fixtures/install/install-from-authed-private-registry-no-slash/.npmrc
@@ -1,0 +1,2 @@
+//registry.yarnpkg.com/:_authToken=abc123
+@types:registry=https://registry.yarnpkg.com

--- a/__tests__/fixtures/install/install-from-authed-private-registry-no-slash/package.json
+++ b/__tests__/fixtures/install/install-from-authed-private-registry-no-slash/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@types/lodash": "4.14.37"
+  }
+}

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -172,7 +172,7 @@ export default class NpmRegistry extends Registry {
       registry = registry.replace(/^https?:/, '');
 
       // Check for bearer token.
-      let auth = this.getScopedOption(registry, '_authToken');
+      let auth = this.getScopedOption(registry.replace(/\/?$/, '/'), '_authToken');
       if (auth) {
         return `Bearer ${String(auth)}`;
       }


### PR DESCRIPTION
This PR was triggered by new discussion on #1666.

I'm not 100% sold on this yet, I'll try to read through the `npm` source code to see what they do.

Which one of these cases are valid (cause this PR would break some of these):

```sh
# Standard setup - works today, both entries have trailing slash
@scoped:registry=https://foo.com/
//foo.com/:_authToken=xyz

# This PR addresses this case - does this work in npm-cli?
@scoped:registry=https://foo.com
//foo.com/:_authToken=xyz

# Is this possible? No trailing slashes
@scoped:registry=https://foo.com
//foo.com:_authToken=xyz

# I keep referring to these as trailing slashes, but really - they're paths
@scoped:registry=https://foo.com/custom/path
//foo.com/custom/path:_authToken=xyz

# And this?
@scoped:registry=https://foo.com/custom/path/
//foo.com/custom/path/:_authToken=xyz

# And this?
@scoped:registry=https://foo.com/custom/path
//foo.com/custom/path/:_authToken=xyz
```
