### PR TITLE
Remove the dependency on the "rc" module

### DIFF
--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -32,28 +32,28 @@ async function execCommand(cmd: string, packageName: string, env = process.env):
 
 test('should add the global yarnrc arguments to the command line', async () => {
   const stdout = await execCommand('cache dir', 'yarnrc-cli');
-  expect(stdout.replace(/\\/g, '/')).toMatch(/^\/tmp\/foobar\/v[0-9]+\n$/);
+  expect(stdout.replace(/\\/g, '/')).toMatch(/^(C:)?\/tmp\/foobar\/v[0-9]+\n$/);
 });
 
 test('should add the command-specific yarnrc arguments to the command line if the command name matches', async () => {
   const stdout = await execCommand('cache dir', 'yarnrc-cli-command-specific-ok');
-  expect(stdout.replace(/\\/g, '/')).toMatch(/^\/tmp\/foobar\/v[0-9]+\n$/);
+  expect(stdout.replace(/\\/g, '/')).toMatch(/^(C:)?\/tmp\/foobar\/v[0-9]+\n$/);
 });
 
 test('should not add the command-specific yarnrc arguments if the command name doesn\'t match', async () => {
   const stdout = await execCommand('cache dir', 'yarnrc-cli-command-specific-ko');
-  expect(stdout.replace(/\\/g, '/')).not.toMatch(/^\/tmp\/foobar\/v[0-9]+\n$/);
+  expect(stdout.replace(/\\/g, '/')).not.toMatch(/^(C:)?\/tmp\/foobar\/v[0-9]+\n$/);
 });
 
 test('should allow overriding the yarnrc values from the command line', async () => {
   const stdout = await execCommand('cache dir --cache-folder /tmp/toto', 'yarnrc-cli');
-  expect(stdout.replace(/\\/g, '/')).toMatch(/^\/tmp\/toto\/v[0-9]+\n$/);
+  expect(stdout.replace(/\\/g, '/')).toMatch(/^(C:)?\/tmp\/toto\/v[0-9]+\n$/);
 });
 
 // Test disabled for now, cf rc.js
 test('should resolve the yarnrc values relative to where the file lives', async () => {
   const stdout = await execCommand('cache dir', 'yarnrc-cli-relative');
-  expect(stdout.replace(/\\/g, '/')).toMatch(/^(\/[^\/]+)+\/foobar\/hello\/world\/v[0-9]+\n$/);
+  expect(stdout.replace(/\\/g, '/')).toMatch(/^(C:)?(\/[^\/]+)+\/foobar\/hello\/world\/v[0-9]+\n$/);
 });
 
 test('should expose `npm_config_argv` environment variable to lifecycle scripts for back compatibility with npm (#684)',

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -51,7 +51,7 @@ test('should allow overriding the yarnrc values from the command line', async ()
 });
 
 // Test disabled for now, cf rc.js
-test.skip('should resolve the yarnrc values relative to where the file lives', async () => {
+test('should resolve the yarnrc values relative to where the file lives', async () => {
   const stdout = await execCommand('cache dir', 'yarnrc-cli-relative');
   expect(stdout.replace(/\\/g, '/')).toMatch(/^(\/[^\/]+)+\/foobar\/hello\/world\/v[0-9]+\n$/);
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node-gyp": "^3.2.1",
     "object-path": "^0.11.2",
     "proper-lockfile": "^2.0.0",
-    "rc": "^1.2.1",
     "read": "^1.0.7",
     "request": "^2.81.0",
     "request-capture-har": "^1.2.2",
@@ -72,6 +71,7 @@
     "gulp-watch": "^4.3.5",
     "jest": "^19.0.2",
     "mock-stdin": "^0.3.0",
+    "shebang-loader": "^0.0.1",
     "temp": "^0.8.3",
     "webpack": "^2.1.0-beta.25",
     "yargs": "^6.3.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "gulp-watch": "^4.3.5",
     "jest": "^19.0.2",
     "mock-stdin": "^0.3.0",
-    "shebang-loader": "^0.0.1",
     "temp": "^0.8.3",
     "webpack": "^2.1.0-beta.25",
     "yargs": "^6.3.0"

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -19,9 +19,6 @@ const compiler = webpack({
   entry: [path.join(basedir, 'src/cli/index.js')],
   module: {
     loaders: [{
-      test: /\/node_modules\/rc\/index\.js$/,
-      loader: 'shebang-loader'
-     }, {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'babel-loader',
@@ -59,9 +56,6 @@ const compilerLegacy = webpack({
       exclude: /node_modules/,
       loader: 'babel-loader',
       query: babelRc.env['pre-node5'],
-    }, {
-      include: [`${basedir}/node_modules/rc/index.js`],
-      loader: 'shebang-loader'
     }]
   },
   plugins: [

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -19,6 +19,9 @@ const compiler = webpack({
   entry: [path.join(basedir, 'src/cli/index.js')],
   module: {
     loaders: [{
+      test: /\/node_modules\/rc\/index\.js$/,
+      loader: 'shebang-loader'
+     }, {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'babel-loader',
@@ -56,7 +59,10 @@ const compilerLegacy = webpack({
       exclude: /node_modules/,
       loader: 'babel-loader',
       query: babelRc.env['pre-node5'],
-    }],
+    }, {
+      include: [`${basedir}/node_modules/rc/index.js`],
+      loader: 'shebang-loader'
+    }]
   },
   plugins: [
     new webpack.BannerPlugin({

--- a/src/rc.js
+++ b/src/rc.js
@@ -1,8 +1,8 @@
 /* @flow */
 
+import {dirname, resolve} from 'path';
 import parse from './lockfile/parse.js';
-
-const rc = require('rc');
+import * as rcUtil from './util/rc.js';
 
 // Keys that will get resolved relative to the path of the rc file they belong to
 const PATH_KEYS = [
@@ -14,20 +14,14 @@ const PATH_KEYS = [
 let rcConfCache;
 let rcArgsCache;
 
-const buildRcConf = () => rc('yarn', {}, [], (fileText) => {
+const buildRcConf = () => rcUtil.findRc('yarn', (fileText, filePath) => {
   const values = parse(fileText, 'yarnrc');
   const keys = Object.keys(values);
 
-  // Unfortunately, the "rc" module we use doesn't tell us the file path :(
-  // cf https://github.com/dominictarr/rc/issues/61
-
   for (const key of keys) {
     for (const pathKey of PATH_KEYS) {
-      if (key.replace(/^(--)?([^.]+\.)+/, '') === pathKey) {
-        // values[key] = resolve(dirname(filePath), values[key]);
-        if (!values[key].startsWith('/')) {
-          delete values[keys];
-        }
+      if (key.replace(/^(--)?([^.]+\.)*/, '') === pathKey) {
+        values[key] = resolve(dirname(filePath), values[key]);
       }
     }
   }

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -1,0 +1,62 @@
+/* @flow */
+
+import {readFileSync} from 'fs';
+import {basename, dirname, join} from 'path';
+
+const etc = '/etc';
+const isWin = process.platform === 'win32';
+const home = isWin ? process.env.USERPROFILE : process.env.HOME;
+
+export function findRc(name: string, parser: Function): Object {
+  let configPaths = [];
+
+  function addConfigPath(... segments) {
+    configPaths.push(join(... segments));
+  }
+
+  function addRecursiveConfigPath(... segments) {
+    const queue = [];
+
+    let oldPath;
+    let path = join(... segments);
+
+    do {
+      queue.unshift(path);
+
+      oldPath = path;
+      path = join(dirname(dirname(path)), basename(path));
+    } while (path !== oldPath);
+
+    configPaths = configPaths.concat(queue);
+  }
+
+  function fetchConfigs(): Object {
+    return Object.assign({}, ... configPaths.map((path) => {
+      try {
+        return parser(readFileSync(path).toString(), path);
+      } catch (error) {
+        return {};
+      }
+    }));
+  }
+
+  if (!isWin) {
+    addConfigPath(etc, name, 'config');
+    addConfigPath(etc, `${name}rc`);
+  }
+
+  if (home) {
+    addConfigPath(home, '.config', name, 'config');
+    addConfigPath(home, '.config', name);
+    addConfigPath(home, `.${name}`, 'config');
+    addConfigPath(home, `.${name}rc`);
+  }
+
+  addRecursiveConfigPath(process.cwd(), `.${name}rc`);
+
+  if (process.env[`${name}_config`.toUpperCase()]) {
+    addConfigPath(process.env[`${name}_config`]);
+  }
+
+  return fetchConfigs();
+}

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -54,8 +54,10 @@ export function findRc(name: string, parser: Function): Object {
 
   addRecursiveConfigPath(process.cwd(), `.${name}rc`);
 
-  if (process.env[`${name}_config`.toUpperCase()]) {
-    addConfigPath(process.env[`${name}_config`]);
+  const envVariable = `${name}_config`.toUpperCase();
+
+  if (process.env[envVariable]) {
+    addConfigPath(process.env[envVariable]);
   }
 
   return fetchConfigs();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,15 +3719,6 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
 
-rc@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
-  dependencies:
-    deep-extend "~0.4.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 rc@~1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.7.tgz#c5ea564bb07aff9fd3a5b32e906c1d3a65940fea"
@@ -4062,6 +4053,10 @@ sha.js@^2.3.6:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
+
+shebang-loader@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shebang-loader/-/shebang-loader-0.0.1.tgz#a4000495d44cceefbec63435e7b1698569fa52ec"
 
 shelljs@^0.7.5:
   version "0.7.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,10 +4054,6 @@ sha.js@^2.3.6:
   dependencies:
     inherits "^2.0.1"
 
-shebang-loader@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/shebang-loader/-/shebang-loader-0.0.1.tgz#a4000495d44cceefbec63435e7b1698569fa52ec"
-
 shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"


### PR DESCRIPTION
**Summary**

We now ship our own logic to search for the Yarnrc file (initially, this change is prompted because the `rc` module doesn't support webpack, but it also allows us to resolve relative paths relatively to the yarnrc file in which they are found).

**Test plan**

Tests should all pass, a skipped test has been enabled.