### PR TITLE
Log the binFolder result from the `bin` command via the reporter.

### DIFF
--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -19,6 +19,6 @@ export function run(
     config.registries[RegistryYarn.registry].folder,
     '.bin',
   );
-  console.log(binFolder);
+  reporter.log(binFolder);
   return Promise.resolve();
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR redirects the output for the `bin` command through the configured reporter, instead of it being hardcoded to `console.log`. This way, in the future the bin command could be logged in different ways besides just printing.

The default behaviour does not change, as the default reporter is the `ConsoleReporter`, which again writes to `stdout`
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

1. run `yarn bin`.
2. verify it outputs to console.
3. (optional) ensure output goes trough the `consoleReporter._log` function

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
