### PR TITLE
Add —non-interactive flag for automated processes

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -88,6 +88,7 @@ commander.option(
   'disable progress bar',
 );
 commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
+commander.option('--non-interactive', 'do not show interactive prompts');
 
 // get command name
 let commandName: ?string = args.shift() || '';
@@ -372,6 +373,7 @@ config.init({
   httpProxy: commander.proxy,
   httpsProxy: commander.httpsProxy,
   networkConcurrency: commander.networkConcurrency,
+  nonInteractive: commander.nonInteractive,
   commandName,
 }).then(() => {
 

--- a/src/config.js
+++ b/src/config.js
@@ -36,12 +36,15 @@ export type ConfigOptions = {
   production?: boolean,
   binLinks?: boolean,
   networkConcurrency?: number,
+  nonInteractive?: boolean,
 
   // Loosely compare semver for invalid cases like "0.01.0"
   looseSemver?: ?boolean,
 
   httpProxy?: ?string,
   httpsProxy?: ?string,
+
+  nonInteractive?: ?boolean,
 
   commandName?: ?string,
 };
@@ -122,6 +125,8 @@ export default class Config {
   ignoreScripts: boolean;
 
   production: boolean;
+
+  nonInteractive: boolean;
 
   //
   cwd: string;
@@ -269,6 +274,8 @@ export default class Config {
 
     this.ignorePlatform = !!opts.ignorePlatform;
     this.ignoreScripts = !!opts.ignoreScripts;
+
+    this.nonInteractive = !!opts.nonInteractive;
 
     this.requestManager.setOptions({
       offline: !!opts.offline && !opts.preferOffline,

--- a/src/config.js
+++ b/src/config.js
@@ -44,8 +44,6 @@ export type ConfigOptions = {
   httpProxy?: ?string,
   httpsProxy?: ?string,
 
-  nonInteractive?: ?boolean,
-
   commandName?: ?string,
 };
 

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -43,7 +43,7 @@ export default class NpmResolver extends RegistryResolver {
     const satisfied = await config.resolveConstraints(Object.keys(body.versions), range);
     if (satisfied) {
       return body.versions[satisfied];
-    } else if (request) {
+    } else if (request && !config.nonInteractive) {
       if (request.resolver && request.resolver.activity) {
         request.resolver.activity.end();
       }


### PR DESCRIPTION
**Summary**

If yarn is used within an automated process (in a CI system, for example), interactive prompts are not desirable.  This adds a commandline flag to remove them.

This resolves https://github.com/yarnpkg/yarn/issues/2625.

**Test plan**

I intentionally misconfigured a package.json with an invalid version of async:

    "async": "^111.5.0",

1) Run 'yarn'.  Output is an interactive menu letting me select a valid version of async to install.
2) Run 'yarn --non-interactive'.  Output is:

yarn install v0.22.0-0
[1/4] 🔍  Resolving packages...
error Couldn't find any versions for "async" that matches "^111.5.0"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

**Pending Issues**

* I wasn't sure how to build an effective test for this option.  If you think this warrants a test I'd appreciate some suggestions.
* I do not know how to update the documentation.