### PR TITLE
fixed import version for not installed dependencies

### DIFF
--- a/__tests__/fixtures/import/missing-dev/package.json
+++ b/__tests__/fixtures/import/missing-dev/package.json
@@ -6,6 +6,6 @@
     "commander": "^2.9.0"
   },
   "devDependencies": {
-    "qs": "^6.3.0"
+    "qs": "6.3.0"
   }
 }

--- a/__tests__/fixtures/import/missing-dev/yarn.lock.import
+++ b/__tests__/fixtures/import/missing-dev/yarn.lock.import
@@ -12,6 +12,6 @@ commander@^2.9.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-qs@^6.3.0:
+qs@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"

--- a/__tests__/fixtures/import/missing-opt/package.json
+++ b/__tests__/fixtures/import/missing-opt/package.json
@@ -6,6 +6,6 @@
     "commander": "^2.9.0"
   },
   "optionalDependencies": {
-    "qs": "^6.3.0"
+    "qs": "6.3.0"
   }
 }

--- a/__tests__/fixtures/import/missing-opt/yarn.lock.import
+++ b/__tests__/fixtures/import/missing-opt/yarn.lock.import
@@ -12,6 +12,6 @@ commander@^2.9.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-qs@^6.3.0:
+qs@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"


### PR DESCRIPTION
Import tests would grab latest version from npm for the lockfile.
This change should make the test pass.