### PR TITLE
Retain string characters if add'l argument has spaces

### DIFF
--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -74,3 +74,13 @@ test.only('properly handle bin scripts', (): Promise<void> => (
     expect(execCommand).toBeCalledWith(...args);
   }) : Promise<void>
 ));
+
+
+test.only('retains string delimiters if args have spaces', (): Promise<void> => (
+  runRun(['cat-names', '--filter', 'cat names'], {}, 'bin', (config) => {
+    const script = path.join(config.cwd, 'node_modules', '.bin', 'cat-names');
+    const args = ['cat-names', config, `"${script}" --filter "cat names"`, config.cwd];
+
+    expect(execCommand).toBeCalledWith(...args);
+  }) : Promise<void>
+));

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -12,6 +12,17 @@ import {fixCmdWinSlashes} from '../../util/fix-cmd-win-slashes.js';
 const leven = require('leven');
 const path = require('path');
 
+function sanitizedArgs(args: Array<string>): Array<string> {
+  const newArgs = [];
+  for (let arg of args) {
+    if (/\s/.test(arg)) {
+      arg = `"${arg}"`;
+    }
+    newArgs.push(arg);
+  }
+  return newArgs;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,
@@ -67,7 +78,8 @@ export async function run(
     if (cmds.length) {
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
-        const cmdWithArgs = stage === action ? `${cmd} ${args.join(' ')}` : cmd;
+        const defaultScriptCmd = `${cmd} ${sanitizedArgs(args).join(' ')}`;
+        const cmdWithArgs = stage === action ? defaultScriptCmd : cmd;
         await execCommand(stage, config, cmdWithArgs, config.cwd);
       }
     } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Consider the instance where you're using optional arguments with `yarn run`, and one of these arguments is a string that contains spaces. At the moment, using the raw `process.argv` to obtain these arguments strips the individual arguments of any string separators. Since these arguments are then used in another command, their original intent is lost.

Examples of this problem, as run on the yarn repo itself:

```
bin/yarn run build -- --module "run | init"
#=> gulp build --module run | init
#=> sh: init: command not found
```

In the above, the command defined in `build` interprets `| init` as a bash command. This is not the intent. `"run | init"` should be maintained as a single argument.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

To fix this, this PR sanitizes the optional arguments used in `execCommand` for the `run` command. It wraps any argument in `"` characters if the argument value itself contains a string character.

```
bin/yarn run build -- --module "run | init"
gulp build --module "run | init"
#=> success!
```

Not that those arguments would be valid for that command, but one can see that the arguments are passed correctly to whatever internal script is specified.