### PR TITLE
Sort outdated packages by name, fixes #2513

### DIFF
--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -120,12 +120,12 @@ test.concurrent('displays correct dependency types', (): Promise<void> => {
 
       // peerDependencies aren't included in the output
       expect(json.data.body.length).toBe(3);
-      expect(body[0][0]).toBe('left-pad');
-      expect(body[0][4]).toBe('dependencies');
-      expect(body[1][0]).toBe('max-safe-integer');
-      expect(body[1][4]).toBe('devDependencies');
-      expect(body[2][0]).toBe('is-online');
-      expect(body[2][4]).toBe('optionalDependencies');
+      expect(body[0][0]).toBe('is-online');
+      expect(body[0][4]).toBe('optionalDependencies');
+      expect(body[1][0]).toBe('left-pad');
+      expect(body[1][4]).toBe('dependencies');
+      expect(body[2][0]).toBe('max-safe-integer');
+      expect(body[2][4]).toBe('devDependencies');
     },
   );
 });

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -377,9 +377,8 @@ export default class PackageRequest {
     const isDepOld = ({current, latest, wanted}) => latest === 'exotic' || (
       latest !== 'exotic' && (semver.lt(current, wanted) || semver.lt(current, latest))
     );
-    const isDepExpected = ({current, wanted}) => current === wanted;
-    const orderByExpected = (depA, depB) => isDepExpected(depA) && !isDepExpected(depB) ? 1 : -1;
+    const orderByName = (depA, depB) => depA.name.localeCompare(depB.name);
 
-    return deps.filter(isDepOld).sort(orderByExpected);
+    return deps.filter(isDepOld).sort(orderByName);
   }
 }


### PR DESCRIPTION
**Summary**

When calling `yarn outdated` the packages are not ordered by name. `npm outdated` orders by name and so does `yarn` when merging this PR.

**Test plan**

See https://github.com/yarnpkg/yarn/issues/2513
