### PR TITLE
fix --verify-tree test stability

### DIFF
--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -47,8 +47,6 @@ test.concurrent('--verify-tree should pass on hoisted dependency ', async (): Pr
 test.concurrent('--verify-tree should check dev dependencies ', async (): Promise<void> => {
   let thrown = false;
   try {
-    // passing production=false explicitly because we have a few tests that touch PRODUCTION env variable and may
-    // affect default config.production resolution
     await runCheck([], {verifyTree: true, production: false}, 'verify-tree-dev');
   } catch (e) {
     thrown = true;

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -15,8 +15,8 @@ const runCheck = buildRun.bind(
   null,
   reporters.ConsoleReporter,
   fixturesLoc,
-  (args, flags, config, reporter): CLIFunctionReturn => {
-    return checkCmd.run(config, reporter, flags, args);
+  async (args, flags, config, reporter): CLIFunctionReturn => {
+    return await checkCmd.run(config, reporter, flags, args);
   },
 );
 

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -15,8 +15,8 @@ const runCheck = buildRun.bind(
   null,
   reporters.ConsoleReporter,
   fixturesLoc,
-  async (args, flags, config, reporter): CLIFunctionReturn => {
-    return await checkCmd.run(config, reporter, flags, args);
+  (args, flags, config, reporter): CLIFunctionReturn => {
+    return checkCmd.run(config, reporter, flags, args);
   },
 );
 
@@ -47,7 +47,9 @@ test.concurrent('--verify-tree should pass on hoisted dependency ', async (): Pr
 test.concurrent('--verify-tree should check dev dependencies ', async (): Promise<void> => {
   let thrown = false;
   try {
-    await runCheck([], {verifyTree: true}, 'verify-tree-dev');
+    // passing production=false explicitly because we have a few tests that touch PRODUCTION env variable and may
+    // affect default config.production resolution
+    await runCheck([], {verifyTree: true, production: false}, 'verify-tree-dev');
   } catch (e) {
     thrown = true;
   }

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -559,42 +559,6 @@ test.concurrent('install should circumvent circular dependencies', (): Promise<v
   });
 });
 
-// don't run this test in `concurrent`, it will affect other tests
-test('install should respect NODE_ENV=production', (): Promise<void> => {
-  const env = process.env.NODE_ENV;
-  process.env.NODE_ENV = 'production';
-  return runInstall({}, 'install-should-respect-node_env', async (config) => {
-    expect(await fs.exists(path.join(config.cwd, 'node_modules/is-negative-zero/package.json'))).toBe(false);
-    // restore env
-    process.env.NODE_ENV = env;
-  });
-});
-
-// don't run this test in `concurrent`, it will affect other tests
-test('install should respect NPM_CONFIG_PRODUCTION=false over NODE_ENV=production', (): Promise<void> => {
-  const env = process.env.NODE_ENV;
-  const prod = process.env.NPM_CONFIG_PRODUCTION;
-  process.env.NODE_ENV = 'production';
-  process.env.NPM_CONFIG_PRODUCTION = 'false';
-  return runInstall({}, 'install-should-respect-npm_config_production', async (config) => {
-    expect(await fs.exists(path.join(config.cwd, 'node_modules/is-negative-zero/package.json'))).toBe(true);
-    // restore env
-    process.env.NODE_ENV = env;
-    process.env.NPM_CONFIG_PRODUCTION = prod;
-  });
-});
-
-// don't run this test in `concurrent`, it will affect other tests
-test('install should respect production flag false over NODE_ENV=production', (): Promise<void> => {
-  const env = process.env.NODE_ENV;
-  process.env.NODE_ENV = 'production';
-  return runInstall({production: 'false'}, 'install-should-respect-production_flag_over_node-env', async (config) => {
-    expect(await fs.exists(path.join(config.cwd, 'node_modules/is-negative-zero/package.json'))).toBe(true);
-    // restore env
-    process.env.NODE_ENV = env;
-  });
-});
-
 test.concurrent('install should resolve circular dependencies 2', (): Promise<void> => {
   return runInstall({}, 'install-should-circumvent-circular-dependencies-2', async (config, reporter) => {
     expect(

--- a/__tests__/fixtures/install/install-should-respect-node_env/package.json
+++ b/__tests__/fixtures/install/install-should-respect-node_env/package.json
@@ -1,8 +1,0 @@
-{
-  "dependencies": {
-    "left-pad": "1.0.0"
-  },
-  "devDependencies": {
-    "is-negative-zero": "1.0.0"
-  }
-}

--- a/__tests__/fixtures/install/install-should-respect-npm_config_production/package.json
+++ b/__tests__/fixtures/install/install-should-respect-npm_config_production/package.json
@@ -1,8 +1,0 @@
-{
-  "dependencies": {
-    "left-pad": "1.0.0"
-  },
-  "devDependencies": {
-    "is-negative-zero": "1.0.0"
-  }
-}

--- a/__tests__/fixtures/install/install-should-respect-production_flag_over_node-env/package.json
+++ b/__tests__/fixtures/install/install-should-respect-production_flag_over_node-env/package.json
@@ -1,8 +1,0 @@
-{
-  "dependencies": {
-    "left-pad": "1.0.0"
-  },
-  "devDependencies": {
-    "is-negative-zero": "1.0.0"
-  }
-}


### PR DESCRIPTION
Fixed flakiness of `--verify-tree should check dev dependencies` test.

We had a few tests that verify that Yarn supports setting config.production via environment variable.
Jest does not allow us to execute a test in complete isolation, if they are in different test suites.
So those few tests that changed environment variable could affect any other test running in parallel with it.

The code that handles env variables is quite straight forward so I don't expect us to break it unintentionally.
And removing the tests that affect global state of Jest sounds like a better alternative to me vs running all tests in sequence by default.