### PR TITLE
Windows: can not run scripts starting with relative path #1729

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -7,7 +7,6 @@ import {MessageError} from '../../errors.js';
 import {registries} from '../../resolvers/index.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
-import {fixCmdWinSlashes} from '../../util/fix-cmd-win-slashes.js';
 
 const leven = require('leven');
 const path = require('path');
@@ -70,8 +69,7 @@ export async function run(
     for (const action of actions) {
       const cmd = scripts[action];
       if (cmd) {
-        const isWin = 'win32' === process.platform;
-        cmds.push([action, isWin ? fixCmdWinSlashes(cmd) : cmd]);
+        cmds.push([action, cmd]);
       }
     }
 

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -6,6 +6,7 @@ import {MessageError, SpawnError} from '../errors.js';
 import * as constants from '../constants.js';
 import * as child from './child.js';
 import {registries} from '../resolvers/index.js';
+import {fixCmdWinSlashes} from './fix-cmd-win-slashes.js';
 
 const path = require('path');
 
@@ -140,6 +141,9 @@ export async function executeLifecycleScript(
     // s - Strip " quote characters from command.
     // c - Run Command and then terminate
     shFlag = '/d /s /c';
+
+    // handle windows run scripts starting with a relative path
+    cmd = fixCmdWinSlashes(cmd);
 
     // handle quotes properly in windows environments - https://github.com/nodejs/node/issues/5060
     conf.windowsVerbatimArguments = true;


### PR DESCRIPTION
**Summary**

Enable the `fixCmdWinSlashes` class for the lifecycle scripts to clean up the
Windows run scripts starting with a relative path.

**Fixes**

- #1729

**Test plan**

Passes existing `fixCmdWinSlashes` class tests. 