### PR TITLE
Providing override for CHILD_CONCURRENCY via ENV

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,7 @@ export type ConfigOptions = {
   production?: boolean,
   binLinks?: boolean,
   networkConcurrency?: number,
+  childConcurrency?: number,
   networkTimeout?: number,
   nonInteractive?: boolean,
 
@@ -107,6 +108,8 @@ export default class Config {
   constraintResolver: ConstraintResolver;
 
   networkConcurrency: number;
+
+  childConcurrency: number;
 
   //
   networkTimeout: number;
@@ -228,6 +231,13 @@ export default class Config {
       opts.networkConcurrency ||
       Number(this.getOption('network-concurrency')) ||
       constants.NETWORK_CONCURRENCY
+    );
+
+    this.childConcurrency = (
+      opts.childConcurrency ||
+      Number(this.getOption('child-concurrency')) ||
+      Number(process.env.CHILD_CONCURRENCY) ||
+      constants.CHILD_CONCURRENCY
     );
 
     this.networkTimeout = (

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,7 +37,7 @@ export const NETWORK_CONCURRENCY = 8;
 export const NETWORK_TIMEOUT = 30 * 1000; // in milliseconds
 
 // max amount of child processes to execute concurrently
-export const CHILD_CONCURRENCY = Number(process.env.CHILD_CONCURRENCY) || 5;
+export const CHILD_CONCURRENCY = 5;
 
 export const REQUIRED_PACKAGE_KEYS = ['name', 'version', '_uid'];
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,7 +37,7 @@ export const NETWORK_CONCURRENCY = 8;
 export const NETWORK_TIMEOUT = 30 * 1000; // in milliseconds
 
 // max amount of child processes to execute concurrently
-export const CHILD_CONCURRENCY = 5;
+export const CHILD_CONCURRENCY = process.env.CHILD_CONCURRENCY || 5;
 
 export const REQUIRED_PACKAGE_KEYS = ['name', 'version', '_uid'];
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,7 +37,7 @@ export const NETWORK_CONCURRENCY = 8;
 export const NETWORK_TIMEOUT = 30 * 1000; // in milliseconds
 
 // max amount of child processes to execute concurrently
-export const CHILD_CONCURRENCY = process.env.CHILD_CONCURRENCY || 5;
+export const CHILD_CONCURRENCY = Number(process.env.CHILD_CONCURRENCY) || 5;
 
 export const REQUIRED_PACKAGE_KEYS = ['name', 'version', '_uid'];
 

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -262,7 +262,7 @@ export default class PackageInstallScripts {
     const waitQueue = new Set();
     const workers = [];
 
-    const set = this.reporter.activitySet(installablePkgs, Math.min(constants.CHILD_CONCURRENCY, workQueue.size));
+    const set = this.reporter.activitySet(installablePkgs, Math.min(this.config.childConcurrency, workQueue.size));
 
     for (const spinner of set.spinners) {
       workers.push(this.worker(spinner, workQueue, installed, waitQueue));


### PR DESCRIPTION
**Summary**

Building native node modules parallely on windows is causing linker errors as iojs.lib/node.lib files could get locked as explained in #2429 

**Test plan**

Set CHILD_CONCURRENCY to 1 and ran yarn install with the package.json having multiple native node modules. Builds ran sequentially.
