### PR TITLE
yarnrc: respect XDG_CONFIG_HOME setting

### DIFF
--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -46,7 +46,11 @@ export default class YarnRegistry extends NpmRegistry {
   constructor(cwd: string, registries: ConfigRegistries, requestManager: RequestManager) {
     super(cwd, registries, requestManager);
 
-    this.homeConfigLoc = path.join(userHome, '.yarnrc');
+    if (process.env.XDG_CONFIG_HOME) {
+      this.homeConfigLoc = path.join(process.env.XDG_CONFIG_HOME, '.yarnrc');
+    } else {
+      this.homeConfigLoc = path.join(userHome, '.yarnrc');
+    }
     this.homeConfig = {};
   }
 


### PR DESCRIPTION
If a user has a XDG_CONFIG_HOME environment variable, read and write
the yarnrc file from XDG_CONFIG_HOME/.yarnrc, not from $HOME/.yarnrc.

The specification can be found here:
https://wiki.archlinux.org/index.php/XDG_Base_Directory_support

Fixes #2334.