### PR TITLE
make add command working with latest tag if offline or preferOffline is setted

### DIFF
--- a/src/package-constraint-resolver.js
+++ b/src/package-constraint-resolver.js
@@ -19,6 +19,11 @@ export default class PackageConstraintResolver {
   config: Config;
 
   reduce(versions: Array<string>, range: string): Promise<?string> {
-    return Promise.resolve(semver.maxSatisfying(versions, range, this.config.looseSemver));
+    if (range === 'latest') {
+      // Usually versions are already ordered and the last one is the latest
+      return Promise.resolve(versions[versions.length - 1]);
+    } else {
+      return Promise.resolve(semver.maxSatisfying(versions, range, this.config.looseSemver));
+    }
   }
 }


### PR DESCRIPTION
**Summary**
The package constraint resolver had some issue with latest tag and if you try to specify --offline or --prefer-offline it throws exception because it does not retrieve the latest cached version :)

**Test plan**
I added two test cases and expanded the test for latest tag.

Let me know if it's ok!
cheers,
Simon
