### PR TITLE
Fix install --production not installing used packages, fixes #2468, #2263 

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -792,7 +792,6 @@ test.concurrent('a subdependency of an optional dependency that fails should be 
     });
   });
 
-// disabled while fix is not merged
 test.concurrent('should not loose dependencies when installing with --production',
   (): Promise<void> => {
     // revealed https://github.com/yarnpkg/yarn/issues/2263

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -793,7 +793,7 @@ test.concurrent('a subdependency of an optional dependency that fails should be 
   });
 
 // disabled while fix is not merged
-test.skip('should not loose dependencies when installing with --production',
+test.concurrent('should not loose dependencies when installing with --production',
   (): Promise<void> => {
     // revealed https://github.com/yarnpkg/yarn/issues/2263
     return runInstall({production: true}, 'prod-should-keep-subdeps', async (config) => {

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -28,7 +28,7 @@ test('Produces valid destination paths for scoped modules', () => {
     _reference: (({}: any): PackageReference),
   }: any): Manifest);
 
-  const info = new HoistManifest(key, parts, pkg, '', () => false);
+  const info = new HoistManifest(key, parts, pkg, '', false, false);
 
   const tree = new Map([
     ['@scoped/dep', info],

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -173,37 +173,34 @@ export default class PackageHoister {
 
   _propagateNonIgnored() {
     //
-    const tovisit: Array<HoistManifest> = [];
+    const toVisit: Array<HoistManifest> = [];
 
     // enumerate all non-ignored packages
     for (const entry of this.tree.entries()) {
       if (!entry[1].isIgnored) {
-        tovisit.push(entry[1]);
+        toVisit.push(entry[1]);
       }
     }
 
     // visit them
-    while (tovisit.length) {
-      const info = tovisit.shift();
+    while (toVisit.length) {
+      const info = toVisit.shift();
       const ref = info.pkg._reference;
       invariant(ref, 'expected reference');
 
       for (const depPattern of ref.dependencies) {
-        //
         const depinfo = this._lookupDependency(info, depPattern);
-
-        //
         if (depinfo && depinfo.isIgnored && depinfo.inheritIsIgnored) {
           depinfo.isIgnored = false;
           info.addHistory(`Mark as non-ignored because of usage by ${info.key}`);
-          tovisit.push(depinfo);
+          toVisit.push(depinfo);
         }
       }
     }
   }
 
   /**
-   * Looks up the package a dependency resolved to
+   * Looks up the package a dependency resolves to
   */
 
   _lookupDependency(info: HoistManifest, depPattern: string): ?HoistManifest {

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -13,8 +13,9 @@ type Parts = Array<string>;
 let historyCounter = 0;
 
 export class HoistManifest {
-  constructor(key: string, parts: Parts, pkg: Manifest, loc: string, isIgnored: () => boolean) {
+  constructor(key: string, parts: Parts, pkg: Manifest, loc: string, isIgnored: boolean, inheritIsIgnored: boolean) {
     this.isIgnored = isIgnored;
+    this.inheritIsIgnored = inheritIsIgnored;
     this.loc = loc;
     this.pkg = pkg;
 
@@ -27,7 +28,8 @@ export class HoistManifest {
     this.addHistory(`Start position = ${key}`);
   }
 
-  isIgnored: () => boolean;
+  isIgnored: boolean;
+  inheritIsIgnored: boolean;
   pkg: Manifest;
   loc: string;
   parts: Parts;
@@ -92,6 +94,7 @@ export default class PackageHoister {
     while (true) {
       let queue = this.levelQueue;
       if (!queue.length) {
+        this._propagateNonIgnored();
         return;
       }
 
@@ -130,7 +133,8 @@ export default class PackageHoister {
 
     //
     let parentParts: Parts = [];
-    let isIgnored = () => ref.ignore;
+    let isIgnored = ref.ignore;
+    let inheritIsIgnored = false;
 
     if (parent) {
       if (!this.tree.get(parent.key)) {
@@ -138,8 +142,9 @@ export default class PackageHoister {
       }
       // non ignored dependencies inherit parent's ignored status
       // parent may transition from ignored to non ignored when hoisted if it is used in another non ignored branch
-      if (!isIgnored() && parent.isIgnored()) {
-        isIgnored = () => !!parent && parent.isIgnored();
+      if (!isIgnored && parent.isIgnored) {
+        isIgnored = parent.isIgnored;
+        inheritIsIgnored = true;
       }
       parentParts = parent.parts;
     }
@@ -148,7 +153,7 @@ export default class PackageHoister {
     const loc: string = this.config.generateHardModulePath(ref);
     const parts = parentParts.concat(pkg.name);
     const key: string = this.implodeKey(parts);
-    const info: HoistManifest = new HoistManifest(key, parts, pkg, loc, isIgnored);
+    const info: HoistManifest = new HoistManifest(key, parts, pkg, loc, isIgnored, inheritIsIgnored);
 
     //
     this.tree.set(key, info);
@@ -160,6 +165,64 @@ export default class PackageHoister {
     }
 
     return info;
+  }
+
+  /**
+   * Propagate inherited ignore statuses from non-ignored to ignored packages
+  */
+
+  _propagateNonIgnored() {
+    //
+    const tovisit: Array<HoistManifest> = [];
+
+    // enumerate all non-ignored packages
+    for (const entry of this.tree.entries()) {
+      if (!entry[1].isIgnored) {
+        tovisit.push(entry[1]);
+      }
+    }
+
+    // visit them
+    while (tovisit.length) {
+      const info = tovisit.shift();
+      const ref = info.pkg._reference;
+      invariant(ref, 'expected reference');
+
+      for (const depPattern of ref.dependencies) {
+        //
+        const depinfo = this._lookupDependency(info, depPattern);
+
+        //
+        if (depinfo && depinfo.isIgnored && depinfo.inheritIsIgnored) {
+          depinfo.isIgnored = false;
+          info.addHistory(`Mark as non-ignored because of usage by ${info.key}`);
+          tovisit.push(depinfo);
+        }
+      }
+    }
+  }
+
+  /**
+   * Looks up the package a dependency resolved to
+  */
+
+  _lookupDependency(info: HoistManifest, depPattern: string): ?HoistManifest {
+    //
+    const pkg = this.resolver.getStrictResolvedPattern(depPattern);
+    const ref = pkg._reference;
+    invariant(ref, 'expected reference');
+
+    //
+    for (let i = info.parts.length; i >= 0; i--) {
+      const checkParts = info.parts.slice(0, i).concat(pkg.name);
+      const checkKey = this.implodeKey(checkParts);
+      const existing = this.tree.get(checkKey);
+      if (existing) {
+        return existing;
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -186,7 +249,7 @@ export default class PackageHoister {
       if (existing) {
         if (existing.loc === info.loc) {
           // switch to non ignored if earlier deduped version was ignored
-          if (existing.isIgnored() && !info.isIgnored()) {
+          if (existing.isIgnored && !info.isIgnored) {
             existing.isIgnored = info.isIgnored;
           }
 
@@ -392,7 +455,7 @@ export default class PackageHoister {
       const ref = info.pkg._reference;
       invariant(ref, 'expected reference');
 
-      if (info.isIgnored()) {
+      if (info.isIgnored) {
         info.addHistory('Deleted as this module was ignored');
       } else {
         visibleFlatTree.push([loc, info]);


### PR DESCRIPTION
**Summary**

When installing only production packages using `yarn install --production`, the packagehoister sometimes ignores packages that are actually used. This can happen when an ignored package is deduped with another ignored package. If so, the isIgnored function won't pick up when the parent of the second package becomes non-ignored due to a dependency that is processed later. This is the cause of bug #2468 and bug #2263 (and probably #2421 too, though I haven't tested that one)

This happens with roughly this dependency tree:
dev A -> B (1)
dev A -> C -> B (2)
normal D -> E -> F -> C (3)

1. B is hoisted to the root, with isIgnored calling parent A.
2. B(2) is deduped to B(1). But, because C is also ignored at this point, the isIgnored function of B isn't changed.
3. A non-ignored dependency on C is added, and C is marked as non-ignored. The isIgnored function of B(1) won't see this change.

Changing the isIgnored function to call both the existing and the deduped isIgnored will cause a stack overflow to happen in the test of 2263, so that solution is out.

To fix this, I have opted to remove the isIgnored function calls, and replace it with a 2 booleans, one to keep the current ignore status and one note wither inheritance is allowed (so it works just like the function call solution). With a processing step after seeding the hoister will then mark all dependencies of non-ignored packages as non-ignored too.

**Test plan**

I have enabled the test from #2263, it runs without errors. Also, I have run a production-only install on the package.json from https://github.com/yarnpkg/yarn/issues/761#issuecomment-273052409, and abbrev is installed there too. `yarn run test` also finishes without any failures.

The algorithm for marking the hoistmanifests will only visit non-ignored ones, and only once, so can't lead to an infinite loop.