### PR TITLE
Set boolean config values correctly

### DIFF
--- a/__tests__/commands/config.js
+++ b/__tests__/commands/config.js
@@ -31,3 +31,21 @@ test('cache-folder flag has higher priorities than .yarnrc file', (): Promise<vo
       expect(config.cacheFolder).toContain('flag_config_folder_dir');
     });
 });
+
+test('set true when option value is empty', (): Promise<void> => {
+  return runConfig(['set', 'strict-ssl', ''], {}, '', (config) => {
+    expect(config.registries.yarn.homeConfig['strict-ssl']).toBe(true);
+  });
+});
+
+test('set value "false" to an option', (): Promise<void> => {
+  return runConfig(['set', 'strict-ssl', 'false'], {}, '', (config) => {
+    expect(config.registries.yarn.homeConfig['strict-ssl']).toBe(false);
+  });
+});
+
+test('set value "true" to an option', (): Promise<void> => {
+  return runConfig(['set', 'strict-ssl', 'true'], {}, '', (config) => {
+    expect(config.registries.yarn.homeConfig['strict-ssl']).toBe(true);
+  });
+});

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -19,8 +19,8 @@ export const {run, setFlags} = buildSubCommands('config', {
     if (args.length === 0 || args.length > 2) {
       return false;
     }
-
-    const [key, val = true] = args;
+    const key = args[0];
+    const val = args[1] || true;
     const yarnConfig = config.registries.yarn;
     await yarnConfig.saveHomeConfig({[key]: val});
     reporter.success(reporter.lang('configSet', key, val));

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -101,6 +101,8 @@ export default class YarnRegistry extends NpmRegistry {
   }
 
   async saveHomeConfig(config: Object): Promise<void> {
+    YarnRegistry.normalizeConfig(config);
+
     for (const key in config) {
       const val = config[key];
 


### PR DESCRIPTION
* Fixes #2434

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

`yarn config set [option] [false|true]` 
should set the option value to false/true respectively. 
Currently it's set to string value "false"/"true".

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

*Test Plan*
* `yarn config set strict-ssl false`
* $HOME/.yarnrc should contain the line:
   strict-ssl false

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
