### PR TITLE
Update to v8-compile-cache@^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "strip-bom": "^3.0.0",
     "tar-fs": "^1.15.1",
     "tar-stream": "^1.5.2",
-    "v8-compile-cache": "^1.0.0",
+    "v8-compile-cache": "^1.1.0",
     "validate-npm-package-license": "^3.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4518,9 +4518,9 @@ uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-v8-compile-cache@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.0.0.tgz#56c809189daa8289a7d049354f61ab9c347f1fc2"
+v8-compile-cache@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.0.tgz#1dc2a340fb8e5f800a32bcdbfb8c23cd747021b9"
 
 v8flags@^2.0.2:
   version "2.0.11"


### PR DESCRIPTION
**Summary**

This version fixes a cache permissions issue. See https://github.com/zertosh/v8-compile-cache/issues/2.

**Test plan**

Tested yarn on a shared Linux box as multiple users.

cc: @Kovensky