### PR TITLE
[Refactoring] [Cleanup] URLs and links now aggregated in constants file

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -75,7 +75,7 @@ type Flags = {
 
 function getUpdateCommand(): ?string {
   if (YARN_INSTALL_METHOD === 'tar') {
-    return 'curl -o- -L https://yarnpkg.com/install.sh | bash';
+    return `curl -o- -L ${constants.YARN_INSTALLER_SH} | bash`;
   }
 
   if (YARN_INSTALL_METHOD === 'homebrew') {
@@ -108,7 +108,7 @@ function getUpdateCommand(): ?string {
 function getUpdateInstaller(): ?string {
   // Windows
   if (YARN_INSTALL_METHOD === 'msi') {
-    return 'https://yarnpkg.com/latest.msi';
+    return constants.YARN_INSTALLER_MSI;
   }
 
   return null;
@@ -767,7 +767,7 @@ export class Install {
 
   async _checkUpdate(): Promise<void> {
     let latestVersion = await this.config.requestManager.request({
-      url: 'https://yarnpkg.com/latest-version',
+      url: constants.SELF_UPDATE_VERSION_URL,
     });
     invariant(typeof latestVersion === 'string', 'expected string');
     latestVersion = latestVersion.trim();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -94,7 +94,7 @@ let commandName: ?string = args.shift() || '';
 let command;
 
 //
-const getDocsLink = (name) => `https://yarnpkg.com/en/docs/cli/${name || ''}`;
+const getDocsLink = (name) => `${constants.YARN_DOCS}${name || ''}`;
 const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
 
 //

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,14 @@ export const DEPENDENCY_TYPES = [
 
 export const YARN_REGISTRY = 'https://registry.yarnpkg.com';
 
+export const YARN_DOCS = 'https://yarnpkg.com/en/docs/cli/';
+export const YARN_INSTALLER_SH = 'https://yarnpkg.com/install.sh';
+export const YARN_INSTALLER_MSI = 'https://yarnpkg.com/latest.msi';
+
+export const SELF_UPDATE_VERSION_URL = 'https://yarnpkg.com/latest-version';
+export const SELF_UPDATE_TARBALL_URL = 'https://yarnpkg.com/latest.tar.gz';
+export const SELF_UPDATE_DOWNLOAD_FOLDER = 'updates';
+
 // lockfile version, bump whenever we make backwards incompatible changes
 export const LOCKFILE_VERSION = 1;
 
@@ -64,10 +72,6 @@ export const CLEAN_FILENAME = '.yarnclean';
 export const DEFAULT_INDENT = '  ';
 export const SINGLE_INSTANCE_PORT = 31997;
 export const SINGLE_INSTANCE_FILENAME = '.yarn-single-instance';
-
-export const SELF_UPDATE_VERSION_URL = 'https://yarnpkg.com/latest-version';
-export const SELF_UPDATE_TARBALL_URL = 'https://yarnpkg.com/latest.tar.gz';
-export const SELF_UPDATE_DOWNLOAD_FOLDER = 'updates';
 
 export const ENV_PATH_KEY = getPathKey(process.platform, process.env);
 


### PR DESCRIPTION
**Summary**

Generic URLs and Links like `https://yarnpkg.com/install.sh` where spread through-out different files, while other related constants like `https://registry.yarnpkg.com` were properly placed in `constants.js` and imported in relevant files.


**Solves**

This PR cleans up the code by centralizing all such links in the proper `constants.js` files as expected.

