### PR TITLE
fix 2083 supportsArchive can be changed with nothing beeing cloned

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -338,7 +338,10 @@ export default class Git {
       }
 
       // `git archive` only accepts a treeish and we have no ref to this commit
-      this.supportsArchive = false;
+      if (this.supportsArchive) {
+        this.supportsArchive = false;
+        await this.fetch();
+      }
       return this.ref = this.hash = hash;
     }
 


### PR DESCRIPTION
Fix bug #2083
The git cloner could start using archive mode and switch back to local clone mode without cloning anything.
As a result, comands are spawned with a bad (non existent) cwd, leading to a ENOENT error.
This error is ms-interpreted a the lack of the git binary (https://github.com/yarnpkg/yarn/blob/master/src/util/child.js#L41)