### PR TITLE
Optimize buildActionsForCopy routine

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -146,9 +146,14 @@ async function buildActionsForCopy(
 
     let destStat;
     try {
+      // try accessing the destination
       destStat = await lstat(dest);
-    } catch (e) {}
+    } catch (e) {
+      // proceed if destination doesn't exist, otherwise error
+      if (e.code !== 'ENOENT') throw e;
+    }
 
+    // if destination exists
     if (destStat) {
       const bothSymlinks = srcStat.isSymbolicLink() && destStat.isSymbolicLink();
       const bothFolders = srcStat.isDirectory() && destStat.isDirectory();
@@ -157,11 +162,11 @@ async function buildActionsForCopy(
       // EINVAL access errors sometimes happen which shouldn't because node shouldn't be giving
       // us modes that aren't valid. investigate this, it's generally safe to proceed.
 
-      // if (srcStat.mode !== destStat.mode) {
-      //   try {
-      //     await access(dest, srcStat.mode);
-      //   } catch (err) {}
-      // }
+      /* if (srcStat.mode !== destStat.mode) {
+        try {
+          await access(dest, srcStat.mode);
+        } catch (err) {}
+      } */
 
       if (bothFiles && srcStat.size === destStat.size && +srcStat.mtime === +destStat.mtime) {
         // we can safely assume this is the same file

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -144,21 +144,24 @@ async function buildActionsForCopy(
       srcFiles = await readdir(src);
     }
 
-    if (await exists(dest)) {
-      const destStat = await lstat(dest);
+    let destStat;
+    try {
+      destStat = await lstat(dest);
+    } catch (e) {}
 
+    if (destStat) {
       const bothSymlinks = srcStat.isSymbolicLink() && destStat.isSymbolicLink();
       const bothFolders = srcStat.isDirectory() && destStat.isDirectory();
       const bothFiles = srcStat.isFile() && destStat.isFile();
 
-      if (srcStat.mode !== destStat.mode) {
-        try {
-          await access(dest, srcStat.mode);
-        } catch (err) {
-          // EINVAL access errors sometimes happen which shouldn't because node shouldn't be giving
-          // us modes that aren't valid. investigate this, it's generally safe to proceed.
-        }
-      }
+      // EINVAL access errors sometimes happen which shouldn't because node shouldn't be giving
+      // us modes that aren't valid. investigate this, it's generally safe to proceed.
+
+      // if (srcStat.mode !== destStat.mode) {
+      //   try {
+      //     await access(dest, srcStat.mode);
+      //   } catch (err) {}
+      // }
 
       if (bothFiles && srcStat.size === destStat.size && +srcStat.mtime === +destStat.mtime) {
         // we can safely assume this is the same file
@@ -186,12 +189,6 @@ async function buildActionsForCopy(
           if (srcFiles.indexOf(file) < 0) {
             const loc = path.join(dest, file);
             possibleExtraneous.add(loc);
-
-            if ((await lstat(loc)).isDirectory()) {
-              for (const file of await readdir(loc)) {
-                possibleExtraneous.add(path.join(loc, file));
-              }
-            }
           }
         }
       }
@@ -207,8 +204,10 @@ async function buildActionsForCopy(
       });
       onDone();
     } else if (srcStat.isDirectory()) {
-      reporter.verbose(reporter.lang('verboseFileFolder', dest));
-      await mkdirp(dest);
+      if (!destStat) {
+        reporter.verbose(reporter.lang('verboseFileFolder', dest));
+        await mkdirp(dest);
+      }
 
       const destParts = dest.split(path.sep);
       while (destParts.length) {


### PR DESCRIPTION
**Summary**

Makes linking faster by reducing the number of file system calls in the `buildActionsForCopy` routine which synchronizes existing `node_modules` tree with the ideal one.

In my test runs (on `yarn` itself, and on [another big project](http://github.com/mapbox/mapbox-gl-js)), it saves about 400ms when running `yarn` without a lock file (or during upgrade).

- Remove redundant `fs.exists` (in favor of `lstat` which is called later anyway)
- Remove unnecessary `fs.access` (which does nothing — it's a placeholder in the code, so should be commented)
- Remove deeper directory traversal for `possibleExtraneous` since it should be populated with the same values later in the queue anyway.
- Avoid calling `mkdirp` if we know the destination folder already exists.

cc @bestander 

**Test plan**

Not necessary — it doesn't change the results of exported functions. Let's see if this PR passes the CI tests.