### PR TITLE
Add `UseBasicParsing` to Invoke-WebRequest in build-chocolatey.ps1

### DIFF
--- a/scripts/build-chocolatey.ps1
+++ b/scripts/build-chocolatey.ps1
@@ -7,7 +7,7 @@ param(
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
-$latest_version = [String](Invoke-WebRequest -Uri https://yarnpkg.com/latest-version)
+$latest_version = [String](Invoke-WebRequest -Uri https://yarnpkg.com/latest-version -UseBasicParsing)
 $latest_chocolatey_version = (Find-Package -Name Yarn).Version
 
 if ([Version]$latest_chocolatey_version -ge [Version]$latest_version) {


### PR DESCRIPTION
 Add `UseBasicParsing` to Invoke-WebRequest so it works in environments without the MSIE engine available. I'm trying to automate the build process for Chocolatey packages (currently I need to run this script manually after every release), and this change should make the script work in Windows Server 2012 R2 environments.

Previously, I was hitting this error on Server 2012 R2:
```
Invoke-WebRequest : The response content cannot be parsed because the Internet 
Explorer engine is not available, or Internet Explorer's first-launch 
configuration is not complete. Specify the UseBasicParsing parameter and try 
again. 
At C:\Jenkins\workspace\yarn-chocolatey\scripts\build-chocolatey.ps1:10 char:28
+ ...  = [String](Invoke-WebRequest -Uri https://yarnpkg.com/latest-version ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotImplemented: (:) [Invoke-WebRequest], NotSupp 
   ortedException
    + FullyQualifiedErrorId : WebCmdletIEDomNotSupportedException,Microsoft.Po 
   werShell.Commands.InvokeWebRequestCommand
```