### PR TITLE
Handling scoped packages offline

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -84,11 +84,13 @@ export default class NpmResolver extends RegistryResolver {
   }
 
   async resolveRequestOffline(): Promise<?Manifest> {
-    // find modules of this name
-    const prefix = `npm-${this.name}-`;
 
-    const cacheFolder = this.config.cacheFolder;
-    invariant(cacheFolder, 'expected packages root');
+    const scope = this.config.registries.npm.getScope(this.name);
+    // find modules of this name
+    const prefix = scope ? this.name.split(/\/|%2f/)[1] : `npm-${this.name}-`;
+
+    invariant(this.config.cacheFolder, 'expected packages root');
+    const cacheFolder = path.join(this.config.cacheFolder, scope ? 'npm-' + scope : '');
 
     const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
       const files = await fs.readdir(cacheFolder);


### PR DESCRIPTION
**Summary**

Addresses #2453. Scoped packages are located in `CACHEFOLDER/REGISTRY-@SCOPE/NAME` opposite to 'regular ones' stored in `CACHEFOLDER/REGISTRY-NAME`. 

**Test plan**

Added unit test that covers offline resolution of scoped package
