### PR TITLE
Add console.warn to process.stdin catch block

### DIFF
--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -117,9 +117,11 @@ export default class BaseReporter {
   _getStandardInput(): Stdin {
     let standardInput;
 
+    // Accessing stdin in a win32 headless process (e.g., Visual Studio) may throw an exception.
     try {
       standardInput = process.stdin;
     } catch (e) {
+      console.warn(e.message);
       delete process.stdin;
       // $FlowFixMe: this is valid!
       process.stdin = new EventEmitter();


### PR DESCRIPTION
**Summary**
Per @Daniel15's suggestion, this PR adds a `console.warn` statement to the `catch` block introduced in PR https://github.com/yarnpkg/yarn/pull/2837.

**Test plan**
I ran the following commands to ensure that my changes didn't introduce any problems:
`yarn run build`
`yarn run lint`
`yarn run test`