### PR TITLE
Reduce complexity of src/cli/index.js

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -207,7 +207,7 @@ test.concurrent('should interpolate aliases', async () => {
   );
 });
 
-test.concurrent('should display correct documentation for aliases', async () => {
+test.concurrent('should display correct documentation link for aliases', async () => {
   await expectAnInfoMessageAfterError(
     execCommand('i', [], 'run-add', true),
     'Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.',
@@ -252,5 +252,19 @@ test.concurrent('should throws missing command for unknown command', async () =>
   await expectAnErrorMessage(
     execCommand('unknown', [], 'run-add', true),
     'Command \"unknown\" not found',
+  );
+});
+
+test.concurrent('should not display documentation link for unknown command', async () => {
+  await expectAnInfoMessageAfterError(
+    execCommand('unknown', [], 'run-add', true),
+    '',
+  );
+});
+
+test.concurrent('should display documentation link for known command', async () => {
+  await expectAnInfoMessageAfterError(
+    execCommand('add', [], 'run-add', true),
+    'Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.',
   );
 });

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -76,7 +76,11 @@ function expectHelpOutputAsSubcommand(stdout) {
 }
 
 function expectAnErrorMessage(command: Promise<Array<?string>>, error: string) : Promise<void> {
-  return command.catch((reason) =>
+  return command
+  .then(function() {
+    throw new Error('the command did not fail');
+  })
+  .catch((reason) =>
     expect(reason.message).toContain(error),
   );
 }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -81,10 +81,6 @@ function expectAnErrorMessage(command: Promise<Array<?string>>, error: string) :
   );
 }
 
-function expectInstallOutput(stdout) {
-  expect(stdout[0]).toEqual(`yarn install v${pkg.version}`);
-}
-
 test.concurrent('should add package', async () => {
   const stdout = await execCommand('add', ['left-pad'], 'run-add', true);
   expectAddSuccessfullOutput(stdout, 'left-pad');
@@ -182,12 +178,12 @@ test.concurrent('should run --version command', async () => {
 
 test.concurrent('should install if no args', async () => {
   const stdout = await execCommand('', [], 'run-add', true);
-  expectInstallOutput(stdout);
+  expect(stdout[0]).toEqual(`yarn install v${pkg.version}`);
 });
 
 test.concurrent('should install if first arg looks like a flag', async () => {
-  const stdout = await execCommand('--offline', [], 'run-add', true);
-  expectInstallOutput(stdout);
+  const stdout = await execCommand('--json', [], 'run-add', true);
+  expect(stdout[stdout.length - 1]).toEqual('{"type":"success","data":"Saved lockfile."}');
 });
 
 test.concurrent('should interpolate aliases', async () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -216,3 +216,24 @@ test.concurrent('should run bin command', async () => {
   expect(stdout[0]).toEqual(path.join(fixturesLoc, 'node_modules', '.bin'));
   expect(stdout.length).toEqual(1);
 });
+
+test.concurrent('should throws missing command for not camelised command', async () => {
+  await expectAnErrorMessage(
+    execCommand('HelP', [], 'run-add', true),
+    'Command \"HelP\" not found',
+  );
+});
+
+test.concurrent('should throws missing command for not alphabetic command', async () => {
+  await expectAnErrorMessage(
+    execCommand('123', [], 'run-add', true),
+    'Command \"123\" not found',
+  );
+});
+
+test.concurrent('should throws missing command for unknown command', async () => {
+  await expectAnErrorMessage(
+    execCommand('unknown', [], 'run-add', true),
+    'Command \"unknown\" not found',
+  );
+});

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -268,3 +268,10 @@ test.concurrent('should display documentation link for known command', async () 
     'Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.',
   );
 });
+
+test.concurrent('should throws missing command for constructor command', async () => {
+  await expectAnErrorMessage(
+    execCommand('constructor', [], 'run-add', true),
+    'Command \"constructor\" not found',
+  );
+});

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -67,6 +67,9 @@ async () => {
   stdout = await execCommand('', 'npm_config_argv_env_vars', env);
   expect(stdout).toContain('##install##');
 
+  stdout = await execCommand('run test', 'npm_config_argv_env_vars', env);
+  expect(stdout).toContain('##test##');
+
   stdout = await execCommand('test', 'npm_config_argv_env_vars', env);
   expect(stdout).toContain('##test##');
 });

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -4,7 +4,7 @@ import * as commands from './index.js';
 import * as constants from '../../constants.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
-import {sortAlpha, hyphenate} from '../../util/misc.js';
+import {sortAlpha, hyphenate, camelCase} from '../../util/misc.js';
 const chalk = require('chalk');
 
 export function run(
@@ -17,24 +17,47 @@ export function run(
   const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
 
   if (args.length) {
-    const helpCommand = hyphenate(args[0]);
-    if (commands[helpCommand]) {
-      commander.on('--help', () => console.log('  ' + getDocsInfo(helpCommand) + '\n'));
-    }
-  } else {
-    commander.on('--help', () => {
-      console.log('  Commands:\n');
-      for (const name of Object.keys(commands).sort(sortAlpha)) {
-        if (commands[name].useless) {
-          continue;
+    const commandName = camelCase(args.shift());
+
+    if (commandName) {
+      const command = commands[commandName];
+
+      if (command) {
+        if (typeof command.setFlags === 'function') {
+          command.setFlags(commander);
         }
 
-        console.log(`    - ${hyphenate(name)}`);
+        const examples: Array<string> = (command && command.examples) || [];
+        if (examples.length) {
+          commander.on('--help', () => {
+            console.log('  Examples:\n');
+            for (const example of examples) {
+              console.log(`    $ yarn ${example}`);
+            }
+            console.log();
+          });
+        }
+        commander.on('--help', () => console.log('  ' + getDocsInfo(commandName) + '\n'));
+
+        commander.help();
+        return Promise.resolve();
       }
-      console.log('\n  Run `' + chalk.bold('yarn help COMMAND') + '` for more information on specific commands.');
-      console.log('  Visit ' + chalk.bold(getDocsLink()) + ' to learn more about Yarn.\n');
-    });
+    }
   }
+
+  commander.on('--help', () => {
+    console.log('  Commands:\n');
+    for (const name of Object.keys(commands).sort(sortAlpha)) {
+      if (commands[name].useless) {
+        continue;
+      }
+
+      console.log(`    - ${hyphenate(name)}`);
+    }
+    console.log('\n  Run `' + chalk.bold('yarn help COMMAND') + '` for more information on specific commands.');
+    console.log('  Visit ' + chalk.bold(getDocsLink()) + ' to learn more about Yarn.\n');
+  });
+
   commander.help();
   return Promise.resolve();
 }

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -7,6 +7,10 @@ import type Config from '../../config.js';
 import {sortAlpha, hyphenate, camelCase} from '../../util/misc.js';
 const chalk = require('chalk');
 
+export function hasWrapper(): boolean {
+  return false;
+}
+
 export function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -117,13 +117,11 @@ if (args.indexOf('--help') >= 0 || args.indexOf('-h') >= 0) {
 }
 
 // if no args or command name looks like a flag then default to `install`
-if (commandName && commandName[0] === '-') {
+if (commandName[0] === '-') {
   args.unshift(commandName);
   commandName = 'install';
 }
 
-//
-invariant(commandName, 'Missing command name');
 const camelised = camelCase(commandName);
 if (camelised) {
   command = commands[camelised];

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -24,19 +24,12 @@ const pkg = require('../../package.json');
 
 loudRejection();
 
-//
 const startArgs = process.argv.slice(0, 2);
-let args = process.argv.slice(2);
 
 // ignore all arguments after a --
-let endArgs = [];
-for (let i = 0; i < args.length; i++) {
-  const arg = args[i];
-  if (arg === '--') {
-    endArgs = args.slice(i + 1);
-    args = args.slice(0, i);
-  }
-}
+const doubleDashIndex = process.argv.findIndex((element) => element === '--');
+const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
+const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
 // NOTE: Pending resolution of https://github.com/tj/commander.js/issues/346
 // Remove this (and subsequent use in the logic below) after bug is resolved and issue is closed

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -40,12 +40,6 @@ const doubleDashIndex = process.argv.findIndex((element) => element === '--');
 const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
 const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
-// NOTE: Pending resolution of https://github.com/tj/commander.js/issues/346
-// Remove this (and subsequent use in the logic below) after bug is resolved and issue is closed
-const ARGS_THAT_SHARE_NAMES_WITH_OPTIONS = [
-  'version',
-];
-
 // set global options
 commander.version(pkg.version);
 commander.usage('[command] [flags]');
@@ -130,7 +124,6 @@ if (camelised) {
 // if command is not recognized, then set default to `run`
 if (!command) {
   args.unshift(commandName);
-  commandName = 'run';
   command = commands.run;
 }
 
@@ -140,11 +133,15 @@ if (command && typeof command.setFlags === 'function') {
 
 commander.parse([
   ...startArgs,
-  ARGS_THAT_SHARE_NAMES_WITH_OPTIONS.indexOf(commandName) === -1 ? commandName : '',
+  // we use this for https://github.com/tj/commander.js/issues/346, otherwise
+  // it will strip some args that match with any options
+  'this-arg-will-get-stripped-later',
   ...getRcArgs(commandName),
   ...args,
 ]);
 commander.args = commander.args.concat(endArgs);
+
+// we strip cmd
 commander.args.shift();
 
 //

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -126,11 +126,9 @@ if (commandName === 'help' && args.length) {
 
 //
 invariant(commandName, 'Missing command name');
-if (!command) {
-  const camelised = camelCase(commandName);
-  if (camelised) {
-    command = commands[camelised];
-  }
+const camelised = camelCase(commandName);
+if (camelised) {
+  command = commands[camelised];
 }
 
 //

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -142,6 +142,8 @@ commander.parse([
 commander.args = commander.args.concat(endArgs);
 
 // we strip cmd
+console.assert(commander.args.length >= 1);
+console.assert(commander.args[0] === 'this-arg-will-get-stripped-later');
 commander.args.shift();
 
 //

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,7 +2,7 @@
 
 import {ConsoleReporter, JSONReporter} from '../reporters/index.js';
 import {registries, registryNames} from '../registries/index.js';
-import * as commands from './commands/index.js';
+import * as _commands from './commands/index.js';
 import * as constants from '../constants.js';
 import * as network from '../util/network.js';
 import {MessageError} from '../errors.js';
@@ -23,6 +23,15 @@ const path = require('path');
 const pkg = require('../../package.json');
 
 loudRejection();
+
+const commands = {..._commands};
+for (const key in aliases) {
+  commands[key] = {
+    run(config: Config, reporter: ConsoleReporter | JSONReporter): Promise<void> {
+      throw new MessageError(`Did you mean \`yarn ${aliases[key]}\`?`);
+    },
+  };
+}
 
 const startArgs = process.argv.slice(0, 2);
 
@@ -110,16 +119,6 @@ if (!commandName || commandName[0] === '-') {
     args.unshift(commandName);
   }
   commandName = 'install';
-}
-
-// aliases: i -> install
-if (commandName && typeof aliases[commandName] === 'string') {
-  const alias = aliases[commandName];
-  command = {
-    run(config: Config, reporter: ConsoleReporter | JSONReporter): Promise<void> {
-      throw new MessageError(`Did you mean \`yarn ${alias}\`?`);
-    },
-  };
 }
 
 //

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -117,7 +117,7 @@ if (commandName[0] === '-') {
 
 let command;
 const camelised = camelCase(commandName);
-if (camelised) {
+if (camelised && Object.prototype.hasOwnProperty.call(commands, camelised)) {
   command = commands[camelised];
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -385,7 +385,7 @@ config.init({
   }
 
   if (commandName) {
-    const actualCommandForHelp = commands[commandName] ? commandName : aliases[commandName];
+    const actualCommandForHelp = aliases[commandName] ? aliases[commandName] : commandName;
     if (command && actualCommandForHelp) {
       reporter.info(getDocsInfo(actualCommandForHelp));
     }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -384,11 +384,10 @@ config.init({
     onUnexpectedError(err);
   }
 
-  if (commandName) {
-    const actualCommandForHelp = aliases[commandName] ? aliases[commandName] : commandName;
-    if (command && actualCommandForHelp) {
-      reporter.info(getDocsInfo(actualCommandForHelp));
-    }
+  if (aliases[commandName]) {
+    reporter.info(getDocsInfo(aliases[commandName]));
+  } else if (commands[commandName]) {
+    reporter.info(getDocsInfo(commandName));
   }
 
   process.exit(1);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -168,7 +168,7 @@ if (typeof command.hasWrapper === 'function') {
 if (commander.json) {
   outputWrapper = false;
 }
-if (outputWrapper && commandName !== 'help') {
+if (outputWrapper) {
   reporter.header(commandName, pkg);
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -37,7 +37,7 @@ const startArgs = process.argv.slice(0, 2);
 
 // ignore all arguments after a --
 const doubleDashIndex = process.argv.findIndex((element) => element === '--');
-let args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
+const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
 const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
 // NOTE: Pending resolution of https://github.com/tj/commander.js/issues/346
@@ -129,18 +129,16 @@ if (camelised) {
   command = commands[camelised];
 }
 
-//
 if (command && typeof command.setFlags === 'function') {
   command.setFlags(commander);
 }
 
-args = [commandName].concat(getRcArgs(commandName), args);
-
-if (ARGS_THAT_SHARE_NAMES_WITH_OPTIONS.indexOf(commandName) >= 0 && args[0] === commandName) {
-  args.shift();
-}
-
-commander.parse(startArgs.concat(args));
+commander.parse([
+  ...startArgs,
+  ARGS_THAT_SHARE_NAMES_WITH_OPTIONS.indexOf(commandName) === -1 ? commandName : '',
+  ...getRcArgs(commandName),
+  ...args,
+]);
 commander.args = commander.args.concat(endArgs);
 
 if (command) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -100,13 +100,12 @@ commander.option('--network-concurrency <number>', 'maximum number of concurrent
 commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
 commander.option('--non-interactive', 'do not show interactive prompts');
 
-// get command name
-let commandName: ?string = args.shift() || '';
-let command;
-
-//
 const getDocsLink = (name) => `${constants.YARN_DOCS}${name || ''}`;
 const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
+
+// get command name
+let commandName: ?string = args.shift() || 'install';
+let command;
 
 //
 if (commandName === '--help' || commandName === '-h') {
@@ -114,10 +113,8 @@ if (commandName === '--help' || commandName === '-h') {
 }
 
 // if no args or command name looks like a flag then default to `install`
-if (!commandName || commandName[0] === '-') {
-  if (commandName) {
-    args.unshift(commandName);
-  }
+if (commandName && commandName[0] === '-') {
+  args.unshift(commandName);
   commandName = 'install';
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -37,7 +37,7 @@ const startArgs = process.argv.slice(0, 2);
 
 // ignore all arguments after a --
 const doubleDashIndex = process.argv.findIndex((element) => element === '--');
-const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
+let args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
 const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
 // NOTE: Pending resolution of https://github.com/tj/commander.js/issues/346
@@ -104,11 +104,15 @@ const getDocsLink = (name) => `${constants.YARN_DOCS}${name || ''}`;
 const getDocsInfo = (name) => 'Visit ' + chalk.bold(getDocsLink(name)) + ' for documentation about this command.';
 
 // get command name
-let commandName: ?string = args.shift() || 'install';
+let commandName: string = args.shift() || 'install';
 let command;
 
-//
 if (commandName === '--help' || commandName === '-h') {
+  commandName = 'help';
+}
+
+if (args.indexOf('--help') >= 0 || args.indexOf('-h') >= 0) {
+  args.unshift(commandName);
   commandName = 'help';
 }
 
@@ -116,12 +120,6 @@ if (commandName === '--help' || commandName === '-h') {
 if (commandName && commandName[0] === '-') {
   args.unshift(commandName);
   commandName = 'install';
-}
-
-//
-if (commandName === 'help' && args.length) {
-  commandName = camelCase(args.shift());
-  args.push('--help');
 }
 
 //
@@ -134,24 +132,6 @@ if (camelised) {
 //
 if (command && typeof command.setFlags === 'function') {
   command.setFlags(commander);
-}
-
-if (args.indexOf('--help') >= 0 || args.indexOf('-h') >= 0) {
-  const examples: Array<string> = (command && command.examples) || [];
-  if (examples.length) {
-    commander.on('--help', () => {
-      console.log('  Examples:\n');
-      for (const example of examples) {
-        console.log(`    $ yarn ${example}`);
-      }
-      console.log();
-    });
-  }
-  commander.on('--help', () => console.log('  ' + getDocsInfo(commandName) + '\n'));
-
-  commander.parse(startArgs.concat(args));
-  commander.help();
-  process.exit(1);
 }
 
 args = [commandName].concat(getRcArgs(commandName), args);

--- a/src/rc.js
+++ b/src/rc.js
@@ -70,7 +70,7 @@ export function getRcArgs(command: string): Array<string> {
 
   let result = rcArgsCache['*'] || [];
 
-  if (command !== '*') {
+  if (command !== '*' && Object.prototype.hasOwnProperty.call(rcArgsCache, command)) {
     result = result.concat(rcArgsCache[command] || []);
   }
 


### PR DESCRIPTION
After working some time on https://github.com/yarnpkg/yarn/pull/2810 I thought that maybe I was trying to reduce the complexity of src/cli/index.js from the wrong point of view.

In this pull request I:
- Cherry picked some commits from https://github.com/yarnpkg/yarn/pull/2810
- Reduce a lot of if statements
- Move all the logic of help in help command

Test plan, add test:
- for not camelised command
- for not alphabetic command
- for not unknown command
- extract npm_config_argv_env_vars correctly if you use 'yarn run test' instead of 'yarn test'
- display the documentation link correctly if we use an alias
- display the documentation link correctly if we use a normal command
- do not display the documentation link correctly if we use have an unknown command

Everything else seems tested properly and this change is less invasive than what i do in https://github.com/yarnpkg/yarn/pull/2810.

@bestander let me know if you like and sorry if I spam you a lot :P 
Feedbacks from everyone are always welcome :) 

Questions:
- Why we camelcase the command name? And after digging in the function we return null if it has an uppercase letter, otherwise we camelcase the command name. I still don't get what it is the use case O.o

Simon

PS I left some other useful commits from https://github.com/yarnpkg/yarn/pull/2810, maybe I will add to this pull request or open others after, in detail: 
- https://github.com/yarnpkg/yarn/pull/2810/commits/13dd05eb0f7be2db668cdf5098d057c8ea06299a
- https://github.com/yarnpkg/yarn/pull/2810/commits/2ae055a9114bbbb9e55ded48984105565e60fb21


