### PR TITLE
Add verbose build log

### DIFF
--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -101,7 +101,8 @@ export default class PackageInstallScripts {
 
     try {
       for (const [stage, cmd] of cmds) {
-        await executeLifecycleScript(stage, this.config, loc, cmd, spinner);
+        const {stdout} = await executeLifecycleScript(stage, this.config, loc, cmd, spinner);
+        this.reporter.verbose(stdout);
       }
     } catch (err) {
       err.message = `${loc}: ${err.message}`;


### PR DESCRIPTION
**Summary**

Outputs build log when using `--verbose` flag as discussed in #2204.

**Test plan**

None! =) I couldn't find a single test for `PackageInstallScripts`, so this change is untested. If that's a deal breaker or an oversight on my part I'll update this PR.