### PR TITLE
Build es5-compatible lib

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,14 @@
         ["transform-runtime", { "polyfill": true, "regenerator": false }]
       ]
     },
+    "es5": {
+      "presets": ["es2015"],
+      "plugins": [
+        ["transform-inline-imports-commonjs"],
+        ["transform-class-properties"],
+        ["transform-runtime", { "polyfill": true, "regenerator": false }]
+      ]
+    },
     "test": {
       "presets": ["es2015-node4"],
       "plugins": [

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 __tests__/fixtures
 lib
 lib-legacy
+lib-es5
 node_modules
 flow-typed
 coverage

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 <PROJECT_ROOT>/coverage/.*
 <PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/lib-es5/.*
 <PROJECT_ROOT>/lib-legacy/.*
 <PROJECT_ROOT>/lib/.*
 <PROJECT_ROOT>/node_modules/babel.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /lib
 /lib-legacy
+/lib-es5
 .DS_Store
 /node_modules
 *.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ function build(lib, opts) {
 
 gulp.task('default', ['build']);
 
-gulp.task('build', ['build-modern', 'build-legacy']);
+gulp.task('build', ['build-modern', 'build-legacy', 'build-es5']);
 
 gulp.task('build-modern', () => {
   return build('lib', babelRc.env.node5);
@@ -38,6 +38,10 @@ gulp.task('build-modern', () => {
 
 gulp.task('build-legacy', () => {
   return build('lib-legacy', babelRc.env['pre-node5']);
+});
+
+gulp.task('build-es5', () => {
+  return build('lib-es5', babelRc.env['es5']);
 });
 
 gulp.task('watch', ['build'], () => {

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -40,6 +40,7 @@ mkdir -p $PACKAGE_TMPDIR/usr/share/doc/yarn/
 mv $PACKAGE_TMPDIR/dist/bin $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/lib $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/lib-legacy $PACKAGE_TMPDIR/usr/share/yarn/
+mv $PACKAGE_TMPDIR/dist/lib-es5 $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/node_modules $PACKAGE_TMPDIR/usr/share/yarn/
 mv $PACKAGE_TMPDIR/dist/package.json $PACKAGE_TMPDIR/usr/share/yarn/
 cp resources/debian/copyright $PACKAGE_TMPDIR/usr/share/doc/yarn/copyright


### PR DESCRIPTION
**Summary**

In order to use yarn's `parse.js` in nodesecurity/nsp (https://github.com/nodesecurity/nsp/pull/142) to be able to support `yarn.lock` and probably in other packages which are not node4 compatible, I want to be able to get es5-compatible version of this library.

**Test plan**

Build works as expected:

```
scripts/build-dist.sh
+ npm run build

> yarn@0.19.0-0 build /Users/lucek/workspace/yarn
> gulp build

[16:22:17] Using gulpfile ~/workspace/yarn/gulpfile.js
[16:22:17] Starting 'build-modern'...
[16:22:17] Starting 'build-legacy'...
[16:22:17] Starting 'build-es5'...
[16:22:31] Finished 'build-modern' after 14 s
[16:22:31] Finished 'build-legacy' after 14 s
[16:22:31] Finished 'build-es5' after 14 s
[16:22:31] Starting 'build'...
[16:22:31] Finished 'build' after 34 μs
```

