### PR TITLE
Fix #2281: prevent hanging when cannot write yarn-error.log file

### DIFF
--- a/__tests__/fixtures/index/run-install-no-write-permissions/package.json
+++ b/__tests__/fixtures/index/run-install-no-write-permissions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test_install_no_write_permissions",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "left-pad": "^1.1.3"
+  }
+}

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -106,3 +106,12 @@ test.concurrent('should run add command with help option', async () => {
   const stdout = await execCommand('add', ['--help'], 'run-help');
   expect(stdout[0]).toEqual('Usage: yarn add [packages ...] [flags]');
 });
+
+test.concurrent('should error with code 1 immediately when cannot write into current folder', async () => {
+  // '__tests__/fixtures/index/run-install-no-write-permissions' folder should have no write permissions
+  try {
+    await execCommand('install', [], 'run-install-no-write-permissions');
+  } catch (err) {
+    expect(err.code).toEqual(1);
+  }
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -340,11 +340,26 @@ function onUnexpectedError(err: Error) {
 
   log.push(`Trace: ${indent(err.stack)}`);
 
-  const errorLoc = path.join(config.cwd, 'yarn-error.log');
-  fs.writeFileSync(errorLoc, log.join('\n\n') + '\n');
+  const bugReportLoc = writeBugReport(log);
 
   reporter.error(reporter.lang('unexpectedError', err.message));
-  reporter.info(reporter.lang('bugReport', errorLoc));
+
+  if (bugReportLoc) {
+    reporter.info(reporter.lang('bugReport', bugReportLoc));
+  }
+}
+
+function writeBugReport(log) : ?string {
+  const bugReportLoc = path.join(config.cwd, 'yarn-error.log');
+
+  try {
+    fs.writeFileSync(bugReportLoc, log.join('\n\n') + '\n');
+  } catch (err) {
+    reporter.error(reporter.lang('fileWriteError', bugReportLoc, err.message));
+    return undefined;
+  }
+
+  return bugReportLoc;
 }
 
 //

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -89,6 +89,7 @@ const messages = {
   noFilePermission: "We don't have permissions to touch the file $0.",
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
   frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
+  fileWriteError: 'Could not write file $0: $1',
 
   yarnOutdated: "Your current version of Yarn is out of date. The latest version is $0 while you're on $1.",
   yarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Fixes #2281 when **yarn install** command is hanging in case current user has no write permissions in the current folder.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`$ mkdir test`
`$ chmod -w test`
`$ cd test`
`$ yarn add left-pad`

Yarn should immediately exit with code 1 and error messages like those:

`error Could not write file ".../yarn-error.log": "EACCES: permission denied, open '.../yarn-error.log'"`
`error An unexpected error occurred: "EACCES: permission denied, mkdir '.../test/node_modules'".`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
