### PR TITLE
Ref #2165 - file-resolver should invalidate cache with a new hash

### DIFF
--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -51,7 +51,14 @@ test('dir', async (): Promise<void> => {
 test('clean', async (): Promise<void> => {
   await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
     let files = await fs.readdir(config.cacheFolder);
-    expect(files.length).toEqual(2); // we need to add one .tmp folder
+    // Asserting cache size is 1...
+    // we need to add one for the .tmp folder
+    //
+    // Per #2860, file: protocol installs may add the same package to the cache
+    // multiple times if it is installed with a force flag or has an install script.
+    // We'll add another for a total of 3 because this particular fixture has
+    // an install script.
+    expect(files.length).toEqual(3);
 
     const out = new stream.PassThrough();
     const reporter = new reporters.JSONReporter({stdout: out});

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "strip-bom": "^3.0.0",
     "tar-fs": "^1.15.1",
     "tar-stream": "^1.5.2",
+    "uuid": "^3.0.1",
     "v8-compile-cache": "^1.1.0",
     "validate-npm-package-license": "^3.0.1"
   },

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -25,6 +25,7 @@ const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
 
 const invariant = require('invariant');
 const path = require('path');
+const uuid = require('uuid');
 
 export const noArguments = true;
 
@@ -98,7 +99,7 @@ class ImportResolver extends BaseResolver {
     info._remote = {
       type: 'copy',
       registry: this.registry,
-      hash: null,
+      hash: `${uuid.v4()}-${new Date().getTime()}`,
       reference: loc,
     };
     return info;

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -9,6 +9,7 @@ import * as fs from '../../util/fs.js';
 
 const invariant = require('invariant');
 const path = require('path');
+const uuid = require('uuid');
 
 type Dependencies = {
   [key: string]: string
@@ -40,7 +41,7 @@ export default class FileResolver extends ExoticResolver {
     manifest._remote = {
       type: 'copy',
       registry,
-      hash: null,
+      hash: `${uuid.v4()}-${new Date().getTime()}`,
       reference: loc,
     };
 
@@ -49,7 +50,7 @@ export default class FileResolver extends ExoticResolver {
     // Normalize relative paths; if anything changes, make a copy of the manifest
     const dependencies = this.normalizeDependencyPaths(manifest.dependencies, loc);
     const optionalDependencies = this.normalizeDependencyPaths(manifest.optionalDependencies, loc);
-    
+
     if (dependencies !== manifest.dependencies || optionalDependencies !== manifest.optionalDependencies) {
       const _manifest = Object.assign({}, manifest);
       if (dependencies != null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4519,7 +4519,7 @@ util@0.10.3, util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
**Summary**
When using a `file:` resolution for dependencies, the dependency is always being pulled from yarn's cache; the first time being the exception, which puts it into the cache.  

Currently the cached package will only have the name and version, like the following:
```sh
ls `yarn cache dir` | grep npm-foo
# npm-foo-0.0.1
```

This change ensures that the compared dependency always generates a new hashed name which will invalidate the cache.  The new hash name looks like:
```js
`npm-${package.name}-${package.version}-${uuid.v4()}-${(new Date()).getTime()}`
```

I've found two small caveats which are worth noting.
1. Once a dependency is installed to the `node_modules` directory, the hash comparison doesn't have any effect when running `yarn install` is called again.  Only package.json `version` differences will have an effect, which are represented with differences in the `yarn.lock` file. This can be circumvented with `yarn install --force`, which invalidates the local package and replaces it with a new copy, even if it is the same version.

Personally, I think this is correct functionality.

```sh
# Package added to node_modules and yarn cache
yarn install
# No effect (lock file is the same, nothing added to cache)
yarn install
# Invalidates cache and overrwrites dependency in node_modules
yarn install --force
```
2. Any install where the local package is not present in `node_modules` or using the `install --force` option, will add a duplicate entry to the yarn cache.  The takeaway here is that we shouldn't cache the dependency at all as suggested [here](https://github.com/yarnpkg/yarn/issues/2165#issuecomment-284664878), but I'm probably not the right person to make that change.

**Test plan**
1. Create two local projects, both with a package.json file and index.js file.  One package depends on the other using a `file:` reference.
```sh

mkdir -p foo
echo "{\"name\":\"foo\", \"version\": \"0.0.1\",\"main\":\"index.js\"}" > foo/package.json
touch foo/index.js
mkdir -p bar
echo "{\"name\":\"bar\", \"version\": \"0.0.1\",\"main\":\"index.js\",\"dependencies\": {\"foo\":\"file:../foo\"}}" > bar/package.json
touch bar/index.js
```
2. Run yarn install on the `bar` package
```sh
cd bar
yarn install
cd ..
```
3. Validate the named hash entry in the cache
```sh
ls `yarn cache dir` | grep npm-foo
# npm-foo-0.0.1-4997b76e-1d5c-4dfa-a001-5d2424c390dc-1488908398088
```

4. Change the index file of foo, remove node_modules of bar and reinstall.
```sh
echo "console.log('test');" > foo/index.js
cd bar
rm -r node_modules
yarn install
```

5. Check foo package index.js file for change
```sh
cat node_modules/foo/index.js
# console.log('test');
```