### PR TITLE
Fix bug for #2117 - http url not working

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -42,6 +42,24 @@ xit('secureUrl', async function (): Promise<void> {
   const reporter = new NoopReporter();
 
   expect(await
+    toThrow(() => {
+      return Git.secureUrl('http://github.com/yarnpkg/yarn.git', '', reporter);
+    }),
+  ).toEqual('https://github.com/yarnpkg/yarn.git');
+
+  expect(await
+    toThrow(() => {
+      return Git.secureUrl('https://github.com/yarnpkg/yarn.git', '', reporter);
+    }),
+  ).toEqual('https://github.com/yarnpkg/yarn.git');
+
+  expect(await
+    toThrow(() => {
+      return Git.secureUrl('git://github.com/yarnpkg/yarn.git', '', reporter);
+    }),
+  ).toEqual('https://github.com/yarnpkg/yarn.git');
+
+  expect(await
          toThrow(() => {
            return Git.secureUrl('http://random.repo', '', reporter);
          }),

--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -29,70 +29,26 @@ test('isCommitHash', () => {
     .toBeFalsy();
 });
 
-async function toThrow(f): Promise <boolean> {
-  try {
-    await f();
-    return false;
-  } catch (e) {
-    return true;
-  }
-}
 
-xit('secureUrl', async function (): Promise<void> {
+test('secureUrl', async function (): Promise<void> {
   const reporter = new NoopReporter();
 
-  expect(await
-    toThrow(() => {
-      return Git.secureUrl('http://github.com/yarnpkg/yarn.git', '', reporter);
-    }),
-  ).toEqual('https://github.com/yarnpkg/yarn.git');
+  let hasException = false;
+  try {
+    await Git.secureUrl('http://fake-fake-fake-fake.com/123.git', '', reporter);
+  } catch (e) {
+    hasException = true;
+  }
+  expect(hasException).toEqual(true);
 
-  expect(await
-    toThrow(() => {
-      return Git.secureUrl('https://github.com/yarnpkg/yarn.git', '', reporter);
-    }),
-  ).toEqual('https://github.com/yarnpkg/yarn.git');
+  let url = await Git.secureUrl('http://github.com/yarnpkg/yarn.git', '', reporter);
+  expect(url).toEqual('https://github.com/yarnpkg/yarn.git');
 
-  expect(await
-    toThrow(() => {
-      return Git.secureUrl('git://github.com/yarnpkg/yarn.git', '', reporter);
-    }),
-  ).toEqual('https://github.com/yarnpkg/yarn.git');
+  url = await Git.secureUrl('https://github.com/yarnpkg/yarn.git', '', reporter);
+  expect(url).toEqual('https://github.com/yarnpkg/yarn.git');
 
-  expect(await
-         toThrow(() => {
-           return Git.secureUrl('http://random.repo', '', reporter);
-         }),
-        ).toEqual(true);
+  url = await Git.secureUrl('git://github.com/yarnpkg/yarn.git', '', reporter);
+  expect(url).toEqual('https://github.com/yarnpkg/yarn.git');
 
-  expect(await
-         toThrow(() => {
-           return Git.secureUrl('http://random.repo', 'ab_12', reporter);
-         }),
-        ).toEqual(true);
-
-  expect(await
-         toThrow(() => {
-           return Git.secureUrl('git://random.repo', '', reporter);
-         }),
-        ).toEqual(true);
-
-  expect(await
-         toThrow(() => {
-           return Git.secureUrl('https://random.repo', '', reporter);
-         }),
-        ).toEqual(false);
-
-  expect(await
-         toThrow(() => {
-           return Git.secureUrl('http://random.repo', 'abc12', reporter);
-         }),
-        ).toEqual(false);
-
-  expect(await
-         toThrow(() => {
-           return Git.secureUrl('git://random.repo', 'abc12', reporter);
-         }),
-        ).toEqual(false);
 },
 );

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -243,6 +243,7 @@ const messages = {
 
   refusingDownloadGitWithoutCommit: 'Refusing to download the git repo $0 over plain git without a commit hash',
   refusingDownloadHTTPWithoutCommit: 'Refusing to download the git repo $0 over HTTP without a commit hash',
+  refusingDownloadHTTPSWithoutCommit: 'Refusing to download the git repo $0 over HTTPS without a commit hash - possible certificate error?',
 
   packageInstalledWithBinaries: 'Installed $0 with binaries:',
   packageHasBinaries: '$0 has binaries:',

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -93,7 +93,7 @@ export default class Git {
   }
 
   /**
-   * attempt to upgrade unsecure protocols to securl protocol
+   * Attempt to upgrade insecure protocols to secure protocol
    */
 
   static async secureUrl(ref: string, hash: string, reporter: Reporter): Promise<string> {
@@ -120,8 +120,22 @@ export default class Git {
       if (await Git.repoExists(secureUrl)) {
         return secureUrl;
       } else {
+        if (await Git.repoExists(ref)) {
+          return ref;
+        } else {
+          throw new SecurityError(
+            reporter.lang('refusingDownloadHTTPWithoutCommit', ref),
+          );
+        }
+      }
+    }
+
+    if (parts.protocol === 'https:') {
+      if (await Git.repoExists(ref)) {
+        return ref;
+      } else {
         throw new SecurityError(
-          reporter.lang('refusingDownloadHTTPWithoutCommit', ref),
+          reporter.lang('refusingDownloadHTTPSWithoutCommit', ref),
         );
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
(whoops branch should've been issue-2117-http-url-not-working...)

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

0. This PR will resolve issue #2117.
1. It will upgrade an HTTP URL to HTTPS and see if that works then fallback to using HTTP if it fails.
2. It will test an HTTPS URL too and verify that the git repos exists
3. Fix and rewrite the broken tests

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The cause of the bug was having a project dependency which itself depended on an HTTP repos.
```
{
  "name": "yarn-test",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "dependencies": {
    "pm2": "^1.1.3"
  }
}
```

Running a yarn install on the above would trigger this error
```
error Refusing to download the git repo http://ikt.pm2.io/ikt.git over HTTP without a commit hash
```

HTTPS is not valid for that domain since they have an `Invalid certificate chain` (refer to #2117 for details).