### PR TITLE
[CI] travis: Use the built-in yarn support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - "6"
   - "4"
 
-sudo: required # Until Yarn repo is added to apt-source-whitelist
+sudo: false
 
 addons:
   apt:
@@ -20,11 +20,11 @@ branches:
   - /^.*-stable$/
 
 cache:
+  yarn: true
   directories:
   - node_modules
   - lib
   - lib-legacy
-  - $HOME/.yarn-cache
 
 env:
   matrix:
@@ -47,13 +47,7 @@ matrix:
       env: TEST_TYPE="test-ci -- -- --maxWorkers 1"
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/bootstrap-env-ubuntu.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install yarn; fi
-
-install:
- - node --version
- - yarn install
+  - node --version
 
 os:
   - linux


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Now that [Travis officially supports yarn](https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn), we no longer need to install it via homebrew/apt-get.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->