### PR TITLE
Lock to minor version 1.1.x of request-capture-har

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "proper-lockfile": "^2.0.0",
     "read": "^1.0.7",
     "request": "^2.75.0",
-    "request-capture-har": "^1.1.4",
+    "request-capture-har": "~1.1.4",
     "rimraf": "^2.5.0",
     "roadrunner": "^1.1.0",
     "semver": "^5.1.0",


### PR DESCRIPTION
request-capture-har 1.2.1 introduced es6 syntax, which breaks yarn install on node 4.x, which is a wide deployment base especially for aws lambda

Closes #2996

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
