### PR TITLE
Add filename output to parse errors

### DIFF
--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -156,9 +156,10 @@ export function* tokenise(input: string): Iterator<Token> {
 }
 
 export class Parser {
-  constructor(input: string) {
+  constructor(input: string, fileLoc: string) {
     this.comments = [];
     this.tokens = tokenise(input);
+    this.fileLoc = fileLoc;
   }
 
   token: Token;
@@ -201,7 +202,7 @@ export class Parser {
   }
 
   unexpected(msg: string = 'Unexpected token') {
-    throw new SyntaxError(`${msg} ${this.token.line}:${this.token.col}`);
+    throw new SyntaxError(`${msg} ${this.token.line}:${this.token.col} in ${this.fileLoc}`);
   }
 
   expect(tokType: string) {
@@ -310,9 +311,9 @@ export class Parser {
   }
 }
 
-export default function(str: string): Object {
+export default function(str: string, fileLoc: string): Object {
   str = stripBOM(str);
-  const parser = new Parser(str);
+  const parser = new Parser(str, fileLoc);
   parser.next();
   return parser.parse();
 }

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -156,12 +156,13 @@ export function* tokenise(input: string): Iterator<Token> {
 }
 
 export class Parser {
-  constructor(input: string, fileLoc: string) {
+  constructor(input: string, fileLoc: string = 'lockfile') {
     this.comments = [];
     this.tokens = tokenise(input);
     this.fileLoc = fileLoc;
   }
 
+  fileLoc: string;
   token: Token;
   tokens: Iterator<Token>;
   comments: Array<string>;
@@ -311,7 +312,7 @@ export class Parser {
   }
 }
 
-export default function(str: string, fileLoc: string): Object {
+export default function(str: string, fileLoc: string = 'lockfile'): Object {
   str = stripBOM(str);
   const parser = new Parser(str, fileLoc);
   parser.next();

--- a/src/lockfile/wrapper.js
+++ b/src/lockfile/wrapper.js
@@ -94,7 +94,7 @@ export default class Lockfile {
 
     if (await fs.exists(lockfileLoc)) {
       rawLockfile = await fs.readFile(lockfileLoc);
-      lockfile = parse(rawLockfile);
+      lockfile = parse(rawLockfile, lockfileLoc);
     } else {
       if (reporter) {
         reporter.info(reporter.lang('noLockfileFound'));

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -78,7 +78,7 @@ export default class YarnRegistry extends NpmRegistry {
 
   async loadConfig(): Promise<void> {
     for (const [isHome, loc, file] of await this.getPossibleConfigLocations('.yarnrc')) {
-      const config = parse(file);
+      const config = parse(file, loc);
 
       if (isHome) {
         this.homeConfig = config;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When running yarn with an invalid lockfile, the errors do not direct you to look at your lockfile. An example of one of these "vague" errors is `error An unexpected error occurred: "Invalid value type 2:0".`

In order to better point people towards the actual issue, this PR adds the filepath output after the error location so that people can find and fix the lockfile issue. After this PR, that same output would instead be `error An unexpected error occurred: "Invalid value type 2:0 in /Users/dawsonbotsford/.yarnrc".`

**Test plan**

This should only be a change in the error message. Are error messages included in the test coverage of yarn?
