### PR TITLE
Fix npm_execpath for bundled release

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -30,7 +30,7 @@ async function makeEnv(stage: string, cwd: string, config: Config): {
 
   env.npm_lifecycle_event = stage;
   env.npm_node_execpath = env.NODE || process.execPath;
-  env.npm_execpath = path.join(__dirname, '..', '..', 'bin', 'yarn.js');
+  env.npm_execpath = env.npm_execpath || process.mainModule.filename;
 
   // Set the env to production for npm compat if production mode.
   // https://github.com/npm/npm/blob/30d75e738b9cb7a6a3f9b50e971adcbe63458ed3/lib/utils/lifecycle.js#L336


### PR DESCRIPTION
**Summary**

Docker is using a bundled version of yarn, and the `yarn.js` is moved to `/usr/local/bin/yarn`.
However yarn always generates `npm_execpath` by the following code: 

```
env.npm_execpath = path.join(__dirname, '..', '..', 'bin', 'yarn.js');
```

Then the generated `npm_execpath` with docker pre-installed yarn will be `/bin/yarn.js` which does not exist.

**Test plan**

#### Test 1: Bundled version:

Run: 

```
docker run --rm -it node:7.7 /bin/bash -c 'echo "{\"scripts\": {\"test\": \"echo \$npm_execpath\"}}" > package.json && yarn test'
```

Output:

```
/usr/local/bin/yarn
```

#### Test 2: Common installed version:

```
docker run --rm -it node:7.7 /bin/bash -c 'curl -o- -L https://yarnpkg.com/install.sh | bash && echo "{\"scripts\": {\"test\": \"echo \$npm_execpath\"}}" > package.json && yarn test'
```

Output:

```
/root/.config/yarn/global/node_modules/yarn/bin/yarn.js
```

#fix #2345 