### PR TITLE
Personal access token for github over http - via env GITHUB_HTTP_AUTH

### DIFF
--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -6,6 +6,7 @@ import HostedGitResolver from './hosted-git-resolver.js';
 export default class GitHubResolver extends HostedGitResolver {
   static protocol = 'github';
   static hostname = 'github.com';
+  static auth = process.env.GITHUB_HTTP_AUTH ? `${process.env.GITHUB_HTTP_AUTH}@` : '';
 
   static isVersion(pattern: string): boolean {
     // github proto
@@ -22,7 +23,7 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getTarballUrl(parts: ExplodedFragment, hash: string): string {
-    return `https://codeload.${this.hostname}/${parts.user}/${parts.repo}/tar.gz/${hash}`;
+    return `https://${this.auth}codeload.${this.hostname}/${parts.user}/${parts.repo}/tar.gz/${hash}`;
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {
@@ -31,10 +32,10 @@ export default class GitHubResolver extends HostedGitResolver {
   }
 
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
+    return `https://${this.auth}${this.hostname}/${parts.user}/${parts.repo}.git`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {
-    return `https://raw.githubusercontent.com/${parts.user}/${parts.repo}/${commit}/${filename}`;
+    return `https://${this.auth}raw.githubusercontent.com/${parts.user}/${parts.repo}/${commit}/${filename}`;
   }
 }


### PR DESCRIPTION
**Summary**

This PR supports importing `github:org/repo` over http even when the repository is private.
It is an alternative to using `git+ssh://git@github.com/org/repo` to force yarn to use git instead of http. When migrating from npm it is one less thing to refactor.

```
GITHUB_HTTP_AUTH=username:personal_access_token yarn install
```

To support importing dependencies hosted in a private github repo
over http, the user authentication needs to be passed:
https://developer.github.com/v3/auth/#basic-authentication

**Test plan**

This PR is a proof of concept: it does that with a shamelessly simple env
variable.
If this makes sense we can consider doing it cleanly.

For example: the current implementation will write the personal auth token in yarn.lock
Not an acceptable practice. Passing the authentication as headers is a good way to avoid that issue.

Let me know if this idea is worth working on.
Thanks!