### PR TITLE
Add missing  ENOENT catch on version choice

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -54,7 +54,7 @@ for (; i < possibles.length; i++) {
     found = true;
     break;
   } catch (err) {
-    if (err.code === 'MODULE_NOT_FOUND') {
+    if (err.code === 'MODULE_NOT_FOUND' || err.code === 'ENOENT') {
       _err = err;
       continue;
     } else {


### PR DESCRIPTION
### Summary

Fresh installs of Yarn don't run because there's no `updates` directory to check for a bin in ([this line](https://github.com/yarnpkg/yarn/blob/master/bin/yarn.js#L17)).

This adds a check for that ENOENT error since if the folder doesn't exists, neither can the file.

### Test Plan

*Before*
```
λ yarn --version
C:\Program Files (x86)\Yarn\bin\yarn.js:61
      throw err;
      ^

Error: ENOENT: no such file or directory, open 'C:\Program Files (x86)\Yarn\updates\0.18.1\lib\cli\index.js'
    at Object.fs.openSync (fs.js:558:18)
    at Object.fs.readFileSync (fs.js:468:33)
    at Object.Module._extensions..js (module.js:579:20)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (C:\Program Files (x86)\Yarn\bin\yarn.js:53:22)
    at Module._compile (module.js:571:32)
```

*After*
```
λ yarn --version
0.20.3
```