### PR TITLE
Improve discoverability of yarnpkg/rfcs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 **Summary**
 
+<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->
+
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 
 **Test plan**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING
 
-Contributions are always welcome, no matter how large or small. Before contributing,
+Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing,
 please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 ## Contributing to Yarn
 
-Contributions are always welcome, no matter how large or small. Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
+Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 See [Contributing](CONTRIBUTING.md).
 


### PR DESCRIPTION
**Summary**

Currently the rfcs repo is not easily discoverable, the only place it appears to be mentioned is in the new issue template. Linking to the repo in more places improves discoverability of yarnpkg/rfcs.
