### PR TITLE
Fix tests when path location of yarn contains spaces

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -22,7 +22,7 @@ Promise<Array<?string>> {
   }
 
   return new Promise((resolve, reject) => {
-    exec(`node ${yarnBin} ${cmd} ${args.join(' ')}`, {cwd:workingDir, env:process.env}, (err, stdout) => {
+    exec(`node "${yarnBin}" ${cmd} ${args.join(' ')}`, {cwd:workingDir, env:process.env}, (err, stdout) => {
       if (err) {
         reject(err);
       } else {

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -20,7 +20,7 @@ async function execCommand(cmd: string, packageName: string, env = process.env):
 
   return new Promise((resolve, reject) => {
 
-    exec(`node ${yarnBin} ${cmd}`, {cwd:packageDir, env}, (err, stdout) => {
+    exec(`node "${yarnBin}" ${cmd}`, {cwd:packageDir, env}, (err, stdout) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
**Summary**

If the path location for Yarn contains spaces, the test suite would fail on a command. The corresponding upstream issue on Node is https://github.com/nodejs/node/issues/6803. This [specific comment](https://github.com/nodejs/node/issues/6803#issuecomment-219756302) noted that the path should be escaped with double quotes.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

1.  The path location to Yarn needs to contain spaces. 
2.  Run `yarn run test`.
3.  Observe a command fail with a corrupted path location.