### PR TITLE
Checks that the webpack builds are working properly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,7 @@ test:
     - yarn check-lockfile
     - yarn build-dist
     - node ./scripts/build-webpack.js
+    - ls -t1 artifacts | head -n2 | while read entry; do node "./artifacts/$entry" --version; done
     - ./scripts/build-deb.sh
     # Test that installing as root works and that it also works
     # behind a user namespace which Circle CI tests are run under


### PR DESCRIPTION
**Summary**

This PR adds a small script to make sure that the generated artifacts (the two most recently modified files) are working properly after `build-webpack.js` has been called.