### PR TITLE
Use release infra rather than ghr to create GitHub releases

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ machine:
 dependencies:
   cache_directories:
     - "~/.cache/yarn"
-    - "~/ghr"
 
   override:
     - which node
@@ -21,14 +20,6 @@ dependencies:
     - ./scripts/bootstrap-env-ubuntu.sh
 
     - yarn install
-
-    # setup ghr
-    - >
-      if [[ ! -e ~/ghr ]]; then
-        curl -L --create-dirs -o ~/ghr/ghr.zip https://github.com/tcnksm/ghr/releases/download/v0.5.0/ghr_v0.5.0_linux_amd64.zip;
-        unzip ~/ghr/ghr.zip -d ~/ghr
-      fi
-    - sudo ln -sF  ~/ghr/ghr /usr/local/bin/ghr
 
 test:
   override:
@@ -49,12 +40,14 @@ deployment:
     tag: /v[0-9]+(\.[0-9]+)*/
     owner: yarnpkg
     commands:
-      - ~/ghr/ghr -prerelease --username yarnpkg --repository yarn --token $KPM_CIRCLE_RELEASE_TOKEN v$(dist/bin/yarn --version) artifacts/
-      - curl https://nightly.yarnpkg.com/sign_releases?token=$SIGN_TOKEN
+      # Only NPM is handled here - All other release files are handled in a webhook.
       - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - ./scripts/set-installation-method.js "`pwd`/package.json" npm
       - npm publish --tag rc
 
 notify:
   webhooks:
-    - url: https://nightly.yarnpkg.com/api/archive_circleci
+    # Handles uploading stable/RC releases to GitHub
+    - url: https://nightly.yarnpkg.com/release_circleci
+    # Handles archiving all builds onto the nightly build site
+    - url: https://nightly.yarnpkg.com/archive_circleci


### PR DESCRIPTION
**Summary**
Currently, our CircleCI build script publishes the GitHub release using [ghr](https://github.com/tcnksm/ghr), whereas AppVeyor publishes the GitHub release using a custom script. To maintain consistency between the two, I've changed the CircleCI build to publish GitHub releases in a way similar to how it's done for AppVeyor builds.

I would have loved to do the release in the `deployment` section of `circle.yml` like we do for `ghr`, but unfortunately this runs too early (before the build log has been saved and artifacts have been archived) so we can't hit the CircleCI API at that point. Running it as a webhook ensures that it runs once the build has fully completed, and the release script can hit the CircleCI API to verify that it's a legitimate build.

Doing release this way also removes the risk of the GitHub access token leaking, as CircleCI no longer needs to have the access token.

**Test plan**
I manually tested the code using a test repo and it worked fine (https://github.com/Daniel15/yarn-release-test/releases/tag/v0.20.3), I'll babysit the next release we do to ensure everything is working as expected.

Closes #2799