### PR TITLE
Add global upgrade-interactive command (#2021)

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -12,6 +12,7 @@ import {Install} from './install.js';
 import {Add} from './add.js';
 import {run as runRemove} from './remove.js';
 import {run as runUpgrade} from './upgrade.js';
+import {run as runUpgradeInteractive} from './upgrade-interactive.js';
 import {linkBin} from '../../package-linker.js';
 import * as fs from '../../util/fs.js';
 
@@ -246,6 +247,23 @@ const {run, setFlags: _setFlags} = buildSubCommands('global', {
 
     // upgrade module
     await runUpgrade(config, reporter, flags, args);
+
+    // update binaries
+    await updateBins();
+  },
+
+  async upgradeInteractive(
+    config: Config,
+    reporter: Reporter,
+    flags: Object,
+    args: Array<string>,
+  ): Promise<void> {
+    await updateCwd(config);
+
+    const updateBins = await initUpdateBins(config, reporter, flags);
+
+    // upgrade module
+    await runUpgradeInteractive(config, reporter, flags, args);
 
     // update binaries
     await updateBins();


### PR DESCRIPTION
**Summary**

Introduce `upgrade-interactive` as a subcommand of `global`.

This closes #2021.

**Test plan**

This PR mimics the way the other subcommands of `global` works: the `upgrade-interactive` command is added as a subcommand of `global`. So it is very similar to how `upgrade` is implemented, nothing fancy.

`upgrade-interactive` already has tests, this commit is only about wiring stuffs together within `global`, I didn't see the need to introduce extra tests.