### PR TITLE
Add `-loader` suffix in webpack, closes #2410

### DIFF
--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -21,10 +21,10 @@ const compiler = webpack({
     loaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: 'babel',
+      loader: 'babel-loader',
     }, {
       test: /\.json$/,
-      loader: 'json',
+      loader: 'json-loader',
     }],
   },
   plugins: [
@@ -57,11 +57,11 @@ const compilerLegacy = webpack({
     loaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: 'babel',
+      loader: 'babel-loader',
       query: babelRc.env['pre-node5'],
     }, {
       test: /\.json$/,
-      loader: 'json',
+      loader: 'json-loader',
     }],
   },
   plugins: [


### PR DESCRIPTION
Bundled builds were not being built correctly..

Example: https://github.com/yarnpkg/yarn/releases/download/v0.19.0/yarn-0.19.0.js
Issue: https://github.com/yarnpkg/yarn/issues/2410

## tl;dr

Just add `-loader` suffix to loaders in to scripts/build-webpack.js. ezpz

## Details

Previously, packages named with `-loader` suffix could be specified as loaders within Webpack without requiring the suffix to be named explicitly. Webpack 2.1.0-beta.26 no longer looks for `-loader` suffix automatically, and packages have to therefore be named explicitly or `-loader` can be added to `resolveLoader.moduleExtensions`.

See: https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.26

This PR explicitly adds `-loader` suffix, and now bundles are correctly built.

### Before

```sh
~/yarn-0.19.0  (yarn@0.19.0)
λ node scripts/build-webpack.js
[]

~/yarn-0.19.0  (yarn@0.19.0)
λ
```

### After

```sh
~/yarn-0.19.0  (yarn@0.19.0)
λ node scripts/build-webpack.js
[ 'node_modules/ansi-escapes/index.js',
  'node_modules/ansi-regex/index.js',
  'node_modules/ansi-styles/index.js',
  'node_modules/array-find-index/index.js',
  'node_modules/asn1/lib/ber/errors.js',
  # ... etc ...
  'src/util/promise.js',
  'src/util/request-manager.js',
  'src/util/stream.js',
  'src/util/version.js' ]

~/yarn-0.19.0  (yarn@0.19.0)
λ
```