### PR TITLE
Fix bug when cannot set a config value to empty string

### DIFF
--- a/__tests__/commands/config.js
+++ b/__tests__/commands/config.js
@@ -32,9 +32,15 @@ test('cache-folder flag has higher priorities than .yarnrc file', (): Promise<vo
     });
 });
 
-test('set true when option value is empty', (): Promise<void> => {
-  return runConfig(['set', 'strict-ssl', ''], {}, '', (config) => {
+test('set true when option value is undefined', (): Promise<void> => {
+  return runConfig(['set', 'strict-ssl'], {}, '', (config) => {
     expect(config.registries.yarn.homeConfig['strict-ssl']).toBe(true);
+  });
+});
+
+test('set empty string to an option', (): Promise<void> => {
+  return runConfig(['set', 'version-tag-prefix', ''], {}, '', (config) => {
+    expect(config.registries.yarn.homeConfig['version-tag-prefix']).toBe('');
   });
 });
 

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -19,8 +19,7 @@ export const {run, setFlags} = buildSubCommands('config', {
     if (args.length === 0 || args.length > 2) {
       return false;
     }
-    const key = args[0];
-    const val = args[1] || true;
+    const [key, val = true] = args;
     const yarnConfig = config.registries.yarn;
     await yarnConfig.saveHomeConfig({[key]: val});
     reporter.success(reporter.lang('configSet', key, val));


### PR DESCRIPTION
* Fixes regression introduced in PR #2440
* Related to #2434

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Currently `$ yarn config set <config_key> ""` sets the respective config value to true. It should be possible to set config values to an empty string.

Omitting config value should still default to **true**, e.g.
`$ yarn config set  strict-ssl`
should set **strict-ssl** config value to **true**.

**Test plan**

`$ yarn config set version-tag-prefix ""`
should set **version-tag-prefix** config value to an empty string.