### PR TITLE
fix errors thrown if symlink source does not exist

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -644,7 +644,12 @@ export async function symlink(src: string, dest: string): Promise<void> {
       await fsSymlink(src, dest, 'junction');
     } else {
       // use relative paths otherwise which will be retained if the directory is moved
-      const relative = path.relative(fs.realpathSync(path.dirname(dest)), fs.realpathSync(src));
+      let relative;
+      if (await exists(src)) {
+        relative = path.relative(fs.realpathSync(path.dirname(dest)), fs.realpathSync(src));
+      } else {
+        relative = path.relative(path.dirname(dest), src);
+      }
       await fsSymlink(relative, dest);
     }
   } catch (err) {


### PR DESCRIPTION
**Summary**
#2454 introduced a regression as during install symlink sources wouldn't always exist at the time of symlink creation so as `fs.realpathSync` checks if the path actually exist the `ENOENT` error might be thrown here.

This PR makes sure we have more defensive approach by checking that symlink source exists before trying to derive absolute symlink path which might throw. So if source doesn't exist we would stick to more conservative relative symlinks otherwise where symlink source itself is not a requirement at least until the symlink is used.

Fixes https://github.com/yarnpkg/yarn/issues/2714
