### PR TITLE
`yarn search`

### DIFF
--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -31,6 +31,7 @@ import * as version from './version.js'; export {version};
 import * as versions from './versions.js'; export {versions};
 import * as why from './why.js'; export {why};
 import * as upgradeInteractive from './upgrade-interactive.js'; export {upgradeInteractive};
+import * as search from './search.js'; export {search};
 
 import buildUseless from './_useless.js';
 

--- a/src/cli/commands/search.js
+++ b/src/cli/commands/search.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+import algoliasearch from 'algoliasearch';
+import type {Reporter} from '../../reporters/index.js';
+import type Config from '../../config.js';
+import {MessageError} from '../../errors.js';
+const pkg = algoliasearch('OFCNCOG2CU', 'd72d98ea78084e9825f39d94816506ce').initIndex('npm-search');
+
+export async function run(
+ config: Config,
+ reporter: Reporter,
+ flags: Object,
+ args: Array<string>,
+): Promise<void> {
+  const query = args.join(' ').trim();
+  if (query === '') {
+    throw new MessageError(config.reporter.lang('searchNeedsQuery'));
+  }
+
+  const results = await pkg.search({query, hitsPerPage: 5});
+
+  if (results.hits.length === 0) {
+    return reporter.info(config.reporter.lang('searchEmpty', query));
+  }
+
+  reporter.info(config.reporter.lang('searchStats', results.nbHits.toLocaleString(), query));
+
+  return reporter.log(results.hits.map((hit) => `${hit.name} \n`).join(''));
+}

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -234,6 +234,11 @@ const messages = {
   errorDecompressingTarball: '$0. Error decompressing $1, it appears to be corrupt.',
   updateInstalling: 'Installing $0...',
   hostedGitResolveError: 'Error connecting to repository. Please, check the url.',
+
+  searchNeedsQuery: 'Please provide a search query.',
+  searchFailed: 'Search is not available right now, please try again later.',
+  searchEmpty: 'No packages found matching $0.',
+  searchStats: 'Search results: $0 packages matching $1. Relevant one(s):',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
# `yarn search`

This PR is a best effort proof of concept adding `yarn search` command to the yarn cli. To search for JavaScript packages.

The proposal is a consistency effort linked to adding `/search` to the yarn website as seen in [yarn/website#322](https://github.com/yarnpkg/website/issues/322).

## Demo

<details>
<summary>GIF</summary>

![](https://i.imgur.com/78Di6eZ.gif)
</details>


## Next steps

While we spent a good amount of time on the website search, the cli command is a best effort proof of concept and we would love your input on it.

Please do add comments and suggestions or just :thumbsup: :-1: the current PR description.

For example we could make it an interactive command much like `yarn upgrade-interactive` (I ❤️ this one) and allow people to select the package to install. What do you think?

We are also missing some metadata, as for the available metadata, have a look at yarn/website#123.

We are not (yet) regular contributors to the yarn cli projects and we might have been doing things the wrong way. If so please tell us and we will fix them.