### PR TITLE
Resolve Git dependencies offline if tarball is available.

### DIFF
--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -15,7 +15,7 @@ export type ExplodedFragment = {
   hash: string,
 };
 
-export function explodeHostedGitFragment(fragment: string, reporter: Reporter): ExplodedFragment {  
+export function explodeHostedGitFragment(fragment: string, reporter: Reporter): ExplodedFragment {
 
   const preParts = fragment.split('@');
   if (preParts.length > 2) {
@@ -39,7 +39,7 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
     throw new MessageError(reporter.lang('invalidHostedGitFragment', fragment));
   }
 
-  const userParts = fragment.split('/');  
+  const userParts = fragment.split('/');
 
   if (userParts.length >= 2) {
 
@@ -140,11 +140,6 @@ export default class HostedGitResolver extends ExoticResolver {
   }
 
   async resolveOverHTTP(url: string): Promise<Manifest> {
-    const shrunk = this.request.getLocked('tarball');
-    if (shrunk) {
-      return shrunk;
-    }
-
     const commit = await this.getRefOverHTTP(url);
     const {config} = this;
 
@@ -201,6 +196,12 @@ export default class HostedGitResolver extends ExoticResolver {
   }
 
   async resolve(): Promise<Manifest> {
+    // If we already have the tarball, just return it without having to make any HTTP requests.
+    const shrunk = this.request.getLocked('tarball');
+    if (shrunk) {
+      return shrunk;
+    }
+
     const httpUrl = this.constructor.getGitHTTPUrl(this.exploded);
     const httpBaseUrl = this.constructor.getGitHTTPBaseUrl(this.exploded);
     const sshUrl = this.constructor.getGitSSHUrl(this.exploded);


### PR DESCRIPTION
**Summary**

When running yarn offline, Git dependencies get trapped in `hasHTTPCapability` even though `resolveOverHTTP` defaults to returning the tarball. This change allows us to bypass that step altogether if the tarball already exists.

Resolves #1925.

**Test plan**

Create a `package.json` with a Git dependency, like:
```
"nomnom": "douglasduteil/nomnom#next"
```

Then:

```
yarn
rm -r node_modules
yarn --offline
```

This should fail prior to this commit, but succeed after.

This change was first proposed in #2705, but @chrisgavin closed the PR and hasn't had a chance to revisit. I'm happy to add unit tests if/as needed, but may need some guidance on mocking offline functionality.