### PR TITLE
Small aliases refactor.

### DIFF
--- a/src/cli/aliases.js
+++ b/src/cli/aliases.js
@@ -1,34 +1,39 @@
 /* @flow */
 
-export default ({
-  // shorthands
-  'run-script': 'run',
+const shorthands: { [key: string]: string } = {
   c: 'config',
   i: 'install',
-  ls: 'list',
+  la: 'list',
+  ll: 'list',
   ln: 'link',
+  ls: 'list',
+  r: 'remove',
   rb: 'rebuild',
-  runScript: 'run',
+  rm: 'remove',
   t: 'test',
   tst: 'test',
   un: 'remove',
   up: 'update',
   v: 'version',
+};
 
-  // affordances
+const affordances: { [key: string]: string } = {
   'add-user': 'login',
-  'dist-tag': 'tag',
-  'dist-tags': 'tag',
   adduser: 'login',
   author: 'owner',
+  'dist-tag': 'tag',
+  'dist-tags': 'tag',
   isntall: 'install',
-  la: 'list',
-  ll: 'list',
-  r: 'remove',
-  rm: 'remove',
+  'run-script': 'run',
+  runScript: 'run',
   show: 'info',
   uninstall: 'remove',
   update: 'upgrade',
   verison: 'version',
   view: 'info',
-}: { [key: string]: ?string });
+};
+
+export default ({
+  ...shorthands,
+  ...affordances,
+}: { [key: string]: string });


### PR DESCRIPTION
I'm working on some code, and rather than including all my commits in one PR, I'd like to separate a few of the smaller, non-related fixes into their own PR's (for easier review).

**Summary**

Locally, I've upgraded my eslint versions, and the current `aliases` file throws lint errors due to the `sort-keys` rule.  This commit fixes the errors by sorting all our keys.  I kept the `shorthands` vs `affordances` separation by using 2 variables and the object spread syntax in the exported value.

**Test plan**

1. I made my changes then ran `yarn build`
2. I ran `./bin/yarn ls` and a few other of the alias commands.
3. Confirmed that the behavior is the same before and after my changes.
4. Run `yarn test`
5. Confirm `__tests__/cli/aliases.js` has no errors
6. open `./coverage/lcov-report/index.html`
7. Confirm that the coverage for `src/cli/aliases.js` is still 100%

