### PR TITLE
add .vscode IDE config folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.log
 /.nyc_output
 /coverage
-/__tests__/fixtures/**/_*
 /dist
 /artifacts
 /updates
@@ -20,8 +19,6 @@
 fbkpm_modules
 test/fixtures/**/.fbkpm
 /tmp/
+/__tests__/fixtures/**/_*
 /__tests__/fixtures/request-cache/GET/localhost/.bin
-
-# IDE
-.idea/
 /__tests__/fixtures/request-cache/


### PR DESCRIPTION
**Summary**

Vscode uses a .vscode folder to hold local configuration, such as launch.json for debugging.
Would prefer to exclude this folder.

**Test plan**

1. Modify launch.json file for vscode.
2. Git shows modified launch.json in working tree.
3. Add ".vscode" to .gitignore, save.
4. Git updates to not show launch.json in working tree.
