### PR TITLE
Supports public and private git repos when using shorted repo syntax

### DIFF
--- a/__tests__/resolvers/exotics/bitbucket-resolver.js
+++ b/__tests__/resolvers/exotics/bitbucket-resolver.js
@@ -76,14 +76,25 @@ test('getTarballUrl should return the correct bitbucket tarball url', () => {
   expect(BitBucketResolver.getTarballUrl(fragment, hash)).toBe(expected);
 });
 
-test('getGitHTTPUrl should return the correct git bitbucket url', () => {
+test('getGitHTTPBaseUrl should return the correct git bitbucket base url', () => {
   const fragment: ExplodedFragment = {
     user: 'foo',
     repo: 'bar',
     hash: '',
   };
 
-  const expected =  _bitBucketBase + fragment.user + '/' + fragment.repo + '.git';
+  const expected =  _bitBucketBase + fragment.user + '/' + fragment.repo;
+  expect(BitBucketResolver.getGitHTTPBaseUrl(fragment)).toBe(expected);
+});
+
+test('getGitHTTPUrl should append ".git" to the HTTP base URL', () => {
+  const fragment: ExplodedFragment = {
+    user: 'foo',
+    repo: 'bar',
+    hash: '',
+  };
+
+  const expected =  BitBucketResolver.getGitHTTPBaseUrl(fragment) + '.git';
   expect(BitBucketResolver.getGitHTTPUrl(fragment)).toBe(expected);
 });
 

--- a/__tests__/resolvers/exotics/github-resolver.js
+++ b/__tests__/resolvers/exotics/github-resolver.js
@@ -27,15 +27,26 @@ test('getGitSSHUrl with no hash', () => {
   expect(gitSSHUrl).toContain('some-user');
 });
 
-test('getGitHTTPUrl should return the correct git github SSH url', () => {
+test('getGitHTTPBaseUrl should return the correct git github HTTP base url', () => {
   const fragment: ExplodedFragment = {
     user: 'foo',
     repo: 'bar',
     hash: '',
   };
 
-  const expected =  'git+ssh://git@github.com/' + fragment.user + '/' + fragment.repo + '.git';
-  expect(GitHubResolver.getGitSSHUrl(fragment)).toBe(expected);
+  const expected =  'https://github.com/' + fragment.user + '/' + fragment.repo;
+  expect(GitHubResolver.getGitHTTPBaseUrl(fragment)).toBe(expected);
+});
+
+test('getGitHTTPUrl should append ".git" to the HTTP base URL', () => {
+  const fragment: ExplodedFragment = {
+    user: 'foo',
+    repo: 'bar',
+    hash: '',
+  };
+
+  const expected =  GitHubResolver.getGitHTTPBaseUrl(fragment) + '.git';
+  expect(GitHubResolver.getGitHTTPUrl(fragment)).toBe(expected);
 });
 
 test('getGitSSHUrl should return URL containing protocol', () => {

--- a/__tests__/resolvers/exotics/gitlab-resolver.js
+++ b/__tests__/resolvers/exotics/gitlab-resolver.js
@@ -27,15 +27,26 @@ test('getGitSSHUrl with no hash', () => {
   expect(gitSSHUrl).toContain('some-user');
 });
 
-test('getGitHTTPUrl should return the correct git gitlab SSH url', () => {
+test('getGitHTTPBaseUrl should return the correct git gitlab HTTP base url', () => {
   const fragment: ExplodedFragment = {
     user: 'foo',
     repo: 'bar',
     hash: '',
   };
 
-  const expected =  'git+ssh://git@gitlab.com/' + fragment.user + '/' + fragment.repo + '.git';
-  expect(GitLabResolver.getGitSSHUrl(fragment)).toBe(expected);
+  const expected =  'https://gitlab.com/' + fragment.user + '/' + fragment.repo;
+  expect(GitLabResolver.getGitHTTPBaseUrl(fragment)).toBe(expected);
+});
+
+test('getGitHTTPUrl should append ".git" to the HTTP base URL', () => {
+  const fragment: ExplodedFragment = {
+    user: 'foo',
+    repo: 'bar',
+    hash: '',
+  };
+
+  const expected =  GitLabResolver.getGitHTTPBaseUrl(fragment) + '.git';
+  expect(GitLabResolver.getGitHTTPUrl(fragment)).toBe(expected);
 });
 
 test('getGitSSHUrl should return URL containing protocol', () => {

--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -11,8 +11,12 @@ export default class BitbucketResolver extends HostedGitResolver {
     return `https://${this.hostname}/${parts.user}/${parts.repo}/get/${hash}.tar.gz`;
   }
 
+  static getGitHTTPBaseUrl(parts: ExplodedFragment): string {
+    return `https://${this.hostname}/${parts.user}/${parts.repo}`;
+  }
+
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
+    return `${BitbucketResolver.getGitHTTPBaseUrl(parts)}.git`;
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {

--- a/src/resolvers/exotics/github-resolver.js
+++ b/src/resolvers/exotics/github-resolver.js
@@ -30,8 +30,12 @@ export default class GitHubResolver extends HostedGitResolver {
       `${parts.hash ? '#' + decodeURIComponent(parts.hash) : ''}`;
   }
 
+  static getGitHTTPBaseUrl(parts: ExplodedFragment): string {
+    return `https://${this.hostname}/${parts.user}/${parts.repo}`;
+  }
+
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
+    return `${GitHubResolver.getGitHTTPBaseUrl(parts)}.git`;
   }
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {

--- a/src/resolvers/exotics/gitlab-resolver.js
+++ b/src/resolvers/exotics/gitlab-resolver.js
@@ -11,8 +11,12 @@ export default class GitLabResolver extends HostedGitResolver {
     return `https://${this.hostname}/${parts.user}/${parts.repo}/repository/archive.tar.gz?ref=${hash}`;
   }
 
+  static getGitHTTPBaseUrl(parts: ExplodedFragment): string {
+    return `https://${this.hostname}/${parts.user}/${parts.repo}`;
+  }
+
   static getGitHTTPUrl(parts: ExplodedFragment): string {
-    return `https://${this.hostname}/${parts.user}/${parts.repo}.git`;
+    return `${GitLabResolver.getGitHTTPBaseUrl(parts)}.git`;
   }
 
   static getGitSSHUrl(parts: ExplodedFragment): string {

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -91,6 +91,11 @@ export default class HostedGitResolver extends ExoticResolver {
     throw new Error('Not implemented');
   }
 
+  static getGitHTTPBaseUrl(exploded: ExplodedFragment): string {
+    exploded;
+    throw new Error('Not implemented');
+  }
+
   static getGitSSHUrl(exploded: ExplodedFragment): string {
     exploded;
     throw new Error('Not implemented');
@@ -196,12 +201,13 @@ export default class HostedGitResolver extends ExoticResolver {
 
   async resolve(): Promise<Manifest> {
     const httpUrl = this.constructor.getGitHTTPUrl(this.exploded);
+    const httpBaseUrl = this.constructor.getGitHTTPBaseUrl(this.exploded);
     const sshUrl = this.constructor.getGitSSHUrl(this.exploded);
 
     // If we can access the files over HTTP then we should as it's MUCH faster than git
     // archive and tarball unarchiving. The HTTP API is only available for public repos
     // though.
-    if (await this.hasHTTPCapability(httpUrl)) {
+    if (await this.hasHTTPCapability(httpBaseUrl)) {
       return await this.resolveOverHTTP(httpUrl);
     }
 


### PR DESCRIPTION
**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using the shortened git syntax such as `github:thedumbterminal/grunt-gemnasium#vx`, yarn tests for HTTP access using a generated URL ending in `.git` this will always return a `301` status even if the user does not have permission to access the repo (private repos would require auth first).

This change now uses a full git URL which does not end in `.git` this means that private repos will fail with `404` so then SSH auth is attempted instead, as long as the correct SSH keys are setup in the users terminal access to the private repo will succeed.

Addresses existing issue: https://github.com/yarnpkg/yarn/issues/2774

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added new unit tests for the new `getGitHTTPBaseUrl` method.

This can be manually tested in the following way:

1. Create a new nam project with: `mkdir /tmp/example; cd /tmp/example; npm init -y`
1. Update package.json to add a public repo to dependencies manually in the format of `"grunt-gemnasium": "github:thedumbterminal/grunt-gemnasium#v1.1.1"`
1. Update package.json to add a private repo to dependencies manually in the same format, (make sure you can only access it via SSH creds).
1. Run: `yarn --verbose`, both modules should be installed.