### PR TITLE
fix #1556: add package name to unmet/incorrect peer dependency warning

### DIFF
--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -273,16 +273,18 @@ export default class PackageLinker {
       }
 
       // validate found peer dependency
-      if (foundDep) {
-        if (range === '*' || semver.satisfies(foundDep.version, range, this.config.looseSemver)) {
-          ref.addDependencies([foundDep.pattern]);
-        } else {
-          this.reporter.warn(this.reporter.lang('incorrectPeer', `${name}@${range}`));
-        }
+      if (foundDep && this._satisfiesPeerDependency(range, foundDep.version)) {
+        ref.addDependencies([foundDep.pattern]);
       } else {
-        this.reporter.warn(this.reporter.lang('unmetPeer', `${name}@${range}`));
+        const depError = foundDep ? 'incorrectPeer' : 'unmetPeer';
+        const [pkgHuman, depHuman] = [`${pkg.name}@${pkg.version}`, `${name}@${range}`];
+        this.reporter.warn(this.reporter.lang(depError, pkgHuman, depHuman));
       }
     }
+  }
+
+  _satisfiesPeerDependency(range: string, version: string): boolean {
+    return range === '*' || semver.satisfies(version, range, this.config.looseSemver);
   }
 
   async init(patterns: Array<string>): Promise<void> {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -145,8 +145,8 @@ const messages = {
   optionalModuleFail: 'This module is OPTIONAL, you can safely ignore this error',
   optionalModuleScriptFail: 'Error running install script for optional dependency: $0',
 
-  unmetPeer: 'Unmet peer dependency $0.',
-  incorrectPeer: 'Incorrect peer dependency $0.',
+  unmetPeer: '$0 has unmet peer dependency $1.',
+  incorrectPeer: '$0 has incorrect peer dependency $1.',
 
   savedNewDependency: 'Saved 1 new dependency.',
   savedNewDependencies: 'Saved $0 new dependencies.',


### PR DESCRIPTION
fixes #1556

before:
`warning Unmet peer dependency "somedep@0.x.x".`

after:
`warning "somepackage@0.2.4" has unmet peer dependency "somedep@0.x.x".`