### PR TITLE
CI stability: running all Jest workers single threaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - TEST_TYPE="build-dist"
     - TEST_TYPE="check-lockfile"
     - TEST_TYPE="lint"
-    - TEST_TYPE="test-ci -- -- --maxWorkers 3"
+    - TEST_TYPE="test-ci -- -- --maxWorkers 1"
 
 matrix:
   exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build_script:
 
 test_script:
   - node --version
-  - npm run test-only -- --maxWorkers 3
+  - npm run test-only -- --maxWorkers 1
 
 artifacts:
   - path: artifacts/*.msi

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ test:
         ./scripts/set-dev-version.js
       fi;
     - yarn lint
-    - yarn test-ci -- -- --maxWorkers 3
+    - yarn test-ci -- -- --maxWorkers 1
     - yarn check-lockfile
     - yarn build-dist
     - node ./scripts/build-webpack.js


### PR DESCRIPTION
**Summary**

We still have too many CI failures because of connection timeouts.
I'll rerun the test on Circle 10 times to verify if decreasing concurrency helps.

