### PR TITLE
Support interactive commands in standard MINGW as well

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,11 @@
 #!/bin/sh
 basedir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 
-is_msys=0
+use_winpty=0
 
 case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-  MSYS_NT*|MINGW*) is_msys=1;;
+  MSYS_NT*|MINGW*) use_winpty=1;;
 esac
 
 command_exists() {
@@ -13,7 +13,7 @@ command_exists() {
 }
 
 if command_exists node; then
-  if [ $is_msys -eq 1 ]; then
+  if [ $use_winpty -eq 1 ]; then
     winpty node "$basedir/yarn.js" "$@"
   else
     node "$basedir/yarn.js" "$@"

--- a/bin/yarn
+++ b/bin/yarn
@@ -5,7 +5,7 @@ is_msys=0
 
 case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-  *MSYS_NT*) is_msys=1;;
+  MSYS_NT*|MINGW*) is_msys=1;;
 esac
 
 command_exists() {

--- a/bin/yarn
+++ b/bin/yarn
@@ -5,7 +5,7 @@ use_winpty=0
 
 case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-  MSYS_NT*|MINGW*) use_winpty=1;;
+  MSYS*|MINGW*) use_winpty=1;;
 esac
 
 command_exists() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Test for both `MSYS*` and `MINGW*` when determine to wrap
the node process in winpty.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I made this previous pull request #2230 for supporting interactive commands in
Git bash for windows.

It turns out that I only made it work for some really old git bash.
Along the way Git bash has changed its default terminal emulator, which means it
went from using a terminal that, resolved to `MSYS*` when invoking the `uname` command,
to a newer one that resolves `MINGW*`

This fix make it work with newer configurations and keeping support to the old version.
Github: #743

**Test plan**

Before this change

```bash
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ uname
MSYS_NT-10.0
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ ./bin/yarn init
yarn init v0.19.0-0
question name (yarn):
```

```bash
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ uname
MINGW64_NT-10.0
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ ./bin/yarn init
yarn init v0.19.0-0
error An unexpected error occurred: "Can't answer a question unless a user TTY".
info If you think this is a bug, please open a bug report with the information provided in "C:\\Users\\bkc\\workspace\\yarn-test\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/init for documentation about this command.
```

After this change:

```bash
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ uname
MSYS_NT-10.0
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ ./bin/yarn init
yarn init v0.19.0-0
question name (yarn):
```

```bash
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ uname
MINGW64_NT-10.0
bkc@DESKTOP-NNSLT74 ~/workspace/yarn-test (master) $ ./bin/yarn init
yarn init v0.19.0-0
question name (yarn):
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

