### PR TITLE
fix: prevent from logging peer-dependencies that are met

### DIFF
--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -348,7 +348,6 @@ export default class PackageResolver {
     }
 
     byName.splice(byName.indexOf(pattern), 1);
-    delete this.patterns[pattern];
   }
 
   /**


### PR DESCRIPTION

**Summary**

Solves the problem where peerDependencies are warning even though they are met. 

**Test plan**

Run `yarn add react react-dom` 

### Before: 

![skjermbilde 2017-02-27 kl 23 56 20](https://cloud.githubusercontent.com/assets/16735925/23383924/e4fa1d66-fd48-11e6-88ba-d0fc4d3108c2.png)

### After: 
![skjermbilde 2017-02-27 kl 23 57 29](https://cloud.githubusercontent.com/assets/16735925/23383925/e4fb706c-fd48-11e6-8361-dc810c63257f.png)

I don't really know if the fix is legit. I removed a line of code, it may be doing something else than it was in my context, but the error is from `lib/package-resolver.js` L370, where it removes the peerDependencies we expect to have ( later adding the peerDep? ) . May need further investigation, but from the second check in `lib/package-linker` , it returns undefined for the package, since it has been removed from `this.patterns`. My suggestion, if this PR is somewhat volatile, is to check the packages you've got from the upper-tree against the ones you have, and then remove dupes. 

Related: 

- #2132 



If there's anything you need for me, feel free to assign me for other stuff. 

Even 
