### PR TITLE
Fix cache test timeout

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -80,9 +80,10 @@ export async function run<T, R>(
   const reporter = new Reporter({stdout, stderr: stdout});
 
   const dir = path.join(fixturesLoc, name);
+  const basename = fixturesLoc ? `${path.basename(dir)}-` : '';
   const cwd = path.join(
     os.tmpdir(),
-    `yarn-${path.basename(dir)}-${Math.random()}`,
+    `yarn-${basename + Math.random()}`,
   );
   await fs.unlink(cwd);
   await fs.copy(dir, cwd, reporter);

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -66,7 +66,7 @@ test('properly handles extra arguments and pre/post scripts', (): Promise<void> 
   });
 });
 
-test.only('properly handle bin scripts', (): Promise<void> => (
+test('properly handle bin scripts', (): Promise<void> => (
   runRun(['cat-names'], {}, 'bin', (config) => {
     const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
     const args = ['cat-names', config, `"${script}" `, config.cwd];


### PR DESCRIPTION
**Summary**

Fixes an issue with tests timing out due to a directory not being created properly for the `cache` command tests.

Also, this removes the `.only` in the run test that snuck in there in #2298.

**Test plan**

All tests should now pass.