### PR TITLE
interpret a tilde at the start of config prefix path as the user's home directory

### DIFF
--- a/__tests__/commands/config.js
+++ b/__tests__/commands/config.js
@@ -5,13 +5,16 @@ import * as reporters from '../../src/reporters/index.js';
 import * as configCmd from '../../src/cli/commands/config.js';
 import {run as buildRun} from './_helpers.js';
 import * as fs from '../../src/util/fs.js';
+import home from 'user-home';
 
 const path = require('path');
+
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'config');
 
 const runConfig = buildRun.bind(
   null,
   reporters.ConsoleReporter,
-  '',
+  fixturesLoc,
   (args, flags, config, reporter): CLIFunctionReturn => {
     config.registries.yarn.homeConfigLoc = path.join(config.cwd, '.yarnrc');
     return configCmd.run(config, reporter, flags, args);
@@ -47,5 +50,11 @@ test('set value "false" to an option', (): Promise<void> => {
 test('set value "true" to an option', (): Promise<void> => {
   return runConfig(['set', 'strict-ssl', 'true'], {}, '', (config) => {
     expect(config.registries.yarn.homeConfig['strict-ssl']).toBe(true);
+  });
+});
+
+test('get prefix interprets tilde', (): Promise<void> => {
+  return runConfig(['get', 'prefix'], {}, 'get-prefix-interprets-tilde', (config) => {
+    expect(config.registries.npm.config.prefix).toBe(`${home}/lol`);
   });
 });

--- a/__tests__/fixtures/config/get-prefix-interprets-tilde/.npmrc
+++ b/__tests__/fixtures/config/get-prefix-interprets-tilde/.npmrc
@@ -1,0 +1,1 @@
+prefix = ~/lol

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -126,6 +126,11 @@ export default class NpmRegistry extends Registry {
 
     for (const [, loc, file] of await this.getPossibleConfigLocations('.npmrc')) {
       const config = Registry.normalizeConfig(ini.parse(file));
+
+      if (config.prefix && userHome) {
+        config.prefix = config.prefix.replace(/^~($|\/)/, `${userHome}$1`);
+      }
+
       for (const key: string in config) {
         config[key] = envReplace(config[key]);
       }


### PR DESCRIPTION
This just interprets `~` as the user's `$HOME` when reading the prefix path in `~/.npmrc` as npm does

this fixes  #2008 

beforehand, running `yarn global add lite-server` with an npmrc containing `prefix = ~/.local/bin` would create a directory called literally `~` and put it in `bin` in there. after this change it puts it in `/usr/chee/.local/bin` for me

xo