### PR TITLE
Add Dockerfile for building Yarn

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# None of the files (other than the Dockerfile) are required to build the Docker
+# container, so we don't need to send *any* files to the Docker daemon.
+*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile for building Yarn.
 
-#FROM debian:stretch-slim
 FROM ubuntu:16.04
 MAINTAINER Daniel Lo Nigro <yarn@dan.cx>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Dockerfile for building Yarn.
+
+#FROM debian:stretch-slim
+FROM ubuntu:16.04
+MAINTAINER Daniel Lo Nigro <daniel@dan.cx>
+
+# Add Yarn package repo - We require Yarn to build Yarn itself :D
+ADD https://dl.yarnpkg.com/debian/pubkey.gpg /tmp/yarn-pubkey.gpg
+RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
+RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+
+# Debian packages
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -y update && \
+  apt-get install -y --no-install-recommends \
+    fakeroot \
+    gcc \
+    git \
+    lintian \
+    make \
+    nodejs \
+    nodejs-legacy \
+    npm \
+    rpm \
+    ruby \
+    ruby-dev \
+    unzip \
+    yarn \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Ruby packages
+RUN gem install fpm
+
+### Custom apps
+# ghr (just needed for releases, could probably be optional)
+ADD https://github.com/tcnksm/ghr/releases/download/v0.5.0/ghr_v0.5.0_linux_amd64.zip /tmp/ghr.zip
+RUN unzip /tmp/ghr.zip -d /usr/local/bin/ && rm /tmp/ghr.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,29 @@
 
 #FROM debian:stretch-slim
 FROM ubuntu:16.04
-MAINTAINER Daniel Lo Nigro <daniel@dan.cx>
+MAINTAINER Daniel Lo Nigro <yarn@dan.cx>
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Add Yarn package repo - We require Yarn to build Yarn itself :D
 ADD https://dl.yarnpkg.com/debian/pubkey.gpg /tmp/yarn-pubkey.gpg
 RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
 RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 
+# Add NodeSource Node.js repo for newer Node.js version
+ADD https://deb.nodesource.com/setup_7.x /tmp/nodesource-setup.sh
+RUN chmod +x /tmp/nodesource-setup.sh && /tmp/nodesource-setup.sh && rm /tmp/nodesource-setup.sh
+
 # Debian packages
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
   apt-get install -y --no-install-recommends \
+    build-essential \
     fakeroot \
     gcc \
     git \
     lintian \
     make \
     nodejs \
-    nodejs-legacy \
-    npm \
     rpm \
     ruby \
     ruby-dev \


### PR DESCRIPTION
**Summary**
Adds a Dockerfile for building Yarn. This is mainly for usage with CircleCI 2.0, however it could be used for development too. Inspired by @ryanwohara's version (https://github.com/yarnpkg/yarn/compare/master...ryanwohara:circleci-2.0), however I didn't use anything from his Dockerfile.

Closes #1903

**Test plan**
Ran `docker build -t yarn-dev .` to build an image, then `docker run -it -v c:\src\yarn:/yarn yarn-dev` to run it and mount `c:\src\yarn` to `/yarn`. Built Yarn and the build process mostly seemed to work. I still need to do a bit more testing though.