### PR TITLE
Make it log "email" instead of "username"

### DIFF
--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -20,7 +20,7 @@ async function getCredentials(config: Config, reporter: Reporter): Promise<?{
   }
 
   if (email) {
-    reporter.info(`${reporter.lang('npmUsername')}: ${email}`);
+    reporter.info(`${reporter.lang('npmEmail')}: ${email}`);
   } else {
     email = await reporter.question(reporter.lang('npmEmail'));
     if (!email) {


### PR DESCRIPTION
I think this is a typo? I noticed it when trying to login:

![image](https://cloud.githubusercontent.com/assets/6251703/24808563/dc76c4b2-1b81-11e7-953b-0a5cf232b592.png)
