### PR TITLE
Generate coverage for uncovered source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "build-win-installer": "scripts\\build-windows-installer.bat"
   },
   "jest": {
+    "collectCoverageFrom": ["src/**/*.js"],
     "timers": "fake",
     "testEnvironment": "node",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
**Summary**

The coverage tool of Jest did not generate the coverage for files that were not covered at all. E.g. files that are completely untested. The bad news: A lot of commands are left untested and the total coverage is significantly lower than before. The good news: after this change, you can actually see which commands require more tests which others might be able to contribute!

To trigger coverage for all files, the option `collectCoverageFrom` can be used per https://github.com/facebook/jest/issues/1211#issuecomment-240266448

**Test plan**

Run `yarn test` and open `coverage/lcov-report/index.html` in a browser of your preference. Observe that a lot of commands are now showing 0% coverage. The previous coverage report did not include these empty coverage files.