### PR TITLE
Fix #1941 - Allow yarn script to be linked

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,5 +1,5 @@
 #!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+basedir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 
 case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;


### PR DESCRIPTION
**Summary**

I would like to be able to call a soft-linked version of the `yarn` shell script. Effectively, Yarn is installed in one location, and I would like to add a soft-link to a `bin` directory already in my `PATH`.

This is useful for manual installations (as outlined under Manual Installation via tarball on the [installation page](https://yarnpkg.com/en/docs/install#alternatives-tab)) or when Yarn is being installed by other package managers (such as Macports, [where we are currently patching this change](https://github.com/macports/macports-ports/pull/48)). 

The use of `readlink` without flags should work on both Linux and BSD variants. Introducing flags like `-f` and `-e` will limit the functionality to GNU's `readlink` (not default on BSDs or macOS), which is why the code forgoes these flags and retains the `echo "$0"`.

While I did not receive much feedback on #1941, I believe a few others may find this useful as well.

**Test plan**

Linting passes.

```shell
$ yarn lint
yarn lint v0.18.0
$ eslint . && flow check 
Found 0 errors
✨  Done in 20.42s.
```

I'm running tests manually without NPM, and have a single **expected** failure.

```shell
$ ./node_modules/.bin/jest --coverage --verbose --maxWorkers 3

Summary of all failing tests
 FAIL  __tests__/commands/global.js (8.273s)
  ● add without flag

    Error: We don't have permissions to touch the file "/opt/local/bin/react-native".
```