### PR TITLE
Fix typo in PATH added by Windows installer

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -39,7 +39,7 @@
 				<Environment
 					Id="BinPath"
 					Name="PATH"
-					Value="[LocalAppDataFolder]Yarn\.bin"
+					Value="[LocalAppDataFolder]Yarn\config\global\node_modules\.bin"
 					Permanent="no"
 					Part="last"
 					Action="set"


### PR DESCRIPTION
**Summary**

Global packages are currently not accessible through the command line because the PATH has been wrongly set through the Windows Installer c091ac4 & #1129

This gives the impression that global packages don't work on Windows at all and has been brought up in issue https://github.com/yarnpkg/yarn/issues/2192#issuecomment-277460434

**Test plan**

This has been tested to work on the original PR #1129. This should just fix a typo in the PATH.