### PR TITLE
Fixed #1242 - missing transitive dependencies

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -740,7 +740,7 @@ if (process.platform !== 'darwin') {
     });
 }
 
-// Covers current behavior, I think this should be changed https://github.com/yarnpkg/yarn/issues/2274
+// Covers current behavior, issue opened whether this should be changed https://github.com/yarnpkg/yarn/issues/2274
 test.concurrent('optional dependency that fails to build should still be installed',
   (): Promise<void> => {
     return runInstall({}, 'should-install-failing-optional-deps', async (config) => {
@@ -754,4 +754,4 @@ test.concurrent('a subdependency of an optional dependency that fails should be 
       assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'optional-failing')));
       assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'sub-dep')));
     });
-}
+  });

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -136,7 +136,7 @@ test.concurrent('hoisting should factor ignored dependencies', async () => {
   });
 });
 
-test.concurrent('--production flag ignores dev dependencies', () => {
+test('--production flag ignores dev dependencies', () => {
   return runInstall({production: true}, 'install-production', async (config) => {
     assert.ok(
       !await fs.exists(path.join(config.cwd, 'node_modules', 'lodash')),
@@ -467,7 +467,7 @@ test.concurrent(
 );
 
 // disabled to resolve https://github.com/yarnpkg/yarn/pull/1210
-test.skip('install should hoist nested bin scripts', (): Promise<void> => {
+test('install should hoist nested bin scripts', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-nested-bin', async (config) => {
     const binScripts = await fs.walk(path.join(config.cwd, 'node_modules', '.bin'));
     // need to double the amount as windows makes 2 entries for each dependency
@@ -727,13 +727,15 @@ test.concurrent('install will not overwrite files in symlinked scoped directorie
   });
 });
 
-test.concurrent.skip('install incompatible optional dependency should still install shared child dependencies',
-  (): Promise<void> => {
-    // this tests for a problem occuring due to optional dependency incompatible with os, in this case fsevents
-    // this would fail on os's incompatible with fsevents, which is everything except osx.
-    return runInstall({}, 'install-should-not-skip-required-shared-deps', async (config) => {
-      assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'deep-extend')));
-      assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'ini')));
-      assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'strip-json-comments')));
+if (process.platform !== 'darwin') {
+  test('install incompatible optional dependency should still install shared child dependencies',
+    (): Promise<void> => {
+      // this tests for a problem occuring due to optional dependency incompatible with os, in this case fsevents
+      // this would fail on os's incompatible with fsevents, which is everything except osx.
+      return runInstall({}, 'install-should-not-skip-required-shared-deps', async (config) => {
+        assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'deep-extend')));
+        assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'ini')));
+        assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'strip-json-comments')));
+      });
     });
-  });
+}

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -467,7 +467,7 @@ test.concurrent(
 );
 
 // disabled to resolve https://github.com/yarnpkg/yarn/pull/1210
-test('install should hoist nested bin scripts', (): Promise<void> => {
+test.skip('install should hoist nested bin scripts', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-nested-bin', async (config) => {
     const binScripts = await fs.walk(path.join(config.cwd, 'node_modules', '.bin'));
     // need to double the amount as windows makes 2 entries for each dependency

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -136,7 +136,7 @@ test.concurrent('hoisting should factor ignored dependencies', async () => {
   });
 });
 
-test('--production flag ignores dev dependencies', () => {
+test.concurrent('--production flag ignores dev dependencies', () => {
   return runInstall({production: true}, 'install-production', async (config) => {
     assert.ok(
       !await fs.exists(path.join(config.cwd, 'node_modules', 'lodash')),

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -727,11 +727,11 @@ test.concurrent('install a module with incompatible optional dependency should s
     });
   });
 
+// this tests for a problem occuring due to optional dependency incompatible with os, in this case fsevents
+// this would fail on os's incompatible with fsevents, which is everything except osx.
 if (process.platform !== 'darwin') {
   test.concurrent('install incompatible optional dependency should still install shared child dependencies',
     (): Promise<void> => {
-      // this tests for a problem occuring due to optional dependency incompatible with os, in this case fsevents
-      // this would fail on os's incompatible with fsevents, which is everything except osx.
       return runInstall({}, 'install-should-not-skip-required-shared-deps', async (config) => {
         assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'deep-extend')));
         assert.ok(await fs.exists(path.join(config.cwd, 'node_modules', 'ini')));

--- a/__tests__/fixtures/install/should-install-failing-optional-deps/optional-failing/install.js
+++ b/__tests__/fixtures/install/should-install-failing-optional-deps/optional-failing/install.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/__tests__/fixtures/install/should-install-failing-optional-deps/optional-failing/package.json
+++ b/__tests__/fixtures/install/should-install-failing-optional-deps/optional-failing/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "optional-failing",
+  "version": "0.0.0",
+  "scripts": {
+    "install": "node install.js"
+  }
+}

--- a/__tests__/fixtures/install/should-install-failing-optional-deps/package.json
+++ b/__tests__/fixtures/install/should-install-failing-optional-deps/package.json
@@ -1,0 +1,5 @@
+{
+  "optionalDependencies": {
+    "optional-failing": "file:optional-failing"
+  }
+}

--- a/__tests__/fixtures/install/should-install-failing-optional-sub-deps/optional-failing/install.js
+++ b/__tests__/fixtures/install/should-install-failing-optional-sub-deps/optional-failing/install.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/__tests__/fixtures/install/should-install-failing-optional-sub-deps/optional-failing/package.json
+++ b/__tests__/fixtures/install/should-install-failing-optional-sub-deps/optional-failing/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "optional-failing",
+  "version": "0.0.0",
+  "scripts": {
+    "install": "node install.js"
+  },
+  "dependencies": {
+    "sub-dep": "file:../sub-dep"
+  }
+}

--- a/__tests__/fixtures/install/should-install-failing-optional-sub-deps/package.json
+++ b/__tests__/fixtures/install/should-install-failing-optional-sub-deps/package.json
@@ -1,0 +1,5 @@
+{
+  "optionalDependencies": {
+    "optional-failing": "file:optional-failing"
+  }
+}

--- a/__tests__/fixtures/install/should-install-failing-optional-sub-deps/sub-dep/install.js
+++ b/__tests__/fixtures/install/should-install-failing-optional-sub-deps/sub-dep/install.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/__tests__/fixtures/install/should-install-failing-optional-sub-deps/sub-dep/package.json
+++ b/__tests__/fixtures/install/should-install-failing-optional-sub-deps/sub-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sub-dep",
+  "version": "0.0.0",
+  "scripts": {
+    "install": "node install.js"
+  }
+}

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -28,7 +28,7 @@ test('Produces valid destination paths for scoped modules', () => {
     _reference: (({}: any): PackageReference),
   }: any): Manifest);
 
-  const info = new HoistManifest(key, parts, pkg, '', false);
+  const info = new HoistManifest(key, parts, pkg, '', () => false);
 
   const tree = new Map([
     ['@scoped/dep', info],

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -137,7 +137,7 @@ export default class PackageHoister {
         return null;
       }
       // non ignored dependencies inherit parent's ignored status
-      // but parent may transition from ignored to non ignored when hoisting
+      // parent may transition from ignored to non ignored when hoisted if it is used in another non ignored branch
       if (!isIgnored() && parent.isIgnored()) {
         isIgnored = () => !!parent && parent.isIgnored();
       }
@@ -185,7 +185,7 @@ export default class PackageHoister {
       const existing = this.tree.get(checkKey);
       if (existing) {
         if (existing.loc === info.loc) {
-          // deduping an unignored reference to an ignored one
+          // switch to non ignored if earlier deduped version was ignored
           if (existing.isIgnored() && !info.isIgnored()) {
             existing.isIgnored = info.isIgnored;
           }

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -130,7 +130,7 @@ export default class PackageHoister {
 
     //
     let parentParts: Parts = [];
-    let isIgnored = () => { return ref.ignore; };
+    let isIgnored = () => ref.ignore;
 
     if (parent) {
       if (!this.tree.get(parent.key)) {
@@ -139,7 +139,7 @@ export default class PackageHoister {
       // non ignored dependencies inherit parent's ignored status
       // but parent may transition from ignored to non ignored when hoisting
       if (!isIgnored() && parent.isIgnored()) {
-        isIgnored = () => { return !!parent && parent.isIgnored(); };
+        isIgnored = () => !!parent && parent.isIgnored();
       }
       parentParts = parent.parts;
     }

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -13,8 +13,8 @@ type Parts = Array<string>;
 let historyCounter = 0;
 
 export class HoistManifest {
-  constructor(key: string, parts: Parts, pkg: Manifest, loc: string, isIgnored: boolean) {
-    this.ignore = isIgnored;
+  constructor(key: string, parts: Parts, pkg: Manifest, loc: string, isIgnored: () => boolean) {
+    this.isIgnored = isIgnored;
     this.loc = loc;
     this.pkg = pkg;
 
@@ -27,7 +27,7 @@ export class HoistManifest {
     this.addHistory(`Start position = ${key}`);
   }
 
-  ignore: boolean;
+  isIgnored: () => boolean;
   pkg: Manifest;
   loc: string;
   parts: Parts;
@@ -130,13 +130,17 @@ export default class PackageHoister {
 
     //
     let parentParts: Parts = [];
-    let isIgnored = ref.ignore;
+    let isIgnored = () => { return ref.ignore; };
 
     if (parent) {
       if (!this.tree.get(parent.key)) {
         return null;
       }
-      isIgnored = isIgnored || parent.ignore;
+      // non ignored dependencies inherit parent's ignored status
+      // but parent may transition from ignored to non ignored when hoisting
+      if (!isIgnored() && parent.isIgnored()) {
+        isIgnored = () => { return parent.isIgnored(); };
+      }
       parentParts = parent.parts;
     }
 
@@ -182,8 +186,8 @@ export default class PackageHoister {
       if (existing) {
         if (existing.loc === info.loc) {
           // deduping an unignored reference to an ignored one
-          if (existing.ignore && !info.ignore) {
-            existing.ignore = false;
+          if (existing.isIgnored() && !info.isIgnored()) {
+            existing.isIgnored = info.isIgnored;
           }
 
           existing.addHistory(`Deduped ${fullKey} to this item`);
@@ -277,7 +281,6 @@ export default class PackageHoister {
     // remove this item from the `tree` map so we can ignore it
     this.tree.delete(key);
 
-    //
     const {parts, duplicate} = this.getNewParts(key, info, rawParts.slice());
     const newKey = this.implodeKey(parts);
     const oldKey = key;
@@ -389,7 +392,7 @@ export default class PackageHoister {
       const ref = info.pkg._reference;
       invariant(ref, 'expected reference');
 
-      if (info.ignore) {
+      if (info.isIgnored()) {
         info.addHistory('Deleted as this module was ignored');
       } else {
         visibleFlatTree.push([loc, info]);

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -139,7 +139,7 @@ export default class PackageHoister {
       // non ignored dependencies inherit parent's ignored status
       // but parent may transition from ignored to non ignored when hoisting
       if (!isIgnored() && parent.isIgnored()) {
-        isIgnored = () => { return parent.isIgnored(); };
+        isIgnored = () => { return !!parent && parent.isIgnored(); };
       }
       parentParts = parent.parts;
     }


### PR DESCRIPTION

**Summary**

Fixes #2142, transitive dependencies now inherit "ignored" state from parent dynamically 

**Test plan**

Test has been added before and now is enabled

