### PR TITLE
Reverted test due to inability to mock process.platform (#2262)

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -131,11 +131,3 @@ export async function run<T, R>(
     throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
   }
 }
-export const setPlatform = (platform : string) : string => {
-  const previous = process.platform;
-  Object.defineProperty(process, 'platform', {
-    value: platform,
-  });
-
-  return previous;
-};

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -2,7 +2,7 @@
 
 jest.mock('../../src/util/execute-lifecycle-script');
 
-import {run as buildRun, setPlatform} from './_helpers.js';
+import {run as buildRun} from './_helpers.js';
 import {BufferReporter} from '../../src/reporters/index.js';
 import {run} from '../../src/cli/commands/run.js';
 import * as fs from '../../src/util/fs.js';
@@ -66,17 +66,11 @@ test('properly handles extra arguments and pre/post scripts', (): Promise<void> 
   });
 });
 
-test('multi-platform bin scripts', () => (
-    ['win32', 'darwin'].reduce((tests, platform) => (
-      tests.then(() =>
-        runRun(['cat-names'], {}, 'bin', (config) => {
-          const originalPlatform = setPlatform(platform);
-          const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
-          const args = ['cat-names', config, `"${script}" `, config.cwd];
+test.only('properly handle bin scripts', (): Promise<void> => (
+  runRun(['cat-names'], {}, 'bin', (config) => {
+    const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
+    const args = ['cat-names', config, `"${script}" `, config.cwd];
 
-          expect(execCommand).toBeCalledWith(...args);
-          setPlatform(originalPlatform);
-        }),
-    ))
-    , Promise.resolve())
+    expect(execCommand).toBeCalledWith(...args);
+  }) : Promise<void>
 ));


### PR DESCRIPTION
**Summary**

This test is too complicated and does not thoroughly test the run command's handling of win32 vs. posix script command mangling.

It is not possible to test win32 and posix from one platform because the path module employed in the test alters its export based on process.platform in Node bootstrap, well before one can mock it. i.e. the test assertion will always be looking for the local platform's path delimiters etc.

One could hardcode path information, but it still feels risky to be changing the process.platform from within one test, for one test.

**Test plan**

The original test asserted that window cmd line formatting is properly applied or not applied, for only the target platform the tests are executed on - that will have to be good enough.

Tests pass.
