### PR TITLE
Increased specificity of Windows platform check

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -131,3 +131,11 @@ export async function run<T, R>(
     throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
   }
 }
+export const setPlatform = (platform : string) : string => {
+  const previous = process.platform;
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+  });
+
+  return previous;
+};

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -2,7 +2,7 @@
 
 jest.mock('../../src/util/execute-lifecycle-script');
 
-import {run as buildRun} from './_helpers.js';
+import {run as buildRun, setPlatform} from './_helpers.js';
 import {BufferReporter} from '../../src/reporters/index.js';
 import {run} from '../../src/cli/commands/run.js';
 import * as fs from '../../src/util/fs.js';
@@ -66,11 +66,17 @@ test('properly handles extra arguments and pre/post scripts', (): Promise<void> 
   });
 });
 
-test('handles bin scripts', (): Promise<void> => {
-  return runRun(['cat-names'], {}, 'bin', (config) => {
-    const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
-    const args = ['cat-names', config, `"${script}" `, config.cwd];
+test('multi-platform bin scripts', () => (
+    ['win32', 'darwin'].reduce((tests, platform) => (
+      tests.then(() =>
+        runRun(['cat-names'], {}, 'bin', (config) => {
+          const originalPlatform = setPlatform(platform);
+          const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
+          const args = ['cat-names', config, `"${script}" `, config.cwd];
 
-    expect(execCommand).toBeCalledWith(...args);
-  });
-});
+          expect(execCommand).toBeCalledWith(...args);
+          setPlatform(originalPlatform);
+        }),
+    ))
+    , Promise.resolve())
+));

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -68,7 +68,7 @@ export async function run(
     for (const action of actions) {
       const cmd = scripts[action];
       if (cmd) {
-        const isWin = /win/.test(process.platform);
+        const isWin = /win32/.test(process.platform);
         cmds.push([action, isWin ? fixCmdWinSlashes(cmd) : cmd]);
       }
     }

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -68,7 +68,7 @@ export async function run(
     for (const action of actions) {
       const cmd = scripts[action];
       if (cmd) {
-        const isWin = /win32/.test(process.platform);
+        const isWin = 'win32' === process.platform;
         cmds.push([action, isWin ? fixCmdWinSlashes(cmd) : cmd]);
       }
     }


### PR DESCRIPTION
**Summary**
Extended regex to match only Windows. Previous regex was matching Darwin in addition to Windows.

yarn run test > all tests pass.

#2261