### PR TITLE
Added timestamps to verbose logs

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -403,6 +403,8 @@ config.init({
   const exit = () => {
     process.exit(0);
   };
+  // verbose logs outputs process.uptime() with this line we can sync uptime to absolute time on the computer
+  reporter.verbose(`current time: ${new Date().toISOString()}`);
 
   const mutex: mixed = commander.mutex;
   if (mutex && typeof mutex === 'string') {

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -46,7 +46,7 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   _verbose(msg: string) {
-    this._logCategory('verbose', 'grey', msg);
+    this._logCategory('verbose', 'grey', `${process.uptime()} ${msg}`);
   }
 
   _verboseInspect(obj: any) {


### PR DESCRIPTION
**Summary**

When debugging issues with verbose logs it is quite useful to know the timings of all operations.

**Test plan**
```
verbose 0.242 current time: 2017-02-08T02:47:26.486Z
...
[3/4] 🔗  Linking dependencies...
verbose 0.445 Creating directory "/Users/bestander/work/temp/chek/node_modules/abbrev".
verbose 0.445 Creating directory "/Users/bestander/work/temp/chek/node_modules/buffer-equal".
verbose 0.445 Creating directory "/Users/bestander/work/temp/chek/node_modules/bunker".
verbose 0.445 Creating directory "/Users/bestander/work/temp/chek/node_modules/burrito".
```
Where 0.445 is in seconds since Yarn process was created.
I found full date/time stamps make the logs harder to read and not very useful repeated thousands of times.