### PR TITLE
Add silent flag to allow raw output

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -75,6 +75,10 @@ commander.option(
   '--no-emoji',
   'disable emoji in output',
 );
+commander.option(
+  '-s, --silent',
+  'raw script output',
+);
 commander.option('--proxy <host>', '');
 commander.option('--https-proxy <host>', '');
 commander.option(
@@ -191,10 +195,11 @@ const reporter = new Reporter({
   emoji: commander.emoji && process.stdout.isTTY && process.platform === 'darwin',
   verbose: commander.verbose,
   noProgress: !commander.progress,
+  isSilent: commander.silent,
 });
+
 reporter.initPeakMemoryCounter();
 
-//
 const config = new Config(reporter);
 
 // print header

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -29,6 +29,7 @@ export type ReporterOptions = {
   stdin?: Stdin,
   emoji?: boolean,
   noProgress?: boolean,
+  silent?: boolean,
 };
 
 export function stringifyLangArgs(args: Array<any>): Array<string> {
@@ -74,6 +75,7 @@ export default class BaseReporter {
   emoji: boolean;
   noProgress: boolean;
   isVerbose: boolean;
+  isSilent: boolean;
   format: Formatter;
 
   peakMemoryInterval: ?number;

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -27,9 +27,10 @@ type Row = Array<string>;
 export default class ConsoleReporter extends BaseReporter {
   constructor(opts: Object) {
     super(opts);
-    this._lastCategorySize = 0;
 
+    this._lastCategorySize = 0;
     this.format = (chalk: any);
+    this.isSilent = !!opts.isSilent;
   }
 
   _lastCategorySize: number;
@@ -142,6 +143,7 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   _log(msg: string) {
+    if (this.isSilent) { return; }
     clearLine(this.stdout);
     this.stdout.write(`${msg}\n`);
   }

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -143,7 +143,9 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   _log(msg: string) {
-    if (this.isSilent) { return; }
+    if (this.isSilent) {
+      return;
+    }
     clearLine(this.stdout);
     this.stdout.write(`${msg}\n`);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR implements a `--silent` flag (`-s` for short) to Yarn's CLI in order to allow raw script output. [This feature is available on npm](https://github.com/rafaelrinaldi/til/blob/master/npm/npm-run-silently.md) and is very useful for when you want to pipe the output of a script as an input of another script.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Add a `foo` script to your `package.json` that prints a simple message:

```json
{
  "scripts": {
    "foo": "echo 'it works'"
  }
}
```

The default behavior will give you the script output followed by a header and a footer added by Yarn:

```sh
$ yarn run foo
yarn run v0.20.0-0
$ echo 'it works' 
it works
✨  Done in 0.14s.
```

However, if you want only the raw script output you can append the `--silent` flag:

```sh
$ yarn run foo --silent # or simply `-s`
it works
```

---

This is my first PR to Yarn so please let me know if I need to change anything in order to make it acceptable for review. Thanks!