### PR TITLE
ignore devDependencies on licenses command if is enable to --prod option

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -195,7 +195,10 @@ export class Install {
    * Create a list of dependency requests from the current directories manifests.
    */
 
-  async fetchRequestFromCwd(excludePatterns?: Array<string> = []): Promise<InstallCwdRequest> {
+  async fetchRequestFromCwd(
+    excludePatterns?: Array<string> = [],
+    noUseIgnore?: boolean = false,
+  ): Promise<InstallCwdRequest> {
     const patterns = [];
     const deps = [];
     const manifest = {};
@@ -231,6 +234,7 @@ export class Install {
       Object.assign(manifest, json);
 
       const pushDeps = (depType, {hint, optional}, isUsed) => {
+        if (noUseIgnore && !isUsed) { return; }
         const depMap = json[depType];
         for (const name in depMap) {
           if (excludeNames.indexOf(name) >= 0) {
@@ -619,9 +623,8 @@ export class Install {
   /**
    * Load the dependency graph of the current install. Only does package resolving and wont write to the cwd.
    */
-
-  async hydrate(fetch?: boolean): Promise<InstallCwdRequest> {
-    const request = await this.fetchRequestFromCwd();
+  async hydrate(fetch?: boolean, noUseIgnore?: boolean): Promise<InstallCwdRequest> {
+    const request = await this.fetchRequestFromCwd([], noUseIgnore);
     const {requests: depRequests, patterns: rawPatterns, ignorePatterns} = request;
 
     await this.resolver.init(depRequests, this.flags.flat);

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -197,7 +197,7 @@ export class Install {
 
   async fetchRequestFromCwd(
     excludePatterns?: Array<string> = [],
-    noUseIgnore?: boolean = false,
+    ignoreUnusedPatterns?: boolean = false,
   ): Promise<InstallCwdRequest> {
     const patterns = [];
     const deps = [];
@@ -234,7 +234,9 @@ export class Install {
       Object.assign(manifest, json);
 
       const pushDeps = (depType, {hint, optional}, isUsed) => {
-        if (noUseIgnore && !isUsed) { return; }
+        if (ignoreUnusedPatterns && !isUsed) {
+          return;
+        }
         const depMap = json[depType];
         for (const name in depMap) {
           if (excludeNames.indexOf(name) >= 0) {
@@ -623,8 +625,8 @@ export class Install {
   /**
    * Load the dependency graph of the current install. Only does package resolving and wont write to the cwd.
    */
-  async hydrate(fetch?: boolean, noUseIgnore?: boolean): Promise<InstallCwdRequest> {
-    const request = await this.fetchRequestFromCwd([], noUseIgnore);
+  async hydrate(fetch?: boolean, ignoreUnusedPatterns?: boolean): Promise<InstallCwdRequest> {
+    const request = await this.fetchRequestFromCwd([], ignoreUnusedPatterns);
     const {requests: depRequests, patterns: rawPatterns, ignorePatterns} = request;
 
     await this.resolver.init(depRequests, this.flags.flat);

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -17,7 +17,7 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
 async function getManifests(config: Config, flags: Object): Promise<Array<Manifest>> {
   const lockfile = await Lockfile.fromDirectory(config.cwd);
   const install = new Install({skipIntegrity: true, ...flags}, config, new NoopReporter(), lockfile);
-  await install.hydrate(true);
+  await install.hydrate(true, true);
 
   let manifests = install.resolver.getManifests();
 


### PR DESCRIPTION
**Summary**
fix: https://github.com/yarnpkg/yarn/issues/2567

`yarn licenses` command generate dependencies tree.
If is enable to production option is ignore only direct devDependencies.
So, has remain dependencies of devDependencies.

I'll try to remove devDependencies from dependencies tree.
How do you think it?

**Test plan**

confirm to exclude devDepensencies packages from license command output when enable to --prod option.

example paclage.json
```
{
  "name": "try-yarn",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "devDependencies": {
    "babel-core": "^6.24.0"
  },
  "dependencies": {
    "react": "^15.4.2"
  }
}
```

```
$ ./node_modules/.bin/yarn licenses ls
yarn licenses v0.23.0-0
├─ ansi-regex@2.1.1
│  ├─ License: MIT
│  └─ URL: https://github.com/chalk/ansi-regex.git
├─ ansi-styles@2.2.1
│  ├─ License: MIT
│  └─ URL: https://github.com/chalk/ansi-styles.git
├─ asap@2.0.5
│  ├─ License: MIT
│  └─ URL: https://github.com/kriskowal/asap.git
├─ babel-code-frame@6.22.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-code-frame
├─ babel-core@6.24.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-core
├─ babel-generator@6.24.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-generator
├─ babel-helpers@6.23.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-helpers
├─ babel-messages@6.23.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-messages
├─ babel-register@6.24.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-register
├─ babel-runtime@6.23.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-runtime
├─ babel-template@6.23.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-template
├─ babel-traverse@6.23.1
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-traverse
├─ babel-types@6.23.0
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-types
├─ babylon@6.16.1
│  ├─ License: MIT
│  └─ URL: https://github.com/babel/babylon
├─ balanced-match@0.4.2
│  ├─ License: MIT
│  └─ URL: git://github.com/juliangruber/balanced-match.git
├─ brace-expansion@1.1.6
│  ├─ License: MIT
│  └─ URL: git://github.com/juliangruber/brace-expansion.git
├─ chalk@1.1.3
│  ├─ License: MIT
│  └─ URL: https://github.com/chalk/chalk.git
├─ concat-map@0.0.1
│  ├─ License: MIT
│  └─ URL: git://github.com/substack/node-concat-map.git
├─ convert-source-map@1.4.0
│  ├─ License: MIT
│  └─ URL: git://github.com/thlorenz/convert-source-map.git
├─ core-js@1.2.7
│  ├─ License: MIT
│  └─ URL: https://github.com/zloirock/core-js.git
├─ core-js@2.4.1
│  ├─ License: MIT
│  └─ URL: https://github.com/zloirock/core-js.git
├─ debug@2.6.3
│  ├─ License: MIT
│  └─ URL: git://github.com/visionmedia/debug.git
├─ detect-indent@4.0.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/detect-indent.git
├─ encoding@0.1.12
│  ├─ License: MIT
│  └─ URL: https://github.com/andris9/encoding.git
├─ escape-string-regexp@1.0.5
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/escape-string-regexp.git
├─ esutils@2.0.2
│  ├─ License: BSD-2-Clause
│  └─ URL: http://github.com/estools/esutils.git
├─ fbjs@0.8.9
│  ├─ License: BSD-3-Clause
│  └─ URL: https://github.com/facebook/fbjs.git
├─ globals@9.16.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/globals.git
├─ has-ansi@2.0.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/has-ansi.git
├─ home-or-tmp@2.0.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/home-or-tmp.git
├─ iconv-lite@0.4.15
│  ├─ License: MIT
│  └─ URL: git://github.com/ashtuchkin/iconv-lite.git
├─ invariant@2.2.2
│  ├─ License: BSD-3-Clause
│  └─ URL: https://github.com/zertosh/invariant
├─ is-finite@1.0.2
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/is-finite.git
├─ is-stream@1.1.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/is-stream.git
├─ isomorphic-fetch@2.2.1
│  ├─ License: MIT
│  └─ URL: https://github.com/matthew-andrews/isomorphic-fetch.git
├─ js-tokens@3.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/lydell/js-tokens.git
├─ jsesc@1.3.0
│  ├─ License: MIT
│  └─ URL: https://github.com/mathiasbynens/jsesc.git
├─ json5@0.5.1
│  ├─ License: MIT
│  └─ URL: https://github.com/aseemk/json5.git
├─ lodash@4.17.4
│  ├─ License: MIT
│  └─ URL: https://github.com/lodash/lodash.git
├─ loose-envify@1.3.1
│  ├─ License: MIT
│  └─ URL: git://github.com/zertosh/loose-envify.git
├─ minimatch@3.0.3
│  ├─ License: ISC
│  └─ URL: git://github.com/isaacs/minimatch.git
├─ minimist@0.0.8
│  ├─ License: MIT
│  └─ URL: git://github.com/substack/minimist.git
├─ mkdirp@0.5.1
│  ├─ License: MIT
│  └─ URL: https://github.com/substack/node-mkdirp.git
├─ ms@0.7.2
│  ├─ License: MIT
│  └─ URL: https://github.com/zeit/ms.git
├─ node-fetch@1.6.3
│  ├─ License: MIT
│  └─ URL: https://github.com/bitinn/node-fetch.git
├─ number-is-nan@1.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/number-is-nan.git
├─ object-assign@4.1.1
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/object-assign.git
├─ os-homedir@1.0.2
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/os-homedir.git
├─ os-tmpdir@1.0.2
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/os-tmpdir.git
├─ path-is-absolute@1.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/path-is-absolute.git
├─ private@0.1.7
│  ├─ License: MIT
│  └─ URL: git://github.com/benjamn/private.git
├─ promise@7.1.1
│  ├─ License: MIT
│  └─ URL: https://github.com/then/promise.git
├─ react@15.4.2
│  ├─ License: BSD-3-Clause
│  └─ URL: https://github.com/facebook/react.git
├─ regenerator-runtime@0.10.3
│  ├─ License: MIT
│  └─ URL: https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime
├─ repeating@2.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/repeating.git
├─ setimmediate@1.0.5
│  ├─ License: MIT
│  └─ URL: https://github.com/YuzuJS/setImmediate.git
├─ slash@1.0.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/slash.git
├─ source-map-support@0.4.13
│  ├─ License: MIT
│  └─ URL: https://github.com/evanw/node-source-map-support
├─ source-map@0.5.6
│  ├─ License: BSD-3-Clause
│  └─ URL: http://github.com/mozilla/source-map.git
├─ strip-ansi@3.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/chalk/strip-ansi.git
├─ supports-color@2.0.0
│  ├─ License: MIT
│  └─ URL: https://github.com/chalk/supports-color.git
├─ to-fast-properties@1.0.2
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/to-fast-properties.git
├─ trim-right@1.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/trim-right.git
├─ ua-parser-js@0.7.12
│  ├─ License: (GPL-2.0 OR MIT)
│  └─ URL: https://github.com/faisalman/ua-parser-js.git
└─ whatwg-fetch@2.0.3
│  ├─ License: MIT
│  └─ URL: https://github.com/github/fetch.git
✨  Done in 0.31s.
```

```
$ ./node_modules/.bin/yarn licenses ls --prod
yarn licenses v0.23.0-0
├─ asap@2.0.5
│  ├─ License: MIT
│  └─ URL: https://github.com/kriskowal/asap.git
├─ core-js@1.2.7
│  ├─ License: MIT
│  └─ URL: https://github.com/zloirock/core-js.git
├─ encoding@0.1.12
│  ├─ License: MIT
│  └─ URL: https://github.com/andris9/encoding.git
├─ fbjs@0.8.9
│  ├─ License: BSD-3-Clause
│  └─ URL: https://github.com/facebook/fbjs.git
├─ iconv-lite@0.4.15
│  ├─ License: MIT
│  └─ URL: git://github.com/ashtuchkin/iconv-lite.git
├─ is-stream@1.1.0
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/is-stream.git
├─ isomorphic-fetch@2.2.1
│  ├─ License: MIT
│  └─ URL: https://github.com/matthew-andrews/isomorphic-fetch.git
├─ js-tokens@3.0.1
│  ├─ License: MIT
│  └─ URL: https://github.com/lydell/js-tokens.git
├─ loose-envify@1.3.1
│  ├─ License: MIT
│  └─ URL: git://github.com/zertosh/loose-envify.git
├─ node-fetch@1.6.3
│  ├─ License: MIT
│  └─ URL: https://github.com/bitinn/node-fetch.git
├─ object-assign@4.1.1
│  ├─ License: MIT
│  └─ URL: https://github.com/sindresorhus/object-assign.git
├─ promise@7.1.1
│  ├─ License: MIT
│  └─ URL: https://github.com/then/promise.git
├─ react@15.4.2
│  ├─ License: BSD-3-Clause
│  └─ URL: https://github.com/facebook/react.git
├─ setimmediate@1.0.5
│  ├─ License: MIT
│  └─ URL: https://github.com/YuzuJS/setImmediate.git
├─ ua-parser-js@0.7.12
│  ├─ License: (GPL-2.0 OR MIT)
│  └─ URL: https://github.com/faisalman/ua-parser-js.git
└─ whatwg-fetch@2.0.3
│  ├─ License: MIT
│  └─ URL: https://github.com/github/fetch.git
✨  Done in 0.22s.
```