### PR TITLE
Fix private urls using colon separator

### DIFF
--- a/__tests__/resolvers/exotics/git-resolver.js
+++ b/__tests__/resolvers/exotics/git-resolver.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import {parse} from 'url';
+
+import GitResolver from '../../../src/resolvers/exotics/git-resolver.js';
+
+test('GitResolver transformUrl method is defined', () => {
+  expect(GitResolver.transformUrl).toBeDefined();
+});
+
+test('GitResolver transformUrl does not affect normal urls', () => {
+
+  const urls = [
+    'git+https://github.com/npm-ml/ocaml.git#npm-4.02.3',
+    'git+ssh://git@gitlab.com/user/repo.git',
+    'git+ssh://git@github.com/user/repo.git',
+    'git+ssh://username@private.url/sub/right-pad',
+    'https://github.com/npm-ml/re',
+    'https://github.com/npm-ml/ocaml.git#npm-4.02.3',
+    'https://git@github.com/stevemao/left-pad.git',
+    'https://bitbucket.org/hgarcia/node-bitbucket-api.git',
+    'https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz',
+    'https://github.com/babel/babel-loader.git#greenkeeper/cross-env-3.1.4',
+    'package@git@bitbucket.org:team/repo.git',
+  ];
+
+  urls.forEach((url) => {
+    expect(GitResolver.transformUrl(parse(url))).toBe(url);
+  });
+
+});
+
+test('GitResolver transformUrl affect host colon separated urls', () => {
+
+  const urls = [
+    'git+ssh://username@private.url:sub/right-pad',
+    'git+ssh://private.url:sub/right-pad',
+    'https://private.url:sub/right-pad',
+  ];
+
+  urls.forEach((url) => {
+    expect(GitResolver.transformUrl(parse(url))).toBe(url.replace(':sub', '/sub'));
+  });
+
+});

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -61,6 +61,14 @@ export default class GitResolver extends ExoticResolver {
     return false;
   }
 
+  // This transformUrl util is here to replace colon separators in the pathname
+  // from private urls. It takes the url parts retrieved using urlFormat and
+  // returns the associated url. Related to #573, introduced in #2519.
+  static transformUrl(parts) : string {
+    const pathname = parts.pathname ? parts.pathname.replace(/^\/:/, '/') : '';
+    return urlFormat({...parts, pathname});
+  }
+
   async resolve(forked?: true): Promise<Manifest> {
     const {url} = this;
 
@@ -94,12 +102,7 @@ export default class GitResolver extends ExoticResolver {
 
     const {config} = this;
 
-    if (parts.pathname) {
-      parts.pathname = parts.pathname.replace(/^\/:/, '/');
-    }
-
-    // $FlowFixMe: https://github.com/facebook/flow/issues/908
-    const transformedUrl = urlFormat(parts);
+    const transformedUrl = GitResolver.transformUrl(parts);
 
     const client = new Git(config, transformedUrl, this.hash);
     const commit = await client.init();

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -145,7 +145,6 @@ export default async function (
       parts.hostname = parts.pathname;
       parts.pathname = '';
     }
-    // $FlowFixMe: https://github.com/facebook/flow/issues/908
     info.homepage = url.format(parts);
   }
 

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -145,6 +145,7 @@ export default async function (
       parts.hostname = parts.pathname;
       parts.pathname = '';
     }
+    // $FlowFixMe: https://github.com/facebook/flow/issues/908
     info.homepage = url.format(parts);
   }
 


### PR DESCRIPTION
People were still experiencing issues with private urls using colons as separator even after the fix introduced in #2384.

This fix basically replace the initial pathname part of the parsed url in the git resolver, and reformat exploded parts onto the equivalent url, removing the colon culprit.

Unsure about why the require onto the `url` module is done the old way, I've decided to follow consistency, but can refactor if needed. Related issues referenced in commit.

:wave: @chrisirhc @lxe