### PR TITLE
Remove `lockfileOutdated` description `$` to allow easier copy/paste

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -234,7 +234,7 @@ const messages = {
   requestFailed: 'Request failed $0',
   tarballNotInNetworkOrCache: '$0: Tarball is not in network and can not be located in cache ($1)',
   fetchBadHash: 'Bad hash. Expected $0 but got $1 ',
-  fetchErrorCorrupt: '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  $ rm -rf $1\n  $ yarn install',
+  fetchErrorCorrupt: '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  rm -rf $1\n  yarn install',
   errorDecompressingTarball: '$0. Error decompressing $1, it appears to be corrupt.',
   updateInstalling: 'Installing $0...',
   hostedGitResolveError: 'Error connecting to repository. Please, check the url.',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -74,7 +74,7 @@ const messages = {
   invalidPackageName: 'Invalid package name.',
   couldntFindManifestIn: "Couldn't find manifest in $0.",
   shrinkwrapWarning: 'npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.',
-  lockfileOutdated: 'Outdated lockfile. Please run `$ yarn install` and try again.',
+  lockfileOutdated: 'Outdated lockfile. Please run `yarn install` and try again.',
   ignoredScripts: 'Ignored scripts due to flag.',
   missingAddDependencies: 'Missing list of packages to add to your project.',
   yesWarning: 'The yes flag has been set. This will automatically answer yes to all questions which may have security implications.',


### PR DESCRIPTION
**Summary**
Remove `$` to allow easier copy/paste

**Test plan**
- Run `yarn outdated` with an outdated lockfile.