### PR TITLE
Fix manifest trivial dependency normalization, fixes #2660

### DIFF
--- a/__tests__/fixtures/normalize-manifest/dedupe all trivial dependencies/actual.json
+++ b/__tests__/fixtures/normalize-manifest/dedupe all trivial dependencies/actual.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "foobar": "*"
+  },
+  "dependencies": {
+    "foobar": "*"
+  }
+}

--- a/__tests__/fixtures/normalize-manifest/dedupe all trivial dependencies/expected.json
+++ b/__tests__/fixtures/normalize-manifest/dedupe all trivial dependencies/expected.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {},
+  "dependencies": {
+    "foobar": "*"
+  },
+  "name": "",
+  "version": ""
+}

--- a/__tests__/fixtures/normalize-manifest/dedupe all trivial dependencies/warnings.json
+++ b/__tests__/fixtures/normalize-manifest/dedupe all trivial dependencies/warnings.json
@@ -1,0 +1,3 @@
+[
+  "No license field"
+]

--- a/__tests__/fixtures/normalize-manifest/dedupe single trivial dependency/actual.json
+++ b/__tests__/fixtures/normalize-manifest/dedupe single trivial dependency/actual.json
@@ -1,0 +1,16 @@
+{
+  "devDependencies": {
+    "foobar1": "*",
+    "foobar2": "2.0.0",
+    "foobar4": "*"
+  },
+  "dependencies": {
+    "foobar1": "1.0.0",
+    "foobar2": "*",
+    "foobar3": "3.0.0"
+  },
+  "optionalDependencies": {
+    "foobar3": "*",
+    "foobar4": "4.0.0"
+  }
+}

--- a/__tests__/fixtures/normalize-manifest/dedupe single trivial dependency/expected.json
+++ b/__tests__/fixtures/normalize-manifest/dedupe single trivial dependency/expected.json
@@ -1,0 +1,14 @@
+{
+  "devDependencies": {
+  },
+  "dependencies": {
+    "foobar1": "1.0.0",
+    "foobar2": "2.0.0"
+  },
+  "optionalDependencies": {
+    "foobar3": "3.0.0",
+    "foobar4": "4.0.0"
+  },
+  "name": "",
+  "version": ""
+}

--- a/__tests__/fixtures/normalize-manifest/dedupe single trivial dependency/warnings.json
+++ b/__tests__/fixtures/normalize-manifest/dedupe single trivial dependency/warnings.json
@@ -1,0 +1,3 @@
+[
+  "No license field"
+]


### PR DESCRIPTION
**Summary**

This PR fixes #2660.

When installing `"connect-mincer": "~1.1.0"`, its dependency `underscore` is not installed. This is caused by the manifest normalization functions.

The manifest of `connect-mincer` lists underscore twice:
```
"dependencies": {
    "mincer": "^1.3.0",
    "underscore": "1.4.x"
  },
  "devDependencies": {
    "async": "*",
    "chai": "*",
    "cheerio": "*",
    "coffee-script": "1.4.x",
    "connect": "*",
    "csso": "*",
    "ejs": "*",
    "express": "^4.13.3",
    "less": "*",
    "mocha": "1.8.x",
    "nib": "*",
    "should": "*",
    "sinon": "1.6.x",
    "stylus": "*",
    "supertest": "*",
    "uglify-js": "*",
    "underscore": "*",
    "wrench": "*"
  },
```
The cleanDependencies function currently keeps the last dependency with version '*' in the order `[ 'optionalDependencies', 'dependencies', 'devDependencies' ]`. In this case, only the reference in devDependencies is kept, and `underscore` is not installed.

Example:
```
"dependencies": { "underscore": "1.4.x", "sinon": "*", },
"devDependencies": { "underscore": "*", "sinon": "1.6.x" },
```
is currently rewritten to:
```
"dependencies": { "sinon": "*" },
"devDependencies": { "underscore": "*" },
```
This PR reworks the cleanDependencies function to look at all dependencies for the same package, and keeps the first non-trivial version (not '' and not '*'). Then, the first reference in the dependency objects (in order `[ 'optionalDependencies', 'dependencies', 'devDependencies' ]`) is rewritten to that version, and the other ones are deleted.
The previous example will now be rewritten to:
```
"dependencies": { "underscore": "1.4.x", "sinon": "1.6.x" },
"devDependencies": { },
```
**Test plan**
- Add low-level unit tests to verify rewriting with some trivial dependencies is now correct. 
- Manually ran `yarn add connect-mincer` and verified that `underscore` is now indeed present in node_modules.

**Important**
The erroneously cleaned dependency information is cached by yarn (in the lock file, maybe in the cache?), so some steps might be needed to fix this problem in existing deployments. I don't have enough overview over the project to see what those might be, though.