### PR TITLE
Replaces assert w/ expect

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -10,7 +10,6 @@ import {Install} from '../../src/cli/commands/install.js';
 import Lockfile from '../../src/lockfile/wrapper.js';
 import {run as check} from '../../src/cli/commands/check.js';
 import * as fs from '../../src/util/fs.js';
-import assert from 'assert';
 import semver from 'semver';
 import {promisify} from '../../src/util/promise';
 import fsNode from 'fs';
@@ -48,9 +47,9 @@ test.concurrent('install with --dev flag', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('left-pad@1.1.0:') === 0);
-    assert.deepEqual(pkg.devDependencies, {'left-pad': '1.1.0'});
-    assert.deepEqual(pkg.dependencies, {});
+    expect(lockfile.indexOf('left-pad@1.1.0:')).toEqual(0);
+    expect(pkg.devDependencies).toEqual({'left-pad': '1.1.0'});
+    expect(pkg.dependencies).toEqual({});
   });
 });
 
@@ -59,9 +58,9 @@ test.concurrent('install with --peer flag', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('left-pad@1.1.0:') === 0);
-    assert.deepEqual(pkg.peerDependencies, {'left-pad': '1.1.0'});
-    assert.deepEqual(pkg.dependencies, {});
+    expect(lockfile.indexOf('left-pad@1.1.0:')).toEqual(0);
+    expect(pkg.peerDependencies).toEqual({'left-pad': '1.1.0'});
+    expect(pkg.dependencies).toEqual({});
   });
 });
 
@@ -70,9 +69,9 @@ test.concurrent('install with --optional flag', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('left-pad@1.1.0:') === 0);
-    assert.deepEqual(pkg.optionalDependencies, {'left-pad': '1.1.0'});
-    assert.deepEqual(pkg.dependencies, {});
+    expect(lockfile.indexOf('left-pad@1.1.0:')).toEqual(0);
+    expect(pkg.optionalDependencies).toEqual({'left-pad': '1.1.0'});
+    expect(pkg.dependencies).toEqual({});
   });
 });
 
@@ -82,7 +81,7 @@ test.concurrent('install with arg that has binaries', (): Promise<void> => {
 
 test.concurrent('add with no manifest creates blank manifest', (): Promise<void> => {
   return runAdd(['lodash'], {}, 'add-with-no-manifest', async (config) => {
-    assert.ok(await fs.exists(path.join(config.cwd, 'package.json')));
+    expect(await fs.exists(path.join(config.cwd, 'package.json'))).toBe(true);
   });
 });
 
@@ -92,36 +91,32 @@ test.concurrent('add should ignore cache', (): Promise<void> => {
   // files in mirror, yarn.lock, package.json and node_modules should reflect that
 
   return runAdd(['left-pad@1.1.0'], {}, 'install-save-to-mirror-when-cached', async (config, reporter) => {
-    assert.equal(
-      await getPackageVersion(config, 'left-pad'),
-      '1.1.0',
-    );
+    expect(await getPackageVersion(config, 'left-pad')).toEqual('1.1.0');
 
     const lockfile = await createLockfile(config.cwd);
+
     const install = new Add(['left-pad@1.1.0'], {}, config, reporter, lockfile);
     await install.init();
-    assert.equal(
-      await getPackageVersion(config, 'left-pad'),
-      '1.1.0',
-    );
-    assert.deepEqual(
+
+    expect(await getPackageVersion(config, 'left-pad')).toEqual('1.1.0');
+
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {'left-pad': '1.1.0'},
-    );
+    ).toEqual({
+      'left-pad': '1.1.0',
+    });
 
     const mirror = await fs.walk(path.join(config.cwd, 'mirror-for-offline'));
-    assert.equal(mirror.length, 1);
-    assert.equal(mirror[0].relative, 'left-pad-1.1.0.tgz');
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].relative).toEqual('left-pad-1.1.0.tgz');
 
     const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileWritten);
-
-    assert.equal(lockFileLines.length, 3);
-
-    assert.equal(lockFileLines[0], 'left-pad@1.1.0:');
-    assert.ok(lockFileLines[2].match(
+    expect(lockFileLines).toHaveLength(3);
+    expect(lockFileLines[0]).toEqual('left-pad@1.1.0:');
+    expect(lockFileLines[2]).toMatch(
       /resolved "https:\/\/registry\.yarnpkg\.com\/left-pad\/-\/left-pad-1\.1\.0\.tgz#[a-f0-9]+"/,
-    ));
+    );
   });
 });
 
@@ -129,14 +124,13 @@ test.concurrent('add should not make package.json strict', (): Promise<void> => 
   return runAdd(['left-pad@^1.1.0'], {}, 'install-no-strict', async (config) => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
 
-    assert(lockfile.indexOf('left-pad@^1.1.0:') >= 0);
-    assert.deepEqual(
+    expect(lockfile.indexOf('left-pad@^1.1.0:')).toBeGreaterThanOrEqual(0);
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {
-        'left-pad': '^1.1.0',
-        'mime-types': '^2.0.0',
-      },
-    );
+    ).toEqual({
+      'left-pad': '^1.1.0',
+      'mime-types': '^2.0.0',
+    });
   });
 });
 
@@ -144,14 +138,13 @@ test.concurrent('add --save-exact should not make all package.json strict', (): 
   return runAdd(['left-pad@1.1.0'], {saveExact: true}, 'install-no-strict-all', async (config) => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
 
-    assert(lockfile.indexOf('left-pad@1.1.0:') === 0);
-    assert.deepEqual(
+    expect(lockfile.indexOf('left-pad@1.1.0:')).toEqual(0);
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {
-        'left-pad': '1.1.0',
-        'mime-types': '^2.0.0',
-      },
-    );
+    ).toEqual({
+      'left-pad': '1.1.0',
+      'mime-types': '^2.0.0',
+    });
   });
 });
 
@@ -183,19 +176,19 @@ test.concurrent('install --initMirror should add init mirror deps from package.j
 
   // initMirror gets converted to save flag in cli/install.js
   return runAdd([], {}, fixture, async (config) => {
-    assert.equal(await getPackageVersion(config, 'mime-types'), '2.0.0');
-    assert(semver.satisfies(await getPackageVersion(config, 'mime-db'), '~1.0.1'));
+    expect(await getPackageVersion(config, 'mime-types')).toEqual('2.0.0');
+    expect(semver.satisfies(await getPackageVersion(config, 'mime-db'), '~1.0.1')).toEqual(true);
 
     const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-    assert.equal(mirror.length, 2);
-    assert.equal(mirror[0].relative.indexOf('mime-db-1.0.'), 0);
-    assert.equal(mirror[1].relative, 'mime-types-2.0.0.tgz');
+    expect(mirror).toHaveLength(2);
+    expect(mirror[0].relative.indexOf('mime-db-1.0.')).toEqual(0);
+    expect(mirror[1].relative).toEqual('mime-types-2.0.0.tgz');
 
     const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileContent);
-    assert.equal(lockFileLines.length, 8);
-    assert.equal(lockFileLines[0].indexOf('mime-db@'), 0);
-    assert.equal(lockFileLines[3].indexOf('mime-types@2.0.0'), 0);
+    expect(lockFileLines).toHaveLength(8);
+    expect(lockFileLines[0].indexOf('mime-db@')).toEqual(0);
+    expect(lockFileLines[3].indexOf('mime-types@2.0.0')).toEqual(0);
   });
 });
 
@@ -207,46 +200,45 @@ test.concurrent('add with new dependency should be deterministic', (): Promise<v
   const fixture = 'install-deterministic';
 
   return runInstall({}, path.join('..', 'add', fixture), async (config): Promise<void> => {
-    assert(semver.satisfies(
-      await getPackageVersion(config, 'mime-db'),
-      '~1.0.1'),
-    );
-    assert.equal(
-      await getPackageVersion(config, 'mime-types'),
-      '2.0.0',
-    );
+    expect(semver.satisfies(await getPackageVersion(config, 'mime-db'), '~1.0.1')).toBe(true);
+    expect(await getPackageVersion(config, 'mime-types')).toEqual('2.0.0');
 
     return runAdd(['mime-db@1.23.0'], {}, fixture, async (config) => {
-      assert(semver.satisfies(
-        await getPackageVersion(config, 'mime-db'),
+      expect(
+        semver.satisfies(await getPackageVersion(config, 'mime-db'),
         '1.23.0',
-      ));
-      assert.equal(
+      )).toEqual(true);
+
+      expect(
         await getPackageVersion(config, 'mime-types'),
+      ).toEqual(
         '2.0.0',
       );
-      assert.equal(
+
+      expect(
         await getPackageVersion(config, 'mime-types/mime-db'),
+      ).toEqual(
         '1.0.3',
       );
-      assert.deepEqual(
-        JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies, {
-          'mime-types': '2.0.0',
-          'mime-db': '1.23.0',
-        },
-      );
+
+      expect(
+        JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
+      ).toEqual({
+        'mime-types': '2.0.0',
+        'mime-db': '1.23.0',
+      });
 
       const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
       const lockFileLines = explodeLockfile(lockFileWritten);
-      assert.equal(lockFileLines.length, 11);
-      assert(lockFileLines.indexOf('mime-db@~1.0.1:') >= 0);
-      assert(lockFileLines.indexOf('mime-db@1.23.0:') >= 0);
-      assert(lockFileLines.indexOf('mime-types@2.0.0:') >= 0);
 
+      expect(lockFileLines).toHaveLength(11);
+      expect(lockFileLines.indexOf('mime-db@~1.0.1:')).toBeGreaterThanOrEqual(0);
+      expect(lockFileLines.indexOf('mime-db@1.23.0:')).toBeGreaterThanOrEqual(0);
+      expect(lockFileLines.indexOf('mime-types@2.0.0:')).toBeGreaterThanOrEqual(0);
 
       const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-      assert.equal(mirror.length, 3);
-      assert.equal(mirror[1].relative, 'mime-db-1.23.0.tgz');
+      expect(mirror).toHaveLength(3);
+      expect(mirror[1].relative).toEqual('mime-db-1.23.0.tgz');
     });
   });
 });
@@ -259,40 +251,48 @@ test.concurrent('add with new dependency should be deterministic 2', (): Promise
   const fixture = 'install-deterministic-2';
 
   return runInstall({}, path.join('..', 'add', fixture), async (config): Promise<void> => {
-    assert.equal(
+    expect(
       await getPackageVersion(config, 'mime-db'),
+    ).toEqual(
       '1.0.1',
     );
-    assert.equal(
+
+    expect(
       await getPackageVersion(config, 'mime-types'),
+    ).toEqual(
       '2.0.0',
     );
 
     return runAdd(['mime-db@1.0.3'], {}, fixture, async (config) => {
-      assert.equal(
+      expect(
         await getPackageVersion(config, 'mime-db'),
+      ).toEqual(
         '1.0.3',
       );
-      assert.equal(
+
+      expect(
         await getPackageVersion(config, 'mime-types'),
+      ).toEqual(
         '2.0.0',
       );
-      assert(!await fs.exists(path.join(config.cwd, 'node_modules/mime-types/node-modules/mime-db')));
-      assert.deepEqual(
-        JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies, {
-          'mime-types': '2.0.0',
-          'mime-db': '1.0.3',
-        },
-      );
+
+      expect(await fs.exists(path.join(config.cwd, 'node_modules/mime-types/node-modules/mime-db'))).toEqual(false);
+
+      expect(
+        JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
+      ).toEqual({
+        'mime-types': '2.0.0',
+        'mime-db': '1.0.3',
+      });
 
       const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
       const lockFileLines = explodeLockfile(lockFileWritten);
       // see why we don't cleanup lockfile https://github.com/yarnpkg/yarn/issues/79
-      assert.equal(lockFileLines.length, 11);
+      expect(lockFileLines).toHaveLength(11);
 
       const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-      assert.equal(mirror.length, 3);
-      assert.equal(mirror[1].relative, 'mime-db-1.0.3.tgz');
+      expect(mirror).toHaveLength(3);
+      expect(mirror[1].relative).toEqual('mime-db-1.0.3.tgz');
     });
   });
 });
@@ -302,14 +302,16 @@ test.concurrent('add with offline mirror', (): Promise<void> => {
   return runAdd(['is-array@^1.0.1'], {}, 'install-with-save-offline-mirror', async (config) => {
     const allFiles = await fs.walk(config.cwd);
 
-    assert(allFiles.findIndex((file): boolean => {
+    expect(allFiles.findIndex((file): boolean => {
       return file.relative === path.join(mirrorPath, 'is-array-1.0.1.tgz');
-    }) !== -1);
+    })).toBeGreaterThanOrEqual(0);
 
     const rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
     const lockfile = parse(rawLockfile);
-    assert.equal(
+
+    expect(
       lockfile['is-array@^1.0.1']['resolved'],
+    ).toEqual(
       'https://registry.yarnpkg.com/is-array/-/is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a',
     );
   });
@@ -321,20 +323,22 @@ test.skip('add-then-install git+ssh from offline mirror', () : Promise<void> => 
 
   return runAdd(['mime-db@git+ssh://git@github.com/jshttp/mime-db.git#1.24.0'], {},
   'install-git-ssh-mirror', async (config, reporter) : Promise<void> => {
-    assert(semver.satisfies(
+    expect(semver.satisfies(
       await getPackageVersion(config, 'mime-db'),
-      '1.24.0'),
-    );
+      '1.24.0',
+    )).toEqual(true);
 
     const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-    assert.equal(mirror.length, 1);
+    expect(mirror).toHaveLength(1);
 
-    assert(mirror[0].relative.match(/mime-db\.git.*/));
+    expect(mirror[0].relative).toMatch(/mime-db\.git.*/);
 
     const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileWritten);
     // lock file contains mirror resolved line
-    expect(lockFileLines.find((line) => line.match(/.*resolved mime-db\.git\-.*/))).toBeDefined();
+    expect(lockFileLines.findIndex((line) => {
+      return line.match(/.*resolved mime-db\.git\-.*/);
+    })).toBeGreaterThanOrEqual(0);
 
     // reinstall
     await fs.unlink(path.join(config.cwd, 'node_modules'));
@@ -343,10 +347,10 @@ test.skip('add-then-install git+ssh from offline mirror', () : Promise<void> => 
     const install = new Install({}, config, reporter, new Lockfile());
     await install.init();
 
-    assert(semver.satisfies(
+    expect(semver.satisfies(
       await getPackageVersion(config, 'mime-db'),
-      '1.24.0'),
-    );
+      '1.24.0',
+    )).toEqual(true);
 
     const newLockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const newLockFileLines = explodeLockfile(newLockFileWritten);
@@ -362,16 +366,16 @@ test.concurrent('install with --save and without offline mirror', (): Promise<vo
 
     const allFiles = await fs.walk(config.cwd);
 
-    assert(allFiles.findIndex((file): boolean => {
+    expect(allFiles.findIndex((file): boolean => {
       return file.relative === `${mirrorPath}/is-array-1.0.1.tgz`;
-    }) === -1);
+    })).toEqual(-1);
 
     const rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
     const lockfile = parse(rawLockfile);
 
-    assert(lockfile['is-array@^1.0.1']['resolved'].match(
+    expect(lockfile['is-array@^1.0.1']['resolved']).toMatch(
       /https:\/\/registry\.yarnpkg\.com\/is-array\/-\/is-array-1\.0\.1\.tgz#[a-f0-9]+/,
-    ));
+    );
   });
 });
 
@@ -382,51 +386,57 @@ test.concurrent('upgrade scenario', (): Promise<void> => {
   const mirrorPath = 'mirror-for-offline';
 
   return runAdd(['left-pad@0.0.9'], {}, 'install-upgrade-scenario', async (config, reporter): Promise<void> => {
-    assert.equal(
+    expect(
       await getPackageVersion(config, 'left-pad'),
+    ).toEqual(
       '0.0.9',
     );
-    assert.deepEqual(
+
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {'left-pad': '0.0.9'},
-    );
+    ).toEqual({
+      'left-pad': '0.0.9',
+    });
 
     const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileWritten);
-    assert.equal(lockFileLines[0], 'left-pad@0.0.9:');
-    assert.equal(lockFileLines.length, 3);
-    assert.ok(lockFileLines[2].match(
+    expect(lockFileLines).toHaveLength(3);
+    expect(lockFileLines[0]).toEqual('left-pad@0.0.9:');
+    expect(lockFileLines[2]).toMatch(
       /resolved "https:\/\/registry\.yarnpkg\.com\/left-pad\/-\/left-pad-0\.0\.9\.tgz#[a-f0-9]+"/,
-    ));
+    );
 
     const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-    assert.equal(mirror.length, 1);
-    assert.equal(mirror[0].relative, 'left-pad-0.0.9.tgz');
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].relative).toEqual('left-pad-0.0.9.tgz');
 
     //
     const add = new Add(['left-pad@1.1.0'], {}, config, reporter, await Lockfile.fromDirectory(config.cwd));
     await add.init();
 
-    assert.equal(
+    expect(
       await getPackageVersion(config, 'left-pad'),
+    ).toEqual(
       '1.1.0',
     );
-    assert.deepEqual(
+
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {'left-pad': '1.1.0'},
-    );
+    ).toEqual({
+      'left-pad': '1.1.0',
+    });
 
     const lockFileWritten2 = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines2 = explodeLockfile(lockFileWritten2);
-    assert.equal(lockFileLines2[0], 'left-pad@1.1.0:');
-    assert.equal(lockFileLines2.length, 3);
-    assert.ok(lockFileLines2[2].match(
+    expect(lockFileLines2).toHaveLength(3);
+    expect(lockFileLines2[0]).toEqual('left-pad@1.1.0:');
+    expect(lockFileLines2[2].match(
       /resolved "https:\/\/registry\.yarnpkg\.com\/left-pad\/-\/left-pad-1.1.0.tgz#[a-f0-9]+"/,
     ));
 
     const mirror2 = await fs.walk(path.join(config.cwd, mirrorPath));
-    assert.equal(mirror2.length, 2);
-    assert.equal(mirror2[1].relative, 'left-pad-1.1.0.tgz');
+    expect(mirror2).toHaveLength(2);
+    expect(mirror2[1].relative, 'left-pad-1.1.0.tgz');
   });
 });
 
@@ -438,43 +448,50 @@ test.concurrent('upgrade scenario 2 (with sub dependencies)', (): Promise<void> 
   const fixture = 'install-upgrade-scenario-2';
 
   return runInstall({}, path.join('..', 'add', fixture), async (config): Promise<void> => {
-    assert(semver.satisfies(
+    expect(semver.satisfies(
       await getPackageVersion(config, 'mime-db'),
-      '~1.0.1'),
-    );
-    assert.equal(
+      '~1.0.1',
+    )).toEqual(true);
+
+    expect(
       await getPackageVersion(config, 'mime-types'),
+    ).toEqual(
       '2.0.0',
     );
 
     return runAdd(['mime-types@2.1.11'], {}, fixture, async (config) => {
-      assert(semver.satisfies(
+      expect(semver.satisfies(
         await getPackageVersion(config, 'mime-db'),
         '~1.23.0',
-      ));
-      assert.equal(
+      )).toEqual(true);
+
+      expect(
         await getPackageVersion(config, 'mime-types'),
+      ).toEqual(
         '2.1.11',
       );
 
       const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
       const lockFileLines = explodeLockfile(lockFileWritten);
-      assert.equal(lockFileLines[0], 'mime-db@~1.23.0:');
-      assert.ok(lockFileLines[2].match(
+
+      expect(lockFileLines[0]).toEqual('mime-db@~1.23.0:');
+      expect(lockFileLines[2]).toMatch(
         /resolved "https:\/\/registry\.yarnpkg\.com\/mime-db\/-\/mime-db-/,
-      ));
-      assert.equal(lockFileLines[3], 'mime-types@2.1.11:');
-      assert.ok(lockFileLines[5].match(
+      );
+
+      expect(lockFileLines[3]).toEqual('mime-types@2.1.11:');
+      expect(lockFileLines[5]).toMatch(
         /resolved "https:\/\/registry\.yarnpkg\.com\/mime-types\/-\/mime-types-2\.1\.11\.tgz#[a-f0-9]+"/,
-      ));
+      );
 
       const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-      assert.equal(mirror.length, 4);
+      expect(mirror).toHaveLength(4);
+
       const newFilesInMirror = mirror.filter((elem): boolean => {
         return elem.relative !== 'mime-db-1.0.3.tgz' && elem.relative !== 'mime-types-2.0.0.tgz';
       });
 
-      assert.equal(newFilesInMirror.length, 2);
+      expect(newFilesInMirror).toHaveLength(2);
     });
   });
 });
@@ -484,55 +501,57 @@ test.concurrent('downgrade scenario', (): Promise<void> => {
   // files in mirror, yarn.lock, package.json and node_modules should reflect that
 
   return runAdd(['left-pad@1.1.0'], {}, 'install-downgrade-scenario', async (config, reporter): Promise<void> => {
-    assert.equal(
+    expect(
       await getPackageVersion(config, 'left-pad'),
+    ).toEqual(
       '1.1.0',
     );
-    assert.deepEqual(
+
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {'left-pad': '1.1.0'},
-    );
+    ).toEqual({
+      'left-pad': '1.1.0',
+    });
 
     const mirrorPath = 'mirror-for-offline';
     const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileWritten);
-
-    assert.equal(lockFileLines[0], 'left-pad@1.1.0:');
-    assert.equal(lockFileLines.length, 3);
-    assert.ok(lockFileLines[2].match(
+    expect(lockFileLines).toHaveLength(3);
+    expect(lockFileLines[0]).toEqual('left-pad@1.1.0:');
+    expect(lockFileLines[2]).toMatch(
       /resolved "https:\/\/registry\.yarnpkg\.com\/left-pad\/-\/left-pad-1\.1\.0\.tgz#[a-f0-9]+"/,
-    ));
+    );
 
     const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-    assert.equal(mirror.length, 1);
-    assert.equal(mirror[0].relative, 'left-pad-1.1.0.tgz');
-
-    //
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].relative).toEqual('left-pad-1.1.0.tgz');
 
     const add = new Add(['left-pad@0.0.9'], {},  config, reporter, await Lockfile.fromDirectory(config.cwd));
     await add.init();
 
-    assert.equal(
+    expect(
       await getPackageVersion(config, 'left-pad'),
+    ).toEqual(
       '0.0.9',
     );
-    assert.deepEqual(
+
+    expect(
       JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies,
-      {'left-pad': '0.0.9'},
-    );
+    ).toEqual({
+      'left-pad': '0.0.9',
+    });
 
     const lockFileWritten2 = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines2 = explodeLockfile(lockFileWritten2);
-
-    assert.equal(lockFileLines2[0], 'left-pad@0.0.9:');
-    assert.equal(lockFileLines2.length, 3);
-    assert.ok(lockFileLines2[2].match(
+    expect(lockFileLines2).toHaveLength(3);
+    expect(lockFileLines2[0]).toEqual('left-pad@0.0.9:');
+    expect(lockFileLines2[2]).toMatch(
       /resolved "https:\/\/registry\.yarnpkg\.com\/left-pad\/-\/left-pad-0\.0\.9\.tgz#[a-f0-9]+"/,
-    ));
+    );
 
     const mirror2 = await fs.walk(path.join(config.cwd, mirrorPath));
-    assert.equal(mirror2.length, 2);
-    assert.equal(mirror2[0].relative, 'left-pad-0.0.9.tgz');
+    expect(mirror2).toHaveLength(2);
+    expect(mirror2[0].relative).toEqual('left-pad-0.0.9.tgz');
   });
 });
 
@@ -570,12 +589,13 @@ test.concurrent('add should put a git dependency to mirror', (): Promise<void> =
     {},
     'install-git-mirror',
     async (config, reporter): Promise<void> => {
-      assert(semver.satisfies(
+      expect(semver.satisfies(
         await getPackageVersion(config, 'mime-db'),
-        '1.24.0'),
-      );
+        '1.24.0',
+      )).toEqual(true);
+
       const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
-      assert.equal(mirror.length, 1);
+      expect(mirror).toHaveLength(1);
       expect(mirror[0].relative).toMatch(/mime-db\.git.*/);
 
       const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
@@ -592,10 +612,11 @@ test.concurrent('add should put a git dependency to mirror', (): Promise<void> =
       const install = new Install({}, config, reporter, await Lockfile.fromDirectory(config.cwd));
       await install.init();
 
-      assert(semver.satisfies(
+      expect(semver.satisfies(
         await getPackageVersion(config, 'mime-db'),
-        '1.24.0'),
-      );
+        '1.24.0',
+      )).toEqual(true);
+
       await fs.unlink(path.join(config.cwd, mirrorPath));
       await fs.unlink(path.join(config.cwd, 'package.json'));
     },
@@ -608,9 +629,9 @@ test.concurrent('add should store latest version in lockfile', (): Promise<void>
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
     const version = pkg.dependencies['max-safe-integer'];
-    assert(semver.valid(version.slice(1)));
-    assert(lockfile.indexOf('max-safe-integer:') === -1);
-    assert(lockfile.indexOf(`max-safe-integer@${version}:`) === 0);
+    expect(semver.valid(version.slice(1))).toBeTruthy();
+    expect(lockfile.indexOf('max-safe-integer:')).toEqual(-1);
+    expect(lockfile.indexOf(`max-safe-integer@${version}:`)).toEqual(0);
   });
 });
 
@@ -640,8 +661,8 @@ test.concurrent('add infers line endings from existing win32 manifest file', asy
   await runAdd(['is-online'], {}, 'add-infers-line-endings-from-existing-manifest-file',
     async (config): Promise<void> => {
       const lockfile = await promisify(fsNode.readFile)(path.join(config.cwd, 'package.json'), 'utf8');
-      assert(/\r\n/.test(lockfile));
-      assert(!/[^\r]\n/.test(lockfile));
+      expect(lockfile).toMatch(/\r\n/);
+      expect(lockfile).not.toMatch(/[^\r]\n/);
     },
     async (cwd): Promise<void> => {
       const existingLockfile = '{ "dependencies": {} }\r\n';
@@ -653,8 +674,8 @@ test.concurrent('add infers line endings from existing unix manifest file', asyn
   await runAdd(['is-online'], {}, 'add-infers-line-endings-from-existing-manifest-file',
     async (config): Promise<void> => {
       const lockfile = await promisify(fsNode.readFile)(path.join(config.cwd, 'package.json'), 'utf8');
-      assert(/[^\r]\n/.test(lockfile));
-      assert(!/\r\n/.test(lockfile));
+      expect(lockfile).toMatch(/[^\r]\n/);
+      expect(lockfile).not.toMatch(/\r\n/);
     },
     async (cwd): Promise<void> => {
       const existingLockfile = '{ "dependencies": {} }\n';
@@ -670,14 +691,14 @@ test.skip('add asks for correct package version if user passes an incorrect one'
     {},
     'add-asks-correct-package-version',
     async (config) => {
-      assert(chosenVersion);
-      assert.equal(await getPackageVersion(config, 'is-array'), chosenVersion);
+      expect(chosenVersion).toBeTruthy();
+      expect(await getPackageVersion(config, 'is-array')).toEqual(chosenVersion);
     },
     () => {
       inquirer.prompt = jest.fn((questions) => {
-        assert(questions.length === 1);
-        assert(questions[0].name === 'package');
-        assert(questions[0].choices.length > 0);
+        expect(questions).toHaveLength(1);
+        expect(questions[0].name).toEqual('package');
+        expect(questions[0].choices.length).toBeGreaterThan(0);
         chosenVersion = questions[0].choices[0];
         return Promise.resolve({package: chosenVersion});
       });
@@ -691,8 +712,8 @@ test.concurrent('install with latest tag', (): Promise<void> => {
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
     const version = await getPackageVersion(config, 'left-pad');
 
-    assert.deepEqual(pkg.dependencies, {'left-pad': `^${version}`});
-    assert(lockfile.indexOf(`left-pad@^${version}:`) === 0);
+    expect(pkg.dependencies).toEqual({'left-pad': `^${version}`});
+    expect(lockfile.indexOf(`left-pad@^${version}:`)).toEqual(0);
   });
 });
 
@@ -705,7 +726,7 @@ test.concurrent('install with latest tag and --offline flag', (): Promise<void> 
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
     const version = await getPackageVersion(config, 'left-pad');
 
-    assert.deepEqual(pkg.dependencies, {'left-pad': `^${version}`});
+    expect(pkg.dependencies).toEqual({'left-pad': `^${version}`});
   });
 });
 
@@ -718,8 +739,8 @@ test.concurrent('install with latest tag and --prefer-offline flag', (): Promise
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
     const version = await getPackageVersion(config, 'left-pad');
 
-    assert.deepEqual(pkg.dependencies, {'left-pad': `^${version}`});
-    assert.notEqual(version, '1.1.0');
+    expect(pkg.dependencies).toEqual({'left-pad': `^${version}`});
+    expect(version).not.toEqual('1.1.0');
   });
 });
 
@@ -730,10 +751,17 @@ test.concurrent('doesn\'t warn when peer dependency is met during add', (): Prom
     async (args, flags, config, reporter, lockfile): Promise<void> => {
       const add = new Add(args, flags, config, reporter, lockfile);
       await add.init();
+
       const output = reporter.getBuffer();
       const warnings = output.filter((entry) => entry.type === 'warning');
-      assert(!warnings.some((warning) => warning.data.toString().toLowerCase().includes('unmet peer')));
-      assert(!warnings.some((warning) => warning.data.toString().toLowerCase().includes('incorrect peer')));
+
+      expect(warnings.some((warning) => {
+        return warning.data.toString().toLowerCase().includes('unmet peer');
+      })).toEqual(false);
+
+      expect(warnings.some((warning) => {
+        return warning.data.toString().toLowerCase().includes('incorrect peer');
+      })).toEqual(false);
     },
     ['react@15.4.2', 'react-dom@15.4.2'],
     {},
@@ -748,9 +776,13 @@ test.concurrent('warns when peer dependency is not met during add', (): Promise<
     async (args, flags, config, reporter, lockfile): Promise<void> => {
       const add = new Add(args, flags, config, reporter, lockfile);
       await add.init();
+
       const output = reporter.getBuffer();
       const warnings = output.filter((entry) => entry.type === 'warning');
-      assert(warnings.some((warning) => warning.data.toString().toLowerCase().includes('unmet peer')));
+
+      expect(warnings.some((warning) => {
+        return warning.data.toString().toLowerCase().includes('unmet peer');
+      })).toEqual(true);
     },
     ['react-dom@15.4.2'],
     {},
@@ -765,9 +797,13 @@ test.concurrent('warns when peer dependency is incorrect during add', (): Promis
     async (args, flags, config, reporter, lockfile): Promise<void> => {
       const add = new Add(args, flags, config, reporter, lockfile);
       await add.init();
+
       const output = reporter.getBuffer();
       const warnings = output.filter((entry) => entry.type === 'warning');
-      assert(warnings.some((warning) => warning.data.toString().toLowerCase().includes('incorrect peer')));
+
+      expect(warnings.some((warning) => {
+        return warning.data.toString().toLowerCase().includes('incorrect peer');
+      })).toEqual(true);
     },
     ['react@0.14.8', 'react-dom@15.4.2'],
     {},

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -4,7 +4,6 @@ import type {CLIFunctionReturn} from '../../src/types.js';
 import * as reporters from '../../src/reporters/index.js';
 import * as checkCmd from '../../src/cli/commands/check.js';
 import {run as buildRun} from './_helpers.js';
-import assert from 'assert';
 
 const path = require('path');
 
@@ -26,7 +25,7 @@ test('--verify-tree should report wrong version ', async (): Promise<void> => {
   } catch (e) {
     thrown = true;
   }
-  assert(thrown);
+  expect(thrown).toEqual(true);
 });
 
 test('--verify-tree should report missing dependency ',
@@ -37,7 +36,7 @@ async (): Promise<void> => {
   } catch (e) {
     thrown = true;
   }
-  assert(thrown);
+  expect(thrown).toEqual(true);
 });
 
 test('--verify-tree should pass on hoisted dependency ',
@@ -53,7 +52,7 @@ async (): Promise<void> => {
   } catch (e) {
     thrown = true;
   }
-  assert(thrown);
+  expect(thrown).toEqual(true);
 });
 
 test('--verify-tree should check skip dev dependencies if --production flag passed',
@@ -65,4 +64,3 @@ test('--verify-tree should check skip deeper dev dependencies',
 async (): Promise<void> => {
   await runCheck([], {verifyTree: true, production: true}, 'verify-tree-dev-deep');
 });
-

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -5,7 +5,6 @@ import {ConsoleReporter} from '../../src/reporters/index.js';
 import {run as buildRun} from './_helpers.js';
 import {run as global} from '../../src/cli/commands/global.js';
 import * as fs from '../../src/util/fs.js';
-import assert from 'assert';
 const isCI = require('is-ci');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
@@ -39,8 +38,8 @@ function getTempGlobalFolder(): string {
 if (isCI) {
   test.concurrent('add without flag', (): Promise<void> => {
     return runGlobal(['add', 'react-native-cli'], {}, 'add-without-flag', async (config) => {
-      assert.ok(await fs.exists(path.join(config.globalFolder, 'node_modules', 'react-native-cli')));
-      assert.ok(await fs.exists(path.join(config.globalFolder, 'node_modules', '.bin', 'react-native')));
+      expect(await fs.exists(path.join(config.globalFolder, 'node_modules', 'react-native-cli'))).toEqual(true);
+      expect(await fs.exists(path.join(config.globalFolder, 'node_modules', '.bin', 'react-native'))).toEqual(true);
     });
   });
 }
@@ -48,7 +47,7 @@ if (isCI) {
 test.concurrent('add with prefix flag', (): Promise<void> => {
   const tmpGlobalFolder = getTempGlobalFolder();
   return runGlobal(['add', 'react-native-cli'], {prefix: tmpGlobalFolder}, 'add-with-prefix-flag', async (config) => {
-    assert.ok(await fs.exists(getGlobalPath(tmpGlobalFolder, 'react-native')));
+    expect(await fs.exists(getGlobalPath(tmpGlobalFolder, 'react-native'))).toEqual(true);
   });
 });
 
@@ -58,7 +57,7 @@ test('add with PREFIX enviroment variable', (): Promise<void> => {
   const envPrefix = process.env.PREFIX;
   process.env.PREFIX = tmpGlobalFolder;
   return runGlobal(['add', 'react-native-cli'], {}, 'add-with-prefix-env', async (config) => {
-    assert.ok(await fs.exists(getGlobalPath(tmpGlobalFolder, 'react-native')));
+    expect(await fs.exists(getGlobalPath(tmpGlobalFolder, 'react-native'))).toEqual(true);
     // restore env
     process.env.PREFIX = envPrefix;
   });

--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -4,7 +4,6 @@ import {ConsoleReporter} from '../../src/reporters/index.js';
 import {run as buildRun} from './_helpers.js';
 import {getGitConfigInfo, run as runInit} from '../../src/cli/commands/init.js';
 import * as fs from '../../src/util/fs.js';
-import assert from 'assert';
 
 const path = require('path');
 
@@ -27,17 +26,17 @@ test.concurrent('init --yes should create package.json with defaults',  (): Prom
     const manifestFile = await fs.readFile(path.join(cwd, 'package.json'));
     const manifest = JSON.parse(manifestFile);
 
-    assert.equal(manifest.name, path.basename(cwd));
-    assert.equal(manifest.main, 'index.js');
-    assert.equal(manifest.version, String(config.getOption('init-version')));
-    assert.equal(manifest.license, String(config.getOption('init-license')));
+    expect(manifest.name).toEqual(path.basename(cwd));
+    expect(manifest.main).toEqual('index.js');
+    expect(manifest.version).toEqual(String(config.getOption('init-version')));
+    expect(manifest.license).toEqual(String(config.getOption('init-license')));
   });
 });
 
 test.concurrent('getGitConfigInfo should not return the git config val', async (): Promise<void> => {
-  assert.equal('hi seb', await getGitConfigInfo('some-info', () => Promise.resolve('hi seb')));
+  expect('hi seb').toEqual(await getGitConfigInfo('some-info', () => Promise.resolve('hi seb')));
 });
 
 test.concurrent('getGitConfigInfo should not fail when git fails', async (): Promise<void> => {
-  assert.equal('', await getGitConfigInfo('some-info', () => Promise.reject(Error())));
+  expect('').toEqual(await getGitConfigInfo('some-info', () => Promise.reject(Error())));
 });

--- a/__tests__/commands/install/integration-deduping.js
+++ b/__tests__/commands/install/integration-deduping.js
@@ -3,7 +3,6 @@
 import {getPackageVersion, runInstall} from '../_helpers.js';
 import * as fs from '../../../src/util/fs.js';
 
-const assert = require('assert');
 const path = require('path');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
@@ -13,8 +12,8 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 0', (): P
   // B@1.0.0
   // should result in B@2.0.0 not flattened
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-0', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-b'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-a/dep-b'), '2.0.0');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-a/dep-b')).toEqual('2.0.0');
   });
 });
 
@@ -23,8 +22,8 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 1', (): P
   // A@2.0.1 -> B@2.0.0
   // should result in B@2.0.0 flattened
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-1', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-b'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-a'), '2.0.1');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-a')).toEqual('2.0.1');
   });
 });
 
@@ -42,12 +41,12 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 2', (): P
   // B@1
 
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-2', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-a'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-a/dep-b'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-c'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-a/dep-c'), '2.0.0');
+    expect(await getPackageVersion(config, 'dep-a')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-a/dep-b')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-c')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-d')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-a/dep-c')).toEqual('2.0.0');
   });
 });
 
@@ -61,11 +60,11 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 3', (): P
   // C@1
   // D@1
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-3', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-a'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-c'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b/dep-c'), '2.0.0');
+    expect(await getPackageVersion(config, 'dep-a')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-c')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-d')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-b/dep-c')).toEqual('2.0.0');
   });
 });
 
@@ -80,11 +79,11 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 4', (): P
   // C@1
   // B@2
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-4', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-a'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-c'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d/dep-c'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b'), '2.0.0');
+    expect(await getPackageVersion(config, 'dep-a')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-c')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-d')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-d/dep-c')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('2.0.0');
   });
 });
 
@@ -101,13 +100,12 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 5', (): P
   //     -> B@2
 
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-5', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-a'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-c'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d/dep-a'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d/dep-b'), '2.0.0');
-
+    expect(await getPackageVersion(config, 'dep-a')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-c')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-d')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-d/dep-a')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-d/dep-b')).toEqual('2.0.0');
   });
 });
 
@@ -128,13 +126,13 @@ test.concurrent(
     // E@2
 
     return runInstall({}, 'install-should-dedupe-avoiding-conflicts-6', async (config): Promise<void> => {
-      assert.equal(await getPackageVersion(config, 'dep-b'), '1.0.0');
-      assert.equal(await getPackageVersion(config, 'dep-c'), '1.0.0');
-      assert.equal(await getPackageVersion(config, 'dep-d'), '2.0.0');
-      assert.equal(await getPackageVersion(config, 'dep-e'), '2.0.0');
+      expect(await getPackageVersion(config, 'dep-b')).toEqual('1.0.0');
+      expect(await getPackageVersion(config, 'dep-c')).toEqual('1.0.0');
+      expect(await getPackageVersion(config, 'dep-d')).toEqual('2.0.0');
+      expect(await getPackageVersion(config, 'dep-e')).toEqual('2.0.0');
 
-      assert.equal(await getPackageVersion(config, 'dep-c/dep-d'), '1.0.0');
-      assert.equal(await getPackageVersion(config, 'dep-c/dep-e'), '1.0.0');
+      expect(await getPackageVersion(config, 'dep-c/dep-d')).toEqual('1.0.0');
+      expect(await getPackageVersion(config, 'dep-c/dep-e')).toEqual('1.0.0');
     });
   },
 );
@@ -159,19 +157,19 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 7', (): P
   // E@2
 
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-7', async (config) => {
-    assert.equal(await getPackageVersion(config, 'dep-a'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-c'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-d'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-e'), '2.0.0');
+    expect(await getPackageVersion(config, 'dep-a')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-b')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-c')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-d')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'dep-e')).toEqual('2.0.0');
 
-    assert.equal(await getPackageVersion(config, 'dep-a/dep-c'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-a/dep-d'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-a/dep-e'), '1.0.0');
+    expect(await getPackageVersion(config, 'dep-a/dep-c')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-a/dep-d')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-a/dep-e')).toEqual('1.0.0');
 
-    assert.equal(await getPackageVersion(config, 'dep-b/dep-c'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b/dep-d'), '1.0.0');
-    assert.equal(await getPackageVersion(config, 'dep-b/dep-e'), '1.0.0');
+    expect(await getPackageVersion(config, 'dep-b/dep-c')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-b/dep-d')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'dep-b/dep-e')).toEqual('1.0.0');
   });
 });
 
@@ -181,12 +179,12 @@ if (!process.env.TRAVIS || process.env.TRAVIS_OS_NAME !== 'osx') {
     // revealed in https://github.com/yarnpkg/yarn/issues/112
     // adapted for https://github.com/yarnpkg/yarn/issues/1158
     return runInstall({}, 'install-should-dedupe-avoiding-conflicts-8', async (config) => {
-      assert.equal(await getPackageVersion(config, 'glob'), '5.0.15');
-      assert.equal(await getPackageVersion(config, 'findup-sync/glob'), '4.3.5');
-      assert.equal(await getPackageVersion(config, 'inquirer'), '0.8.5');
-      assert.equal(await getPackageVersion(config, 'lodash'), '3.10.1');
-      assert.equal(await getPackageVersion(config, 'ast-query/lodash'), '4.15.0');
-      assert.equal(await getPackageVersion(config, 'run-async'), '0.1.0');
+      expect(await getPackageVersion(config, 'glob')).toEqual('5.0.15');
+      expect(await getPackageVersion(config, 'findup-sync/glob')).toEqual('4.3.5');
+      expect(await getPackageVersion(config, 'inquirer')).toEqual('0.8.5');
+      expect(await getPackageVersion(config, 'lodash')).toEqual('3.10.1');
+      expect(await getPackageVersion(config, 'ast-query/lodash')).toEqual('4.15.0');
+      expect(await getPackageVersion(config, 'run-async')).toEqual('0.1.0');
     });
   });
 }
@@ -195,12 +193,12 @@ test.concurrent('install should dedupe dependencies avoiding conflicts 9', (): P
   // revealed in https://github.com/yarnpkg/yarn/issues/112
   // adapted for https://github.com/yarnpkg/yarn/issues/1158
   return runInstall({}, 'install-should-dedupe-avoiding-conflicts-9', async (config) => {
-    assert.equal(await getPackageVersion(config, 'glob'), '5.0.15');
-    assert.equal(await getPackageVersion(config, 'findup-sync/glob'), '4.3.5');
-    assert.equal(await getPackageVersion(config, 'inquirer'), '0.8.5');
-    assert.equal(await getPackageVersion(config, 'lodash'), '3.10.1');
-    assert.equal(await getPackageVersion(config, 'ast-query/lodash'), '4.15.0');
-    assert.equal(await getPackageVersion(config, 'run-async'), '0.1.0');
+    expect(await getPackageVersion(config, 'glob')).toEqual('5.0.15');
+    expect(await getPackageVersion(config, 'findup-sync/glob')).toEqual('4.3.5');
+    expect(await getPackageVersion(config, 'inquirer')).toEqual('0.8.5');
+    expect(await getPackageVersion(config, 'lodash')).toEqual('3.10.1');
+    expect(await getPackageVersion(config, 'ast-query/lodash')).toEqual('4.15.0');
+    expect(await getPackageVersion(config, 'run-async')).toEqual('0.1.0');
   });
 });
 
@@ -217,7 +215,7 @@ test.concurrent('install should hardlink repeated dependencies', (): Promise<voi
       config.cwd,
       'node_modules/c/node_modules/a/package.json',
     ));
-    assert.equal(b_a.ino, c_a.ino);
+    expect(b_a.ino).toEqual(c_a.ino);
   });
 });
 
@@ -234,6 +232,6 @@ test.concurrent('install should not hardlink repeated dependencies if linkDuplic
       config.cwd,
       'node_modules/c/node_modules/a/package.json',
     ));
-    assert(b_a.ino != c_a.ino);
+    expect(b_a.ino).not.toEqual(c_a.ino);
   });
 });

--- a/__tests__/commands/install/integration-hoisting.js
+++ b/__tests__/commands/install/integration-hoisting.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import assert from 'assert';
 import {getPackageVersion, runInstall} from '../_helpers.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
@@ -10,7 +9,7 @@ test.concurrent('install hoister should prioritise popular transitive dependenci
   //        -> c
   //           -> b-2
   return runInstall({}, 'install-should-prioritise-popular-transitive', async (config) => {
-    assert.equal(await getPackageVersion(config, 'b'), '2.0.0');
-    assert.equal(await getPackageVersion(config, 'a/b'), '0.0.0');
+    expect(await getPackageVersion(config, 'b')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'a/b')).toEqual('0.0.0');
   });
 });

--- a/__tests__/commands/install/unit.js
+++ b/__tests__/commands/install/unit.js
@@ -5,7 +5,6 @@ import {Install} from '../../../src/cli/commands/install.js';
 import Lockfile from '../../../src/lockfile/wrapper.js';
 import Config from '../../../src/config.js';
 
-const assert = require('assert');
 const path = require('path');
 
 const fixturesLoc = path.join(__dirname, '..', '..', 'fixtures', 'install');
@@ -16,7 +15,7 @@ test.concurrent('flat arg is inherited from root manifest', async (): Promise<vo
   const config = await Config.create({cwd});
   const install = new Install({}, config, reporter, new Lockfile());
   return install.fetchRequestFromCwd().then(function({manifest}) {
-    assert.equal(manifest.flat, true);
-    assert.equal(install.flags.flat, true);
+    expect(manifest.flat).toEqual(true);
+    expect(install.flags.flat).toEqual(true);
   });
 });

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -2,7 +2,6 @@
 import type {Reporter} from '../../src/reporters/index.js';
 
 import * as fs from '../../src/util/fs.js';
-import assert from 'assert';
 import {run as pack} from '../../src/cli/commands/pack.js';
 import * as reporters from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
@@ -105,7 +104,7 @@ test.concurrent('pack should work with a minimal example', (): Promise<void> => 
       path.join(cwd, 'pack-minimal-test-v1.0.0'),
     );
 
-    assert.ok(files);
+    expect(files.length).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -118,7 +117,7 @@ test.concurrent('pack should inlude all files listed in the files array', (): Pr
     );
     const expected = ['index.js', 'a.js', 'b.js'];
     expected.forEach((filename) => {
-      assert(files.indexOf(filename) >= 0);
+      expect(files.indexOf(filename)).toBeGreaterThanOrEqual(0);
     });
   });
 });
@@ -133,7 +132,7 @@ test.concurrent('pack should include mandatory files not listed in files array i
     );
     const expected = ['package.json', 'readme.md', 'license', 'changelog'];
     expected.forEach((filename) => {
-      assert(files.indexOf(filename) >= 0);
+      expect(files.indexOf(filename)).toBeGreaterThanOrEqual(0);
     });
   });
 });
@@ -145,9 +144,9 @@ test.concurrent('pack should exclude mandatory files from ignored directories', 
       path.join(cwd, 'exclude-mandatory-files-from-ignored-directories-v1.0.0.tgz'),
       path.join(cwd, 'exclude-mandatory-files-from-ignored-directories-v1.0.0'),
     );
-    assert(files.indexOf('index.js') >= 0);
-    assert(files.indexOf('package.json') >= 0);
-    assert(files.indexOf('node_modules') === -1);
+    expect(files.indexOf('index.js')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('package.json')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('node_modules')).toEqual(-1);
   });
 });
 
@@ -161,7 +160,7 @@ test.concurrent('pack should exclude all other files if files array is not empty
     );
     const excluded = ['c.js'];
     excluded.forEach((filename) => {
-      assert(!(files.indexOf(filename) >= 0));
+      expect(files.indexOf(filename)).toEqual(-1);
     });
   });
 });
@@ -174,7 +173,7 @@ test.concurrent('pack should exclude all dotflies if not in files and files not 
       path.join(cwd, 'files-exclude-dotfile-v1.0.0.tgz'),
       path.join(cwd, 'files-exclude-dotfile-v1.0.0'),
     );
-    assert(!(files.indexOf('.dotfile') >= 0));
+    expect(files.indexOf('.dotfile')).toEqual(-1);
   });
 });
 
@@ -186,6 +185,6 @@ test.concurrent('pack should exclude all files in dot-directories if not in file
       path.join(cwd, 'files-exclude-dotdir-v1.0.0.tgz'),
       path.join(cwd, 'files-exclude-dotdir-v1.0.0'),
     );
-    assert(!(files.indexOf('a.js') >= 0));
+    expect(files.indexOf('a.js')).toEqual(-1);
   });
 });

--- a/__tests__/commands/upgrade.js
+++ b/__tests__/commands/upgrade.js
@@ -5,7 +5,6 @@ import {explodeLockfile, run as buildRun} from './_helpers.js';
 import {run as upgrade} from '../../src/cli/commands/upgrade.js';
 import * as fs from '../../src/util/fs.js';
 import * as reporters from '../../src/reporters/index.js';
-import assert from 'assert';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
@@ -35,10 +34,10 @@ test.concurrent('works with no arguments', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('left-pad@^1.0.0:') === 0);
+    expect(lockfile.indexOf('left-pad@^1.0.0:')).toEqual(0);
     // the below test passes when it should fail
     // manifest doesn't get updated when ran without args
-    assert.deepEqual(pkg.dependencies, {'left-pad': '^1.0.0'});
+    expect(pkg.dependencies).toEqual({'left-pad': '^1.0.0'});
   });
 });
 
@@ -47,10 +46,10 @@ test.concurrent('works with single argument', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('left-pad@^1.0.0:') >= 0);
-    assert(lockfile.indexOf('max-safe-integer@^1.0.1:') >= 0);
-    assert.equal(pkg.dependencies['left-pad'], '^1.0.0');
-    assert.notEqual(pkg.dependencies['max-safe-integer'], '^1.0.0');
+    expect(lockfile.indexOf('left-pad@^1.0.0:')).toBeGreaterThanOrEqual(0);
+    expect(lockfile.indexOf('max-safe-integer@^1.0.1:')).toBeGreaterThanOrEqual(0);
+    expect(pkg.dependencies['left-pad']).toEqual('^1.0.0');
+    expect(pkg.dependencies['max-safe-integer']).not.toEqual('^1.0.0');
   });
 });
 
@@ -60,12 +59,13 @@ test.concurrent('works with multiple arguments', (): Promise<void> => {
       const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
       const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-      assert(lockfile.indexOf('left-pad@^1.1.3:') >= 0);
-      assert(lockfile.indexOf('max-safe-integer@^1.0.1:') >= 0);
-      assert(lockfile.indexOf('is-negative-zero@^1.0.0:') >= 0);
-      assert.notEqual(pkg.dependencies['left-pad'], '^1.0.0');
-      assert.notEqual(pkg.dependencies['max-safe-integer'], '^1.0.0');
-      assert.equal(pkg.dependencies['is-negative-zero'], '^1.0.0');
+      expect(lockfile.indexOf('left-pad@^1.1.3:')).toBeGreaterThanOrEqual(0);
+      expect(lockfile.indexOf('max-safe-integer@^1.0.1:')).toBeGreaterThanOrEqual(0);
+      expect(lockfile.indexOf('is-negative-zero@^1.0.0:')).toBeGreaterThanOrEqual(0);
+
+      expect(pkg.dependencies['left-pad']).not.toEqual('^1.0.0');
+      expect(pkg.dependencies['max-safe-integer']).not.toEqual('^1.0.0');
+      expect(pkg.dependencies['is-negative-zero']).toEqual('^1.0.0');
     },
   );
 });
@@ -75,10 +75,10 @@ test.concurrent('respects dependency type', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('max-safe-integer@^1.0.0:') >= 0);
-    assert(lockfile.indexOf('left-pad@^1.1.3:') >= 0);
-    assert.deepEqual(pkg.dependencies, {'max-safe-integer': '^1.0.0'});
-    assert.deepEqual(pkg.devDependencies, {'left-pad': '^1.1.3'});
+    expect(lockfile.indexOf('max-safe-integer@^1.0.0:')).toBeGreaterThanOrEqual(0);
+    expect(lockfile.indexOf('left-pad@^1.1.3:')).toBeGreaterThanOrEqual(0);
+    expect(pkg.dependencies).toEqual({'max-safe-integer': '^1.0.0'});
+    expect(pkg.devDependencies).toEqual({'left-pad': '^1.1.3'});
   });
 });
 
@@ -88,8 +88,8 @@ test.concurrent('respects --ignore-engines flag', (): Promise<void> => {
       const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
       const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-      assert(lockfile.indexOf('hawk@0.10:') >= 0);
-      assert.deepEqual(pkg.dependencies, {hawk: '0.10'});
+      expect(lockfile.indexOf('hawk@0.10:')).toBeGreaterThanOrEqual(0);
+      expect(pkg.dependencies).toEqual({hawk: '0.10'});
     },
   );
 });
@@ -99,8 +99,8 @@ test.concurrent('upgrades from fixed version to latest', (): Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
 
-    assert(lockfile.indexOf('max-safe-integer@^1.0.1:') === 0);
-    assert.deepEqual(pkg.dependencies, {'max-safe-integer': '^1.0.1'});
+    expect(lockfile.indexOf('max-safe-integer@^1.0.1:')).toEqual(0);
+    expect(pkg.dependencies).toEqual({'max-safe-integer': '^1.0.1'});
   });
 });
 
@@ -112,23 +112,27 @@ test.concurrent('upgrades dependency packages not in registry', (): Promise<void
 
     const lockFileIncludes = (sha) => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    assert(
+    expect(
       lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`),
+    ).toEqual(true,
       'Lockfile should point to the same yarn-test-git-repo branch.',
     );
 
-    assert(
-      !lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    expect(
+      lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    ).toEqual(false,
       'Lockfile should update yarn-test-git-repo SHA.',
     );
 
-    assert(
+    expect(
       lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`),
+    ).toEqual(true,
       'Lockfile should point to the same e2e-test-repo branch.',
     );
 
-    assert(
+    expect(
       lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705'),
+    ).toEqual(true,
       'Lockfile should keep latest e2e-test-repo SHA.',
     );
   });
@@ -142,23 +146,27 @@ test.concurrent('upgrades dev dependency packages not in registry', (): Promise<
 
     const lockFileIncludes = (sha) => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    assert(
+    expect(
       lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`),
+    ).toEqual(true,
       'Lockfile should point to the same yarn-test-git-repo branch.',
     );
 
-    assert(
-      !lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    expect(
+      lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    ).toEqual(false,
       'Lockfile should update yarn-test-git-repo SHA.',
     );
 
-    assert(
+    expect(
       lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`),
+    ).toEqual(true,
       'Lockfile should point to the same e2e-test-repo branch.',
     );
 
-    assert(
+    expect(
       lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705'),
+    ).toEqual(true,
       'Lockfile should keep latest e2e-test-repo SHA.',
     );
   });
@@ -172,23 +180,27 @@ test.concurrent('upgrades optional dependency packages not in registry', (): Pro
 
     const lockFileIncludes = (sha) => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    assert(
+    expect(
       lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`),
+    ).toEqual(true,
       'Lockfile should point to the same yarn-test-git-repo branch.',
     );
 
-    assert(
-      !lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    expect(
+      lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    ).toEqual(false,
       'Lockfile should update yarn-test-git-repo SHA.',
     );
 
-    assert(
+    expect(
       lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`),
+    ).toEqual(true,
       'Lockfile should point to the same e2e-test-repo branch.',
     );
 
-    assert(
+    expect(
       lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705'),
+    ).toEqual(true,
       'Lockfile should keep latest e2e-test-repo SHA.',
     );
   });
@@ -202,23 +214,27 @@ test.concurrent('upgrades peer dependency packages not in registry', (): Promise
 
     const lockFileIncludes = (sha) => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    assert(
+    expect(
       lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`),
+    ).toEqual(true,
       'Lockfile should point to the same yarn-test-git-repo branch.',
     );
 
-    assert(
-      !lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    expect(
+      lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40'),
+    ).toEqual(false,
       'Lockfile should update yarn-test-git-repo SHA.',
     );
 
-    assert(
+    expect(
       lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`),
+    ).toEqual(true,
       'Lockfile should point to the same e2e-test-repo branch.',
     );
 
-    assert(
+    expect(
       lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705'),
+    ).toEqual(true,
       'Lockfile should keep latest e2e-test-repo SHA.',
     );
   });
@@ -230,9 +246,13 @@ test.concurrent('warns when peer dependency is not met after upgrade', (): Promi
     fixturesLoc,
     async (args, flags, config, reporter): Promise<void> => {
       await upgrade(config, reporter, flags, args);
+
       const output = reporter.getBuffer();
       const warnings = output.filter((entry) => entry.type === 'warning');
-      assert(warnings.some((warning) => warning.data.toString().toLowerCase().includes('incorrect peer')));
+
+      expect(warnings.some((warning) => {
+        return warning.data.toString().toLowerCase().includes('incorrect peer');
+      })).toEqual(true);
     },
     ['themer'],
     {},
@@ -246,9 +266,13 @@ test.concurrent('doesn\'t warn when peer dependency is still met after upgrade',
     fixturesLoc,
     async (args, flags, config, reporter): Promise<void> => {
       await upgrade(config, reporter, flags, args);
+
       const output = reporter.getBuffer();
       const warnings = output.filter((entry) => entry.type === 'warning');
-      assert(!warnings.some((warning) => warning.data.toString().toLowerCase().includes('peer')));
+
+      expect(warnings.some((warning) => {
+        return warning.data.toString().toLowerCase().includes('peer');
+      })).toEqual(false);
     },
     ['themer'],
     {},
@@ -259,12 +283,12 @@ test.concurrent('doesn\'t warn when peer dependency is still met after upgrade',
 test.concurrent('can prune the offline mirror', (): Promise<void> => {
   return runUpgrade(['dep-a@1.1.0'], {}, 'prune-offline-mirror', async (config): ?Promise<void> => {
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
-    assert(lockfile.indexOf('dep-a@1.1.0:') === 0);
+    expect(lockfile.indexOf('dep-a@1.1.0:')).toEqual(0);
 
     const mirrorPath = 'mirror-for-offline';
-    assert(await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-a-1.1.0.tgz`)));
-    assert(!await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-a-1.0.0.tgz`)));
+    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-a-1.1.0.tgz`))).toEqual(true);
+    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-a-1.0.0.tgz`))).toEqual(false);
     // In 1.1.0, dep-a doesn't depend on dep-b anymore, so dep-b should be pruned
-    assert(!await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-b-1.0.0.tgz`)));
+    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-b-1.0.0.tgz`))).toEqual(false);
   });
 });

--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -4,7 +4,6 @@ import {BufferReporter} from '../../src/reporters/index.js';
 import {run as why} from '../../src/cli/commands/why.js';
 import * as reporters from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
-import assert from 'assert';
 import path from 'path';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
@@ -76,34 +75,34 @@ test.concurrent('throws error if module does not exist', (): Promise<void> => {
   });
 });
 
-test.concurrent('should determine that the module installed because it is in dependencies', 
+test.concurrent('should determine that the module installed because it is in dependencies',
 (): Promise<void> => {
   return runWhy({}, ['mime-types'], 'basic', (config, reporter) => {
-    const report = reporter.getBuffer(); 
-    assert.equal(report[report.length - 1].data, reporter.lang('whySpecifiedSimple', 'dependencies'));
+    const report = reporter.getBuffer();
+    expect(report[report.length - 1].data).toEqual(reporter.lang('whySpecifiedSimple', 'dependencies'));
   });
 });
 
-test.concurrent('should determine that the module installed because it is in devDependencies', 
+test.concurrent('should determine that the module installed because it is in devDependencies',
 (): Promise<void> => {
   return runWhy({}, ['left-pad'], 'basic', (config, reporter) => {
-    const report = reporter.getBuffer(); 
-    assert.equal(report[report.length - 1].data, reporter.lang('whySpecifiedSimple', 'devDependencies'));
+    const report = reporter.getBuffer();
+    expect(report[report.length - 1].data).toEqual(reporter.lang('whySpecifiedSimple', 'devDependencies'));
   });
 });
 
-test.concurrent('should determine that the module installed because mime-types depend on it', 
+test.concurrent('should determine that the module installed because mime-types depend on it',
 (): Promise<void> => {
   return runWhy({}, ['mime-db'], 'basic', (config, reporter) => {
-    const report = reporter.getBuffer(); 
-    assert.equal(report[report.length - 1].data, reporter.lang('whyDependedOnSimple', 'mime-types'));
+    const report = reporter.getBuffer();
+    expect(report[report.length - 1].data).toEqual(reporter.lang('whyDependedOnSimple', 'mime-types'));
   });
 });
 
-test.concurrent('should determine that the module installed because it is hoisted from glob depend on it', 
+test.concurrent('should determine that the module installed because it is hoisted from glob depend on it',
 (): Promise<void> => {
   return runWhy({}, ['glob#minimatch'], 'basic', (config, reporter) => {
-    const report = reporter.getBuffer(); 
-    assert.equal(report[report.length - 2].data, reporter.lang('whyHoistedTo', 'glob#minimatch'));
+    const report = reporter.getBuffer();
+    expect(report[report.length - 2].data).toEqual(reporter.lang('whyHoistedTo', 'glob#minimatch'));
   });
 });

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -76,7 +76,7 @@ test('should only expose non-internal configs', async () => {
 });
 
 test('should run both prepublish and prepare when installing, but not prepublishOnly', async () => {
-  let stdout = await execCommand('install', 'lifecycle-scripts');
+  const stdout = await execCommand('install', 'lifecycle-scripts');
 
   expect(stdout).toMatch(/^running the prepublish hook$/m);
   expect(stdout).toMatch(/^running the prepare hook$/m);

--- a/__tests__/util/env-replace.js
+++ b/__tests__/util/env-replace.js
@@ -1,17 +1,16 @@
 /* @flow */
 import envReplace from '../../src/util/env-replace';
-import assert from 'assert';
 
 describe('environment variable replacement', () => {
   it('will replace a token that exists in the environment', () => {
     let result = envReplace('test ${a} replacement', {a: 'token'});
-    assert(result === 'test token replacement', `result: ${result}`);
+    expect(result).toEqual('test token replacement', `result: ${result}`);
 
     result = envReplace('${a} replacement', {a: 'token'});
-    assert(result === 'token replacement', `result: ${result}`);
+    expect(result).toEqual('token replacement', `result: ${result}`);
 
     result = envReplace('${a}', {a: 'token'});
-    assert(result === 'token', `result: ${result}`);
+    expect(result).toEqual('token', `result: ${result}`);
   });
 
   it('will not replace a token that does not exist in the environment', () => {
@@ -20,13 +19,13 @@ describe('environment variable replacement', () => {
       envReplace('${a} replacement', {b: 'token'});
     } catch (err) {
       thrown = true;
-      assert(err.message === 'Failed to replace env in config: ${a}', `error message: ${err.message}`);
+      expect(err.message).toEqual('Failed to replace env in config: ${a}', `error message: ${err.message}`);
     }
-    assert(thrown);
+    expect(thrown).toEqual(true);
   });
 
   it('will not replace a token when a the token-replacement mechanism is prefixed a backslash literal', () => {
     const result = envReplace('\\${a} replacement', {a: 'token'});
-    assert(result === '\\${a} replacement', `result: ${result}`);
+    expect(result).toEqual('\\${a} replacement', `result: ${result}`);
   });
 });

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -62,11 +62,11 @@ export default class GitFetcher extends BaseFetcher {
     const tarballModernMirrorPath = this.getTarballMirrorPath();
     const tarballCachePath = this.getTarballCachePath();
 
-      const tarballMirrorPath =
-        tarballModernMirrorPath && !await fsUtil.exists(tarballModernMirrorPath) &&
-        tarballLegacyMirrorPath && await fsUtil.exists(tarballLegacyMirrorPath)
-        ? tarballLegacyMirrorPath
-        : tarballModernMirrorPath;
+    const tarballMirrorPath =
+      tarballModernMirrorPath && !await fsUtil.exists(tarballModernMirrorPath) &&
+      tarballLegacyMirrorPath && await fsUtil.exists(tarballLegacyMirrorPath)
+      ? tarballLegacyMirrorPath
+      : tarballModernMirrorPath;
 
     const tarballPath = override || tarballMirrorPath || tarballCachePath;
 


### PR DESCRIPTION
Fix #3006 - Replace `assert` invocations by `expect()...` matchers.