### PR TITLE
fix the location for yarn-error.log and add a test case

### DIFF
--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -19,10 +19,8 @@ async function setupWorkingDir(fixture: string): Promise<string> {
 }
 
 function execCommand(workingDir: string, cacheDir: string): Promise<string> {
-  const relativeBin = path.relative(workingDir, yarnBin);
-
   return new Promise((resolve, reject) => {
-    exec(`node "${relativeBin}" tag rm non-existing-pkg non-existing-tag --cache-folder ${cacheDir} | cat`,
+    exec(`node "${yarnBin}" tag rm non-existing-pkg non-existing-tag --cache-folder ${cacheDir} | cat`,
     {cwd: workingDir}, (err, stdout) => {
       if (err) {
         reject(err);

--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -1,0 +1,43 @@
+/* @flow */
+const path = require('path');
+const exec = require('child_process').exec;
+import * as fs from '../../src/util/fs.js';
+import makeTemp from '../_temp.js';
+import NoopReporter from '../../src/reporters/base-reporter.js';
+import * as constants from '../../src/constants.js';
+import assert from 'assert';
+
+const yarnBin = path.join(__dirname, '..', '..', 'bin', 'yarn.js');
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'index');
+
+async function setupWorkingDir(fixture: string): Promise<string> {
+  const srcDir = path.join(fixturesLoc, fixture);
+  const workingDir = await makeTemp(fixture);
+  await fs.copy(srcDir, workingDir, new NoopReporter());
+
+  return workingDir;
+}
+
+function execCommand(workingDir: string, cacheDir: string): Promise<string> {
+  const relativeBin = path.relative(workingDir, yarnBin);
+
+  return new Promise((resolve, reject) => {
+    exec(`node "${relativeBin}" tag rm non-existing-pkg non-existing-tag --cache-folder ${cacheDir} | cat`,
+    {cwd: workingDir}, (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(workingDir);
+      }
+    });
+  });
+}
+
+test('Verify path errorReport log', async () => {
+  const workingDir = await setupWorkingDir('run-failing-custom-script');
+  const cacheDir = path.join(workingDir, 'cache');
+  await fs.mkdirp(cacheDir);
+
+  await execCommand(workingDir, cacheDir);
+  assert.ok(await fs.exists(path.join(cacheDir, 'v' + String(constants.CACHE_VERSION), 'yarn-error.log')));
+});

--- a/__tests__/fixtures/index/run-failing-custom-script/package.json
+++ b/__tests__/fixtures/index/run-failing-custom-script/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test_run_failing_custom_script",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "custom-script": "tag rm non-existing-pkg non-existing-tag"
+  },
+  "dependencies": {
+    "n": "^2.1.4"
+  }
+}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -345,7 +345,7 @@ function onUnexpectedError(err: Error) {
 }
 
 function writeErrorReport(log) : ?string {
-  const errorReportLoc = path.join(config.cwd, 'yarn-error.log');
+  const errorReportLoc = path.join(config.cacheFolder, 'yarn-error.log');
 
   try {
     fs.writeFileSync(errorReportLoc, log.join('\n\n') + '\n');
@@ -362,7 +362,7 @@ config.init({
   binLinks: commander.binLinks,
   modulesFolder: commander.modulesFolder,
   globalFolder: commander.globalFolder,
-  cacheRootFolder: commander.cacheFolder,
+  cacheFolder: commander.cacheFolder,
   preferOffline: commander.preferOffline,
   captureHar: commander.har,
   ignorePlatform: commander.ignorePlatform,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
In order to change the folder where `yarn-error.log` is placed, we changed the path from `config.cwd` to `config.cacheFolder`. In the process of testing we also discovered a bug with specifying a cache folder from the command line.
The test executes a command that will error a `yarn-error.log` and verifies that this log is created in the specified cache folder.
Fixes #2719 
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Run `yarn test`

or by hand: run the command `yarn tag rm non-existing-pkg non-existing-tag` and press enter, then verify that the reporter put the error log in the cache folder. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
