### PR TITLE
[WIP] Feature: git dependencies can be without package json

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -54,6 +54,7 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/babel/babel-loader.git#greenkeeper/cross-env-3.1.4'); // hash with slashes
+addTest('https://github.com/bestander/chrome-live-reload.git'); // no package.json
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -54,7 +54,7 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/babel/babel-loader.git#greenkeeper/cross-env-3.1.4'); // hash with slashes
-addTest('https://github.com/bestander/chrome-live-reload.git'); // no package.json
+addTest('https://github.com/bestander/chrome-app-livereload.git'); // no package.json
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -424,7 +424,7 @@ config.init({
   reporter.verbose(err.stack);
 
   if (err instanceof MessageError) {
-    reporter.error(err.message);
+    reporter.error(err);
   } else {
     onUnexpectedError(err);
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -424,7 +424,7 @@ config.init({
   reporter.verbose(err.stack);
 
   if (err instanceof MessageError) {
-    reporter.error(err);
+    reporter.error(err.message);
   } else {
     onUnexpectedError(err);
   }

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -111,11 +111,13 @@ export default class GitResolver extends ExoticResolver {
       const {filename} = registries[registry];
 
       const file = await client.getFile(filename);
+      let json;
       if (!file) {
-        return null;
+        json = {};
+      } else {
+        json = await config.readJson(`${transformedUrl}/${filename}`, () => JSON.parse(file));
       }
 
-      const json = await config.readJson(`${transformedUrl}/${filename}`, () => JSON.parse(file));
       json._uid = commit;
       json._remote = {
         resolved: `${transformedUrl}#${commit}`,

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -116,7 +116,6 @@ export default class GitResolver extends ExoticResolver {
       }
 
       const json = await config.readJson(`${transformedUrl}/${filename}`, () => JSON.parse(file));
-
       json._uid = commit;
       json._remote = {
         resolved: `${transformedUrl}#${commit}`,


### PR DESCRIPTION
**Summary**

Implements #2621 #1011.
Adds feature from Bower where dependencies could be used without package.json/bower.json.

This is a dirty hack that breaks some assumptions that Yarn makes throughout the code.
Needs some cleanup.

**Test plan**

- added test
- yarn add <git url without package.json> gets it installed with generated package.json