### PR TITLE
Fixes #1306. Using a dist-tag during install will supply a specific

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -169,6 +169,36 @@ export class Add extends Install {
 
       // depType is calculated when `yarn upgrade` command is used
       const target = depType || this.flagToOrigin;
+      const parts = PackageRequest.normalizePattern(pattern);
+      let version;
+      if (parts.hasVersion && parts.range) {
+        // if the user specified a range then use it verbatim
+        version = pkg.version;
+      } else if (PackageRequest.getExoticResolver(pattern)) {
+        // wasn't a name/range tuple so this is just a raw exotic pattern
+        version = pattern;
+      } else if (tilde) { // --save-tilde
+        version = `~${pkg.version}`;
+      } else if (exact) { // --save-exact
+        version = pkg.version;
+      } else { // default to save prefix
+        version = `${String(this.config.getOption('save-prefix'))}${pkg.version}`;
+      }
+
+      // build up list of objects to put ourselves into from the cli args
+      const targetKeys: Array<string> = [];
+      if (dev) {
+        targetKeys.push('devDependencies');
+      }
+      if (peer) {
+        targetKeys.push('peerDependencies');
+      }
+      if (optional) {
+        targetKeys.push('optionalDependencies');
+      }
+      if (!targetKeys.length) {
+        targetKeys.push('dependencies');
+      }
 
       // add it to manifest
       const {object} = manifests[ref.registry];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Fixes #1306. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Previously, using `yarn install <package>@<dist-tag>` left the `dist-tag` in package.json by default. Now, the dist-tag is replaced in package.json with the actual version number. Latest, beta, next, etc.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
