### PR TITLE
Implemented mutex system to make bin links be generated consistently in Windows

### DIFF
--- a/src/util/mutex.js
+++ b/src/util/mutex.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+const lockPromises: Map<any, Promise<*>> = new Map();
+
+/**
+ * Acquires a mutex lock over the given key. If the lock can't be acquired, it waits until it's available.
+ * @param key Key to get the lock for.
+ * @return {Promise.<Function>} A Promise that resolves when the lock is acquired, with the function that
+ * must be called to release the lock.
+ */
+export default (key: any): Promise<Function> => {
+  let unlockNext;
+  const willLock = new Promise((resolve) => unlockNext = resolve);
+  const lockPromise = lockPromises.get(key) || Promise.resolve();
+  const willUnlock = lockPromise.then(() => unlockNext);
+  lockPromises.set(key, lockPromise.then(() => willLock));
+  return willUnlock;
+};


### PR DESCRIPTION
Fixes https://github.com/yarnpkg/yarn/issues/828 and https://github.com/yarnpkg/yarn/issues/2356

**Summary**

`cmd-shim` (used to generate executables on the `.bin` dir on Windows) is not an atomic operation. So, a race condition can happen where 2 packages that produce the same CLI executable will produce an unusable `cmd` file.
Additional context: https://github.com/yarnpkg/yarn/issues/828#issuecomment-270035847
Examples of packages which produce the same CLI:
* `karma` and `karma-cli` produce the shortcut `karma`.
* `gulp` and `gulp-cli` produce the shortcut `gulp`.
* `grunt` and `grunt-cli` produce the shortcut `grunt`.

To solve this, I've implemented a Mutex (loosely based on [await-mutex](https://github.com/mgtitimoli/await-mutex)) around the usage of `cmd-shim`. It's not the most efficient way, but it's the most practical one, given how the linker is implemented.

A person has reported that this same bug happens in `npm`, but maybe it's less frequent because `yarn` is more aggressive with concurrency? Would it be better to implement this `Mutex` on `cmd-shim` itself? And if so, when can we expect Yarn to get the updated version of `cmd-shim`? Multiple packages having the same CLI are pretty common on build tools or test runners, and this bug basically makes Yarn unpredictable in Windows.

**Test plan**

Because this is a race condition, it's tricky to reproduce. I've managed to reproduce it with a complex project about 50% of the time.
* Go to a Windows machine
* Clone [woocommerce-services](https://github.com/Automattic/woocommerce-services), checkout the branch `try/yarn`
* Run `yarn install`
* Inspect the file `node_modules\.bin\karma.cmd`. If you see garbage characters at the end of the file, then you've managed to reproduce the bug (and if you are using this Yarn PR, it means I screwed up something).
* Alternatively, you can run `npm test` (it uses the `karma.cmd` program), if it gives an error before even starting, then that's the bug (ignore the Webpack tests, it's an old branch, if you get that far it means it's working).