### PR TITLE
Fix `yarn version` which yields same output as `yarn --version` (#2491)

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -170,8 +170,13 @@ if (commandName === 'help' || args.indexOf('--help') >= 0 || args.indexOf('-h') 
   process.exit(1);
 }
 
+if (!command) {
+  args.unshift(commandName);
+  command = commands.run;
+}
+invariant(command, 'missing command');
+
 // parse flags
-args.unshift(commandName);
 commander.parse(startArgs.concat(args));
 commander.args = commander.args.concat(endArgs);
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -38,6 +38,12 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
+// NOTE: Pending resolution of https://github.com/tj/commander.js/issues/346
+// Remove this (and subsequent use in the logic below) after bug is resolved and issue is closed
+const ARGS_THAT_SHARE_NAMES_WITH_OPTIONS = [
+  'version',
+];
+
 // set global options
 commander.version(pkg.version);
 commander.usage('[command] [flags]');
@@ -170,13 +176,13 @@ if (commandName === 'help' || args.indexOf('--help') >= 0 || args.indexOf('-h') 
   process.exit(1);
 }
 
-if (!command) {
-  args.unshift(commandName);
-  command = commands.run;
-}
-invariant(command, 'missing command');
-
 // parse flags
+args.unshift(commandName);
+
+if (ARGS_THAT_SHARE_NAMES_WITH_OPTIONS.indexOf(commandName) >= 0 && args[0] === commandName) {
+  args.shift();
+}
+
 commander.parse(startArgs.concat(args));
 commander.args = commander.args.concat(endArgs);
 


### PR DESCRIPTION
There was a conflict when commander attempts to parse the incoming args between the command executed and the options since the name `version` was shared. In other words, executing the command `yarn version` would yield the same output as `yarn --version`. This fixes #2491. This also seems to relate to PR #2268.

Let me know what you think. And sorry for the issue reference spam! Thanks!
