### PR TITLE
Normalize the author and the repository fields

### DIFF
--- a/__tests__/normalize-manifest.js
+++ b/__tests__/normalize-manifest.js
@@ -95,6 +95,11 @@ test('util.extractDescription', () => {
   expect(util.extractDescription(undefined)).toEqual(undefined);
 });
 
+test('util.extractRepositoryUrl', () => {
+  expect(util.extractRepositoryUrl('https://github.com/yarnpkg/yarn.git')).toEqual('https://github.com/yarnpkg/yarn.git');
+  expect(util.extractRepositoryUrl({type: 'git', url: 'https://github.com/yarnpkg/yarn.git'})).toEqual('https://github.com/yarnpkg/yarn.git');
+});
+
 // fill out expected and normalize paths
 function expand<T>(expected: T): T {
   if (expected.man && Array.isArray(expected.man)) {

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -96,3 +96,11 @@ export function extractDescription(readme: mixed): ?string {
 
   return lines.slice(start, end).join(' ');
 }
+
+
+export function extractRepositoryUrl(repository: mixed): any {
+  if (!repository || typeof repository !== 'object' || !repository.url) {
+    return repository;
+  }
+  return repository.url;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fix for #2179, and a similar issue. The interactive prompt of `yarn init` can't display the nested sub-question for the questions when there are no default values of the repository and the fields have Object values in `package.json`. This error also happens for the author field as well since the field is allowed to be used Object in package.json.

See also
+ [author in package.json](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
+ [repository in package.json](https://docs.npmjs.com/files/package.json#repository)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I've added a test into `__test__`.