### PR TITLE
Refactored integrity generation and check

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -677,6 +677,27 @@ test.concurrent('install should write and read integrity file based on lockfile 
   });
 });
 
+test.concurrent('install should not continue if integrity check passes', (): Promise<void> => {
+  return runInstall({}, 'lockfile-stability', async (config, reporter) => {
+
+    await fs.writeFile(path.join(config.cwd, 'node_modules', 'yarn.test'), 'YARN TEST');
+
+    // install should bail out with integrity check and not remove extraneous file
+    let reinstall = new Install({}, config, reporter, await Lockfile.fromDirectory(config.cwd));
+    await reinstall.init();
+
+    expect(await fs.exists(path.join(config.cwd, 'node_modules', 'yarn.test')));
+
+    await fs.unlink(path.join(config.cwd, 'node_modules', 'yarn.test'));
+
+    reinstall = new Install({}, config, reporter, await Lockfile.fromDirectory(config.cwd));
+    await reinstall.init();
+
+    expect(!await fs.exists(path.join(config.cwd, 'node_modules', 'yarn.test')));
+
+  });
+});
+
 test.concurrent('install should not rewrite lockfile with no substantial changes', (): Promise<void> => {
   const fixture = 'lockfile-no-rewrites';
 

--- a/__tests__/commands/install/unit.js
+++ b/__tests__/commands/install/unit.js
@@ -10,24 +10,6 @@ const path = require('path');
 
 const fixturesLoc = path.join(__dirname, '..', '..', 'fixtures', 'install');
 
-test.concurrent('integrity hash respects flat and production flags', async () => {
-  const cwd = path.join(fixturesLoc, 'noop');
-  const reporter = new NoopReporter();
-  const config = await Config.create({cwd}, reporter);
-
-  const lockfile = new Lockfile();
-
-  const install = new Install({}, config, reporter, lockfile);
-
-  const install2 = new Install({flat: true}, config, reporter, lockfile);
-  expect(install2.generateIntegrityHash('foo', [])).not.toEqual(install.generateIntegrityHash('foo', []));
-
-  const config2 = await Config.create({cwd, production: true}, reporter);
-  const install3 = new Install({}, config2, reporter, lockfile);
-  expect(install3.generateIntegrityHash('foo', [])).not.toEqual(install.generateIntegrityHash('foo', []));
-  expect(install3.generateIntegrityHash('foo', [])).not.toEqual(install2.generateIntegrityHash('foo', []));
-});
-
 test.concurrent('flat arg is inherited from root manifest', async (): Promise<void> => {
   const cwd = path.join(fixturesLoc, 'top-level-flat-parameter');
   const reporter = new NoopReporter();

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -150,7 +150,7 @@ async function integrityHashCheck(
   const install = new Install(flags, config, reporter, lockfile);
 
   // get patterns that are installed when running `yarn install`
-  // TODO measure slowdown here
+  // TODO hydrate takes longer then install command bailout https://github.com/yarnpkg/yarn/issues/2514
   const {patterns: rawPatterns} = await install.hydrate(true);
   const patterns = await install.flatten(rawPatterns);
   const lockSource = lockStringify(lockfile.getLockfile(install.resolver.patterns));

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -157,10 +157,10 @@ async function integrityHashCheck(
 
   const match = await integrityChecker.check(patterns, lockfile, lockSource, flags);
   for (const pattern of match.missingPatterns) {
-    reportError('lockfileNotContainPatter', pattern);
+    reportError('lockfileNotContainPattern', pattern);
   }
   if (match.integrityFileMissing) {
-    reportError('noIntegirtyHashFile');
+    reportError('noIntegrityHashFile');
   }
   if (!match.integrityHashMatches) {
     reportError('integrityHashesDontMatch');
@@ -218,7 +218,7 @@ export async function run(
   // check if patterns exist in lockfile
   for (const pattern of patterns) {
     if (!lockfile.getLocked(pattern)) {
-      reportError('lockfileNotContainPatter', pattern);
+      reportError('lockfileNotContainPattern', pattern);
     }
   }
 

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -163,7 +163,7 @@ async function integrityHashCheck(
     reportError('noIntegirtyHashFile');
   }
   if (!match.integrityHashMatches) {
-    reportError('integrityHashesDontMatch', match.hashExpected, match.hashActual);
+    reportError('integrityHashesDontMatch');
   }
 
   if (errCount > 0) {

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -1,11 +1,12 @@
 /* @flow */
 
-import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
-import {Install} from './install.js';
+import {InstallationIntegrityChecker} from '../../integrity-checker.js';
 import Lockfile from '../../lockfile/wrapper.js';
+import type {Reporter} from '../../reporters/index.js';
 import * as fs from '../../util/fs.js';
+import {Install} from './install.js';
 
 const semver = require('semver');
 const path = require('path');
@@ -142,29 +143,27 @@ async function integrityHashCheck(
     reporter.error(reporter.lang(msg, ...vars));
     errCount++;
   }
+  const integrityChecker = new InstallationIntegrityChecker(config);
 
   const lockfile = await Lockfile.fromDirectory(config.cwd);
   const install = new Install(flags, config, reporter, lockfile);
 
   // get patterns that are installed when running `yarn install`
+  // TODO measure slowdown here
   const {patterns: rawPatterns} = await install.hydrate(true);
   const patterns = await install.flatten(rawPatterns);
 
-  // check if patterns exist in lockfile
-  for (const pattern of patterns) {
-    if (!lockfile.getLocked(pattern)) {
-      reportError('lockfileNotContainPatter', pattern);
-    }
+  const match = await integrityChecker.check(patterns, lockfile);
+  for(pattern of match.missingPatterns) {
+    reportError('lockfileNotContainPatter', pattern);
   }
-
-  const integrityLoc = await install.getIntegrityHashLocation();
-  if (integrityLoc && await fs.exists(integrityLoc)) {
-    const match = await install.matchesIntegrityHash(patterns);
-    if (match.matches === false) {
-      reportError('integrityHashesDontMatch', match.expected, match.actual);
-    }
-  } else {
+  if (match.integrityFileMissing) {
     reportError('noIntegirtyHashFile');
+  }
+  if (!match.integrityHashMatches) {
+    // TODO has value is irrelevant in error report
+    // reportError('integrityHashesDontMatch', match.expected, match.actual);
+    reportError('integrityHashesDontMatch');
   }
 
   if (errCount > 0) {

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -563,7 +563,6 @@ export class Install {
     const lockSource = lockStringify(this.lockfile.getLockfile(this.resolver.patterns));
 
     // write integrity hash
-    // TODO don't rewrite file on every install
     await this.integrityChecker.save(patterns, lockSource, this.flags);
 
     const lockFileHasAllPatterns = patterns.filter((p) => !this.lockfile.getLocked(p)).length === 0;

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -563,7 +563,7 @@ export class Install {
     const lockSource = lockStringify(this.lockfile.getLockfile(this.resolver.patterns));
 
     // write integrity hash
-    await this.integrityChecker.save(patterns, lockSource, this.flags);
+    await this.integrityChecker.save(patterns, lockSource, this.flags, this.resolver.usedRegistries);
 
     const lockFileHasAllPatterns = patterns.filter((p) => !this.lockfile.getLocked(p)).length === 0;
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -6,8 +6,8 @@ import type {Manifest, DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
 import type {RegistryNames} from '../../registries/index.js';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
-import {registryNames} from '../../registries/index.js';
 import {MessageError} from '../../errors.js';
+import {InstallationIntegrityChecker} from '../../integrity-checker.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import lockStringify from '../../lockfile/stringify.js';
 import PackageFetcher from '../../package-fetcher.js';
@@ -20,9 +20,7 @@ import {registries} from '../../registries/index.js';
 import {clean} from './clean.js';
 import * as constants from '../../constants.js';
 import * as fs from '../../util/fs.js';
-import * as crypto from '../../util/crypto.js';
 import map from '../../util/map.js';
-import {sortAlpha} from '../../util/misc.js';
 
 const invariant = require('invariant');
 const semver = require('semver');
@@ -39,13 +37,6 @@ export type InstallCwdRequest = {
   ignorePatterns: Array<string>,
   usedPatterns: Array<string>,
   manifest: Object,
-};
-
-export type IntegrityMatch = {
-  actual: string,
-  expected: string,
-  loc: string,
-  matches: boolean,
 };
 
 type Flags = {
@@ -179,6 +170,7 @@ export class Install {
 
     this.resolver = new PackageResolver(config, lockfile);
     this.fetcher = new PackageFetcher(config, this.resolver);
+    this.integrityChecker = new InstallationIntegrityChecker(config);
     this.compatibility = new PackageCompatibility(config, this.resolver, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
     this.scripts = new PackageInstallScripts(config, this.resolver, this.flags.force);
@@ -197,6 +189,7 @@ export class Install {
   compatibility: PackageCompatibility;
   fetcher: PackageFetcher;
   rootPatternsToOrigin: { [pattern: string]: string };
+  integrityChecker: InstallationIntegrityChecker;
 
   /**
    * Create a list of dependency requests from the current directories manifests.
@@ -307,16 +300,17 @@ export class Install {
     if (this.flags.skipIntegrityCheck || this.flags.force) {
       return false;
     }
-
-    const match = await this.matchesIntegrityHash(patterns);
+    const match = await this.integrityChecker.check();
     const haveLockfile = await fs.exists(path.join(this.config.cwd, constants.LOCKFILE_FILENAME));
+    // TODO check fs.stat of node_modules content
+    const haveModulesInstalled = false;
 
-    if (match.matches && haveLockfile) {
+    if (match && haveLockfile) {
       this.reporter.success(this.reporter.lang('upToDate'));
       return true;
     }
 
-    if (!patterns.length && !match.expected) {
+    if (!patterns.length && !haveModulesInstalled) {
       this.reporter.success(this.reporter.lang('nothingToInstall'));
       await this.createEmptyManifestFolders();
       await this.saveLockfileAndIntegrity(patterns);
@@ -398,8 +392,7 @@ export class Install {
 
     steps.push(async (curr: number, total: number) => {
       // remove integrity hash to make this operation atomic
-      const loc = await this.getIntegrityHashLocation();
-      await fs.unlink(loc);
+      await this.integrityChecker.removeIntegrityFile();
       this.reporter.step(curr, total, this.reporter.lang('linkingDependencies'), emoji.get('link'));
       await this.linker.init(patterns, this.flags.linkDuplicates);
     });
@@ -605,111 +598,6 @@ export class Install {
 
   _logSuccessSaveLockfile() {
     this.reporter.success(this.reporter.lang('savedLockfile'));
-  }
-
-  /**
-   * Check if the integrity hash of this installation matches one on disk.
-   */
-
-  async matchesIntegrityHash(patterns: Array<string>): Promise<IntegrityMatch> {
-    const loc = await this.getIntegrityHashLocation();
-    if (!await fs.exists(loc)) {
-      return {
-        actual: '',
-        expected: '',
-        loc,
-        matches: false,
-      };
-    }
-
-    const lockSource = lockStringify(this.lockfile.getLockfile(this.resolver.patterns));
-    const actual = this.generateIntegrityHash(lockSource, patterns);
-    const expected = (await fs.readFile(loc)).trim();
-
-    return {
-      actual,
-      expected,
-      loc,
-      matches: actual === expected,
-    };
-  }
-
-  /**
-   * Get the location of an existing integrity hash. If none exists then return the location where we should
-   * write a new one.
-   */
-
-  async getIntegrityHashLocation(): Promise<string> {
-    // build up possible folders
-    const possibleFolders = [];
-    if (this.config.modulesFolder) {
-      possibleFolders.push(this.config.modulesFolder);
-    }
-
-    // get a list of registry names to check existence in
-    let checkRegistryNames = this.resolver.usedRegistries;
-    if (!checkRegistryNames.length) {
-      // we haven't used any registries yet
-      checkRegistryNames = registryNames;
-    }
-
-    // ensure we only write to a registry folder that was used
-    for (const name of checkRegistryNames) {
-      const loc = path.join(this.config.cwd, this.config.registries[name].folder);
-      possibleFolders.push(loc);
-    }
-
-    // if we already have an integrity hash in one of these folders then use it's location otherwise use the
-    // first folder
-    const possibles = possibleFolders.map((folder): string => path.join(folder, constants.INTEGRITY_FILENAME));
-    let loc = possibles[0];
-    for (const possibleLoc of possibles) {
-      if (await fs.exists(possibleLoc)) {
-        loc = possibleLoc;
-        break;
-      }
-    }
-    return loc;
-  }
-  /**
-   * Write the integrity hash of the current install to disk.
-   */
-
-  async writeIntegrityHash(lockSource: string, patterns: Array<string>): Promise<void> {
-    const loc = await this.getIntegrityHashLocation();
-    invariant(loc, 'expected integrity hash location');
-    await fs.mkdirp(path.dirname(loc));
-    await fs.writeFile(loc, this.generateIntegrityHash(lockSource, patterns));
-  }
-
-  /**
-   * Generate integrity hash of input lockfile.
-   */
-
-  generateIntegrityHash(lockfile: string, patterns: Array<string>): string {
-    const opts = [lockfile];
-
-    opts.push(`patterns:${patterns.sort(sortAlpha).join(',')}`);
-
-    if (this.flags.flat) {
-      opts.push('flat');
-    }
-
-    if (this.config.production) {
-      opts.push('production');
-    }
-
-    const linkedModules = this.config.linkedModules;
-    if (linkedModules.length) {
-      opts.push(`linked:${linkedModules.join(',')}`);
-    }
-
-    const mirror = this.config.getOfflineMirrorPath();
-    if (mirror != null) {
-      opts.push(`mirror:${mirror}`);
-    }
-
-    return crypto.hash(opts.join('-'), 'sha256');
   }
 
   /**

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -56,7 +56,7 @@ commander.option('--har', 'save HAR output of network traffic');
 commander.option('--ignore-platform', 'ignore platform checks');
 commander.option('--ignore-engines', 'ignore engines check');
 commander.option('--ignore-optional', 'ignore optional dependencies');
-commander.option('--force', 'install and build scripts even if they were built before, overwrite lockfile');
+commander.option('--force', 'install and build packages even if they were built before, overwrite lockfile');
 commander.option('--skip-integrity-check', 'run install without checking if node_modules is installed');
 commander.option('--no-bin-links', "don't generate bin links when setting up packages");
 commander.option('--flat', 'only allow one version of a package');

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -16,8 +16,6 @@ export type IntegrityCheckResult = {
   integrityFileMissing: boolean,
   integrityHashMatches?: boolean,
   missingPatterns: Array<string>,
-  hashExpected?: string,
-  hashActual?: string,
 };
 
 /**
@@ -114,8 +112,6 @@ export default class InstallationIntegrityChecker {
       integrityFileMissing,
       integrityHashMatches: actual === expected,
       missingPatterns,
-      hashExpected: expected,
-      hashActual: actual,
     };
   }
 

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -1,0 +1,160 @@
+/* @flow */
+
+import type Config from './config.js';
+import {registryNames} from './registries/index.js';
+import type {Manifest} from './types.js';
+import * as crypto from './util/crypto.js';
+import * as fs from './util/fs.js';
+import {sortAlpha} from './util/misc.js';
+
+const invariant = require('invariant');
+const path = require('path');
+
+export type IntegrityMatch = {
+  actual: string,
+  expected: string,
+  loc: string,
+  matches: boolean,
+};
+/**
+ *
+ */
+export default class InstallationIntegrityChecker {
+  constructor(config: Config) {
+    this.config = config;
+    this.files = [];
+
+  }
+
+  config: Config;
+
+  files: Array<string>;
+
+  /**
+   * Get the location of an existing integrity hash. If none exists then return the location where we should
+   * write a new one.
+   */
+
+  async getIntegrityHashLocation(): Promise<string> {
+    // build up possible folders
+    const possibleFolders = [];
+    if (this.config.modulesFolder) {
+      possibleFolders.push(this.config.modulesFolder);
+    }
+
+    // get a list of registry names to check existence in
+    let checkRegistryNames = this.resolver.usedRegistries;
+    if (!checkRegistryNames.length) {
+      // we haven't used any registries yet
+      checkRegistryNames = registryNames;
+    }
+
+    // ensure we only write to a registry folder that was used
+    for (const name of checkRegistryNames) {
+      const loc = path.join(this.config.cwd, this.config.registries[name].folder);
+      possibleFolders.push(loc);
+    }
+
+    // if we already have an integrity hash in one of these folders then use it's location otherwise use the
+    // first folder
+    const possibles = possibleFolders.map((folder): string => path.join(folder, constants.INTEGRITY_FILENAME));
+    let loc = possibles[0];
+    for (const possibleLoc of possibles) {
+      if (await fs.exists(possibleLoc)) {
+        loc = possibleLoc;
+        break;
+      }
+    }
+    return loc;
+  }
+  /**
+   * Write the integrity hash of the current install to disk.
+   */
+
+  async writeIntegrityHash(lockSource: string, patterns: Array<string>): Promise<void> {
+    const loc = await this.getIntegrityHashLocation();
+    invariant(loc, 'expected integrity hash location');
+    await fs.mkdirp(path.dirname(loc));
+    await fs.writeFile(loc, this.generateIntegrityHash(lockSource, patterns));
+  }
+
+  /**
+   * Generate integrity hash of input lockfile.
+   */
+
+  generateIntegrityHash(lockfile: string, patterns: Array<string>): string {
+    const opts = [lockfile];
+
+    opts.push(`patterns:${patterns.sort(sortAlpha).join(',')}`);
+
+    if (this.flags.flat) {
+      opts.push('flat');
+    }
+
+    if (this.config.production) {
+      opts.push('production');
+    }
+
+    const linkedModules = this.config.linkedModules;
+    if (linkedModules.length) {
+      opts.push(`linked:${linkedModules.join(',')}`);
+    }
+
+    const mirror = this.config.getOfflineMirrorPath();
+    if (mirror != null) {
+      opts.push(`mirror:${mirror}`);
+    }
+
+    return crypto.hash(opts.join('-'), 'sha256');
+  }
+
+  /**
+   * Check if the integrity hash of this installation matches one on disk.
+   */
+
+  async matchesIntegrityHash(patterns: Array<string>): Promise<IntegrityMatch> {
+    const loc = await this.getIntegrityHashLocation();
+    if (!await fs.exists(loc)) {
+      return {
+        actual: '',
+        expected: '',
+        loc,
+        matches: false,
+      };
+    }
+
+    const lockSource = lockStringify(this.lockfile.getLockfile(this.resolver.patterns));
+    const actual = this.generateIntegrityHash(lockSource, patterns);
+    const expected = (await fs.readFile(loc)).trim();
+
+    return {
+      actual,
+      expected,
+      loc,
+      matches: actual === expected,
+    };
+  }
+
+  check(): Promise<boolean> {
+    // read integrity file
+    // check if core files exist
+    // check hash code is the same
+  }
+
+  save(): Promise<void> {
+    // read files in node_modules
+    // generate hash
+    // save integrity file
+  }
+
+  // TODO consider optimizations
+  // TODO provide API for post install hook???
+
+  async removeIntegrityFile(): Promise<void> {
+    const loc = this.getIntegrityHashLocation();
+    await fs.unlink(loc);
+  }
+
+  init(): void {
+  }
+}

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -2,7 +2,8 @@
 
 import type Config from './config.js';
 import {registryNames} from './registries/index.js';
-import type {Manifest} from './types.js';
+import lockStringify from './lockfile/stringify.js';
+import Lockfile from './lockfile/wrapper.js';
 import * as crypto from './util/crypto.js';
 import * as fs from './util/fs.js';
 import {sortAlpha} from './util/misc.js';
@@ -10,47 +11,36 @@ import {sortAlpha} from './util/misc.js';
 const invariant = require('invariant');
 const path = require('path');
 
-export type IntegrityMatch = {
-  actual: string,
-  expected: string,
-  loc: string,
-  matches: boolean,
+export type IntegrityCheckResult = {
+  integrityFileMissing: boolean,
+  integrityHashMatches?: boolean,
+  missingPatterns: Array<string>
 };
+
 /**
  *
  */
 export default class InstallationIntegrityChecker {
   constructor(config: Config) {
     this.config = config;
-    this.files = [];
-
   }
 
   config: Config;
-
-  files: Array<string>;
 
   /**
    * Get the location of an existing integrity hash. If none exists then return the location where we should
    * write a new one.
    */
 
-  async getIntegrityHashLocation(): Promise<string> {
+  async _getIntegrityHashLocation(): Promise<string> {
     // build up possible folders
     const possibleFolders = [];
     if (this.config.modulesFolder) {
       possibleFolders.push(this.config.modulesFolder);
     }
 
-    // get a list of registry names to check existence in
-    let checkRegistryNames = this.resolver.usedRegistries;
-    if (!checkRegistryNames.length) {
-      // we haven't used any registries yet
-      checkRegistryNames = registryNames;
-    }
-
     // ensure we only write to a registry folder that was used
-    for (const name of checkRegistryNames) {
+    for (const name of registryNames) {
       const loc = path.join(this.config.cwd, this.config.registries[name].folder);
       possibleFolders.push(loc);
     }
@@ -67,22 +57,12 @@ export default class InstallationIntegrityChecker {
     }
     return loc;
   }
-  /**
-   * Write the integrity hash of the current install to disk.
-   */
-
-  async writeIntegrityHash(lockSource: string, patterns: Array<string>): Promise<void> {
-    const loc = await this.getIntegrityHashLocation();
-    invariant(loc, 'expected integrity hash location');
-    await fs.mkdirp(path.dirname(loc));
-    await fs.writeFile(loc, this.generateIntegrityHash(lockSource, patterns));
-  }
 
   /**
    * Generate integrity hash of input lockfile.
    */
 
-  generateIntegrityHash(lockfile: string, patterns: Array<string>): string {
+  _generateIntegrityHash(lockfile: string, patterns: Array<string>): string {
     const opts = [lockfile];
 
     opts.push(`patterns:${patterns.sort(sortAlpha).join(',')}`);
@@ -101,60 +81,49 @@ export default class InstallationIntegrityChecker {
     }
 
     const mirror = this.config.getOfflineMirrorPath();
-    if (mirror != null) {
+    if (mirror !== null) {
       opts.push(`mirror:${mirror}`);
     }
 
     return crypto.hash(opts.join('-'), 'sha256');
   }
 
-  /**
-   * Check if the integrity hash of this installation matches one on disk.
-   */
-
-  async matchesIntegrityHash(patterns: Array<string>): Promise<IntegrityMatch> {
-    const loc = await this.getIntegrityHashLocation();
-    if (!await fs.exists(loc)) {
+  async check(patterns: Array<string>, lockfile: Lockfile): Promise<IntegrityCheckResult> {
+    // check if patterns exist in lockfile
+    const missingPatterns = patterns.filter(p => !lockfile.getLocked(p));
+    const loc = await this._getIntegrityHashLocation();
+    const integrityFileMissing = !await fs.exists(loc);
+    if (missingPatterns.length || integrityFileMissing) {
       return {
-        actual: '',
-        expected: '',
-        loc,
-        matches: false,
+        integrityFileMissing,
+        missingPatterns,
       };
     }
 
-    const lockSource = lockStringify(this.lockfile.getLockfile(this.resolver.patterns));
-    const actual = this.generateIntegrityHash(lockSource, patterns);
+    const lockSource = lockStringify(lockfile.getLockfile(patterns));
+    const actual = this._generateIntegrityHash(lockSource, patterns);
     const expected = (await fs.readFile(loc)).trim();
 
     return {
-      actual,
-      expected,
-      loc,
-      matches: actual === expected,
+      integrityFileMissing,
+      integrityHashMatches: actual === expected,
+      missingPatterns,
     };
   }
 
-  check(): Promise<boolean> {
-    // read integrity file
-    // check if core files exist
-    // check hash code is the same
+  /**
+   * Write the integrity hash of the current install to disk.
+   */
+  async save(patterns: Array<string>, lockSource: string): Promise<void> {
+    const loc = await this._getIntegrityHashLocation();
+    invariant(loc, 'expected integrity hash location');
+    await fs.mkdirp(path.dirname(loc));
+    await fs.writeFile(loc, this._generateIntegrityHash(lockSource, patterns));
   }
-
-  save(): Promise<void> {
-    // read files in node_modules
-    // generate hash
-    // save integrity file
-  }
-
-  // TODO consider optimizations
-  // TODO provide API for post install hook???
 
   async removeIntegrityFile(): Promise<void> {
-    const loc = this.getIntegrityHashLocation();
+    const loc = this._getIntegrityHashLocation();
     await fs.unlink(loc);
   }
 
-  init(): void {
-  }
 }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -253,7 +253,7 @@ const messages = {
 
   couldBeDeduped: '$0 could be deduped from $1 to $2',
   lockfileNotContainPatter: 'Lockfile does not contain pattern: $0',
-  integrityHashesDontMatch: 'Integrity hashes don\'t match, expected $0 but got $1',
+  integrityHashesDontMatch: 'Integrity hashes don\'t match',
   noIntegirtyHashFile: 'Couldn\'t find an integrity hash file',
   packageNotInstalled: '$0 not installed',
   optionalDepNotInstalled: 'Optional dependency $0 not installed',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -252,9 +252,9 @@ const messages = {
   packageHasNoBinaries: '$0 has no binaries',
 
   couldBeDeduped: '$0 could be deduped from $1 to $2',
-  lockfileNotContainPatter: 'Lockfile does not contain pattern: $0',
+  lockfileNotContainPattern: 'Lockfile does not contain pattern: $0',
   integrityHashesDontMatch: 'Integrity hashes don\'t match',
-  noIntegirtyHashFile: 'Couldn\'t find an integrity hash file',
+  noIntegrityHashFile: 'Couldn\'t find an integrity hash file',
   packageNotInstalled: '$0 not installed',
   optionalDepNotInstalled: 'Optional dependency $0 not installed',
   packageWrongVersion: '$0 is wrong version: expected $1, got $2',


### PR DESCRIPTION
**Summary**

I plan to improve integrity check code so that it could also verify node_modules structure.
This PR moves most of the integrity checking and saving code into a separate class, no actual changes to the logic.

**Test plan**

All tests should pass (integrity checks are covered with integration tests)

Pending things to do:
- a bit of cleanup