### PR TITLE
Fix #2177 - Remove GLOBAL_INSTALL_DIRECTORY const

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -27,7 +27,6 @@ if (semver.satisfies(ver, '>=5.0.0')) {
 // ensure cache directory exists
 var mkdirp = require('mkdirp');
 var constants = require('../lib-legacy/constants');
-mkdirp.sync(constants.GLOBAL_INSTALL_DIRECTORY);
 mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
 
 // init roadrunner

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,7 +49,6 @@ function getCacheDirectory(): string {
   return getDirectory('cache');
 }
 
-export const GLOBAL_INSTALL_DIRECTORY = path.join(userHome, '.yarn');
 export const MODULE_CACHE_DIRECTORY = getCacheDirectory();
 export const CONFIG_DIRECTORY = getDirectory('config');
 export const LINK_REGISTRY_DIRECTORY = path.join(CONFIG_DIRECTORY, 'link');


### PR DESCRIPTION
**Summary**

The GLOBAL_INSTALL_DIRECTORY (`~/.yarn`) is created by Yarn, but appears to have been replaced by `~/.config/yarn` in #1679, and is therefore unused. This PR removes the constant and the command that creates the directory.

For clarity: the `~/.config/yarn` consists of `CONFIG_DIRECTORY` and `GLOBAL_MODULE_DIRECTORY`, as built by the `getDirectory()` function in `src/constants.js`.

You may find #2177 helpful.

**Test plan**

I have run both the linter and the test suite. Note that I had to run the test suite manually and that there was a single error due to permissions on my system.

```shell
$ yarn run lint
yarn run v0.18.0
$ eslint . && flow check 
Found 0 errors
✨  Done in 14.54s.
```

```shell
$ yarn run test
yarn run v0.18.0
npm run lint && npm run test-only 
sh: npm: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

$ ./node_modules/.bin/jest --coverage --verbose --maxWorkers 3
Summary of all failing tests
 FAIL  __tests__/commands/global.js (7.19s)
  ● add without flag

    Error: We don't have permissions to touch the file "/opt/local/bin/react-native".
```