### PR TITLE
add Named Constructor for Config and create a real NoopReporter

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -114,15 +114,14 @@ export async function run<T, R>(
   }
 
   try {
-    const config = new Config(reporter);
-    await config.init({
+    const config = await Config.create({
       binLinks: !!flags.binLinks,
       cwd,
       globalFolder: path.join(cwd, '.yarn-global'),
       cacheFolder: flags.cacheFolder || path.join(cwd, '.yarn-cache'),
       linkFolder: path.join(cwd, '.yarn-link'),
       production: flags.production,
-    });
+    }, reporter);
 
     const install = await factory(args, flags, config, reporter, lockfile, () => out);
 

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -17,9 +17,8 @@ async function runInfo(
   checkSteps?: ?(config: Config, output: any) => ?Promise<void>,
 ): Promise<void> {
   const reporter = new BufferReporter({stdout: null, stdin: null});
-  const config = new Config(reporter);
   const cwd = name && path.join(fixturesLoc, name);
-  await config.init({cwd});
+  const config = await Config.create({cwd}, reporter);
   await info(config, reporter, flags, args);
 
   if (checkSteps) {

--- a/__tests__/commands/install/unit.js
+++ b/__tests__/commands/install/unit.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as reporters from '../../../src/reporters/index.js';
+import {NoopReporter} from '../../../src/reporters/index.js';
 import {Install} from '../../../src/cli/commands/install.js';
 import Lockfile from '../../../src/lockfile/wrapper.js';
 import Config from '../../../src/config.js';
@@ -12,9 +12,8 @@ const fixturesLoc = path.join(__dirname, '..', '..', 'fixtures', 'install');
 
 test.concurrent('integrity hash respects flat and production flags', async () => {
   const cwd = path.join(fixturesLoc, 'noop');
-  const reporter = new reporters.NoopReporter();
-  const config = new Config(reporter);
-  await config.init({cwd});
+  const reporter = new NoopReporter();
+  const config = await Config.create({cwd}, reporter);
 
   const lockfile = new Lockfile();
 
@@ -23,8 +22,7 @@ test.concurrent('integrity hash respects flat and production flags', async () =>
   const install2 = new Install({flat: true}, config, reporter, lockfile);
   expect(install2.generateIntegrityHash('foo', [])).not.toEqual(install.generateIntegrityHash('foo', []));
 
-  const config2 = new Config(reporter);
-  await config2.init({cwd, production: true});
+  const config2 = await Config.create({cwd, production: true}, reporter);
   const install3 = new Install({}, config2, reporter, lockfile);
   expect(install3.generateIntegrityHash('foo', [])).not.toEqual(install.generateIntegrityHash('foo', []));
   expect(install3.generateIntegrityHash('foo', [])).not.toEqual(install2.generateIntegrityHash('foo', []));
@@ -32,9 +30,8 @@ test.concurrent('integrity hash respects flat and production flags', async () =>
 
 test.concurrent('flat arg is inherited from root manifest', async (): Promise<void> => {
   const cwd = path.join(fixturesLoc, 'top-level-flat-parameter');
-  const reporter = new reporters.NoopReporter();
-  const config = new Config(reporter);
-  await config.init({cwd});
+  const reporter = new NoopReporter();
+  const config = await Config.create({cwd});
   const install = new Install({}, config, reporter, new Lockfile());
   return install.fetchRequestFromCwd().then(function({manifest}) {
     assert.equal(manifest.flat, true);

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -62,13 +62,12 @@ export async function run(
   }
 
   try {
-    const config = new Config(reporter);
-    await config.init({
+    const config = await Config.create({
       cwd,
       globalFolder: path.join(tmpRoot, '.yarn/.global'),
       cacheFolder: path.join(tmpRoot, '.yarn'),
       linkFolder: path.join(tmpRoot, '.yarn/.link'),
-    });
+    }, reporter);
 
     await pack(config, reporter, flags, []);
 

--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -21,9 +21,7 @@ async function runWhy(
   const reporter = new reporters.BufferReporter({stdout: null, stdin: null});
 
   try {
-    const config = new Config(reporter);
-    await config.init({cwd});
-
+    const config = await Config.create({cwd}, reporter);
     await why(config, reporter, flags, args);
 
     if (checkSteps) {

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -1,6 +1,7 @@
 /* @flow */
 /* eslint max-len: 0 */
 
+import {Reporter} from '../src/reporters/index.js';
 import TarballFetcher, {LocalTarballFetcher} from '../src/fetchers/tarball-fetcher.js';
 import BaseFetcher from '../src/fetchers/base-fetcher.js';
 import CopyFetcher from '../src/fetchers/copy-fetcher.js';
@@ -101,7 +102,7 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
     hash: 'foo',
     reference: url,
     registry: 'npm',
-  }, await Config.create());
+  }, await Config.create({}, new Reporter()));
   let error;
   try {
     await fetcher.fetch();

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -5,18 +5,11 @@ import TarballFetcher, {LocalTarballFetcher} from '../src/fetchers/tarball-fetch
 import BaseFetcher from '../src/fetchers/base-fetcher.js';
 import CopyFetcher from '../src/fetchers/copy-fetcher.js';
 import GitFetcher from '../src/fetchers/git-fetcher.js';
-import {NoopReporter} from '../src/reporters/index.js';
 import Config from '../src/config.js';
 import mkdir from './_temp.js';
 import * as fs from '../src/util/fs.js';
 
 const path = require('path');
-
-async function createConfig(): Promise<Config> {
-  const config = new Config(new NoopReporter());
-  await config.init();
-  return config;
-}
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
@@ -27,7 +20,7 @@ test('BaseFetcher.fetch', async () => {
     registry: 'npm',
     reference: '',
     hash: null,
-  }, await createConfig());
+  }, await Config.create());
   let error;
 
   try {
@@ -49,7 +42,7 @@ test('CopyFetcher.fetch', async () => {
     reference: a,
     registry: 'npm',
     hash: null,
-  }, await createConfig());
+  }, await Config.create());
   await fetcher.fetch();
   const content = await fs.readFile(path.join(b, 'package.json'));
   expect(content).toBe('{}');
@@ -58,7 +51,7 @@ test('CopyFetcher.fetch', async () => {
 });
 
 test('GitFetcher.fetch fetchFromLocal not in network or cache', async () => {
-  const config = await createConfig();
+  const config = await Config.create();
   const dir = await mkdir('git-fetcher');
   const fetcher = new GitFetcher(dir, {
     type: 'git',
@@ -80,7 +73,7 @@ test('GitFetcher.fetch', async () => {
     reference: 'https://github.com/sindresorhus/beeper',
     hash: '8beb0413a8028ca2d52dbb86c75f42069535591b',
     registry: 'npm',
-  }, await createConfig());
+  }, await Config.create());
   await fetcher.fetch();
   const name = (await fs.readJson(path.join(dir, 'package.json'))).name;
   expect(name).toBe('beeper');
@@ -93,7 +86,7 @@ test('TarballFetcher.fetch', async () => {
     hash: '51f12d36860fc3d2ab747377991746e8ea3faabb',
     reference: 'https://github.com/sindresorhus/beeper/archive/master.tar.gz',
     registry: 'npm',
-  }, await createConfig());
+  }, await Config.create());
 
   await fetcher.fetch();
   const name = (await fs.readJson(path.join(dir, 'package.json'))).name;
@@ -108,7 +101,7 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
     hash: 'foo',
     reference: url,
     registry: 'npm',
-  }, await createConfig());
+  }, await Config.create());
   let error;
   try {
     await fetcher.fetch();
@@ -125,7 +118,7 @@ test('TarballFetcher.fetch supports local ungzipped tarball', async () => {
     hash: '25c5098052a7bd322c7db80c26852e9209f98d4f',
     reference: path.join(__dirname, 'fixtures', 'fetchers', 'tarball', 'ungzipped.tar'),
     registry: 'npm',
-  }, await createConfig());
+  }, await Config.create());
   await fetcher.fetch();
   const name = (await fs.readJson(path.join(dir, 'package.json'))).name;
   expect(name).toBe('beeper');
@@ -135,7 +128,7 @@ test('TarballFetcher.fetch properly stores tarball of package in offline mirror'
   const dir = await mkdir('tarball-fetcher');
   const offlineMirrorDir = await mkdir('offline-mirror');
 
-  const config = await createConfig();
+  const config = await Config.create();
   config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
 
   const fetcher = new TarballFetcher(dir, {
@@ -154,7 +147,7 @@ test('TarballFetcher.fetch properly stores tarball of scoped package in offline 
   const dir = await mkdir('tarball-fetcher');
   const offlineMirrorDir = await mkdir('offline-mirror');
 
-  const config = await createConfig();
+  const config = await Config.create();
   config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
 
   const fetcher = new TarballFetcher(dir, {

--- a/__tests__/normalize-manifest.js
+++ b/__tests__/normalize-manifest.js
@@ -33,8 +33,7 @@ for (const name of nativeFs.readdirSync(fixturesLoc)) {
       actualWarnings.push(msg);
     };
 
-    const config = new Config(reporter);
-    await config.init({cwd: loc});
+    const config = await Config.create({cwd: loc}, reporter);
 
     let actual   = await fs.readJson(path.join(loc, 'actual.json'));
     const expected = await fs.readJson(path.join(loc, 'expected.json'));

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -30,12 +30,11 @@ function addTest(pattern, registry = 'npm', init: ?(cacheFolder: string) => Prom
       await init(cacheFolder);
     }
 
-    const config = new Config(reporter);
-    await config.init({
+    const config = await Config.create({
       cwd: loc,
       offline,
       cacheFolder,
-    });
+    }, reporter);
     const resolver = new PackageResolver(config, lockfile);
     await resolver.init([{pattern, registry}]);
 

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -1,21 +1,13 @@
 /* @flow */
 /* eslint max-len: 0 */
 
-import {NoopReporter} from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
-import type {ConfigOptions} from '../../src/config.js';
 import * as fs from '../../src/util/fs.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 const https = require('https');
 const path = require('path');
-
-async function createConfig(opts: ConfigOptions = {}): Promise<Config> {
-  const config = new Config(new NoopReporter());
-  await config.init(opts);
-  return config;
-}
 
 test('RequestManager.request with cafile', async () => {
   let body;
@@ -26,7 +18,7 @@ test('RequestManager.request with cafile', async () => {
   const server = https.createServer(options, (req, res) => { res.end('ok'); });
   try {
     server.listen(0);
-    const config = await createConfig({'cafile': path.join(__dirname, '..', 'fixtures', 'certificates', 'cacerts.pem')});
+    const config = await Config.create({'cafile': path.join(__dirname, '..', 'fixtures', 'certificates', 'cacerts.pem')});
     const port = server.address().port;
     body = await config.requestManager.request({url: `https://localhost:${port}/?nocache`, headers: {Connection: 'close'}});
   } finally {
@@ -48,7 +40,7 @@ test('RequestManager.request with ca (string)', async () => {
     const hasPemPrefix = (block) => block.startsWith('-----BEGIN ');
     const caCerts = bundle.split(/(-----BEGIN .*\r?\n[^-]+\r?\n--.*)/).filter(hasPemPrefix);
     // the 2nd cert is valid one
-    const config = await createConfig({'ca': caCerts[1]});
+    const config = await Config.create({'ca': caCerts[1]});
     const port = server.address().port;
     body = await config.requestManager.request({url: `https://localhost:${port}/?nocache`, headers: {Connection: 'close'}});
   } finally {
@@ -69,7 +61,7 @@ test('RequestManager.request with ca (array)', async () => {
     const bundle = await fs.readFile(path.join(__dirname, '..', 'fixtures', 'certificates', 'cacerts.pem'));
     const hasPemPrefix = (block) => block.startsWith('-----BEGIN ');
     const caCerts = bundle.split(/(-----BEGIN .*\r?\n[^-]+\r?\n--.*)/).filter(hasPemPrefix);
-    const config = await createConfig({'ca': caCerts});
+    const config = await Config.create({'ca': caCerts});
     const port = server.address().port;
     body = await config.requestManager.request({url: `https://localhost:${port}/?nocache`, headers: {Connection: 'close'}});
   } finally {
@@ -90,7 +82,7 @@ test('RequestManager.request with mutual TLS', async () => {
   const server = https.createServer(options, (req, res) => { res.end('ok'); });
   try {
     server.listen(0);
-    const config = await createConfig({
+    const config = await Config.create({
       'cafile': path.join(__dirname, '..', 'fixtures', 'certificates', 'server-ca-cert.pem'),
       'key': await fs.readFile(path.join(__dirname, '..', 'fixtures', 'certificates', 'client-key.pem')),
       'cert': await fs.readFile(path.join(__dirname, '..', 'fixtures', 'certificates', 'client-cert.pem')),
@@ -104,7 +96,7 @@ test('RequestManager.request with mutual TLS', async () => {
 });
 
 test('RequestManager.execute Request 403 error', async () => {
-  const config = await createConfig({});
+  const config = await Config.create({});
   jest.mock('request', (factory) => (options) => {
     options.callback('', {statusCode: 403}, '');
     return {
@@ -121,7 +113,7 @@ test('RequestManager.execute Request 403 error', async () => {
 });
 
 test('RequestManager.request with offlineNoRequests', async () => {
-  const config = await createConfig({offline: true});
+  const config = await Config.create({offline: true});
   try {
     await config.requestManager.request({url: `https://localhost:port/?nocache`, headers: {Connection: 'close'}});
   } catch (err) {
@@ -130,7 +122,7 @@ test('RequestManager.request with offlineNoRequests', async () => {
 });
 
 test('RequestManager.saveHar no captureHar error message', async () => {
-  const config = await createConfig({captureHar: false});
+  const config = await Config.create({captureHar: false});
   try {
     config.requestManager.saveHar('testFile');
   } catch (err) {

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -1,6 +1,7 @@
 /* @flow */
 /* eslint max-len: 0 */
 
+import {Reporter} from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
 import * as fs from '../../src/util/fs.js';
 
@@ -96,7 +97,7 @@ test('RequestManager.request with mutual TLS', async () => {
 });
 
 test('RequestManager.execute Request 403 error', async () => {
-  const config = await Config.create({});
+  const config = await Config.create({}, new Reporter());
   jest.mock('request', (factory) => (options) => {
     options.callback('', {statusCode: 403}, '');
     return {
@@ -113,7 +114,7 @@ test('RequestManager.execute Request 403 error', async () => {
 });
 
 test('RequestManager.request with offlineNoRequests', async () => {
-  const config = await Config.create({offline: true});
+  const config = await Config.create({offline: true}, new Reporter());
   try {
     await config.requestManager.request({url: `https://localhost:port/?nocache`, headers: {Connection: 'close'}});
   } catch (err) {
@@ -122,7 +123,7 @@ test('RequestManager.request with offlineNoRequests', async () => {
 });
 
 test('RequestManager.saveHar no captureHar error message', async () => {
-  const config = await Config.create({captureHar: false});
+  const config = await Config.create({captureHar: false}, new Reporter());
   try {
     config.requestManager.saveHar('testFile');
   } catch (err) {

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ import * as constants from './constants.js';
 import ConstraintResolver from './package-constraint-resolver.js';
 import RequestManager from './util/request-manager.js';
 import {registries, registryNames} from './registries/index.js';
+import {NoopReporter} from './reporters/index.js';
 import map from './util/map.js';
 
 const detectIndent = require('detect-indent');
@@ -552,5 +553,11 @@ export default class Config {
         throw err;
       }
     }
+  }
+
+  static async create(opts: ConfigOptions = {}, reporter: Reporter = new NoopReporter()): Promise<Config> {
+    const config = new Config(reporter);
+    await config.init(opts);
+    return config;
   }
 }

--- a/src/reporters/index.js
+++ b/src/reporters/index.js
@@ -4,5 +4,5 @@ export {default as ConsoleReporter} from './console/console-reporter.js';
 export {default as BufferReporter} from './buffer-reporter.js';
 export {default as EventReporter} from './event-reporter.js';
 export {default as JSONReporter} from './json-reporter.js';
-export {default as NoopReporter} from './base-reporter.js';
+export {default as NoopReporter} from './noop-reporter.js';
 export {default as Reporter} from './base-reporter.js';

--- a/src/reporters/noop-reporter.js
+++ b/src/reporters/noop-reporter.js
@@ -1,0 +1,82 @@
+/* @flow */
+/* eslint no-unused-vars: 0 */
+
+import type {
+  ReporterSpinnerSet,
+    ReporterSelectOption,
+    Trees,
+    Stdout,
+    Stdin,
+    Package,
+    ReporterSpinner,
+    QuestionOptions,
+} from './types.js';
+import type {LanguageKeys} from './lang/en.js';
+import type {Formatter} from './format.js';
+import {defaultFormatter} from './format.js';
+import * as languages from './lang/index.js';
+import isCI from 'is-ci';
+import BaseReporter from './base-reporter.js';
+
+export default class NoopReporter extends BaseReporter {
+  lang(key: LanguageKeys, ...args: Array<mixed>): string { return 'do nothing'; }
+  verbose(msg: string) {}
+  verboseInspect(val: any) {}
+  initPeakMemoryCounter() {}
+  checkPeakMemory() {}
+  close() {}
+  getTotalTime(): number { return 0; }
+  list(key: string, items: Array<string>, hints?: Object) {}
+  tree(key: string, obj: Trees) {}
+  step(current: number, total: number, message: string, emoji?: string) {}
+  error(message: string) {}
+  info(message: string) {}
+  warn(message: string) {}
+  success(message: string) {}
+  log(message: string) {}
+  command(command: string) {}
+  inspect(value: any) {}
+  header(command: string, pkg: Package) {}
+  footer(showPeakMemory: boolean) {}
+  table(head: Array<string>, body: Array<Array<string>>) {}
+
+  activity(): ReporterSpinner {
+    return {
+      tick(name: string) {},
+      end() {},
+    };
+  }
+
+  activitySet(total: number, workers: number): ReporterSpinnerSet {
+    return {
+      spinners: Array(workers).fill({
+        clear() {},
+        setPrefix() {},
+        tick() {},
+        end() {},
+      }),
+      end() {},
+    };
+  }
+
+  question(question: string, options?: QuestionOptions = {}): Promise<string> {
+    return Promise.reject(new Error('Not implemented'));
+  }
+
+  async questionAffirm(question: string): Promise<boolean> {
+    await this.question(question);
+    return false;
+  }
+
+  select(header: string, question: string, options: Array<ReporterSelectOption>): Promise<string> {
+    return Promise.reject(new Error('Not implemented'));
+  }
+
+  progress(total: number): () => void {
+    return function() {};
+  }
+
+  disableProgress() {
+    this.noProgress = true;
+  }
+}


### PR DESCRIPTION
These are the first steps to achieve some better understading of yarn internalities :)

First of all, I created a named constructor of the Config because I noticed that every time there was this pattern

```
const config = new Config(reporter);
await config.init({...});
```

now we have something like this

```
const config = await Config.create({...}, reporter); // if reporter is not NoopReporter
const config = await Config.create({...}, reporter); // otherwise we can do this
```

Pros:
- Removes many useless imports
- Better encapsulation
- Hides the temporal coupling between config constructor and init

Cons:
- I do not touch the initialization part in src/config.js because it hides too much complexity, maybe before it is useful add some unit testing ;)

Secondly, I created a real noop reporter

Pros:
- The time of tests on my machine drops from 91s to 64s
- Better clarification because if some tests really needs the BaseReporter, now is clear

Cons:
- Now NoopReporter extends BaseReporter, I preffered this way for now to be less invasive as possible

@bestander let me know if you like these tiny steps and after I will go with other tiny steps :)