### PR TITLE
Make yarn interactive commands run in Git Bash/MSYS environment

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,8 +1,11 @@
 #!/bin/sh
 basedir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 
+is_msys=0
+
 case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+  *MSYS_NT*) is_msys=1;;
 esac
 
 command_exists() {
@@ -10,7 +13,11 @@ command_exists() {
 }
 
 if command_exists node; then
-  node "$basedir/yarn.js" "$@"
+  if [ $is_msys -eq 1 ]; then
+    winpty node "$basedir/yarn.js" "$@"
+  else
+    node "$basedir/yarn.js" "$@"
+  fi
   ret=$?
 # Debian and Ubuntu use "nodejs" as the name of the binary, not "node", so we
 # search for that too. See:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

The problem is caused by mintty, and it manifests weirdly because in most circumstances you can get interactive node programs to work because of a hack introduced via aliasing/wrapping commands in the bash profile:

```
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test $ type node
node is aliased to `winpty node.exe'
```

After a bit of digging I found the culprit in `/etc/profile.d/aliases.sh`

```bash
case "$TERM" in
xterm*)
        # The following programs are known to require a Win32 Console
        # for interactive usage, therefore let's launch them through winpty
        # when run inside `mintty`.
        for name in node ipython php php5 psql python2.7
        do
                case "$(type -p "$name".exe 2>/dev/null)" in
                ''|/usr/bin/*) continue;;
                esac
                alias $name="winpty $name.exe"
        done
        ;;
esac
```

Git bash wraps `node`, `ipython`, `php`, `php5`, `psql`, `python2.7` in a program called `winpty`
which means when yarn invokes node, this hack is not invoked as well.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Related to issue #743 

**Test plan**

I'm not sure how to setup an environment that could run an automated test for this case correctly
but I made the following before and after test:

```
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test $ ./bin/yarn init
yarn init v0.17.10
error An unexpected error occurred: "Can't answer a question unless a user TTY".
info If you think this is a bug, please open a bug report with the information p                                                                                                                                                    rovided in "C:\\Users\\bkc\\workspace\\yarn-test\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/init for documentation about this com                                                                                                                                                    mand.
```

After wrapping the process in winpty:

```
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test $ ./bin/yarn init
yarn init v0.17.10
question name (yarn-test):
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

