### PR TITLE
Use gunzip-maybe instead of reimplementing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "death": "^1.0.0",
     "debug": "^2.2.0",
     "detect-indent": "^5.0.0",
+    "gunzip-maybe": "^1.4.0",
     "ini": "^1.3.4",
     "inquirer": "^3.0.1",
     "invariant": "^2.2.0",

--- a/src/util/stream.js
+++ b/src/util/stream.js
@@ -2,59 +2,6 @@
 
 const invariant = require('invariant');
 const stream = require('stream');
-const zlib = require('zlib');
-
-function hasGzipHeader(chunk: Buffer): boolean {
-  return chunk[0] === 0x1F && chunk[1] === 0x8B && chunk[2] === 0x08;
-}
-
-type UnpackOptions = duplexStreamOptions;
-
-export class UnpackStream extends stream.Transform {
-  constructor(options?: UnpackOptions) {
-    super(options);
-    this._srcStream = null;
-    this._readHeader = false;
-    this.once('pipe', (src: stream.Readable) => {
-      this._srcStream = src;
-    });
-  }
-
-  _srcStream: ?stream.Readable;
-  _readHeader: boolean;
-
-  _transform(
-    chunk: Buffer | string,
-    encoding: string,
-    callback: (error: ?Error, data?: Buffer | string) => void,
-  ) {
-    if (!this._readHeader) {
-      this._readHeader = true;
-      invariant(chunk instanceof Buffer, 'Chunk must be a buffer');
-      if (hasGzipHeader(chunk)) {
-        // Stop receiving data from the src stream, and pipe it instead to zlib,
-        // then pipe it's output through us.
-        const unzipStream = zlib.createUnzip();
-        unzipStream.on('error', (err) => this.emit('error', err));
-
-        const srcStream = this._srcStream;
-        invariant(srcStream, 'How? To get here a stream must have been piped!');
-        srcStream
-          .pipe(unzipStream)
-          .pipe(this);
-
-        // Unpipe after another stream has been piped so it's always piping to
-        // something, thus avoiding pausing it.
-        srcStream.unpipe(this);
-        unzipStream.write(chunk);
-        this._srcStream = null;
-        callback();
-        return;
-      }
-    }
-    callback(null, chunk);
-  }
-}
 
 export class ConcatStream extends stream.Transform {
   constructor(done: (buf: Buffer) => void) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,7 +1347,7 @@ duplexer2@0.0.2:
   dependencies:
     readable-stream "~1.1.9"
 
-duplexify@^3.5.0:
+duplexify@^3.1.2, duplexify@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.0.tgz#1aa773002e1578457e9d9d4a50b0ccaaebcbd604"
   dependencies:
@@ -2161,6 +2161,17 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
+gunzip-maybe@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz#7d8316c8d0571e1d08a5a79e46fff0afe8172b19"
+  dependencies:
+    browserify-zlib "^0.1.4"
+    is-deflate "^1.0.0"
+    is-gzip "^1.0.0"
+    peek-stream "^1.1.0"
+    pumpify "^1.3.3"
+    through2 "^2.0.3"
+
 handlebars@^4.0.3:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
@@ -2390,6 +2401,10 @@ is-ci@^1.0.10, is-ci@^1.0.9:
   dependencies:
     ci-info "^1.0.0"
 
+is-deflate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-deflate/-/is-deflate-1.0.0.tgz#c862901c3c161fb09dac7cdc7e784f80e98f2f14"
+
 is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
@@ -2439,6 +2454,10 @@ is-glob@^3.1.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-gzip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
 
 is-my-json-valid@^2.10.0:
   version "2.16.0"
@@ -3598,6 +3617,13 @@ pbkdf2@^3.0.3:
   dependencies:
     create-hmac "^1.1.2"
 
+peek-stream@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.2.tgz#97eb76365bcfd8c89e287f55c8b69d4c3e9bcc52"
+  dependencies:
+    duplexify "^3.5.0"
+    through2 "^2.0.3"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -3687,6 +3713,14 @@ pump@^1.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.3.5.tgz#1b671c619940abcaeac0ad0e3a3c164be760993b"
+  dependencies:
+    duplexify "^3.1.2"
+    inherits "^2.0.1"
+    pump "^1.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -4360,7 +4394,7 @@ throat@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
 
-through2@2.X, through2@^2, through2@^2.0.0, through2@^2.0.1:
+through2@2.X, through2@^2, through2@^2.0.0, through2@^2.0.1, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:


### PR DESCRIPTION
**Summary**

Following the PR to use `tar-fs` (#2826), I was looking at ways to solve #2629, and noticed that yarn had its own ad-hoc implementation of gunzipping the archives while there exists an available implementation already, by the same person who made `tar-fs`.

Even though it does not improve the situation for #2629 (of course), I thought it would make sense to use an existing library instead of an adhoc implementation.

**Test plan**

I ran `yarn` in a project with lots of dependencies, no `node_modules` and an empty cache.
I used the default network concurrency of 8.
Everything worked as expected.