### PR TITLE
Fix install crashing when only stderr is not a TTY

### DIFF
--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -355,7 +355,7 @@ export default class ConsoleReporter extends BaseReporter {
       };
     }
 
-    if (!this.isTTY) {
+    if (!this.stderr.isTTY) {
       return function() {
         // TODO what should the behaviour here be? we could buffer progress messages maybe
       };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fix install crashing when only stderr is not a TTY. Check that stderr is a TTY before rendering the progress bar, which requires a TTY specific `stderr.columns` property.

The code previously checked if *stdout* is a TTY, which fails when stdout is a TTY, but stderr is not. Now we check the stream that we're actually going to use.

Fixes #2200.

**Test plan**

The repro script from #2200 succeeded after making this change:
```js
const { spawn } = require('child_process');

const yarn = spawn('yarn', ['add', 'react'], {
  stdio: [process.stdin, process.stdout, 'pipe']
})
yarn.stderr.on('data', (data) => {
  console.log(data.toString());
})
```