### PR TITLE
[CI] enabled node 4 in Travis builds + more CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: node_js
 
 node_js:
   - "6"
+  - "4"
 
 sudo: required # Until Yarn repo is added to apt-source-whitelist
 
@@ -30,27 +31,37 @@ env:
   - TEST_TYPE="build-dist"
   - TEST_TYPE="check-lockfile"
   - TEST_TYPE="lint"
-  - NODE_VERSION="6" TEST_TYPE="test-ci"
-  - NODE_VERSION="4" TEST_TYPE="test-ci"
+  - TEST_TYPE="test-ci"
 
 matrix:
   exclude:
     - env: TEST_TYPE="build-dist"
       os: osx
+    - env: TEST_TYPE="build-dist"
+      node_js: "4"
     - env: TEST_TYPE="check-lockfile"
       os: osx
+    - env: TEST_TYPE="check-lockfile"
+      node_js: "4"
     - env: TEST_TYPE="lint"
       os: osx
+    - env: TEST_TYPE="lint"
+      node_js: "4"
+    - env: TEST_TYPE="test-ci"
+      os: osx
+      node_js: "4"
 
 before_install:
-  - ./scripts/bootstrap-env-ubuntu.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/bootstrap-env-ubuntu.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install yarn; fi
 
 install:
  - node --version
  - yarn install
 
 os:
-  #- osx
+  - osx
   - linux
 
 script: yarn $TEST_TYPE

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -14,7 +14,7 @@ import semver from 'semver';
 import {promisify} from '../../src/util/promise';
 import fsNode from 'fs';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
 const path = require('path');
 

--- a/__tests__/commands/install/integration-deduping.js
+++ b/__tests__/commands/install/integration-deduping.js
@@ -4,7 +4,7 @@ import {getPackageVersion, runInstall} from '../_helpers.js';
 
 const assert = require('assert');
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
 test.concurrent('install should dedupe dependencies avoiding conflicts 0', (): Promise<void> => {
   // A@2.0.1 -> B@2.0.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ build_script:
   - npm run build-win-installer
 
 test_script:
+  - node --version
   - npm run test-only
 
 artifacts:


### PR DESCRIPTION
**Summary**

- Travis was not running tests in Node 4 (see `node --version` output in https://travis-ci.org/yarnpkg/yarn/jobs/188493526)
- Added `node --version` to appveyor builds logs
- Added OSX Node 6 builds to Travis builds
- increased timeouts for the longest running tests
