### PR TITLE
Apply the network-concurrency option to the package fetchers

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -81,7 +81,7 @@ commander.option(
   '--no-progress',
   'disable progress bar',
 );
-commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests');
+commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
 
 // get command name
 let commandName: ?string = args.shift() || '';

--- a/src/config.js
+++ b/src/config.js
@@ -100,6 +100,8 @@ export default class Config {
   //
   constraintResolver: ConstraintResolver;
 
+  networkConcurrency: number;
+
   //
   requestManager: RequestManager;
 
@@ -205,6 +207,12 @@ export default class Config {
       this.rootModuleFolders.push(path.join(this.cwd, registry.folder));
     }
 
+    this.networkConcurrency = (
+      opts.networkConcurrency ||
+      Number(this.getOption('network-concurrency')) ||
+      constants.NETWORK_CONCURRENCY
+    );
+
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
       httpProxy: String(opts.httpProxy || this.getOption('proxy') || ''),
@@ -214,8 +222,7 @@ export default class Config {
       cafile: String(opts.cafile || this.getOption('cafile') || ''),
       cert: String(opts.cert || this.getOption('cert') || ''),
       key: String(opts.key || this.getOption('key') || ''),
-      networkConcurrency: Number(opts.networkConcurrency || this.getOption('network-concurrency') ||
-        constants.NETWORK_CONCURRENCY),
+      networkConcurrency: this.networkConcurrency,
     });
 
     //init & create cacheFolder, tempFolder

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -106,6 +106,6 @@ export default class PackageFetcher {
       if (tick) {
         tick(ref.name);
       }
-    });
+    }, this.config.networkConcurrency);
   }
 }


### PR DESCRIPTION
**Summary**

This is a follow-up from https://github.com/yarnpkg/yarn/pull/2129 where the network concurrency was not being passed down to the package fetcher, so the problem was not fixed in that scenario.

**Test plan**

Running `yarn install --concurrency 1` on https://github.com/albertfdp/yarn-github-repos should not raise a Connection reset by peer error.

