### PR TITLE
Fix user home config conflicting with the test suite

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -106,8 +106,6 @@ export async function run<T, R>(
 
   // remove the lockfile if we create one and it didn't exist before
   const lockfile = await createLockfile(cwd);
-  const homeFolderLocation = process.env.YARN_HOME_FOLDER;
-  process.env.YARN_HOME_FOLDER = path.join(cwd, '.yarn-home');
 
   // create directories
   await fs.mkdirp(path.join(cwd, '.yarn-global'));
@@ -131,14 +129,12 @@ export async function run<T, R>(
       production: flags.production,
     }, reporter);
 
-    const install = await factory(args, flags, config, reporter, lockfile, () => out);
+    const install = await factory(args, flags, config, reporter, lockfile, () => out, path.join(cwd, '.yarn-home'));
 
     if (checkInstalled) {
       await checkInstalled(config, reporter, install);
     }
   } catch (err) {
     throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
-  } finally {
-    process.env.YARN_HOME_FOLDER = homeFolderLocation;
   }
 }

--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -106,12 +106,15 @@ export async function run<T, R>(
 
   // remove the lockfile if we create one and it didn't exist before
   const lockfile = await createLockfile(cwd);
+  const homeFolderLocation = process.env.YARN_HOME_FOLDER;
+  process.env.YARN_HOME_FOLDER = path.join(cwd, '.yarn-home');
 
   // create directories
   await fs.mkdirp(path.join(cwd, '.yarn-global'));
   await fs.mkdirp(path.join(cwd, '.yarn-link'));
   await fs.mkdirp(path.join(cwd, '.yarn-cache'));
   await fs.mkdirp(path.join(cwd, 'node_modules'));
+  await fs.mkdirp(path.join(cwd, '.yarn-home'));
 
   // make sure the cache folder been created in temp folder
   if (flags.cacheFolder) {
@@ -135,5 +138,7 @@ export async function run<T, R>(
     }
   } catch (err) {
     throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
+  } finally {
+    process.env.YARN_HOME_FOLDER = homeFolderLocation;
   }
 }

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -3,7 +3,6 @@
 import type {CLIFunctionReturn} from '../../src/types.js';
 import {ConsoleReporter} from '../../src/reporters/index.js';
 import {run as buildRun} from './_helpers.js';
-import {run as global} from '../../src/cli/commands/global.js';
 import * as fs from '../../src/util/fs.js';
 const isCI = require('is-ci');
 
@@ -17,7 +16,15 @@ const runGlobal = buildRun.bind(
   null,
   ConsoleReporter,
   fixturesLoc,
-  (args, flags, config, reporter): CLIFunctionReturn => {
+  (args, flags, config, reporter, _lockfile, _out, homeFolderLocation): CLIFunctionReturn => {
+    const automock = jest.genMockFromModule('../../src/util/user-home-dir');
+    jest.setMock('../../src/util/user-home-dir', Object.assign(automock, homeFolderLocation));
+
+    jest.resetModules();
+    jest.mock('../../src/util/user-home-dir');
+
+    const global = require('../../src/cli/commands/global.js').run;
+    jest.unmock('../../src/util/user-home-dir');
     return global(config, reporter, flags, args);
   },
 );

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -17,14 +17,16 @@ const runGlobal = buildRun.bind(
   ConsoleReporter,
   fixturesLoc,
   (args, flags, config, reporter, _lockfile, _out, homeFolderLocation): CLIFunctionReturn => {
-    const automock = jest.genMockFromModule('../../src/util/user-home-dir');
-    jest.setMock('../../src/util/user-home-dir', Object.assign(automock, homeFolderLocation));
+    const automock = jest.genMockFromModule('../../src/constants');
+    jest.setMock('../../src/constants', Object.assign(automock, {
+      GLOBAL_MODULE_DIRECTORY: homeFolderLocation,
+    }));
 
     jest.resetModules();
-    jest.mock('../../src/util/user-home-dir');
+    jest.mock('../../src/constants');
 
     const global = require('../../src/cli/commands/global.js').run;
-    jest.unmock('../../src/util/user-home-dir');
+    jest.unmock('../../src/constants');
     return global(config, reporter, flags, args);
   },
 );

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -99,7 +99,7 @@ export default class NpmRegistry extends Registry {
   async getPossibleConfigLocations(filename: string): Promise<Array<[boolean, string, string]>> {
     const possibles = [
       [false, path.join(this.cwd, filename)],
-      [true, this.config.userconfig || path.join(process.env.YARN_HOME_FOLDER || userHome, filename)],
+      [true, this.config.userconfig || path.join(userHome, filename)],
       [false, path.join(getGlobalPrefix(), filename)],
     ];
 

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -99,7 +99,7 @@ export default class NpmRegistry extends Registry {
   async getPossibleConfigLocations(filename: string): Promise<Array<[boolean, string, string]>> {
     const possibles = [
       [false, path.join(this.cwd, filename)],
-      [true, this.config.userconfig || path.join(userHome, filename)],
+      [true, this.config.userconfig || path.join(process.env.YARN_HOME_FOLDER || userHome, filename)],
       [false, path.join(getGlobalPrefix(), filename)],
     ];
 


### PR DESCRIPTION
**Summary**
The test suite did not properly isolate the home config from
influencing the behavior of the tests. Therefore if a user
used the global configuration and also cloned Yarn, the tests could fail.

A primary example of that was when a user set the prefix value.
If the user would set the prefix, the test suite would fail.

**Test plan**

1. Install `yarn` on your machine following https://yarnpkg.com/en/docs/install
2. `yarn config set prefix /usr/local` (or any other location)
3. Clone `yarn`
4. Execute the test suite of `yarn`

Without this fix, `react-native` would be installed in `/usr/local/bin/` and the test suite fails in `__tests__/commands/global.js`. Now the prefix is correctly set and `react-native` is installed in the proper location.