### PR TITLE
Throw error on `--frozen-lockfile` failing check instead of simply bailing out

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -303,8 +303,7 @@ export class Install {
     const haveLockfile = await fs.exists(path.join(this.config.cwd, constants.LOCKFILE_FILENAME));
 
     if (this.flags.frozenLockfile && !this.lockFileInSync(patterns)) {
-      this.reporter.error(this.reporter.lang('frozenLockfileError'));
-      return true;
+      throw new MessageError(this.reporter.lang('frozenLockfileError'));
     }
 
     if (!this.flags.skipIntegrity && !this.flags.force && match.matches && haveLockfile) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #2538.

If `--frozen-lockfile` is used while doing a `yarn install`, and it finds that the lockfile needs to be updated, it simply bails out with an error message. The return code is 0 in this case. We really should return a non-zero return code.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This switch was added for CI purposes. It's kind of silly it returns 0 on failure.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Go to any directory with a `package.json` and `yarn.lock`, delete `yarn.lock`, and do:

```
$ yarn install --frozen-lockfile
yarn install v0.21.0-0
info No lockfile found.
[1/4] Resolving packages...
warning browser-sync > localtunnel > request > node-uuid@1.4.7: use uuid module instead
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
$ echo $?
1
```