### PR TITLE
Don't push duplicated elements to config.rootModuleFolders

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -204,7 +204,10 @@ export default class Config {
 
       this.registries[key] = registry;
       this.registryFolders.push(registry.folder);
-      this.rootModuleFolders.push(path.join(this.cwd, registry.folder));
+      const rootModuleFolder = path.join(this.cwd, registry.folder);
+      if (this.rootModuleFolders.indexOf(rootModuleFolder) < 0) {
+        this.rootModuleFolders.push(rootModuleFolder);
+      }
     }
 
     this.networkConcurrency = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`this.rootModuleFolders` has duplicated entries since it is already initialized [here](https://github.com/yarnpkg/yarn/blob/master/src/config.js#L275).

Discovered this while working on #2375 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

It's very unlikely that this change introduces a regression that is not already covered by the test suite.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
