### PR TITLE
support relative symlinks in yarn script

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,5 +1,5 @@
 #!/bin/sh
-basedir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
+basedir=$(dirname "$(readlink -f "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
 
 use_winpty=0
 


### PR DESCRIPTION
**Summary**

https://github.com/yarnpkg/yarn/issues/1941 is great, but it doesn't support relative symlinks.
Given the following symlink `yarn -> ../share/yarn/bin/yarn` you get `Error: Cannot find module '/share/yarn/bin/yarn.js'`.

**Test plan**

Just link the `yarn` script with `ln -rs`. Then run it. With this patch it's going to work. I think this is 0.19 material. Basically a bugfix.
