### PR TITLE
Treat some configs as internal to fix #2286.

### DIFF
--- a/__tests__/fixtures/lifecycle-scripts/dont-expose-internal-configs-to-env/log-configs.js
+++ b/__tests__/fixtures/lifecycle-scripts/dont-expose-internal-configs-to-env/log-configs.js
@@ -1,0 +1,7 @@
+const configs = {};
+for (const key in process.env) {
+  if (key.startsWith('npm_config_')) {
+    configs[key] = process.env[key];
+  }
+}
+console.log(`##${JSON.stringify(configs)}##`);

--- a/__tests__/fixtures/lifecycle-scripts/dont-expose-internal-configs-to-env/log-configs.js
+++ b/__tests__/fixtures/lifecycle-scripts/dont-expose-internal-configs-to-env/log-configs.js
@@ -1,7 +1,8 @@
-const configs = {};
-for (const key in process.env) {
-  if (key.startsWith('npm_config_')) {
+// As this file won't be transpiled, we use ES5 here.
+var configs = {};
+for (var key in process.env) {
+  if (key.indexOf('npm_config_') === 0) {
     configs[key] = process.env[key];
   }
 }
-console.log(`##${JSON.stringify(configs)}##`);
+console.log('##' + JSON.stringify(configs) + '##');

--- a/__tests__/fixtures/lifecycle-scripts/dont-expose-internal-configs-to-env/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/dont-expose-internal-configs-to-env/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dont-exposing-internal-configs-to-env",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "prepublish" : "node log-configs.js",
+    "pretest" : "node log-configs.js"
+  }
+}

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -48,7 +48,7 @@ async () => {
 test('should only expose non-internal configs', async () => {
   const env = Object.assign({}, process.env);
   const internalConfigKeys = ['lastUpdateCheck'];
-  const nonInternalConfigKeys = ['registry'];
+  const nonInternalConfigKeys = ['user_agent'];
   const prefix = 'npm_config_';
   [...internalConfigKeys, ...nonInternalConfigKeys].forEach((key) => {
     delete env[prefix + key];

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -12,16 +12,13 @@ const yarnBin = path.join(__dirname, '../bin/yarn.js');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
-async function execCommand(cmd: string, packageName: string): Promise<string> {
+async function execCommand(cmd: string, packageName: string, env = process.env): Promise<string> {
   const srcPackageDir = path.join(fixturesLoc, packageName);
   const packageDir = await makeTemp(packageName);
 
   await fs.copy(srcPackageDir, packageDir, new NoopReporter());
 
   return new Promise((resolve, reject) => {
-    const env = Object.assign({}, process.env);
-
-    delete env.npm_config_argv;
 
     exec(`node ${yarnBin} ${cmd}`, {cwd:packageDir, env}, (err, stdout) => {
       if (err) {
@@ -35,12 +32,45 @@ async function execCommand(cmd: string, packageName: string): Promise<string> {
 
 test('should expose `npm_config_argv` environment variable to lifecycle scripts for back compatibility with npm (#684)',
 async () => {
-  let stdout = await execCommand('install', 'npm_config_argv_env_vars');
+  const env = Object.assign({}, process.env);
+  delete env.npm_config_argv;
+
+  let stdout = await execCommand('install', 'npm_config_argv_env_vars', env);
   expect(stdout).toContain('##install##');
 
-  stdout = await execCommand('', 'npm_config_argv_env_vars');
+  stdout = await execCommand('', 'npm_config_argv_env_vars', env);
   expect(stdout).toContain('##install##');
 
-  stdout = await execCommand('test', 'npm_config_argv_env_vars');
+  stdout = await execCommand('test', 'npm_config_argv_env_vars', env);
   expect(stdout).toContain('##test##');
+});
+
+test('should only expose non-internal configs', async () => {
+  const env = Object.assign({}, process.env);
+  const internalConfigKeys = ['lastUpdateCheck'];
+  const nonInternalConfigKeys = ['registry'];
+  const prefix = 'npm_config_';
+  [...internalConfigKeys, ...nonInternalConfigKeys].forEach((key) => {
+    delete env[prefix + key];
+  });
+
+  let stdout = await execCommand('install', 'dont-expose-internal-configs-to-env', env);
+  stdout = stdout.substring(
+    stdout.indexOf('##') + 2,
+    stdout.lastIndexOf('##'),
+  );
+  let configs = {};
+  try {
+    configs = JSON.parse(stdout);
+  } catch (e) {}
+
+  internalConfigKeys.forEach((key) => {
+    const val = configs[prefix + key];
+    expect(val).toBeUndefined();
+  });
+
+  nonInternalConfigKeys.forEach((key) => {
+    const val = configs[prefix + key];
+    expect(val).toBeDefined();
+  });
 });

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -17,6 +17,11 @@ export type LifecycleReturn = Promise<{
 
 const IGNORE_MANIFEST_KEYS = ['readme'];
 
+// We treat these configs as internal, thus not expose them to process.env.
+// This helps us avoid some gyp issues when building native modules.
+// See https://github.com/yarnpkg/yarn/issues/2286.
+const IGNORE_CONFIG_KEYS = ['lastUpdateCheck'];
+
 async function makeEnv(stage: string, cwd: string, config: Config): {
   [key: string]: string
 } {
@@ -69,7 +74,7 @@ async function makeEnv(stage: string, cwd: string, config: Config): {
     ...Object.keys(config.registries.npm.config),
   ]);
   for (const key of keys) {
-    if (key.match(/:_/)) {
+    if (key.match(/:_/) || IGNORE_CONFIG_KEYS.indexOf(key) >= 0) {
       continue;
     }
 


### PR DESCRIPTION
**Summary**
Ignore some configs when making env.

**Test plan**

Before change:
```
env['npm_config_lastUpdateCheck'] != undefined
env['npm_config_registry'] != undefined
```

After change:
```
env['npm_config_lastUpdateCheck'] == undefined
env['npm_config_registry'] != undefined
```