### PR TITLE
Remove logic for loading self-update versions

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -9,16 +9,12 @@ var semver = require('semver');
 var ver = process.versions.node;
 ver = ver.split('-')[0]; // explode and truncate tag from version #511
 
-var possibles = [];
-var found = false;
-var _err;
+var path = null;
 
 if (semver.satisfies(ver, '>=5.0.0')) {
-  possibles.push('../updates/current/lib/cli/index.js');
-  possibles.push('../lib/cli/index.js');
+  path = '../lib/cli/index.js';
 } else if (semver.satisfies(ver, '>=4.0.0')) {
-  possibles.push('../updates/current/lib-legacy/cli/index.js');
-  possibles.push('../lib-legacy/cli/index.js');
+  path = '../lib-legacy/cli/index.js';
 } else {
   console.log(require('chalk').red('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.'));
   process.exit(1);
@@ -46,23 +42,4 @@ roadrunner.set('CACHE_BREAKER', {version: YARN_VERSION});
 // save cache on SIGINT
 roadrunner.setup(constants.CACHE_FILENAME);
 
-var i = 0;
-for (; i < possibles.length; i++) {
-  var possible = possibles[i];
-  try {
-    module.exports = require(possible);
-    found = true;
-    break;
-  } catch (err) {
-    if (err.code === 'MODULE_NOT_FOUND') {
-      _err = err;
-      continue;
-    } else {
-      throw err;
-    }
-  }
-}
-
-if (!found) {
-  throw _err || new Error('Failed to load');
-}
+module.exports = require(path);


### PR DESCRIPTION
**Summary**
Updates `bin/yarn.js` to remove the logic that looks for an updated version of Yarn in `updates/current`. This will stop Yarn from loading older versions that were installed using `self-update`.

**Test plan**
Tried both `.\bin\yarn --version` and `node .\bin\yarn.js --version`, both still work as expected 