### PR TITLE
Automatically update Homebrew package when new versions are released

### DIFF
--- a/jenkins_jobs.groovy
+++ b/jenkins_jobs.groovy
@@ -62,3 +62,22 @@ job('yarn-chocolatey') {
     mailer 'yarn@dan.cx'
   }
 }
+
+job('yarn-homebrew') {
+  description 'Ensures the Homebrew package for Yarn is up-to-date'
+  label 'linuxbrew'
+  scm {
+    github 'yarnpkg/yarn', 'master'
+  }
+  triggers {
+    yarnStableVersionChange delegate
+  }
+  steps {
+    shell './scripts/update-homebrew.sh'
+  }
+  publishers {
+    gitHubIssueNotifier {
+    }
+    mailer 'yarn@dan.cx'
+  }
+}

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Pushes the latest Yarn version to Homebrew
+
+set -ex
+
+version=`curl --fail https://yarnpkg.com/latest-version`
+
+# Ensure Linuxbrew is on the PATH
+PATH=$PATH:$HOME/.linuxbrew/bin/
+# Ensure homebrew-core is pointing to Homebrew rather than Linuxbrew
+pushd ~/.linuxbrew/Library/Taps/homebrew/homebrew-core
+#git remote set-url origin https://github.com/Daniel15/homebrew-core # for testing
+git remote set-url origin https://github.com/homebrew/homebrew-core
+# Remove any existing branch (eg. if the previous attempt failed)
+git branch -D yarn-$version || true
+popd
+
+# Grab latest Yarn release so we can hash it
+url=https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz
+tempfile=`mktemp -t 'yarn-release-XXXXXXXX.tar.gz'`
+curl --fail -L -o $tempfile $url
+hash=`sha256sum $tempfile | head -c 64`
+
+# Update the formula!
+# "BROWSER=/bin/true" is a hack around https://github.com/Homebrew/brew/issues/2468
+BROWSER=/bin/true brew bump-formula-pr --strict yarn --url=$url --sha256=$hash --message="This PR was automatically created via a script. Contact @Daniel15 with any questions."


### PR DESCRIPTION
**Summary**
Adds a script to update Homebrew using their `brew-formula-pr` command. This runs fine on Linuxbrew. Also adds a Jenkins job for it.

**Test plan**
Manually tested the script with the origin set to a test repo: https://github.com/Daniel15/homebrew-core/pull/2

cc @SimenB 

Closes #2841