### PR TITLE
switched to tar-fs from node-tar to unpack tars

### DIFF
--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -14,7 +14,7 @@ const os = require('os');
 const stream = require('stream');
 
 const zlib = require('zlib');
-const tar = require('tar');
+const tarFs = require('tar-fs');
 const fs2 = require('fs');
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'pack');
@@ -83,8 +83,12 @@ export async function getFilesFromArchive(source, destination): Promise<Array<st
   const unzip = new Promise((resolve, reject) => {
     fs2.createReadStream(source)
       .pipe(new zlib.Gunzip())
-      .pipe(tar.Extract({path: destination, strip: 1}))
-      .on('end', resolve)
+      .pipe(tarFs.extract(destination, {
+        strip: 1,
+        dmode: parseInt(555, 8), // all dirs should be readable
+        fmode: parseInt(444, 8) // all files should be readable
+      }))
+      .on('finish', resolve)
       .on('error', reject);
   });
   await unzip;

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -85,8 +85,8 @@ export async function getFilesFromArchive(source, destination): Promise<Array<st
       .pipe(new zlib.Gunzip())
       .pipe(tarFs.extract(destination, {
         strip: 1,
-        dmode: parseInt(555, 8), // all dirs should be readable
-        fmode: parseInt(444, 8), // all files should be readable
+        dmode: 0o555, // all dirs should be readable
+        fmode: 0o444, // all files should be readable
       }))
       .on('finish', resolve)
       .on('error', reject);

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -86,7 +86,7 @@ export async function getFilesFromArchive(source, destination): Promise<Array<st
       .pipe(tarFs.extract(destination, {
         strip: 1,
         dmode: parseInt(555, 8), // all dirs should be readable
-        fmode: parseInt(444, 8) // all files should be readable
+        fmode: parseInt(444, 8), // all files should be readable
       }))
       .on('finish', resolve)
       .on('error', reject);

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -64,7 +64,6 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/yarnpkg/e2e-test-repo.git#greenkeeper/cross-env-3.1.4'); // hash with slashes
-addTest('ssh://git@bitbucket.org/bestander/test-repo.git'); // bitbucket with archive protocol supported
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -64,6 +64,7 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/yarnpkg/e2e-test-repo.git#greenkeeper/cross-env-3.1.4'); // hash with slashes
+addTest('ssh://git@bitbucket.org/bestander/test-repo.git'); // bitbucket with archive protocol supported
 addTest('gitlab:leanlabsio/kanban'); // gitlab
 addTest('gist:d59975ac23e26ad4e25b'); // gist url
 addTest('bitbucket:hgarcia/node-bitbucket-api'); // bitbucket url

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "semver": "^5.1.0",
     "strip-bom": "^3.0.0",
     "tar-fs": "^1.15.1",
-    "tar-stream": "^1.1.2",
+    "tar-stream": "^1.5.2",
     "v8-compile-cache": "^1.0.0",
     "validate-npm-package-license": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
     "roadrunner": "^1.1.0",
     "semver": "^5.1.0",
     "strip-bom": "^3.0.0",
-    "tar": "^2.2.1",
     "tar-fs": "^1.15.1",
-    "tar-stream": "^1.5.2",
+    "tar-stream": "^1.1.2",
     "v8-compile-cache": "^1.0.0",
     "validate-npm-package-license": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "semver": "^5.1.0",
     "strip-bom": "^3.0.0",
     "tar": "^2.2.1",
+    "tar-fs": "^1.15.1",
     "tar-stream": "^1.5.2",
     "v8-compile-cache": "^1.0.0",
     "validate-npm-package-license": "^3.0.1"

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,7 +31,7 @@ export const CACHE_VERSION = 1;
 export const LOCKFILE_VERSION = 1;
 
 // max amount of network requests to perform concurrently
-export const NETWORK_CONCURRENCY = 8;
+export const NETWORK_CONCURRENCY = 16;
 
 // max amount of child processes to execute concurrently
 export const CHILD_CONCURRENCY = 5;

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -35,8 +35,8 @@ export default class GitFetcher extends BaseFetcher {
 
     return new Promise((resolve, reject) => {
       const untarStream = tarFs.extract(this.dest, {
-        dmode: parseInt(555, 8), // all dirs should be readable
-        fmode: parseInt(444, 8), // all files should be readable
+        dmode: 0o555, // all dirs should be readable
+        fmode: 0o444, // all files should be readable
       });
 
       const hashStream = new crypto.HashStream();

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -36,7 +36,7 @@ export default class GitFetcher extends BaseFetcher {
     return new Promise((resolve, reject) => {
       const untarStream = tarFs.extract(this.dest, {
         dmode: parseInt(555, 8), // all dirs should be readable
-        fmode: parseInt(444, 8) // all files should be readable
+        fmode: parseInt(444, 8), // all files should be readable
       });
 
       const hashStream = new crypto.HashStream();

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -7,7 +7,7 @@ import Git from '../util/git.js';
 import * as fsUtil from '../util/fs.js';
 import * as crypto from '../util/crypto.js';
 
-const tar = require('tar');
+const tarFs = require('tar-fs');
 const url = require('url');
 const path = require('path');
 const fs = require('fs');
@@ -34,7 +34,10 @@ export default class GitFetcher extends BaseFetcher {
     }
 
     return new Promise((resolve, reject) => {
-      const untarStream = tar.Extract({path: this.dest});
+      const untarStream = tarFs.extract(this.dest, {
+        dmode: parseInt(555, 8), // all dirs should be readable
+        fmode: parseInt(444, 8) // all files should be readable
+      });
 
       const hashStream = new crypto.HashStream();
 
@@ -42,7 +45,7 @@ export default class GitFetcher extends BaseFetcher {
       cachedStream
         .pipe(hashStream)
         .pipe(untarStream)
-        .on('end', () => {
+        .on('finish', () => {
           const expectHash = this.hash;
           const actualHash = hashStream.getHash();
           if (!expectHash || expectHash === actualHash) {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -79,8 +79,8 @@ export default class TarballFetcher extends BaseFetcher {
     const extractorStream = new UnpackStream();
     const untarStream = tarFs.extract(this.dest, {
       strip: 1,
-      dmode: parseInt(555, 8), // all dirs should be readable
-      fmode: parseInt(444, 8), // all files should be readable
+      dmode: 0o555, // all dirs should be readable
+      fmode: 0o444, // all files should be readable
     });
 
     extractorStream

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -80,7 +80,7 @@ export default class TarballFetcher extends BaseFetcher {
     const untarStream = tarFs.extract(this.dest, {
       strip: 1,
       dmode: parseInt(555, 8), // all dirs should be readable
-      fmode: parseInt(444, 8) // all files should be readable
+      fmode: parseInt(444, 8), // all files should be readable
     });
 
     extractorStream

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -11,7 +11,7 @@ import * as fsUtil from '../util/fs.js';
 
 const invariant = require('invariant');
 const path = require('path');
-const tar = require('tar');
+const tarFs = require('tar-fs');
 const url = require('url');
 const fs = require('fs');
 
@@ -77,7 +77,11 @@ export default class TarballFetcher extends BaseFetcher {
   } {
     const validateStream = new crypto.HashStream();
     const extractorStream = new UnpackStream();
-    const untarStream = tar.Extract({path: this.dest, strip: 1});
+    const untarStream = tarFs.extract(this.dest, {
+      strip: 1,
+      dmode: parseInt(555, 8), // all dirs should be readable
+      fmode: parseInt(444, 8) // all files should be readable
+    });
 
     extractorStream
       .pipe(untarStream)
@@ -88,7 +92,7 @@ export default class TarballFetcher extends BaseFetcher {
           entry.props.gid = entry.gid = 0;
         }
       })
-      .on('end', () => {
+      .on('finish', () => {
         const expectHash = this.hash;
         const actualHash = validateStream.getHash();
         if (!expectHash || expectHash === actualHash) {

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -17,7 +17,6 @@ const tarStream = require('tar-stream');
 const url = require('url');
 import {createWriteStream} from 'fs';
 
-
 type GitRefs = {
   [name: string]: string
 };
@@ -302,8 +301,9 @@ export default class Git {
               fileContent += decoder.write(buffer);
             });
             stream.on('end', () => {
-              fileContent += decoder.end();
-              update(fileContent);
+              // $FlowFixMe: suppressing this error due to bug https://github.com/facebook/flow/pull/3483
+              const remaining: string = decoder.end();
+              update(fileContent + remaining);
               next();
             });
             stream.resume();

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -55,8 +55,8 @@ export default class Git {
    */
 
   static async hasArchiveCapability(gitUrl: string): Promise<boolean> {
-    // USER@HOSTNAME
-    const match = gitUrl.match(/^(.*?)@(.*?)$/);
+    // USER@HOSTNAME:PATHNAME
+    const match = gitUrl.match(/^(.*?)@(.*?):(.*?)$/);
     if (!match) {
       return false;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,10 @@ chokidar@^1.4.3, chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
@@ -1372,7 +1376,7 @@ end-of-stream@1.0.0:
   dependencies:
     once "~1.3.0"
 
-end-of-stream@^1.0.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.1.0.tgz#e9353258baa9108965efc41cb0ef8ade2f3cfb07"
   dependencies:
@@ -3386,7 +3390,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -3650,6 +3654,13 @@ public-encrypt@^4.0.0:
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
+
+pump@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.2.tgz#3b3ee6512f94f0e575538c17995f9f16990a5d51"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -4244,6 +4255,15 @@ tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.6.tgz#206be8e188860b514425375e6f1ae89bfb01fd8d"
 
+tar-fs@^1.15.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.15.1.tgz#f4622f5d5e250742b3679a9a8463acfc12cdefd1"
+  dependencies:
+    chownr "^1.0.1"
+    mkdirp "^0.5.0"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
 tar-pack@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.3.0.tgz#30931816418f55afc4d21775afdd6720cee45dae"
@@ -4257,7 +4277,7 @@ tar-pack@~3.3.0:
     tar "~2.2.1"
     uid-number "~0.0.6"
 
-tar-stream@^1.5.2:
+tar-stream@^1.1.2, tar-stream@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,7 +4277,7 @@ tar-pack@~3.3.0:
     tar "~2.2.1"
     uid-number "~0.0.6"
 
-tar-stream@^1.1.2, tar-stream@^1.5.2:
+tar-stream@^1.1.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
   dependencies:
@@ -4286,7 +4286,7 @@ tar-stream@^1.1.2, tar-stream@^1.5.2:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
-tar@^2.0.0, tar@^2.2.1, tar@~2.2.1:
+tar@^2.0.0, tar@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,7 +4277,7 @@ tar-pack@~3.3.0:
     tar "~2.2.1"
     uid-number "~0.0.6"
 
-tar-stream@^1.1.2:
+tar-stream@^1.1.2, tar-stream@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
   dependencies:


### PR DESCRIPTION
**Summary**

A mitigation for https://github.com/yarnpkg/yarn/issues/2629
Also fixes #961

Based on a few ad-hoc tests (//gitlab.com/linagora/petals-cockpit.git#075bac4c54fee466568c000c7ffe8025f593e212) tar-fs seems to make less IO thus is more stable and a bit faster.

I noticed that we never tested git repos that support archive.
Did they ever work?

----
Test data:

1. Using offline-mirror (no download), on my MBPro 13", clean cache and using `node-tar` to unzip files.
Concurrency 12 - fails
Concurrency 8 - 18 seconds
Concurrency 4 - 18 seconds
Concurrency 2 - 21 seconds

2. Using offline-mirror (no download), on my MBPro 13", clean cache and using `tar-fs` to unzip files.
Concurrency 12 - 15 seconds
Concurrency 8 - 15 seconds
Concurrency 4 - 17 seconds
Concurrency 2 - 18 seconds

3. Downloading packages from internet, on my MBPro 13", clean cache and using `tar-fs` to unzip files.
Concurrency 12 - failed once
Concurrency 8 - 21 seconds
Concurrency 4 - 23 seconds
Concurrency 2 - 34 seconds


**Test plan**
- All changes are covered with tests (verified every change)
- Could not properly test git archives (see https://github.com/yarnpkg/yarn/issues/2831) but did an ad-hoc test via `yarn add ssh://git@bitbucket.org/bestander/test-repo.git` and made sure that archive was accessed and installed.
