### PR TITLE
gracefully handle process.stdin exceptions

### DIFF
--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -18,6 +18,7 @@ import * as languages from './lang/index.js';
 import isCI from 'is-ci';
 
 const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 type Language = $Keys<typeof languages>;
 
@@ -55,7 +56,7 @@ export default class BaseReporter {
 
     this.stdout = opts.stdout || process.stdout;
     this.stderr = opts.stderr || process.stderr;
-    this.stdin = opts.stdin || process.stdin;
+    this.stdin = opts.stdin || this._getStandardInput();
     this.emoji = !!opts.emoji;
     this.noProgress = !!opts.noProgress || isCI;
     this.isVerbose = !!opts.verbose;
@@ -112,6 +113,21 @@ export default class BaseReporter {
 
   _verbose(msg: string) {}
   _verboseInspect(val: any) {}
+
+  _getStandardInput(): Stdin {
+    let standardInput;
+
+    try {
+      standardInput = process.stdin;
+    } catch (e) {
+      delete process.stdin;
+      // $FlowFixMe: this is valid!
+      process.stdin = new EventEmitter();
+      standardInput = process.stdin;
+    }
+
+    return standardInput;
+  }
 
   initPeakMemoryCounter() {
     this.checkPeakMemory();


### PR DESCRIPTION
**Summary**
Several users of Visual Studio 2015 & 2017's NPM Task Runner extension have reported problems on Windows 7 with regard to running Yarn commands inside the IDE's Task Runner Explorer window. Interestingly enough, this doesn't appear to be an issue on Windows 10.

A fix for this problem was attempted [here](https://github.com/yarnpkg/yarn/pull/1000). The Angular CLI project also encountered the same problem, and it was fixed [here](https://github.com/angular/angular-cli/pull/4871).

This PR takes a very similar approach as that taken by the Angular CLI team. The PR also doesn't specifically test for the "win32" platform, as who knows what other platforms are really impacted by this.

**Test plan**
I ran the following commands to ensure that my changes didn't introduce any problems:
`yarn run build`
`yarn run lint`
`yarn run test`