### PR TITLE
Fix "file://" URI to accept absolute paths

### DIFF
--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -17,7 +17,7 @@ type Dependencies = {
 export default class FileResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
     super(request, fragment);
-    this.loc = util.removePrefix(fragment, 'file:');
+    this.loc = util.removePrefix(fragment, 'file://');
   }
 
   loc: string;
@@ -72,11 +72,14 @@ export default class FileResolver extends ExoticResolver {
     let temp = section;
 
     for (const [k, v] of util.entries(section)) {
-      if (typeof v === 'string' && v.startsWith('file:') && !path.isAbsolute(v)) {
-        if (temp === section) {
-          temp = Object.assign({}, section);
+      if (typeof v === 'string' && v.startsWith('file://')) {
+        let lv = util.removePrefix(v, 'file://');
+        if (!path.isAbsolute(lv)) {
+          if (temp === section) {
+            temp = Object.assign({}, section);
+          }
+          temp[k] = `file://${path.relative(this.config.cwd, path.join(loc, lv))}`;
         }
-        temp[k] = `file:${path.relative(this.config.cwd, path.join(loc, util.removePrefix(v, 'file:')))}`;
       }
     }
 


### PR DESCRIPTION
**Summary**

The check for absolute path should be done against the path without the `file://` prefix and in order to unambiguously check for absolute paths, the `file://` URI scheme should always start with double slash (as required by the specification), a third slash would make the path absolute.

**Example**
The following is a excerpt of a `package.json`
```json
{
  "dependencies": {
    "my-package": "file:///home/kronuz/packages/my_package"
  }
}
```