### PR TITLE
add a description field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.21.0-0",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
+  "description": "📦🐈 Fast, reliable, and secure dependency management.",
   "dependencies": {
     "babel-runtime": "^6.0.0",
     "bytes": "^2.4.0",


### PR DESCRIPTION
**Summary**

add a description field to the package.json which is used on [npmjs.com](https://npmjs.com), [yarnpkg.com/search](https://yarnpkg.com/search) and more places, right now the description will be read out of the first part of the readme, which isn't that useful:

```
description: '<p align="center">   <a href="https://yarnpkg.com/">     <img alt="Yarn" src="https://github.com/yarnpkg/assets/blob/master/yarn-kitten-full.png?raw=true" width="546">   </a> </p>',
```

The npm site renders this as html, while yarnpkg.com/search renders it as escaped text, so plain text is the best choice for this case.

I picked the description from on github to replicate here.

**Test plan**

There's not really code change here