### PR TITLE
Add Jenkins jobs to repo

### DIFF
--- a/jenkins-jobs.groovy
+++ b/jenkins-jobs.groovy
@@ -1,0 +1,64 @@
+// Jenkins build jobs for Yarn
+// https://build.dan.cx/view/Yarn/
+
+/**
+ * Trigger that fires when a new stable Yarn version is released
+ * This could probably be smarter in the future (eg. handle it using a webhook
+ * rather than polling the version number)
+ */
+def yarnStableVersionChange = {
+  triggerContext -> triggerContext.with {
+    urlTrigger {
+      cron 'H/15 * * * *'
+      url('https://yarnpkg.com/latest-version') {
+        inspection 'change'
+      }
+    }
+  }
+}
+
+matrixJob('yarn-e2e') {
+  displayName 'Yarn End To End'
+  description 'Nightly end-to-end tests for Yarn'
+  scm {
+    github 'yarnpkg/yarn', 'master'
+  }
+  triggers {
+    cron '@midnight'
+  }
+  axes {
+    text 'os', 'ubuntu-16.04', 'ubuntu-14.04', 'ubuntu-12.04'
+    label 'label', 'docker' // Only run on build hosts that have Docker
+  }
+  steps {
+    // 192.168.122.1:3142 is apt-cacher-ng on the Docker host
+    shell '''
+      cd end_to_end_tests
+      APT_PROXY=192.168.122.1:3142 ./test-$os.sh
+    '''
+  }
+  publishers {
+    gitHubIssueNotifier {
+    }
+  }
+}
+
+job('yarn-chocolatey') {
+  displayName 'Yarn Chocolatey'
+  description 'Ensures the Chocolatey package for Yarn is up-to-date'
+  label 'windows'
+  scm {
+    github 'yarnpkg/yarn', 'master'
+  }
+  triggers {
+    yarnStableVersionChange delegate
+  }
+  steps {
+    powerShell '.\\scripts\\build-chocolatey.ps1 -Publish'
+  }
+  publishers {
+    gitHubIssueNotifier {
+    }
+    mailer 'yarn@dan.cx'
+  }
+}


### PR DESCRIPTION
**Summary**
I've got some Jenkins build jobs for Yarn (to run the end-to-end tests, and to update the Chocolatey package). Originally I configured them through the Jenkins UI, but I've swiched to configuring them through the [job-dsl plugin](https://plugins.jenkins.io/job-dsl) so I can commit the job definitions to source control, similar to how we have the CircleCI, TravisCI and AppVeyor configs in source control.

**Test plan**
https://build.dan.cx/view/Yarn/