### PR TITLE
Specify TCP timeout when downloading packages

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -90,6 +90,7 @@ commander.option(
   'disable progress bar',
 );
 commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
+commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
 commander.option('--non-interactive', 'do not show interactive prompts');
 
 // get command name

--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,7 @@ export type ConfigOptions = {
   production?: boolean,
   binLinks?: boolean,
   networkConcurrency?: number,
+  networkTimeout?: number,
   nonInteractive?: boolean,
 
   // Loosely compare semver for invalid cases like "0.01.0"
@@ -106,6 +107,9 @@ export default class Config {
   constraintResolver: ConstraintResolver;
 
   networkConcurrency: number;
+
+  //
+  networkTimeout: number;
 
   //
   requestManager: RequestManager;
@@ -226,6 +230,12 @@ export default class Config {
       constants.NETWORK_CONCURRENCY
     );
 
+    this.networkTimeout = (
+      opts.networkTimeout ||
+      Number(this.getOption('network-timeout')) ||
+      constants.NETWORK_TIMEOUT
+    );
+
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
       httpProxy: String(opts.httpProxy || this.getOption('proxy') || ''),
@@ -236,6 +246,7 @@ export default class Config {
       cert: String(opts.cert || this.getOption('cert') || ''),
       key: String(opts.key || this.getOption('key') || ''),
       networkConcurrency: this.networkConcurrency,
+      networkTimeout: this.networkTimeout,
     });
     this._cacheRootFolder = String(
       opts.cacheFolder ||

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,9 @@ export const LOCKFILE_VERSION = 1;
 // max amount of network requests to perform concurrently
 export const NETWORK_CONCURRENCY = 8;
 
+// HTTP timeout used when downloading packages
+export const NETWORK_TIMEOUT = 30 * 1000; // in milliseconds
+
 // max amount of child processes to execute concurrently
 export const CHILD_CONCURRENCY = 5;
 

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -43,6 +43,7 @@ type RequestParams<T> = {
   ca?: Array<string>,
   cert?: string,
   networkConcurrency?: number,
+  timeout?: number,
   key?: string,
   forever?: boolean,
   strictSSL?: boolean,
@@ -98,6 +99,7 @@ export default class RequestManager {
   offlineQueue: Array<RequestOptions>;
   queue: Array<Object>;
   max: number;
+  timeout: number;
   cache: {
     [key: string]: Promise<any>
   };
@@ -116,6 +118,7 @@ export default class RequestManager {
     cafile?: string,
     cert?: string,
     networkConcurrency?: number,
+    networkTimeout?: number,
     key?: string,
   }) {
     if (opts.userAgent != null) {
@@ -148,6 +151,10 @@ export default class RequestManager {
 
     if (opts.networkConcurrency != null) {
       this.max = opts.networkConcurrency;
+    }
+
+    if (opts.networkTimeout != null) {
+      this.timeout = opts.networkTimeout;
     }
 
     if (opts.cafile != null && opts.cafile != '') {
@@ -271,6 +278,11 @@ export default class RequestManager {
       return true;
     }
 
+    // TCP timeout
+    if (code === 'ESOCKETTIMEDOUT') {
+      return true;
+    }
+
     return false;
   }
 
@@ -325,7 +337,6 @@ export default class RequestManager {
       rejectNext(err);
     };
 
-    //
     let calledOnError = false;
     const onError = (err) => {
       if (calledOnError) {
@@ -397,6 +408,10 @@ export default class RequestManager {
 
     if (this.key != null) {
       params.key = this.key;
+    }
+
+    if (this.timeout != null) {
+      params.timeout = this.timeout;
     }
 
     const request = this._getRequestModule();


### PR DESCRIPTION
It's been an old and annoying issue: yarn doesn't specify `fetch` timeout when downloading packages, causing `yarn install` to hang forever on network issues.

Steps to reproduce:

1) Install toxiproxy (proxy to simulate network latency [[1]](http://madebymunsters.com/blog/posts/simulating-poor-network-conditions-with-toxiproxy/), [[2]](https://github.com/Shopify/toxiproxy))
2. Configure toxiproxy to simulate the latency:

```
~/.bin/toxiproxy-cli create yarnpkg --listen localhost:8888 -u registry.yarnpkg.com:443
~/.bin/toxiproxy-cli toxic add yarnpkg -t latency -a latency=9000 -a jitter=50
```

3. Point `yarn.lock` to use `localhost:8888` as a host for package registry

4. Run `yarn install` and see the process hanging

***

The issue has been reported multiple times and it's a very easy fix; I'm surprised that I'm the first one to look into it. As mentioned in the `fetch` [documentation](https://github.com/request/request#timeouts), "requests to external servers should have a timeout attached". 

Specifying timeout is a critical thing for distributed software and build tools. Earlier this week we found our build servers hanging on `yarn install` step for 40 minutes until it was hard killed. It took us a while to find that it was a network problem with connectivity between EC2 and `registry.yarnpkg.com`. Having the `fetch` timeout would help us to discover the issue and see the timeout error, as well as not causing build servers to hang until a hard kill.

fixes https://github.com/yarnpkg/yarn/issues/764, https://github.com/yarnpkg/yarn/issues/1289, https://github.com/yarnpkg/yarn/issues/2351

@bestander 