### PR TITLE
Remove Roadrunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /dist-debug
 /artifacts
 /updates
-/.roadrunner.json
 /resources/winsetup/generated.wxs
 /resources/winsetup/obj
 /resources/winsetup/bin

--- a/.npmignore
+++ b/.npmignore
@@ -26,7 +26,6 @@
 /dist
 /dist-debug
 /__tests__
-/.roadrunner.json
 .vs
 *.msi
 *.nupkg

--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -30,21 +30,4 @@ var mkdirp = require('mkdirp');
 var constants = require('../lib-legacy/constants');
 mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
 
-// init roadrunner
-var YARN_VERSION = require('../package.json').version;
-var roadrunner = require('roadrunner');
-
-// load cache
-roadrunner.load(constants.CACHE_FILENAME);
-var cacheVersion = roadrunner.get('CACHE_BREAKER').version;
-if (!cacheVersion || cacheVersion !== YARN_VERSION) {
-  // reset cache if it's for an older yarn
-  roadrunner.reset(constants.CACHE_FILENAME);
-}
-// set this cache to the current yarn version
-roadrunner.set('CACHE_BREAKER', {version: YARN_VERSION});
-
-// save cache on SIGINT
-roadrunner.setup(constants.CACHE_FILENAME);
-
 module.exports = require(path);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "request": "^2.81.0",
     "request-capture-har": "^1.2.2",
     "rimraf": "^2.5.0",
-    "roadrunner": "^1.1.0",
     "semver": "^5.1.0",
     "strip-bom": "^3.0.0",
     "tar-fs": "^1.15.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -63,7 +63,6 @@ export const MODULE_CACHE_DIRECTORY = getCacheDirectory();
 export const CONFIG_DIRECTORY = getDirectory('config');
 export const LINK_REGISTRY_DIRECTORY = path.join(CONFIG_DIRECTORY, 'link');
 export const GLOBAL_MODULE_DIRECTORY = path.join(CONFIG_DIRECTORY, 'global');
-export const CACHE_FILENAME = path.join(MODULE_CACHE_DIRECTORY, '.roadrunner.json');
 
 export const INTEGRITY_FILENAME = '.yarn-integrity';
 export const LOCKFILE_FILENAME = 'yarn.lock';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,10 +3980,6 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-roadrunner@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/roadrunner/-/roadrunner-1.1.0.tgz#1180a30d64e1970d8f55dd8cb0da8ffccecad71e"
-
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"


### PR DESCRIPTION
**Summary**
Now that we're including the bundled .js file in the tarball, we don't really need Roadrunner. @bestander suggested removing it in #3030:

> What do you think of getting rid of roadrunner as well? The extra cache layer for people who run from master branch does not make much impact.

**Test plan**
`./bin/yarn install`, it worked as expected.

Closes #3075, #3037, #2959