### PR TITLE
added unit tests for package-hoister

### DIFF
--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -1,25 +1,105 @@
 /* @flow */
 
 import PackageHoister, {HoistManifest} from '../src/package-hoister.js';
-import type PackageResolver from '../src/package-resolver.js';
+import PackageResolver from '../src/package-resolver.js';
 import type PackageReference from '../src/package-reference.js';
 import type Config from '../src/config.js';
 import type {Manifest} from '../src/types.js';
 
 const path = require('path');
 
-test('Produces valid destination paths for scoped modules', () => {
-  const expected = path.join(__dirname, './node_modules/@scoped/dep');
-  const scopedPackageName = '@scoped/dep';
+const CWD = 'tmp';
 
+function createManifestForUid(uid, dependencies): Manifest {
+  const name = uid.split('@')[0];
+  return (({
+    name,
+    _reference: (({
+      name,
+      uid,
+      dependencies,
+    }: any): PackageReference),
+  }: any): Manifest);
+}
+
+// Rig up a PackageHoister to use for testing.
+// `testModules` is a hash where:
+//   key is the module uid, in the form name@version ('lodash@1.2.3')
+//   value is an array of strings of dependencies (['lodash@1.2.3', 'grunt@4.5.6'])
+// These modules will be loaded into a mock PackageResolver that will use the hash's keys to resolve the package.
+function createTestFixture(testModules = {}): Object {
   const config = (({
-    cwd: __dirname,
+    cwd: CWD,
     getFolder(): string {
       return 'node_modules';
     },
+    generateHardModulePath(pkg: ?PackageReference): string {
+      return pkg.uid;
+    },
   }: any): Config);
 
-  const resolver = (({}: any): PackageResolver);
+  // build Manifests with just enough information to get the PackageHoister to work.
+  const packageResolver = new PackageResolver(config, undefined);
+  Object.keys(testModules).map((uid) => {
+    const packageManifest = createManifestForUid(uid, testModules[uid]);
+
+    // load the manifest into the PackageResolver
+    packageResolver.addPattern(uid, packageManifest);
+  });
+
+  const packageHoister = new PackageHoister(config, packageResolver, false);
+
+  const atPath = function(...installPaths): string {
+    const rootPath = config.modulesFolder || path.join(config.cwd, 'node_modules');
+    return path.join(rootPath, ...installPaths);
+  };
+
+  const ignorePackage = function(uid) {
+    packageResolver.getStrictResolvedPattern(uid)._reference.ignore = true;
+  };
+
+  return {
+    config,
+    packageResolver,
+    packageHoister,
+    atPath,
+    ignorePackage,
+  };
+}
+
+beforeEach(function() {
+  jasmine.addMatchers({
+    toContainPackage(): any {
+      return {
+        compare(received, uid, expectedInstallPath): any {
+          let pass: boolean = false;
+          received.forEach((pkg) => {
+            const [location: string, hoistManifest: HoistManifest] = pkg;
+            if (location === expectedInstallPath && hoistManifest.pkg._reference.uid === uid) {
+              pass = true;
+            }
+          });
+
+          if (pass) {
+            return {
+              pass: true,
+              message: () => `expected ${received} to not contain package UID ${uid} at path ${expectedInstallPath}`,
+            };
+          } else {
+            return {
+              pass: false,
+              message: () => `expected ${received} to contain package UID ${uid} at path ${expectedInstallPath}`,
+            };
+          }
+        },
+      };
+    },
+  });
+});
+
+test('Produces valid destination paths for scoped modules', () => {
+  const expected = path.join(CWD, 'node_modules', '@scoped', 'dep');
+  const scopedPackageName = '@scoped/dep';
 
   const key = scopedPackageName;
   const parts = [scopedPackageName];
@@ -34,11 +114,205 @@ test('Produces valid destination paths for scoped modules', () => {
     ['@scoped/dep', info],
   ]);
 
-  const packageHoister = new PackageHoister(config, resolver, false);
-  packageHoister.tree = tree;
+  const fixture = createTestFixture();
+  fixture.packageHoister.tree = tree;
 
-  const result = packageHoister.init();
+  const result = fixture.packageHoister.init();
   const [actual] = result[0];
 
   expect(actual).toEqual(expected);
+});
+
+test('hoists dependencies of dependencies up to root level when no version conflicts exist', () => {
+  const {atPath, packageHoister} = createTestFixture({
+    'a@1.0.0': ['b@1.0.0'],
+    'b@1.0.0': [],
+  });
+
+  packageHoister.seed(['a@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(2);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+});
+
+
+test('leaves dependencies of dependencies at leaf level when version conflict exists', () => {
+  const {atPath, packageHoister} = createTestFixture({
+    'a@1.0.0': ['b@2.0.0'],
+    'b@1.0.0': [],
+    'b@2.0.0': [],
+  });
+
+  packageHoister.seed(['a@1.0.0', 'b@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(3);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('b@2.0.0', atPath('a', 'node_modules', 'b'));
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+});
+
+test('eliminates duplicates when multiple packages depend on the same package', () => {
+  // a@1 -> b@1 -> d@1
+  //     -> c@1 -> d@1
+  // should become
+  // a@1
+  // b@1
+  // c@1
+  // d@1
+  const {atPath, packageHoister} = createTestFixture({
+    'a@1.0.0': ['b@1.0.0', 'c@1.0.0'],
+    'b@1.0.0': ['d@1.0.0'],
+    'c@1.0.0': ['d@1.0.0'],
+    'd@1.0.0': [],
+  });
+
+  packageHoister.seed(['a@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(4);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+  expect(result).toContainPackage('c@1.0.0', atPath('c'));
+  expect(result).toContainPackage('d@1.0.0', atPath('d'));
+});
+
+test('eliminates duplicates when version conflicts exist', () => {
+  // a@1 -> b@1 -> c@1 -> d@2
+  //            -> e@1 -> d@2
+  //     -> d@1
+  // should become
+  // a@1
+  // b@1
+  // c@1 -> d@2
+  // d@1
+  // e@1 -> d@2
+  const {atPath, packageHoister} = createTestFixture({
+    'a@1.0.0': ['b@1.0.0', 'd@1.0.0'],
+    'b@1.0.0': ['c@1.0.0', 'e@1.0.0'],
+    'c@1.0.0': ['d@2.0.0'],
+    'e@1.0.0': ['d@2.0.0'],
+    'd@1.0.0': [],
+    'd@2.0.0': [],
+  });
+
+  packageHoister.seed(['a@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(7);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+  expect(result).toContainPackage('c@1.0.0', atPath('c'));
+  expect(result).toContainPackage('d@1.0.0', atPath('d'));
+  expect(result).toContainPackage('e@1.0.0', atPath('e'));
+  expect(result).toContainPackage('d@2.0.0', atPath('c', 'node_modules', 'd'));
+  expect(result).toContainPackage('d@2.0.0', atPath('e', 'node_modules', 'd'));
+});
+
+test('uses the modulesFolder configuration option as the first part of the path', () => {
+  const {atPath, config, packageHoister} = createTestFixture({
+    'a@1.0.0': ['b@2.0.0'],
+    'b@1.0.0': [],
+    'b@2.0.0': [],
+  });
+  config.modulesFolder = path.join('modules', 'folder');
+
+  packageHoister.seed(['a@1.0.0', 'b@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(3);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+  expect(result).toContainPackage('b@2.0.0', atPath('a', 'node_modules', 'b'));
+});
+
+test('does not include ignored packages or their dependencies', () => {
+  const {atPath, ignorePackage, packageHoister} = createTestFixture({
+    'a@1.0.0': ['c@1.0.0'],
+    'b@1.0.0': [],
+    'c@1.0.0': [],
+  });
+  ignorePackage('a@1.0.0');
+
+  packageHoister.seed(['a@1.0.0', 'b@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(1);
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+});
+
+test('includes ignored packages dependencies if another non-ignored package depends on it', () => {
+  const {atPath, ignorePackage, packageHoister} = createTestFixture({
+    'a@1.0.0': ['c@1.0.0'],
+    'b@1.0.0': ['c@1.0.0'],
+    'c@1.0.0': [],
+  });
+  ignorePackage('a@1.0.0');
+
+  packageHoister.seed(['a@1.0.0', 'b@1.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(2);
+  expect(result).toContainPackage('b@1.0.0', atPath('b'));
+  expect(result).toContainPackage('c@1.0.0', atPath('c'));
+});
+
+test('considers ignored packages when determining hoisting', () => {
+  // a@1 -> d@1 -> c@2
+  // b@3(ignored) -> c@5
+  // should become
+  // a@1
+  // d@1 -> c@2
+  //
+  // Normally c@2 would hoist to the root, but it cannot because c@5 would be there if it was not ignored.
+  // This preserves deterministic install paths wheter packages are ignored or not.
+  const {atPath, ignorePackage, packageHoister} = createTestFixture({
+    'a@1.0.0': ['d@1.0.0'],
+    'b@3.0.0': ['c@5.0.0'],
+    'd@1.0.0': ['c@2.0.0'],
+    'c@2.0.0': [],
+    'c@5.0.0': [],
+  });
+  ignorePackage('b@3.0.0');
+
+  packageHoister.seed(['a@1.0.0', 'b@3.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(3);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('d@1.0.0', atPath('d'));
+  expect(result).toContainPackage('c@2.0.0', atPath('d', 'node_modules', 'c'));
+});
+
+test('will hoist packages under subdirectories when they cannot hoist to root', () => {
+  // a@1 -> b@1 -> c@1 -> d@1
+  // b@2(ignored) -> c@2 -> d@2
+  // should become
+  // a@1 -> b@1
+  //     -> c@1
+  //     -> d@1
+  //
+  // b,c,d@1 cannot hoist to the root because their @2 versions would be there if not ignored.
+  // However they can still flaten under a@1.
+  const {atPath, ignorePackage, packageHoister} = createTestFixture({
+    'a@1.0.0': ['b@1.0.0'],
+    'b@1.0.0': ['c@1.0.0'],
+    'c@1.0.0': ['d@1.0.0'],
+    'b@2.0.0': ['c@2.0.0'],
+    'c@2.0.0': ['d@2.0.0'],
+    'd@1.0.0': [],
+    'd@2.0.0': [],
+  });
+  ignorePackage('b@2.0.0');
+
+  packageHoister.seed(['a@1.0.0', 'b@2.0.0']);
+  const result = packageHoister.init();
+
+  expect(result.length).toEqual(4);
+  expect(result).toContainPackage('a@1.0.0', atPath('a'));
+  expect(result).toContainPackage('b@1.0.0', atPath('a', 'node_modules', 'b'));
+  expect(result).toContainPackage('c@1.0.0', atPath('a', 'node_modules', 'c'));
+  expect(result).toContainPackage('d@1.0.0', atPath('a', 'node_modules', 'd'));
 });

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -2,6 +2,7 @@
 
 import PackageHoister, {HoistManifest} from '../src/package-hoister.js';
 import PackageResolver from '../src/package-resolver.js';
+import Lockfile from '../src/lockfile/wrapper.js';
 import type PackageReference from '../src/package-reference.js';
 import type Config from '../src/config.js';
 import type {Manifest} from '../src/types.js';
@@ -27,19 +28,20 @@ function createManifestForUid(uid, dependencies): Manifest {
 //   key is the module uid, in the form name@version ('lodash@1.2.3')
 //   value is an array of strings of dependencies (['lodash@1.2.3', 'grunt@4.5.6'])
 // These modules will be loaded into a mock PackageResolver that will use the hash's keys to resolve the package.
-function createTestFixture(testModules = {}): Object {
+function createTestFixture(testModules: any = {}): any {
   const config = (({
     cwd: CWD,
     getFolder(): string {
       return 'node_modules';
     },
     generateHardModulePath(pkg: ?PackageReference): string {
-      return pkg.uid;
+      return pkg ? pkg.uid : '';
     },
   }: any): Config);
 
   // build Manifests with just enough information to get the PackageHoister to work.
-  const packageResolver = new PackageResolver(config, undefined);
+  const lockfile = new Lockfile();
+  const packageResolver = new PackageResolver(config, lockfile);
   Object.keys(testModules).map((uid) => {
     const packageManifest = createManifestForUid(uid, testModules[uid]);
 

--- a/flow-typed/npm/jest_v14.0.x.js
+++ b/flow-typed/npm/jest_v14.0.x.js
@@ -45,6 +45,7 @@ type JestExpectType = {
   toMatchSnapshot(): void;
   toThrow(message?: string | Error): void;
   toThrowError(message?: string): void;
+  toContainPackage(packageName: string, path: string): void;
 }
 
 declare function expect(value: any): JestExpectType;
@@ -68,4 +69,5 @@ declare var jest: {
 
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number;
+  addMatchers(matcher: Object): void;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Add a series of unit tests for `PackageHoister`.

Previously there was only 1 unit test (not including integration tests).

With this PR, there are now enough unit testa to bump coverage of the `package-hoister.js` file to ~93% (correction, after I rebased from current master it dropped to ~88%. I guess more code was added recently).  I really wanted to get as close to 100% coverage as possible, but I've been starting at this one file for a couple days and not sure what scenarios would hit some branches in the code.

The real motivation was to understand how PackageHoister works in hopes of trying to look more into issue #2673 and I figured, how better to figure out how it works than to write tests for it!

**Test plan**

```
$ npm run test-only __tests__/package-hoister.js

----------------------|----------|----------|----------|----------|----------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------|----------|----------|----------|----------|----------------|
All files             |    53.86 |    45.89 |    44.87 |    54.45 |                |
 src                  |    59.31 |    53.25 |    54.55 |    58.75 |                |
  package-hoister.js  |    88.75 |    72.16 |      100 |    88.41 |... 494,497,498 |
  package-resolver.js |    17.26 |    21.05 |    24.24 |    17.37 |... 453,459,461 |
 src/util             |    30.93 |    24.53 |    21.74 |    30.56 |                |
  blocking-queue.js   |    21.05 |    18.75 |    21.43 |    21.05 |... 133,134,135 |
  map.js              |    72.73 |    55.56 |      100 |       70 |         7,8,16 |
  misc.js             |    34.48 |    16.67 |     12.5 |       60 |          60,62 |
----------------------|----------|----------|----------|----------|----------------|
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        1.258s
Ran all test suites matching "__tests__/package-hoister.js".
```

**Additional notes**

if you run all the tests, there seems to be 2 Flow warnings and 3 test errors. These happened after I merged in the current master code and I believe they are errors in current `master`, not my added test code.

I made a custom jasmine matcher in the test file to clean up the tests. Jest has its own way of doing that, but Yarn seems to be on an older version of Jest, so I had to add it right to Jasmine. Flow was not happy with this new matcher, so I added it to the main type definition for Jasmine in `yarn/flow-typed/npm/jest-v14.0.x.js` even though that function only exists in `__tests__/package-hoister.js` but I had no idea how to tell Flow to allow that method only in that one file. If someone has a better idea, please let me know!

