### PR TITLE
Use sync version of fs.symlink. Fixes #2326

### DIFF
--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -27,7 +27,8 @@ export async function linkBin(src: string, dest: string): Promise<void> {
     await cmdShim(src, dest);
   } else {
     await fs.mkdirp(path.dirname(dest));
-    await fs.symlink(src, dest);
+    // Async symlink creates invalid symlinks, see issue #2326
+    fs.symlinkSync(src, dest);
     await fs.chmod(dest, '755');
   }
 }

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -25,6 +25,7 @@ export const mkdirp: (path: string) => Promise<void> = promisify(require('mkdirp
 export const exists: (path: string) => Promise<boolean>  = promisify(fs.exists, true);
 export const lstat: (path: string) => Promise<fs.Stats> = promisify(fs.lstat);
 export const chmod: (path: string, mode: number | string) => Promise<void> = promisify(fs.chmod);
+export const symlinkSync: (target: string, path: string, type?: 'dir' | 'file' | 'junction') => void = fs.symlinkSync;
 
 const fsSymlink: (
   target: string,


### PR DESCRIPTION
See Bug #2326 for a full explanation, but the issue is that for some reason `fs.symlink` is creating invalid symlinks during a global binary installation. This change switches to use `fs.symlinkSync`, which fixes the issue on my machine.

This is my first time poking around the yarn codebase, so I'm sure I did something wrong here. I

**Test plan**

I don't really know how to automate testing here. On my local machine global installation fails without this change. With this change it is successful:

```
yarn global v0.19.0-0
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed fastrealpath@0.1.1 with binaries:
      - realpath
Done in 0.69s.
```