### PR TITLE
Tests stability improvements

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -12,7 +12,6 @@ import Config from '../../src/config.js';
 
 const stream = require('stream');
 const path = require('path');
-const os = require('os');
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'install');
 
@@ -81,21 +80,12 @@ export async function run<T, R>(
 
   let cwd;
   if (fixturesLoc) {
-    // if fixture loc is not set create a tmp dir so that we don't copy CWD during test run
     const dir = path.join(fixturesLoc, name);
-    cwd = path.join(
-      os.tmpdir(),
-      `yarn-${path.basename(dir)}-${Math.random()}`,
-    );
-    await fs.unlink(cwd);
+    cwd = await fs.makeTempDir(path.basename(dir));
     await fs.copy(dir, cwd, reporter);
   } else {
-    cwd = path.join(
-      os.tmpdir(),
-      `yarn-${Math.random()}`,
-    );
-    await fs.unlink(cwd);
-    await fs.mkdirp(cwd);
+    // if fixture loc is not set then CWD is some empty temp dir    
+    cwd = await fs.makeTempDir();
   }
 
   for (const {basename, absolute} of await fs.walk(cwd)) {

--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -79,7 +79,16 @@ export async function run<T, R>(
 
   const reporter = new Reporter({stdout, stderr: stdout});
 
-  const dir = path.join(fixturesLoc, name);
+  let dir = path.join(fixturesLoc, name);
+  if (!fixturesLoc) {
+    // if fixture loc is not set create a tmp dir so that we don't copy CWD during test run
+    dir = path.join(
+      os.tmpdir(),
+      `yarn-${path.basename(dir)}-${Math.random()}`,
+    );
+    fs.mkdirp(dir);
+
+  }
   const cwd = path.join(
     os.tmpdir(),
     `yarn-${path.basename(dir)}-${Math.random()}`,

--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -79,22 +79,24 @@ export async function run<T, R>(
 
   const reporter = new Reporter({stdout, stderr: stdout});
 
-  let dir = path.join(fixturesLoc, name);
-  if (!fixturesLoc) {
+  let cwd;
+  if (fixturesLoc) {
     // if fixture loc is not set create a tmp dir so that we don't copy CWD during test run
-    dir = path.join(
+    const dir = path.join(fixturesLoc, name);
+    cwd = path.join(
       os.tmpdir(),
       `yarn-${path.basename(dir)}-${Math.random()}`,
     );
-    fs.mkdirp(dir);
-
+    await fs.unlink(cwd);
+    await fs.copy(dir, cwd, reporter);
+  } else {
+    cwd = path.join(
+      os.tmpdir(),
+      `yarn-${Math.random()}`,
+    );
+    await fs.unlink(cwd);
+    await fs.mkdirp(cwd);
   }
-  const cwd = path.join(
-    os.tmpdir(),
-    `yarn-${path.basename(dir)}-${Math.random()}`,
-  );
-  await fs.unlink(cwd);
-  await fs.copy(dir, cwd, reporter);
 
   for (const {basename, absolute} of await fs.walk(cwd)) {
     if (basename.toLowerCase() === '.ds_store') {

--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -8,8 +8,6 @@ import * as fs from '../../src/util/fs.js';
 
 const path = require('path');
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
-
 const runConfig = buildRun.bind(
   null,
   reporters.ConsoleReporter,

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -6,6 +6,7 @@ import {run as buildRun} from './_helpers.js';
 import {run as global} from '../../src/cli/commands/global.js';
 import * as fs from '../../src/util/fs.js';
 import assert from 'assert';
+const isCI = require('is-ci');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
@@ -34,12 +35,15 @@ function getTempGlobalFolder(): string {
   return path.join(os.tmpdir(), `yarn-global-${Math.random()}`);
 }
 
-test.concurrent('add without flag', (): Promise<void> => {
-  return runGlobal(['add', 'react-native-cli'], {}, 'add-without-flag', async (config) => {
-    assert.ok(await fs.exists(path.join(config.globalFolder, 'node_modules', 'react-native-cli')));
-    assert.ok(await fs.exists(path.join(config.globalFolder, 'node_modules', '.bin', 'react-native')));
+// this test has global folder side effects, run it only in CI
+if (isCI) {
+  test.concurrent('add without flag', (): Promise<void> => {
+    return runGlobal(['add', 'react-native-cli'], {}, 'add-without-flag', async (config) => {
+      assert.ok(await fs.exists(path.join(config.globalFolder, 'node_modules', 'react-native-cli')));
+      assert.ok(await fs.exists(path.join(config.globalFolder, 'node_modules', '.bin', 'react-native')));
+    });
   });
-});
+}
 
 test.concurrent('add with prefix flag', (): Promise<void> => {
   const tmpGlobalFolder = getTempGlobalFolder();

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -174,7 +174,9 @@ test.concurrent('writes a lockfile even when there are no dependencies', (): Pro
   });
 });
 
-test.concurrent("throws an error if existing lockfile isn't satisfied with --frozen-lockfile", async (): Promise<void> => {
+test.concurrent(
+  'throws an error if existing lockfile isn't satisfied with --frozen-lockfile', 
+  async (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
 
   let thrown = false;

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -177,16 +177,16 @@ test.concurrent('writes a lockfile even when there are no dependencies', (): Pro
 test.concurrent(
   "throws an error if existing lockfile isn't satisfied with --frozen-lockfile", 
   async (): Promise<void> => {
-  const reporter = new reporters.ConsoleReporter({});
+    const reporter = new reporters.ConsoleReporter({});
 
-  let thrown = false;
-  try {
-    await runInstall({frozenLockfile: true}, 'install-throws-error-if-not-satisfied-and-frozen-lockfile', () => {});
-  } catch (err) {
-    thrown = true;
-    expect(err.message).toContain(reporter.lang('frozenLockfileError'));
-  }
-  assert(thrown);
+    let thrown = false;
+    try {
+      await runInstall({frozenLockfile: true}, 'install-throws-error-if-not-satisfied-and-frozen-lockfile', () => {});
+    } catch (err) {
+      thrown = true;
+      expect(err.message).toContain(reporter.lang('frozenLockfileError'));
+    }
+    assert(thrown);
 });
 
 test.concurrent('install transitive optional dependency from lockfile', (): Promise<void> => {

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -187,7 +187,7 @@ test.concurrent(
       expect(err.message).toContain(reporter.lang('frozenLockfileError'));
     }
     assert(thrown);
-});
+  });
 
 test.concurrent('install transitive optional dependency from lockfile', (): Promise<void> => {
   return runInstall({}, 'install-optional-dep-from-lockfile', (config, reporter, install) => {

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -175,7 +175,7 @@ test.concurrent('writes a lockfile even when there are no dependencies', (): Pro
 });
 
 test.concurrent(
-  'throws an error if existing lockfile isn't satisfied with --frozen-lockfile', 
+  "throws an error if existing lockfile isn't satisfied with --frozen-lockfile", 
   async (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
 

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -174,18 +174,17 @@ test.concurrent('writes a lockfile even when there are no dependencies', (): Pro
   });
 });
 
-test.concurrent("throws an error if existing lockfile isn't satisfied with --frozen-lockfile", (): Promise<void> => {
+test.concurrent("throws an error if existing lockfile isn't satisfied with --frozen-lockfile", async (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
 
-  return new Promise((resolve) => {
-    try {
-      runInstall({frozenLockfile: true}, 'install-throws-error-if-not-satisfied-and-frozen-lockfile', () => {});
-    } catch (err) {
-      expect(err.message).toContain(reporter.lang('frozenLockfileError'));
-    } finally {
-      resolve();
-    }
-  });
+  let thrown = false;
+  try {
+    await runInstall({frozenLockfile: true}, 'install-throws-error-if-not-satisfied-and-frozen-lockfile', () => {});
+  } catch (err) {
+    thrown = true;
+    expect(err.message).toContain(reporter.lang('frozenLockfileError'));
+  }
+  assert(thrown);
 });
 
 test.concurrent('install transitive optional dependency from lockfile', (): Promise<void> => {

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -41,13 +41,13 @@ export async function run(
       const registry = config.registries[registryName];
       const object = rootManifests[registryName].object;
 
-      constants.DEPENDENCY_TYPES.forEach((type) =>  {
+      for (const type of constants.DEPENDENCY_TYPES) {
         const deps = object[type];
         if (deps && deps[name]) {
           found = true;
           delete deps[name];
         }
-      });
+      }
 
       const possibleManifestLoc = path.join(config.cwd, registry.folder, name);
       if (await fs.exists(possibleManifestLoc)) {

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -41,13 +41,13 @@ export async function run(
       const registry = config.registries[registryName];
       const object = rootManifests[registryName].object;
 
-      for (const type of constants.DEPENDENCY_TYPES) {
+      constants.DEPENDENCY_TYPES.forEach((type) =>  {
         const deps = object[type];
         if (deps && deps[name]) {
           found = true;
           delete deps[name];
         }
-      }
+      });
 
       const possibleManifestLoc = path.join(config.cwd, registry.folder, name);
       if (await fs.exists(possibleManifestLoc)) {

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -510,3 +510,14 @@ export async function writeFilePreservingEol(path: string, data: string) : Promi
   }
   await promisify(fs.writeFile)(path, data);
 }
+
+// not a strict polyfill for Node's fs.mkdtemp
+export async function makeTempDir(prefix?: string): Promise<string> {
+  const dir = path.join(
+    os.tmpdir(),
+    `yarn-${prefix || ''}-${Date.now()}-${Math.random()}`,
+  );
+  await unlink(dir);
+  await mkdirp(dir);
+  return dir;
+}


### PR DESCRIPTION
**Summary**

I am working on Ubuntu on Windows and had to fix a few issues with tests that were broken.
 
- cache tests were slowed down because all of them were copying root folder to a temp location
- if node is installed globally with root then `global` tests were failing for non root users
- fixed a weird Ubuntu on Windows issue (going to report this over there)