### PR TITLE
Remove fallback npmjs.org auth data

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -172,28 +172,12 @@ export default class NpmRegistry extends Registry {
       return this.token;
     }
 
-    for (let registry of [this.getRegistry(packageName), '', DEFAULT_REGISTRY]) {
-      registry = registry.replace(/^https?:/, '');
+    const registry = this.getRegistry(packageName).replace(/^https?:/, '');
 
-      // Check for bearer token.
-      let auth = this.getScopedOption(registry.replace(/\/?$/, '/'), '_authToken');
-      if (auth) {
-        return `Bearer ${String(auth)}`;
-      }
-
-      // Check for basic auth token.
-      auth = this.getScopedOption(registry, '_auth');
-      if (auth) {
-        return `Basic ${String(auth)}`;
-      }
-
-      // Check for basic username/password auth.
-      const username = this.getScopedOption(registry, 'username');
-      const password = this.getScopedOption(registry, '_password');
-      if (username && password) {
-        const pw = new Buffer(String(password), 'base64').toString();
-        return 'Basic ' + new Buffer(String(username) + ':' + pw).toString('base64');
-      }
+    // Check for bearer token.
+    const auth = this.getScopedOption(registry.replace(/\/?$/, '/'), '_authToken');
+    if (auth) {
+      return `Bearer ${String(auth)}`;
     }
 
     return '';


### PR DESCRIPTION
**Problem**

The current behaviour is that for scoped packages (`@<scope>/<pkgName>`) yarn always sends an authentication to the registry. This was introduced in #1146 in order to support private packages on npmjs.org
When a user is loggedin on the cli to npmjs.org and has configured a different pirvate registry, which in most cases is a proxy to npmjs.org, yarn still sends the npmjs.org auth data to the private registry, making the private-registry fail as it does not know anything about npmjs.org credentials.

**Summary**

The technical reason this happens is that because of the changes in #1146 the flag ‘always-auth’ is set to true for scoped packages (which is actually fine I think), but the method to retrieve the authToken/credentials has a fallback to npmjs.org auth data.
https://github.com/yarnpkg/yarn/blob/master/src/registries/npm-registry.js#L175
The fix was simply to remove all fallbacks from getAuth().
Imho the Fallback to npmjs.org-credentials should never happen, as yarn should never ever send credentials from npmjs.org to any other API besides npmjs.org.
The fallback to `''` is most probably in there with old npm clients which were storing credentials without a registry-scope in the config. I couldn't find where `--registry` was added but it was already available in 1.4.

By looking at it I saw that it still supports insecure plaintext basic auth which is a feature from npm <= 1.4, so I took the risk and removed it. Neither npm >= 2 or yarn do save basic auth data anymore and npm 2 was released in 2014. (`_token` is also dropped in npm@5)

**Test plan**

I could add some unit-tests for npm-registry, though the critical part would more be to do integration tests.
But I wait for initial feedback before writing tests.

Fixes #2953 #2151 