### PR TITLE
(2301) Release notes in Chocolatey package

### DIFF
--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -34,7 +34,7 @@ utilization.
 		<iconUrl>https://cdn.rawgit.com/yarnpkg/assets/master/yarn-kitten-circle.png</iconUrl>
 		<docsUrl>https://yarnpkg.com/en/docs/</docsUrl>
 		<bugTrackerUrl>https://github.com/yarnpkg/yarn/issues</bugTrackerUrl>
-
+		<releaseNotes>https://github.com/yarnpkg/yarn/releases/tag/v$version$</releaseNotes>
 		<dependencies>
 			<dependency id="nodejs.install" version="6.0" />
 		</dependencies>


### PR DESCRIPTION
**Summary**

Added releaseNotes to base nuspec file.

**Test plan**

I had to modify the chocolatley build script locally to get around a machine issue, but verified that the nuspec file was properly transformed by the build process.

**Nuspec input:**
![image](https://cloud.githubusercontent.com/assets/10888433/21338308/b8a4e376-c63a-11e6-8f4a-b0cea302f192.png)

**Embedded nuspec inside chocolately build output:**
![image](https://cloud.githubusercontent.com/assets/10888433/21338328/fa67a424-c63a-11e6-86c8-23d1456d2654.png)


