### PR TITLE
Add project commands `yarn run` could run

### DIFF
--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -25,13 +25,18 @@ test('lists all available commands with no arguments', (): Promise<void> => {
   return runRun([], {}, 'no-args', (config, reporter): ?Promise<void> => {
     const rprtr = new reporters.BufferReporter({stdout: null, stdin: null});
     const scripts = ['build', 'prestart', 'start'];
+    const hints = {
+      build: "echo 'building'",
+      prestart: "echo 'prestart'",
+      start: 'node index.js',
+    };
     const bins = ['cat-names'];
 
     // Emulate run output
     rprtr.error(rprtr.lang('commandNotSpecified'));
     rprtr.info(`${rprtr.lang('binCommands')}${bins.join(', ')}`);
     rprtr.info(rprtr.lang('possibleCommands'));
-    rprtr.list('possibleCommands', scripts);
+    rprtr.list('possibleCommands', scripts, hints);
     rprtr.error(rprtr.lang('commandNotSpecified'));
 
     expect(reporter.getBuffer()).toEqual(rprtr.getBuffer());

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -44,9 +44,17 @@ export async function run(
       visitedBinFolders.add(binFolder);
     }
   }
-  if (pkg.scripts) {
+  const pkgScripts = pkg.scripts;
+  const cmdHints = {};
+  if (pkgScripts) {
     // inherit `scripts` from manifest
-    pkgCommands = Object.keys(pkg.scripts);
+    pkgCommands = Object.keys(pkgScripts).sort();
+
+    // add command hints (what the actual yarn command will do)
+    for (const cmd of pkgCommands) {
+      cmdHints[cmd] = pkgScripts[cmd] || '';
+    }
+
     Object.assign(scripts, pkg.scripts);
   }
 
@@ -92,7 +100,7 @@ export async function run(
     reporter.error(reporter.lang('commandNotSpecified'));
     reporter.info(`${reporter.lang('binCommands') + binCommands.join(', ')}`);
     reporter.info(`${reporter.lang('possibleCommands')}`);
-    reporter.list('possibleCommands', pkgCommands.sort());
+    reporter.list('possibleCommands', pkgCommands, cmdHints);
     await reporter.question(reporter.lang('commandQuestion')).then(
       (answer) => runCommand(answer.split(' ')),
       () => reporter.error(reporter.lang('commandNotSpecified')),

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -136,7 +136,7 @@ export default class BaseReporter {
   }
 
   // TODO
-  list(key: string, items: Array<string>) {}
+  list(key: string, items: Array<string>, hints?: Object) {}
 
   // Outputs basic tree structure to console
   tree(key: string, obj: Trees) {}

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -107,10 +107,18 @@ export default class ConsoleReporter extends BaseReporter {
     this.log('' + value);
   }
 
-  list(key: string, items: Array<string>) {
+  list(key: string, items: Array<string>, hints?: Object) {
     const gutterWidth = (this._lastCategorySize || 2) - 1;
-    for (const item of items) {
-      this._log(`${repeat(' ', gutterWidth)}- ${item}`);
+
+    if (hints) {
+      for (const item of items) {
+        this._log(`${repeat(' ', gutterWidth)}- ${item}`);
+        this._log(`  ${repeat(' ', gutterWidth)} ${hints[item]}`);
+      }
+    } else {
+      for (const item of items) {
+        this._log(`${repeat(' ', gutterWidth)}- ${item}`);
+      }
     }
   }
 

--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -1,6 +1,10 @@
 /* @flow */
 
-import type {ReporterSpinnerSet, Trees, ReporterSpinner} from './types.js';
+import type {
+  ReporterSpinnerSet,
+  Trees,
+  ReporterSpinner,
+} from './types.js';
 import BaseReporter from './base-reporter.js';
 
 export default class JSONReporter extends BaseReporter {
@@ -26,8 +30,8 @@ export default class JSONReporter extends BaseReporter {
     this._dump('verbose', msg);
   }
 
-  list(type: string, items: Array<string>) {
-    this._dump('list', {type, items});
+  list(type: string, items: Array<string>, hints?: Object) {
+    this._dump('list', {type, items, hints});
   }
 
   tree(type: string, trees: Trees) {


### PR DESCRIPTION
**Summary**

Closes #2194.

This pull request improves `yarn run` by adding the project commands that would be run when used by `yarn run`.

Essentially, this makes `yarn run` with no arguments show the same thing as `npm run` with no arguments.

**Test plan**

Here's what I have now: http://i.imgur.com/6MKIPya.png

(Ignore the `vundefined` version—I fixed that after the screenshot).

**WIP**

I am vastly unfamiliar with Flow and types in general so this PR is far from finished. Here are things I could use help with:

* The linting error about `pkg.scripts` being undefined
* `run` uses `log` from `ConsoleReporter`, which takes an `Array<string>`. The new scripts array is an array of objects of `{script: command}`[1] structure. I'm not sure how to get both working at the same time without breaking other stuff... so I used `Array<any>` and did some gross checking before printing just to make sure the output looks fine.

I'll also add/fix tests once I fix my implementation.

I'm read the Flow docs and asking around, but any help would be appreciated :-)

[1] For example `{test: 'jest --coverage', lint: 'standard'}`.
