### PR TITLE
[FIXES #2096] fix relative symlinks of symlinks

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -419,7 +419,7 @@ export async function symlink(src: string, dest: string): Promise<void> {
       await fsSymlink(src, dest, 'junction');
     } else {
       // use relative paths otherwise which will be retained if the directory is moved
-      const relative = path.relative(path.dirname(dest), src);
+      const relative = path.relative(fs.realpathSync(path.dirname(dest)), fs.realpathSync(src));
       await fsSymlink(relative, dest);
     }
   } catch (err) {


### PR DESCRIPTION
**Summary**

This makes `yarn link` work when `$HOME/.config/yarn/link/` is itself a symlink.

---

The following commit forces symlinks to be relative: https://github.com/yarnpkg/yarn/commit/36d73cc3bb0e3c4afcea4f25b06cc76b7b5531fa

This isn't ideal, although it enables some portability it breaks others. For example, it is not uncommon for `$HOME/.config` itself to be be a symlink: `$HOME/.config` -> `$HOME/src/stefanpenner/dotfiles`. 

Now when running `yarn link` inside `$HOME/src/ember-cli/ember-cli` we end up with:
```js
path.relative('/Users/spenner/.config/yarn/link/ember-cli', '/Users/spenner/src/ember-cli/ember-cli');
=> '../../../src/ember-cli/ember-cli'
```

Which results in the link located at: `/Users/spenner/.config/yarn/link/ember-cli` pointing to
`/Users/spenner/.config/src/ember-cli/ember-cli` rather then `/Users/spenner/src/ember-cli/ember-cli`

This is because `/Users/spenner/.config` is actually a symlink pointing to `/Users/spenner/src/stefanpenner/dotfiles/.config/`

--- 

This PR mitigates he issue raised in #2096, but reifying the paths via `realpathSync` before deriving the relative path. This ensures that at the time of linking, the paths are correct. This doesn't fix all issues, e.g. symlinks cannot always be changed after this reification.

**Test plan**

`src/lib/fs.js` appears currently untested... if this is an approach you all would like to take I can add some tests.