### PR TITLE
Add "Too many arguments" message to `info` and improve code coverage

### DIFF
--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import * as reporters from '../../src/reporters/index.js';
 import {run as info} from '../../src/cli/commands/info.js';
 import {BufferReporter} from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
@@ -47,7 +48,7 @@ const expectedKeys = [
 ];
 
 test.concurrent('without arguments and in directory containing a valid package file', (): Promise<void> => {
-  return runInfo(['.'], {}, 'local',
+  return runInfo([], {}, 'local',
     (config, output): ?Promise<void> => {
       const actualKeys = Object.keys(output);
       expectedKeys.forEach((key) => expect(actualKeys).toContain(key));
@@ -124,6 +125,24 @@ test.concurrent('with two arguments and second argument path containing non-exis
   return runInfo(['yarn', 'repository.unknown.type'], {}, '',
     (config, output): ?Promise<void> => {
       expect(output).toBe(undefined);
+    },
+  );
+});
+
+test.concurrent('reports error on invalid package names', (): Promise<void> => {
+  const reporter = new reporters.ConsoleReporter({});
+  return runInfo(['YARN.invalid.package.name.YARN'], {}, '',
+    (config, output): ?Promise<void> => {
+      expect(output).toContain(reporter.lang('infoFail', 2));
+    },
+  );
+});
+
+test.concurrent('reports error with too many arguments', (): Promise<void> => {
+  const reporter = new reporters.ConsoleReporter({});
+  return runInfo(['yarn', 'version', 'extra.invalid.arg'], {}, '',
+    (config, output): ?Promise<void> => {
+      expect(output).toContain(reporter.lang('tooManyArguments', 2));
     },
   );
 });

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -43,6 +43,7 @@ export async function run(
  args: Array<string>,
 ): Promise<void> {
   if (args.length > 2) {
+    reporter.error(reporter.lang('tooManyArguments', 2));
     return;
   }
 


### PR DESCRIPTION
I'm working on some code, and rather than including all my commits in one PR, I'd like to separate a few of the smaller, non-related fixes into their own PR's (for easier review).

**Summary**

This is a very small change to get the code coverage of the `info` command up to 100%.  The currently included versions of `jest` and `babel-jest` still have slightly incorrect coverage reports, but updating them gives `100%` on this file.  I would like to upgrade all the modules in this repo, but it might make more sense for that to be in a different PR? (I didn't include `package.json` or `yarn.lock` updates in this PR)

**Test plan**

1. Run `yarn test`
2. Confirm `__tests__/commands/info.js` has no errors
3. `open ./coverage/lcov-report/index.html`
3. Confirm that the coverage for `src/commands/info.js` has improved
