### PR TITLE
Fix a bug in the Hosted Git resolver, where it would make an HTTP request even if a mirrored tarball is present.

### DIFF
--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -186,6 +186,10 @@ export default class HostedGitResolver extends ExoticResolver {
   }
 
   async hasHTTPCapability(url: string): Promise<boolean> {
+    if (this.request.getLocked('tarball')) {
+      return true;
+    }
+
     return (await this.config.requestManager.request({
       url,
       method: 'HEAD',


### PR DESCRIPTION
**Summary**
After mirroring a package locally, specifically [web-component-tester](https://www.npmjs.com/package/web-component-tester) and attempting to install the dependency offline from the mirror I discovered Yarn makes an HTTP request. This means the installation fails if you pass `--offline` to Yarn or don't have an internet connection.

If in offline mode the error "Can't make a request in offline mode" is displayed, otherwise an error about being unable to resolve github.com is shown.

It appears this problem occurs because the package in question references a shorthand GitHub dependency (`"test-fixture": "PolymerElements/test-fixture"`). A URL for this is created which gets passed through the hosted Git resolver. The hosted Git resolver then attempts to determine if this URL "hasHTTPCapability" by making a request to it. This fails in offline mode.

The fix I have made here is simply to assert that the URL "hasHTTPCapability" if a mirror tarball for it exists. Sorry if this is not the right fix, but I am not very familiar with the codebase so I tried to make the simplest change possible.

**Test plan**
```
git clone https://github.com/chrisgavin/fake-package
cd fake-package
yarn install
yarn install --offline
```

This fails before applying my patch, but succeeds afterwards.