### PR TITLE
Unescapes ESC character, fixing #2439

### DIFF
--- a/__tests__/reporters/base-reporter.js
+++ b/__tests__/reporters/base-reporter.js
@@ -113,3 +113,9 @@ test('BaseReporter.disableProgress', () => {
   reporter.disableProgress();
   expect(reporter.noProgress).toBeTruthy();
 });
+
+test('BaseReporter.termstrings', () => {
+  const reporter = new BaseReporter();
+  const expected = '"\u001b[2mjsprim#\u001b[22mjson-schema" not installed';
+  expect(reporter.lang('packageNotInstalled', '\u001b[2mjsprim#\u001b[22mjson-schema')).toEqual(expected);
+});

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -37,7 +37,10 @@ export function stringifyLangArgs(args: Array<any>): Array<string> {
       return val.inspect();
     } else {
       try {
-        return JSON.stringify(val) || val + '';
+        const str = JSON.stringify(val) || val + '';
+	// should match all "u001b" that follow an odd number of backslashes and convert them to ESC
+	// we do this because the JSON.stringify process has escaped these characters
+        return str.replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b');
       } catch (e) {
         return util.inspect(val);
       }


### PR DESCRIPTION
Ping @bestander 

**Summary**

This PR fixes #2439 by automatically unescaping the ESC character (`\u001b`) from the stringified version of the arguments passed to `reporter.lang`.

I'm a bit concerned about potential security breaks that could occur should a third-party-providen string contain a literal ESC (let's say a package named "\u001bhello"), which is why this regex [is a bit more complex](https://regex101.com/r/mSWp0d/1) than it could be: it checks that the `\u001b` character isn't escaped before unescaping it. So:

```
'\\u001bhello' => '\u001bhello'
'\\\\u001bhello' => '\\\u001bhello'
```

This way, even if a package name (or anything else) contains "\u001b" somewhere in the argument, it won't be interpreted provided that the string has been escaped beforehand (ideally before adding the styles to it). That being said, I'm not sure this escaping is already done, so maybe this PR isn't the right place to be concerned about that.

WDYT? Would you prefer a simpler regex?

**Test plan**

<img width="630" alt="screen shot 2017-02-21 at 5 43 41 pm" src="https://cloud.githubusercontent.com/assets/1037931/23177048/5ece801e-f85d-11e6-88fe-66f0d10c21ad.png">
