### PR TITLE
Allow production=false flag to override production ENV

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -417,6 +417,17 @@ test('install should respect NPM_CONFIG_PRODUCTION=false over NODE_ENV=productio
   });
 });
 
+// don't run this test in `concurrent`, it will affect other tests
+test('install should respect production flag false over NODE_ENV=production', (): Promise<void> => {
+  const env = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  return runInstall({production: 'false'}, 'install-should-respect-production_flag_over_node-env', async (config) => {
+    expect(await fs.exists(path.join(config.cwd, 'node_modules/is-negative-zero/package.json'))).toBe(true);
+    // restore env
+    process.env.NODE_ENV = env;
+  });
+});
+
 test.concurrent('install should resolve circular dependencies 2', (): Promise<void> => {
   return runInstall({}, 'install-should-circumvent-circular-dependencies-2', async (config, reporter) => {
     assert.equal(

--- a/__tests__/fixtures/install/install-should-respect-production_flag_over_node-env/package.json
+++ b/__tests__/fixtures/install/install-should-respect-production_flag_over_node-env/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "left-pad": "1.0.0"
+  },
+  "devDependencies": {
+    "is-negative-zero": "1.0.0"
+  }
+}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -54,7 +54,7 @@ commander.option('--ignore-optional', 'ignore optional dependencies');
 commander.option('--force', 'ignore all caches');
 commander.option('--no-bin-links', "don't generate bin links when setting up packages");
 commander.option('--flat', 'only allow one version of a package');
-commander.option('--prod, --production', '');
+commander.option('--prod, --production [prod]', '');
 commander.option('--no-lockfile', "don't read or generate a lockfile");
 commander.option('--pure-lockfile', "don't generate a lockfile");
 commander.option('--frozen-lockfile', "don't generate a lockfile and fail if an update is needed");

--- a/src/config.js
+++ b/src/config.js
@@ -232,6 +232,7 @@ export default class Config {
     await fs.mkdirp(this.tempFolder);
 
     if (this.getOption('production') || (
+        opts.production !== 'false' &&
         process.env.NODE_ENV === 'production' &&
         process.env.NPM_CONFIG_PRODUCTION !== 'false' &&
         process.env.YARN_PRODUCTION !== 'false')) {
@@ -256,7 +257,7 @@ export default class Config {
     this.modulesFolder = opts.modulesFolder;
     this.globalFolder = opts.globalFolder || constants.GLOBAL_MODULE_DIRECTORY;
     this.linkFolder = opts.linkFolder || constants.LINK_REGISTRY_DIRECTORY;
-    this.production = !!opts.production;
+    this.production = !!opts.production && opts.production !== 'false';
     this.offline = !!opts.offline;
     this.binLinks = !!opts.binLinks;
 

--- a/src/config.js
+++ b/src/config.js
@@ -231,12 +231,15 @@ export default class Config {
     await fs.mkdirp(this.cacheFolder);
     await fs.mkdirp(this.tempFolder);
 
-    if (this.getOption('production') || (
-        opts.production !== 'false' &&
+    if (opts.production === 'false') {
+      this.production = false;
+    } else if (this.getOption('production') ||
         process.env.NODE_ENV === 'production' &&
         process.env.NPM_CONFIG_PRODUCTION !== 'false' &&
-        process.env.YARN_PRODUCTION !== 'false')) {
+        process.env.YARN_PRODUCTION !== 'false') {
       this.production = true;
+    } else {
+      this.production = !!opts.production;
     }
   }
 
@@ -257,7 +260,6 @@ export default class Config {
     this.modulesFolder = opts.modulesFolder;
     this.globalFolder = opts.globalFolder || constants.GLOBAL_MODULE_DIRECTORY;
     this.linkFolder = opts.linkFolder || constants.LINK_REGISTRY_DIRECTORY;
-    this.production = !!opts.production && opts.production !== 'false';
     this.offline = !!opts.offline;
     this.binLinks = !!opts.binLinks;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Add ability to pass `production=false` when running `yarn install`, which will take precedence over the environment variable `NODE_ENV=production`.

This will allow you to have your NODE_ENV set as production while still installing dev dependencies, e.g. when running a script such `yarn install && yarn run build` to build your code in production mode while installing dev dependencies required for the build.

Closes #2167 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

A passing test is included.

I've also tested locally.

Currently it will accept `production=false`, `production=0`, `prod=false`, `prod=0`. Any other value will be considered true, including empty.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

