### PR TITLE
set default network concurrency to 8

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -31,7 +31,7 @@ export const CACHE_VERSION = 1;
 export const LOCKFILE_VERSION = 1;
 
 // max amount of network requests to perform concurrently
-export const NETWORK_CONCURRENCY = 15;
+export const NETWORK_CONCURRENCY = 8;
 
 // max amount of child processes to execute concurrently
 export const CHILD_CONCURRENCY = 5;


### PR DESCRIPTION

**Summary**

Mitigation for https://github.com/yarnpkg/yarn/issues/2629.
With less tarballs being exploded concurrently we get less IO errors.

**Test plan**

I've tested React Native and there is not difference in fetching time between concurrency 4 and 15 (~21 seconds on MBPro 13").
Same results shown here https://github.com/yarnpkg/yarn/issues/2629#issuecomment-283691556.
