### PR TITLE
Do not try to resolve optionalDependencies defined with file:<path> when --ignore-optional is set

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -737,3 +737,28 @@ test.concurrent.skip('install incompatible optional dependency should still inst
       assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'strip-json-comments')));
     });
   });
+
+test.concurrent('ignores unreachable file: optionalDependencies', () => {
+  return runInstall({optional: true}, 'install-optional-dep-file-unreachable', async (config) => {
+    assert.ok(!(await fs.exists(path.join(config.cwd, 'node_modules', 'optionalreachable'))));
+  });
+});
+
+test.concurrent('does not install reachable file: optionalDependencies', () => {
+  return runInstall({optional: true}, 'install-optional-dep-file-reachable', async (config) => {
+    assert.ok(!(await fs.exists(path.join(config.cwd, 'node_modules', 'reachable'))));
+  });
+});
+
+test.concurrent('fails on unreachable file: dependencies', () => {
+  return runInstall({}, 'install-dep-file-unreachable', () => {
+    assert(false, 'should not be installable');
+  })
+  .catch(e => assert(e, 'An error should be received'));
+});
+
+test.concurrent('installs reachable file: dependencies', () => {
+  return runInstall({}, 'install-dep-file-reachable', async (config) => {
+    assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'reachable')));
+  });
+});

--- a/__tests__/fixtures/install/install-dep-file-reachable/package.json
+++ b/__tests__/fixtures/install/install-dep-file-reachable/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "reachable": "file:./reachable"
+  }
+}

--- a/__tests__/fixtures/install/install-dep-file-reachable/reachable/package.json
+++ b/__tests__/fixtures/install/install-dep-file-reachable/reachable/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "reachable",
+  "version": "0.0.0"
+}

--- a/__tests__/fixtures/install/install-dep-file-unreachable/package.json
+++ b/__tests__/fixtures/install/install-dep-file-unreachable/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "unreachable": "file:./unreachable"
+  }
+}

--- a/__tests__/fixtures/install/install-optional-dep-file-reachable/optionalreachable/package.json
+++ b/__tests__/fixtures/install/install-optional-dep-file-reachable/optionalreachable/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "optionalreachable",
+  "version": "0.0.0"
+}

--- a/__tests__/fixtures/install/install-optional-dep-file-reachable/package.json
+++ b/__tests__/fixtures/install/install-optional-dep-file-reachable/package.json
@@ -1,0 +1,5 @@
+{
+  "optionalDependencies": {
+    "optionalreachable": "file:./optionalreachable"
+  }
+}

--- a/__tests__/fixtures/install/install-optional-dep-file-unreachable/package.json
+++ b/__tests__/fixtures/install/install-optional-dep-file-unreachable/package.json
@@ -1,0 +1,5 @@
+{
+  "optionalDependencies": {
+    "unreachable": "file:./unreachable"
+  }
+}

--- a/__tests__/fixtures/install/install-optional-dep-file/package.json
+++ b/__tests__/fixtures/install/install-optional-dep-file/package.json
@@ -1,0 +1,5 @@
+{
+  "optionalDependencies": {
+    "unreachable": "file:./unreachable"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
for an optional dependency using <file:PATH>, yarn --ignore-optional is failing returning the path does not exists. It should not:

https://github.com/yarnpkg/yarn/issues/2149

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

- Ensure yarn --ignore-optional is not failing when an optionalDependency defined as __file:<path>__ path is not found
- Ensure yarn --ignore-optional is not installing optionalDependency defined as __file:<path>__ path even if it's resolved found
- Ensure yarn is failing when an dependency defined as __file:<path>__ path is not found
- Ensure yarn is installing a dependency defined as __file:<path>__ path when it's found

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

