### PR TITLE
Show homepage of outdated dependencies

### DIFF
--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -81,8 +81,9 @@ test.concurrent('works with exotic resolvers', (): Promise<void> => {
   return runOutdated([], {}, 'exotic-resolvers',
     (config, reporter, out): ?Promise<void> => {
       const json: Object = JSON.parse(out);
-      const first = ['max-safe-integer', '1.0.1', 'exotic', 'exotic', 'dependencies'];
-      const second = ['yarn', '0.16.2', 'exotic', 'exotic', 'dependencies'];
+      const first = ['max-safe-integer', '1.0.1', 'exotic', 'exotic', 'dependencies',
+                     'https://github.com/sindresorhus/max-safe-integer.git'];
+      const second = ['yarn', '0.16.2', 'exotic', 'exotic', 'dependencies', 'yarnpkg/yarn'];
 
       expect(json.data.body.length).toBe(2);
       expect(json.data.body[0]).toEqual(first);

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -41,10 +41,11 @@ export async function run(
         reporter.format.green(info.wanted),
         reporter.format.magenta(info.latest),
         getNameFromHint(info.hint),
+        reporter.format.cyan(info.url),
       ];
     });
 
-    reporter.table(['Package', 'Current', 'Wanted', 'Latest', 'Package Type'], body);
+    reporter.table(['Package', 'Current', 'Wanted', 'Latest', 'Package Type', 'URL'], body);
   }
 
   return Promise.resolve();

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -56,9 +56,9 @@ export async function run(
 
   const getNameFromHint = (hint) => hint ? `${hint}Dependencies` : 'dependencies';
 
-  const maxLengthArr = {name: 0, current: 0, latest: 0};
+  const maxLengthArr = {name: 0, current: 0, latest: 0, url: 0};
   deps.forEach((dep) =>
-    ['name', 'current', 'latest'].forEach((key) => {
+    ['name', 'current', 'latest', 'url'].forEach((key) => {
       maxLengthArr[key] = Math.max(maxLengthArr[key], dep[key].length);
     }),
   );
@@ -86,7 +86,8 @@ export async function run(
     const name = colorizeName(dep)(padding('name'));
     const current = reporter.format.blue(padding('current'));
     const latest = colorizeDiff(dep.current, padding('latest'));
-    return `${name}  ${current}  ❯  ${latest}`;
+    const url = reporter.format.cyan(dep.url);
+    return `${name}  ${current}  ❯  ${latest}  ${url}`;
   };
 
   const groupedDeps = deps.reduce((acc, dep) => {

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -56,9 +56,9 @@ export async function run(
 
   const getNameFromHint = (hint) => hint ? `${hint}Dependencies` : 'dependencies';
 
-  const maxLengthArr = {name: 0, current: 0, latest: 0, url: 0};
+  const maxLengthArr = {name: 0, current: 0, latest: 0};
   deps.forEach((dep) =>
-    ['name', 'current', 'latest', 'url'].forEach((key) => {
+    ['name', 'current', 'latest'].forEach((key) => {
       maxLengthArr[key] = Math.max(maxLengthArr[key], dep[key].length);
     }),
   );

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -329,19 +329,21 @@ export default class PackageRequest {
         const {name, version: current} = locked;
         let latest = '';
         let wanted = '';
+        let url = '';
 
         const normalized = PackageRequest.normalizePattern(pattern);
 
         if (PackageRequest.getExoticResolver(pattern) ||
             PackageRequest.getExoticResolver(normalized.range)) {
           latest = wanted = 'exotic';
+          url = normalized.range;
         } else {
           const registry = config.registries[locked.registry];
 
-          ({latest, wanted} = await registry.checkOutdated(config, name, normalized.range));
+          ({latest, wanted, url} = await registry.checkOutdated(config, name, normalized.range));
         }
 
-        return ({name, current, wanted, latest, hint});
+        return ({name, current, wanted, latest, url, hint});
       }),
     );
 

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -19,6 +19,7 @@ export type RegistryRequestOptions = {
 export type CheckOutdatedReturn = Promise<{
   wanted: string,
   latest: string,
+  url: string
 }>;
 
 export default class BaseRegistry {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -84,9 +84,13 @@ export default class NpmRegistry extends Registry {
       throw new Error('couldnt find ' + name);
     }
 
+    const {repository, homepage} = req;
+    const url = homepage || (repository && repository.url) || '';
+
     return {
       latest: req['dist-tags'].latest,
       wanted: (await NpmResolver.findVersionInRegistryResponse(config, range, req)).version,
+      url,
     };
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -141,5 +141,6 @@ export type Dependency = {
   current: string,
   wanted: string,
   latest: string,
+  url: string,
   hint: ?string
 };


### PR DESCRIPTION
**Summary**

When viewing outdated dependencies via `yarn outdated` or `yarn upgrade-interactive`, it is often desirable to look at what has changed in the dependent package.  While we don’t have easy access to each dependency’s CHANGELOG, we do have access to its homepage or repository URL.

This PR adds a new column to the output of `yarn outdated` and `yarn upgrade-interactive` to show a URL for each dependency.  Some terminal programs, such as iTerm, allow clicking on URLs to open them in a browser, making this very convenient.  Other terminals only allow copy and paste, but that’s still more convenient than manually attempting to find the package’s homepage.

This feature was inspired by a similar feature of [npm-check](https://github.com/dylang/npm-check).

**Test plan**

Run `yarn outdated` and `yarn upgrade-interactive` with both 0.17.10 (current release) and with this PR applied and check that the new column appears.

`yarn outdated`:

Before:
![screen shot 2016-12-09 at 4 48 48 pm](https://cloud.githubusercontent.com/assets/1406203/21069529/9bdd137a-be2f-11e6-8476-16b57d1027fe.png)

After:
![screen shot 2016-12-09 at 4 49 34 pm](https://cloud.githubusercontent.com/assets/1406203/21069538/c4ddf276-be2f-11e6-975e-a7096e92b1dd.png)

`yarn upgrade-interactive`:

Before:
![screen shot 2016-12-09 at 4 49 12 pm](https://cloud.githubusercontent.com/assets/1406203/21069535/be8afe82-be2f-11e6-820b-08f72fadbf0e.png)

After:
![screen shot 2016-12-09 at 4 49 54 pm](https://cloud.githubusercontent.com/assets/1406203/21069542/ca810ae2-be2f-11e6-969e-61f1ba1a9352.png)

**Implementation notes**

* For normal dependencies, the URL comes from `NpmRegistry.checkOutdated()`, which has access to the information in the dependency's `package.json` file.  Note that unlike `yarn licenses`, these commands prefer to use the `homepage` in preference to the `repository.url`, as that's generally a better place to go for release announcements and such.

* The URL gets passed up to `PackageRequest.getOutdatedPackages()`.  For "exotic" dependencies, we don't have `package.json` information available, so we use the normalized version pattern's range instead, as that will often be a git or file URL.  Perhaps more could be done here.

* `yarn upgrade-interactive` formats its own table by padding the columns.  I explicitly do not pad the url column as it is the last column and doesn't need it.  If there are packages with long names or long URLs, there will be some line wrapping going on, and adding extra spaces to the end of every URL just makes the problem worse.  The tradeoff is that if another column is later added after the URL, padding will need to be added at that time.

* I had to add URLs to one of the test cases, as it checks the entire output row.  I'm not thrilled with this extra coupling, but chose to keep the form of the current test.
