### PR TITLE
issue 2495: warn users when install yarn globally with yarn

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -179,6 +179,9 @@ const {run, setFlags: _setFlags} = buildSubCommands('global', {
     await updateCwd(config);
 
     const updateBins = await initUpdateBins(config, reporter, flags);
+    if (args.includes('yarn')) {
+      reporter.warn(reporter.lang('packageContainsYarnAsGlobal'));
+    }
 
     // install module
     const lockfile = await Lockfile.fromDirectory(config.cwd);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -265,6 +265,7 @@ const messages = {
   importFailed: 'Import of $0 for $1 failed, resolving normally.',
   importResolveFailed: 'Import of $0 failed starting in $1',
   importResolvedRangeMatch: 'Using version $0 of $1 instead of $2 for $3',
+  packageContainsYarnAsGlobal: 'Installing Yarn via Yarn will result in you having two separate versions of Yarn installed at the same time, which is not recommended. To update Yarn please follow https://yarnpkg.com/en/docs/install .',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Built upon this original [PR](https://github.com/yarnpkg/yarn/pull/2577/files) from [mnsn](https://github.com/mnsn)

Add a warning when a user is installing Yarn globally with Yarn, see the [issue](https://github.com/yarnpkg/yarn/issues/2495) for more details 

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Do we need tests for this warning?

I've build yarn locally and used that binary to install yarn globally and I get the warning. Should we add tests for this warning? wdwt

<img width="1399" alt="screen shot 2017-03-15 at 09 20 06 2" src="https://cloud.githubusercontent.com/assets/1868592/23941432/b4a27298-0960-11e7-87da-b7465ba10662.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
