### PR TITLE
Fix registry auth comparison for explicit port numbers

### DIFF
--- a/__tests__/registries/is-request-to-registry.js
+++ b/__tests__/registries/is-request-to-registry.js
@@ -1,0 +1,46 @@
+/* @flow */
+/* eslint yarn-internal/warn-language: 0 */
+
+import isRequestToRegistry from '../../src/registries/is-request-to-registry.js';
+
+test('isRequestToRegistry functional test', () => {
+  expect(isRequestToRegistry(
+    'http://foo.bar:80/foo/bar/baz',
+    'http://foo.bar/foo/',
+  )).toBe(true);
+
+  expect(isRequestToRegistry(
+    'http://foo.bar/foo/bar/baz',
+    'http://foo.bar/foo/',
+  )).toBe(true);
+
+  expect(isRequestToRegistry(
+    'https://foo.bar:443/foo/bar/baz',
+    'https://foo.bar/foo/',
+  )).toBe(true);
+
+  expect(isRequestToRegistry(
+      'https://foo.bar/foo/bar/baz',
+      'https://foo.bar:443/foo/',
+    )).toBe(true);
+
+  expect(isRequestToRegistry(
+    'http://foo.bar:80/foo/bar/baz',
+    'https://foo.bar/foo/',
+  )).toBe(false);
+
+  expect(isRequestToRegistry(
+    'http://foo.bar/blah/whatever/something',
+    'http://foo.bar/foo/',
+  )).toBe(false);
+
+  expect(isRequestToRegistry(
+    'https://wrong.thing/foo/bar/baz',
+    'https://foo.bar/foo/',
+  )).toBe(false);
+
+  expect(isRequestToRegistry(
+    'https://foo.bar:1337/foo/bar/baz',
+    'https://foo.bar/foo/',
+  )).toBe(false);
+});

--- a/src/registries/is-request-to-registry.js
+++ b/src/registries/is-request-to-registry.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+import url from 'url';
+
+export default function isRequestToRegistry(requestUrl: string, registry: string): boolean {
+  const requestParsed = url.parse(requestUrl);
+  const registryParsed = url.parse(registry);
+  const requestPort = getPortOrDefaultPort(requestParsed.port, requestParsed.protocol);
+  const registryPort = getPortOrDefaultPort(registryParsed.port, registryParsed.protocol);
+  const requestPath = requestParsed.path || '';
+  const registryPath = registryParsed.path || '';
+
+  return (requestParsed.protocol === registryParsed.protocol) &&
+        (requestParsed.hostname === registryParsed.hostname) &&
+        (requestPort === registryPort) &&
+        requestPath.startsWith(registryPath);
+}
+
+function getPortOrDefaultPort(port: ?string, protocol: ?string): ?string {
+  const defaultPort = !port;
+  if (defaultPort && protocol === 'https:') {
+    return '443';
+  }
+  if (defaultPort && protocol === 'http:') {
+    return '80';
+  }
+  return port;
+}

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -9,6 +9,7 @@ import NpmResolver from '../resolvers/registries/npm-resolver.js';
 import envReplace from '../util/env-replace.js';
 import Registry from './base-registry.js';
 import {addSuffix, removePrefix} from '../util/misc';
+import isRequestToRegistry from './is-request-to-registry.js';
 
 const defaults = require('defaults');
 const userHome = require('user-home');
@@ -58,7 +59,7 @@ export default class NpmRegistry extends Registry {
       || removePrefix(requestUrl, registry)[0] === '@';
 
     const headers = {};
-    if (this.token || (alwaysAuth && requestUrl.startsWith(registry))) {
+    if (this.token || (alwaysAuth && isRequestToRegistry(requestUrl, registry))) {
       const authorization = this.getAuth(pathname);
       if (authorization) {
         headers.authorization = authorization;


### PR DESCRIPTION
**Summary**
I use a private NPM registry hosted via Artifactory.  When using Yarn, I'm unable to install my modules when it gets to the "Fetching packages" phase, but it gets through the resolving packages phase using the private registry just fine.  I traced it back to the `npm-registry.js` doing a comparison to see if the request string `requestUrl.startsWith(registry)` this comparison fails on my server because the request url looks like 
`https://my.server:443/path/to/registry/-/something/somefile.tgz`
and the registry url looks like:
`https://my.server/path/to/registry/`

These are clearly requests to the same url repo, but a string.startsWith doesn't understand that.  As a result, the requests are made without auth info and fail with a Not authorized error.  Similar errors would occur with the string.startsWith on differing capitalization.

**Test plan**

I added tests for the function that does the registry comparisons in the `__tests__/registries` folder.   The tests cover both positive and negative cases for the new comparison function.

Run before change:
With `.npmrc` content in the folder:
```
registry = https://myserver.mydomain.com/artifactory/api/npm/npm-mkto
_auth = myAuthStringSomeCrazyThing=
always-auth = true
```

```
$ yarn install
yarn install v0.19.1
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
error An unexpected error occurred: "https://myserver.mydomain.com:443/artifactory/api/npm/npm-mkto/react-height/-/react-height-2.2.0.tgz: Request failed \"401 Unauthorized\"".
info If you think this is a bug, please open a bug report with the information provided in "/usr/src/app/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
Run in the same folder with this PR:
```
$ yarn install
yarn install v0.21.0-0
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 115.13s.