### PR TITLE
Update to flow 0.43.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,4 +16,4 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.42.0
+^0.43.0

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-no-async-without-await": "^1.0.0",
     "eslint-plugin-react": "5.2.2",
     "eslint-plugin-yarn-internal": "file:scripts/eslint-rules",
-    "flow-bin": "^0.42.0",
+    "flow-bin": "^0.43.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.0.0",
     "gulp-if": "^2.0.1",

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -209,7 +209,7 @@ export default class InstallationIntegrityChecker {
       Object.assign({}, {checkFiles: false}, flags), // don't generate files when checking, we check the files below
       loc.locationFolder);
     const expectedRaw = await fs.readFile(loc.locationPath);
-    let expected: IntegrityFile;
+    let expected: ?IntegrityFile;
     try {
       expected = JSON.parse(expectedRaw);
     } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,13 +1805,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.42.0:
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.42.0.tgz#05dd754b6b052de7b150f9210e2160746961e3cf"
-
-flow@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/flow/-/flow-0.2.3.tgz#f8da65efa249127ec99376a28896572a9795d1af"
+flow-bin@^0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.43.0.tgz#5cd16696be4311c0b14f0932e89ba8661a39b1c1"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
**Summary**

Routine update. https://github.com/facebook/flow/releases/tag/v0.43.0

Not sure how that extra "flow" dep snuck in #2970. I tried v0.21.2 and master, and both yarn's remove that "flow" dep.
 
**Test plan**

`flow`.
