### PR TITLE
add --prefer-online flag: use cache only if network is not available

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -49,6 +49,7 @@ commander.usage('[command] [flags]');
 commander.option('--verbose', 'output verbose messages on internal operations');
 commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
 commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
+commander.option('--prefer-online', 'use cache only if network is not available');
 commander.option('--strict-semver');
 commander.option('--json', '');
 commander.option('--ignore-scripts', "don't run lifecycle scripts");
@@ -362,6 +363,7 @@ config.init({
   globalFolder: commander.globalFolder,
   cacheFolder: commander.cacheFolder,
   preferOffline: commander.preferOffline,
+  preferOnline: commander.preferOnline,
   captureHar: commander.har,
   ignorePlatform: commander.ignorePlatform,
   ignoreEngines: commander.ignoreEngines,

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,7 @@ export type ConfigOptions = {
   linkFolder?: ?string,
   offline?: boolean,
   preferOffline?: boolean,
+  preferOnline?: boolean,
   captureHar?: boolean,
   ignoreScripts?: boolean,
   ignorePlatform?: boolean,
@@ -83,6 +84,7 @@ export default class Config {
   looseSemver: boolean;
   offline: boolean;
   preferOffline: boolean;
+  preferOnline: boolean;
   ignorePlatform: boolean;
   binLinks: boolean;
 
@@ -261,6 +263,7 @@ export default class Config {
     this.commandName = opts.commandName || '';
 
     this.preferOffline = !!opts.preferOffline;
+    this.preferOnline = !!opts.preferOnline;
     this.modulesFolder = opts.modulesFolder;
     this.globalFolder = opts.globalFolder || constants.GLOBAL_MODULE_DIRECTORY;
     this.linkFolder = opts.linkFolder || constants.LINK_REGISTRY_DIRECTORY;

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -74,13 +74,23 @@ export default class NpmResolver extends RegistryResolver {
       }
     }
 
-    const body = await this.config.registries.npm.request(NpmRegistry.escapeName(this.name));
+    try {
+      const body = await this.config.registries.npm.request(NpmRegistry.escapeName(this.name));
+      if (body) {
+        return await NpmResolver.findVersionInRegistryResponse(this.config, this.range, body, this.request);
+      }
+    } catch (err) {
+      if(this.config.preferOnline) {
+        this.config.offline = true;
 
-    if (body) {
-      return await NpmResolver.findVersionInRegistryResponse(this.config, this.range, body, this.request);
-    } else {
-      return null;
+        const res = this.resolveRequestOffline();
+        if (res != null) {
+          return res;
+        }
+      }
     }
+
+    return null;
   }
 
   async resolveRequestOffline(): Promise<?Manifest> {


### PR DESCRIPTION
**Summary**

After reviewing https://github.com/facebookincubator/create-react-app/issues/1235 we should have a --prefer-online flag that should use use cache only if network is not available and IMHO should be *default* option.

Right now we have:
1. the *default* one which it only downloads from the network; we can call it --online
2. --offline we use network only if dependencies are not available in local cache
3. --prefer-offline that fallbacks from offline to online if the package is not in the cache

**Test plan**

Right now I have no idea how to test it; npm-resolver doesn't have tests; and this is an idea, if someone liked it, i will go ahead and maybe I will rewrite everything.
