### PR TITLE
Resolves issues with git+ssh when ssh daemon has banner set.

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -349,7 +349,8 @@ export default class Git {
   }
 
   async setRefRemote(): Promise<string> {
-    const stdout = await child.spawn('git', ['ls-remote','-q', '--tags', '--heads', this.url],{env:{GIT_SSH_COMMAND:'ssh -q'}});
+    const stdout = await child.spawn('git', ['ls-remote', '-q', '--tags', '--heads', this.url], 
+    {env: {GIT_SSH_COMMAND:'ssh -q'}});
     const refs = Git.parseRefs(stdout);
     return await this.setRef(refs);
   }


### PR DESCRIPTION
Currently with yarn when using git+ssh yarn fails to download and install the module if your ssh connection first includes a banner.  This change silences the banner by using the -q option on ssh to not show the banner during the connection negotiation along with specifying git cli to reference ssh with the -q option.