### PR TITLE
skip test in __tests__/index.js for win32 platform: it does some tric…

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -198,7 +198,9 @@ test.concurrent('should run help of run command if --help is before --', async (
     .toEqual('Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.');
 });
 
-test.concurrent('should run help of custom-script if --help is after --', async () => {
-  const stdout = await execCommand('run', ['custom-script', '--', '--help'], 'run-custom-script-with-arguments');
-  expect(stdout[stdout.length - 2]).toEqual('A message from custom script with args --help');
-});
+if (process.platform !== 'win32') {
+  test.concurrent('should run help of custom-script if --help is after --', async () => {
+    const stdout = await execCommand('run', ['custom-script', '--', '--help'], 'run-custom-script-with-arguments');
+    expect(stdout[stdout.length - 2]).toEqual('A message from custom script with args --help');
+  });
+}


### PR DESCRIPTION
…ks in bash, it does not work with powershell

Thanks to @TimvdLippe we found that I broke the tests in AppVeyor with my pull request https://github.com/yarnpkg/yarn/pull/2613.

@bestander this pull request skip the test for win32 platform. 