### PR TITLE
Change log level of optional deps to warn

### DIFF
--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -111,7 +111,7 @@ export default class PackageInstallScripts {
 
       if (ref.optional) {
         ref.ignore = true;
-        this.reporter.error(this.reporter.lang('optionalModuleScriptFail', err.message));
+        this.reporter.warn(this.reporter.lang('optionalModuleScriptFail', err.message));
         this.reporter.info(this.reporter.lang('optionalModuleFail'));
       } else {
         throw err;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The error output of failing optional dependencies can be very intimidating since most of the time yarn will display a huge stack trace (see below).
This PR changes the log level from `error` to `warn` to make the output less intimidating for users.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Here is the output of a failed install of `canvas` as a optional dependency:

[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
[1/1] ⢀ canvas: ERR! configure error
[-/1] ⢀ waiting...
[-/1] ⢀ waiting...
[-/1] ⢀ waiting...
warning Error running install script for optional dependency: "/Users/lukasgeiger/code/nteract/node_modules/canvas: Command failed.\nExit code: 1\nCommand: sh\nArguments: -c node-gyp rebuild\nDirectory: /Users/lukasgeiger/code/nteract/node_modules/canvas\nOutput:\ngyp info it worked if it ends with ok\ngyp info using node-gyp@3.4.0\ngyp info using node@7.3.0 | darwin | x64\ngyp info spawn /usr/local/bin/python2\ngyp info spawn args [ '/Users/lukasgeiger/code/yarn/node_modules/node-gyp/gyp/gyp_main.py',\ngyp info spawn args   'binding.gyp',\ngyp info spawn args   '-f',\ngyp info spawn args   'make',\ngyp info spawn args   '-I',\ngyp info spawn args   '/Users/lukasgeiger/code/nteract/node_modules/canvas/build/config.gypi',\ngyp info spawn args   '-I',\ngyp info spawn args   '/Users/lukasgeiger/code/yarn/node_modules/node-gyp/addon.gypi',\ngyp info spawn args   '-I',\ngyp info spawn args   '/Users/lukasgeiger/.node-gyp/7.3.0/include/node/common.gypi',\ngyp info spawn args   '-Dlibrary=shared_library',\ngyp info spawn args   '-Dvisibility=default',\ngyp info spawn args   '-Dnode_root_dir=/Users/lukasgeiger/.node-gyp/7.3.0',\ngyp info spawn args   '-Dnode_gyp_dir=/Users/lukasgeiger/code/yarn/node_modules/node-gyp',\ngyp info spawn args   '-Dnode_lib_file=node.lib',\ngyp info spawn args   '-Dmodule_root_dir=/Users/lukasgeiger/code/nteract/node_modules/canvas',\ngyp info spawn args   '--depth=.',\ngyp info spawn args   '--no-parallel',\ngyp info spawn args   '--generator-output',\ngyp info spawn args   'build',\ngyp info spawn args   '-Goutput_dir=.' ]\nPackage cairo was not found in the pkg-config search path.\nPerhaps you should add the directory containing `cairo.pc'\nto the PKG_CONFIG_PATH environment variable\nNo package 'cairo' found\ngyp: Call to './util/has_lib.sh freetype' returned exit status 0 while in binding.gyp. while trying to load binding.gyp\ngyp ERR! configure error \ngyp ERR! stack Error: `gyp` failed with exit code: 1\ngyp ERR! stack     at ChildProcess.onCpExit (/Users/lukasgeiger/code/yarn/node_modules/node-gyp/lib/configure.js:305:16)\ngyp ERR! stack     at emitTwo (events.js:106:13)\ngyp ERR! stack     at ChildProcess.emit (events.js:191:7)\ngyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)\ngyp ERR! System Darwin 16.3.0\ngyp ERR! command \"/usr/local/Cellar/node/7.3.0/bin/node\" \"/Users/lukasgeige
✨  Done in 13.03s.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
