### PR TITLE
Adds prepare & prepublishOnly lifecycle hooks

### DIFF
--- a/__tests__/fixtures/lifecycle-scripts/lifecycle-scripts/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/lifecycle-scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "lifecycle-scripts",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "prepublish": "echo running the prepublish hook",
+    "prepublishOnly": "echo running the prepublishOnly hook",
+    "prepare": "echo running the prepare hook"
+  }
+}

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -74,3 +74,12 @@ test('should only expose non-internal configs', async () => {
     expect(val).toBeDefined();
   });
 });
+
+test('should run both prepublish and prepare when installing, but not prepublishOnly', async () => {
+  let stdout = await execCommand('install', 'lifecycle-scripts');
+
+  expect(stdout).toMatch(/^running the prepublish hook$/m);
+  expect(stdout).toMatch(/^running the prepare hook$/m);
+
+  expect(stdout).not.toMatch(/^running the prepublishOnly hook$/m);
+});

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -784,5 +784,6 @@ export async function wrapLifecycle(config: Config, flags: Object, factory: () =
 
   if (!config.production) {
     await config.executeLifecycleScript('prepublish');
+    await config.executeLifecycleScript('prepare');
   }
 }

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -63,6 +63,8 @@ async function publish(
 
   // TODO this might modify package.json, do we need to reload it?
   await config.executeLifecycleScript('prepublish');
+  await config.executeLifecycleScript('prepublishOnly');
+  await config.executeLifecycleScript('prepare');
 
   // create body
   const root = {


### PR DESCRIPTION
**Summary**

This PR is a followup to #1499. We wish to add support for both `prepare` and `prepublishOnly` but aren't yet sure about the versioning we'd like Yarn to follow, so we preferred to remove the warning for the time being.

**Test plan**

I've added some tests on `yarn install` to check that the lifecycle hooks are correctly called, by I'm not sure it will be possible on `yarn publish`.