### PR TITLE
Move ROOT_USER to a separate file, fixes #2807

### DIFF
--- a/__tests__/constants.js
+++ b/__tests__/constants.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {getPathKey, isRootUser} from '../src/constants.js';
+import {getPathKey} from '../src/constants.js';
 
 test('getPathKey', () => {
   expect(getPathKey('win32', {PATH: 'foobar'})).toBe('PATH');
@@ -9,10 +9,4 @@ test('getPathKey', () => {
   expect(getPathKey('win32', {})).toBe('Path');
   expect(getPathKey('linux', {})).toBe('PATH');
   expect(getPathKey('darwin', {})).toBe('PATH');
-});
-
-test('isRootUser', () => {
-  expect(isRootUser(null)).toBe(false);
-  expect(isRootUser(1001)).toBe(false);
-  expect(isRootUser(0)).toBe(true);
 });

--- a/__tests__/util/root-user.js
+++ b/__tests__/util/root-user.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+import {isRootUser} from '../../src/util/root-user.js';
+
+test('isRootUser', () => {
+  expect(isRootUser(null)).toBe(false);
+  expect(isRootUser(1001)).toBe(false);
+  expect(isRootUser(0)).toBe(true);
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -90,16 +90,3 @@ export function getPathKey(platform: string, env: Env): string {
 
   return pathKey;
 }
-
-function getUid(): ?number {
-  if (process.platform !== 'win32' && process.getuid) {
-    return process.getuid();
-  }
-  return null;
-}
-
-export const ROOT_USER = isRootUser(getUid());
-
-export function isRootUser(uid: ?number): boolean {
-  return uid === 0;
-}

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -8,6 +8,7 @@ import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
 import BaseFetcher from './base-fetcher.js';
 import * as fsUtil from '../util/fs.js';
+import ROOT_USER from '../util/root-user.js';
 
 const invariant = require('invariant');
 const path = require('path');
@@ -83,7 +84,7 @@ export default class TarballFetcher extends BaseFetcher {
       .pipe(untarStream)
       .on('error', reject)
       .on('entry', (entry: Object) => {
-        if (constants.ROOT_USER) {
+        if (ROOT_USER) {
           entry.props.uid = entry.uid = 0;
           entry.props.gid = entry.gid = 0;
         }

--- a/src/util/root-user.js
+++ b/src/util/root-user.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+function getUid(): ?number {
+  if (process.platform !== 'win32' && process.getuid) {
+    return process.getuid();
+  }
+  return null;
+}
+
+export default isRootUser(getUid());
+
+export function isRootUser(uid: ?number): boolean {
+  return uid === 0;
+}

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -1,6 +1,8 @@
 /* @flow */
+
+import ROOT_USER from './root-user.js';
+
 const path = require('path');
-const {ROOT_USER} = require('../constants');
 
 const userHomeDir = (process.platform === 'linux' && ROOT_USER) ?
   path.resolve('/usr/local/share') :


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

This fixes the circular dependency that caused #2807.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Packages installed with `sudo yarn global add` should now go to `/usr/local/share/yarn` instead of `/root/.config/yarn`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
