### PR TITLE
Add v8-compile-cache

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -20,6 +20,11 @@ if (semver.satisfies(ver, '>=5.0.0')) {
   process.exit(1);
 }
 
+// load v8-compile-cache
+if (semver.satisfies(ver, '>=5.7.0')) {
+  require('v8-compile-cache');
+}
+
 // ensure cache directory exists
 var mkdirp = require('mkdirp');
 var constants = require('../lib-legacy/constants');

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "strip-bom": "^3.0.0",
     "tar": "^2.2.1",
     "tar-stream": "^1.5.2",
+    "v8-compile-cache": "^1.0.0",
     "validate-npm-package-license": "^3.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4533,6 +4533,10 @@ uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
+v8-compile-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.0.0.tgz#56c809189daa8289a7d049354f61ab9c347f1fc2"
+
 v8flags@^2.0.2:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.0.11.tgz#bca8f30f0d6d60612cc2c00641e6962d42ae6881"


### PR DESCRIPTION
**Summary**

This change makes it so that `yarn` can take advantage of V8's compile cache, and improve startup times. From https://raw.githubusercontent.com/zertosh/v8-compile-cache/v1.0.0/README.md:

> `v8-compile-cache` attaches a `require` hook to use [V8's code cache](https://v8project.blogspot.com/2015/07/code-caching.html) to speed up instantiation time. The "code cache" is the work of parsing and compiling done by V8.
> The ability to tap into V8 to produce/consume this cache was introduced in [Node v5.7.0](https://nodejs.org/en/blog/release/v5.7.0/).

`time`time ./bin/yarn.js config list` goes from 0.22s to 0.18s. config list` goes from 0.22s to 0.18s.

**Test plan**

`./bin/yarn.js`, `./bin/yarn.js add underscore` and `./bin/yarn.js config list`. All work.