### PR TITLE
Add option to disable the self-update check

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -662,6 +662,11 @@ export class Install {
       return;
     }
 
+    // don't check if disabled
+    if (this.config.getOption('disable-self-update-check')) {
+      return;
+    }
+
     // only check for updates once a day
     const lastUpdateCheck = Number(this.config.getOption('lastUpdateCheck')) || 0;
     if (lastUpdateCheck && Date.now() - lastUpdateCheck < ONE_DAY) {


### PR DESCRIPTION
**Summary**

Allow disabling of the self-update check with a `disable-self-update-check` option.

t16181086

**Test plan**

Forced the outdated prompt to appear, and verified that adding `disable-self-update-check true` to a `.yarnrc` file prevented it from appearing.

There's currently no tests for the self-update checks.

// cc @bestander 