### PR TITLE
[CI] circle: Fix the yarn cache directory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
 
 dependencies:
   cache_directories:
-    - "~/.yarn-cache"
+    - "~/.cache/yarn"
     - "~/ghr"
 
   override:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

yarn is [now cached in ~/.cache/yarn](https://github.com/yarnpkg/yarn/blob/a1192e596b85acb2f63daa1cbf30e662c2125310/src/constants.js#L41), not ~/.yarn-cache.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
