### PR TITLE
Add package name to chooseVersionFromList message

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -54,7 +54,7 @@ const messages = {
   couldntFindMatch: "Couldn't find match for $0 in $1 for $2.",
   couldntFindPackageInCache: "Couldn't find any versions for $0 that matches $1 in our cache. Possible versions: $2",
   couldntFindVersionThatMatchesRange: "Couldn't find any versions for $0 that matches $1",
-  chooseVersionFromList: 'Please choose a version from this list:',
+  chooseVersionFromList: 'Please choose a version of $0 from this list:',
   moduleNotInManifest: "This module isn't specified in a manifest.",
   unknownFolderOrTarball: "Passed folder/tarball doesn't exist,",
   unknownPackage: "Couldn't find package $0.",

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -55,7 +55,7 @@ export default class NpmResolver extends RegistryResolver {
       const response: {[key: string]: ?string} = await inquirer.prompt([{
         name: 'package',
         type: 'list',
-        message: config.reporter.lang('chooseVersionFromList'),
+        message: config.reporter.lang('chooseVersionFromList', body.name),
         choices: Object.keys(body.versions).reverse(),
         pageSize,
       }]);


### PR DESCRIPTION
**Summary**
I don't use mouses much so the behavior of the list prompt made me confused in the first place. After some rounds of scrolling through the list using arrows, I didn't know which package the version mismatch came from until I scroll my mouse.

The position of `chooseVersionFromList` message is fixed on the top line so I think `Please choose a version of $0 from this list:` would be more obvious to users than `Please choose a version from this list:`

**Test plan**
![](https://fat.gfycat.com/ThornySplendidAndeancondor.gif)
https://gfycat.com/ThornySplendidAndeancondor#?speed=2

