### PR TITLE
Use ES6 import syntax everywhere

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -14,7 +14,7 @@ import {getPackageVersion, explodeLockfile, runInstall, createLockfile} from '..
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
 
-let request = require('request');
+const request = require('request');
 const semver = require('semver');
 const path = require('path');
 const stream = require('stream');
@@ -38,7 +38,6 @@ async function mockConstants(base: Config, mocks: Object, cb: (config: Config) =
   jest.setMock('../../../src/constants', Object.assign(automock, mocks));
 
   jest.resetModules();
-  request = require('request');
 
   jest.mock('../../../src/constants');
   await cb(await require('../../../src/config.js').default.create(opts, base.reporter));

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -11,7 +11,7 @@ import {buildTree} from './list.js';
 import {wrapLifecycle, Install} from './install.js';
 import {MessageError} from '../../errors.js';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 export class Add extends Install {
   constructor(

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -4,7 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import RegistryYarn from '../../resolvers/registries/yarn-resolver.js';
 
-const path = require('path');
+import path from 'path';
 
 export function hasWrapper() {}
 

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -6,7 +6,7 @@ import buildSubCommands from './_build-sub-commands.js';
 import * as fs from '../../util/fs.js';
 import {METADATA_FILENAME} from '../../constants';
 
-const path = require('path');
+import path from 'path';
 
 export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] !== 'dir';

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -8,8 +8,8 @@ import type {Reporter} from '../../reporters/index.js';
 import * as fs from '../../util/fs.js';
 import {Install} from './install.js';
 
-const semver = require('semver');
-const path = require('path');
+import semver from 'semver';
+import path from 'path';
 
 export const requireLockfile = false;
 export const noArguments = true;

--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -7,7 +7,7 @@ import {sortFilter, ignoreLinesToRegex} from '../../util/filter.js';
 import {CLEAN_FILENAME} from '../../constants.js';
 import * as fs from '../../util/fs.js';
 
-const path = require('path');
+import path from 'path';
 
 export const requireLockfile = true;
 export const noArguments = true;

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -30,7 +30,7 @@ class GlobalAdd extends Add {
   }
 }
 
-const path = require('path');
+import path from 'path';
 
 export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] !== 'bin';

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -5,7 +5,7 @@ import * as constants from '../../constants.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {sortAlpha, hyphenate, camelCase} from '../../util/misc.js';
-const chalk = require('chalk');
+import chalk from 'chalk';
 
 export function hasWrapper(): boolean {
   return false;

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -23,8 +23,8 @@ import {YARN_REGISTRY, LOCKFILE_FILENAME} from '../../constants.js';
 
 const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 export const noArguments = true;
 

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -4,7 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 import parsePackageName from '../../util/parse-package-name.js';
-const semver = require('semver');
+import semver from 'semver';
 
 function clean(object: any): any {
   if (Array.isArray(object)) {

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -8,8 +8,8 @@ import * as child from '../../util/child.js';
 import * as fs from '../../util/fs.js';
 import * as validate from '../../util/normalize-manifest/validate.js';
 
-const objectPath = require('object-path');
-const path = require('path');
+import objectPath from 'object-path';
+import path from 'path';
 
 export function setFlags(commander: Object) {
   commander.option('-y, --yes', 'use default options');

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -22,13 +22,13 @@ import * as constants from '../../constants.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
-const invariant = require('invariant');
-const semver = require('semver');
-const emoji = require('node-emoji');
-const isCI = require('is-ci');
-const path = require('path');
+import invariant from 'invariant';
+import semver from 'semver';
+import emoji from 'node-emoji';
+import isCI from 'is-ci';
+import path from 'path';
 
-const {version: YARN_VERSION, installationMethod: YARN_INSTALL_METHOD} = require('../../../package.json');
+import {version as YARN_VERSION, installationMethod as YARN_INSTALL_METHOD} from '../../../package.json';
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
 export type InstallCwdRequest = {

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -8,7 +8,7 @@ import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import buildSubCommands from './_build-sub-commands.js';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] != 'generate-disclaimer';

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -6,8 +6,8 @@ import {MessageError} from '../../errors.js';
 import * as fs from '../../util/fs.js';
 import {getBinFolder as getGlobalBinFolder} from './global';
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 export async function getRegistryFolder(config: Config, name: string): Promise<string> {
   if (config.modulesFolder) {

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -8,7 +8,7 @@ import type {Tree, Trees} from '../../reporters/types.js';
 import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 export const requireLockfile = true;
 

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -7,10 +7,10 @@ import * as fs from '../../util/fs.js';
 import {sortFilter, ignoreLinesToRegex} from '../../util/filter.js';
 import {MessageError} from '../../errors.js';
 
-const zlib = require('zlib');
-const path = require('path');
-const tar = require('tar-stream');
-const fs2 = require('fs');
+import zlib from 'zlib';
+import path from 'path';
+import tar from 'tar-stream';
+import fs2 from 'fs';
 
 const IGNORE_FILENAMES = [
   '.yarnignore',

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -10,10 +10,10 @@ import * as fs from '../../util/fs.js';
 import {pack} from './pack.js';
 import {getToken} from './login.js';
 
-const invariant = require('invariant');
-const crypto = require('crypto');
-const url = require('url');
-const fs2 = require('fs');
+import invariant from 'invariant';
+import crypto from 'crypto';
+import url from 'url';
+import fs2 from 'fs';
 
 export function setFlags(commander: Object) {
   versionSetFlags(commander);

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -10,7 +10,7 @@ import {NoopReporter} from '../../reporters/index.js';
 import * as fs from '../../util/fs.js';
 import * as constants from '../../constants.js';
 
-const path = require('path');
+import path from 'path';
 
 export const requireLockfile = true;
 

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -8,8 +8,8 @@ import {registries} from '../../resolvers/index.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
-const leven = require('leven');
-const path = require('path');
+import leven from 'leven';
+import path from 'path';
 
 function sanitizedArgs(args: Array<string>): Array<string> {
   const newArgs = [];

--- a/src/cli/commands/unlink.js
+++ b/src/cli/commands/unlink.js
@@ -7,7 +7,7 @@ import * as fs from '../../util/fs.js';
 import {getRegistryFolder} from './link.js';
 import {getBinFolder as getGlobalBinFolder} from './global';
 
-const path = require('path');
+import path from 'path';
 
 export async function run(
   config: Config,

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -9,7 +9,7 @@ import {Add} from './add.js';
 import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 
-const tty = require('tty');
+import tty from 'tty';
 
 export const requireLockfile = true;
 

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -9,9 +9,9 @@ import {spawn} from '../../util/child.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
-const invariant = require('invariant');
-const semver = require('semver');
-const path = require('path');
+import invariant from 'invariant';
+import semver from 'semver';
+import path from 'path';
 
 const NEW_VERSION_FLAG = '--new-version [version]';
 function isValidNewVersion(oldVersion: string, newVersion: string, looseSemver: boolean): boolean {

--- a/src/cli/commands/versions.js
+++ b/src/cli/commands/versions.js
@@ -3,7 +3,7 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 
-const YARN_VERSION = require('../../../package.json').version;
+import {version as YARN_VERSION} from '../../../package.json';
 
 export async function run(
  config: Config,

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -12,10 +12,10 @@ import {MessageError} from '../../errors.js';
 
 export const requireLockfile = true;
 
-const invariant = require('invariant');
-const bytes = require('bytes');
-const emoji = require('node-emoji');
-const path = require('path');
+import invariant from 'invariant';
+import bytes from 'bytes';
+import emoji from 'node-emoji';
+import path from 'path';
 
 async function cleanQuery(config: Config, query: string): Promise<string> {
   // if a location was passed then turn it into a hash query

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -11,16 +11,16 @@ import Config from '../config.js';
 import {getRcArgs} from '../rc.js';
 import {camelCase} from '../util/misc.js';
 
-const chalk = require('chalk');
-const commander = require('commander');
-const fs = require('fs');
-const invariant = require('invariant');
-const lockfile = require('proper-lockfile');
-const loudRejection = require('loud-rejection');
-const net = require('net');
-const onDeath = require('death');
-const path = require('path');
-const pkg = require('../../package.json');
+import chalk from 'chalk';
+import commander from 'commander';
+import fs from 'fs';
+import invariant from 'invariant';
+import lockfile from 'proper-lockfile';
+import loudRejection from 'loud-rejection';
+import net from 'net';
+import onDeath from 'death';
+import path from 'path';
+import pkg from '../../package.json';
 
 loudRejection();
 

--- a/src/config.js
+++ b/src/config.js
@@ -15,9 +15,9 @@ import {registries, registryNames} from './registries/index.js';
 import {NoopReporter} from './reporters/index.js';
 import map from './util/map.js';
 
-const detectIndent = require('detect-indent');
-const invariant = require('invariant');
-const path = require('path');
+import detectIndent from 'detect-indent';
+import invariant from 'invariant';
+import path from 'path';
 
 export type ConfigOptions = {
   cwd?: ?string,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-const path = require('path');
-const userHome = require('./util/user-home-dir').default;
+import path from 'path';
+import userHome from './util/user-home-dir';
 
 type Env = {
   [key: string]: ? string

--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -8,7 +8,7 @@ import type Config from '../config.js';
 import * as constants from '../constants.js';
 import * as fs from '../util/fs.js';
 
-const path = require('path');
+import path from 'path';
 
 export default class BaseFetcher {
   constructor(dest: string, remote: PackageRemote, config: Config) {

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -8,12 +8,12 @@ import * as fsUtil from '../util/fs.js';
 import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
 
-const tarFs = require('tar-fs');
-const url = require('url');
-const path = require('path');
-const fs = require('fs');
+import tarFs from 'tar-fs';
+import url from 'url';
+import path from 'path';
+import fs from 'fs';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 export default class GitFetcher extends BaseFetcher {
   async getLocalAvailabilityStatus(): Promise<bool> {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -9,10 +9,10 @@ import * as crypto from '../util/crypto.js';
 import BaseFetcher from './base-fetcher.js';
 import * as fsUtil from '../util/fs.js';
 
-const path = require('path');
-const tarFs = require('tar-fs');
-const url = require('url');
-const fs = require('fs');
+import path from 'path';
+import tarFs from 'tar-fs';
+import url from 'url';
+import fs from 'fs';
 
 export default class TarballFetcher extends BaseFetcher {
   async setupMirrorFromCache(): Promise<?string> {

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -10,8 +10,8 @@ import * as fs from './util/fs.js';
 import {sortAlpha, compareSortedArrays} from './util/misc.js';
 
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 export type IntegrityCheckResult = {
   integrityFileMissing: boolean,

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -5,8 +5,8 @@ import {LOCKFILE_VERSION} from '../constants.js';
 import {MessageError} from '../errors.js';
 import map from '../util/map.js';
 
-const invariant = require('invariant');
-const stripBOM = require('strip-bom');
+import invariant from 'invariant';
+import stripBOM from 'strip-bom';
 
 const VERSION_REGEX = /^yarn lockfile v(\d+)$/;
 

--- a/src/lockfile/wrapper.js
+++ b/src/lockfile/wrapper.js
@@ -9,8 +9,8 @@ import parse from './parse.js';
 import * as constants from '../constants.js';
 import * as fs from '../util/fs.js';
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 export {default as parse} from './parse';
 export {default as stringify} from './stringify';

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -8,11 +8,12 @@ import {MessageError} from './errors.js';
 import map from './util/map.js';
 import {entries} from './util/misc.js';
 
-const invariant = require('invariant');
-const semver = require('semver');
+import invariant from 'invariant';
+import semver from 'semver';
 
+import {version as yarnVersion} from '../package.json';
 const VERSIONS = Object.assign({}, process.versions, {
-  yarn: require('../package.json').version,
+  yarn: yarnVersion,
 });
 
 function isValid(items: Array<string>, actual: string): boolean {

--- a/src/package-constraint-resolver.js
+++ b/src/package-constraint-resolver.js
@@ -3,7 +3,7 @@
 import type {Reporter} from './reporters/index.js';
 import type Config from './config.js';
 
-const semver = require('semver');
+import semver from 'semver';
 
 // This isn't really a "proper" constraint resolver. We just return the highest semver
 // version in the versions passed that satisfies the input range. This vastly reduces

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -5,8 +5,8 @@ import type Config from './config.js';
 import type {Manifest} from './types.js';
 import {sortAlpha} from './util/misc.js';
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 type Parts = Array<string>;
 

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -9,8 +9,8 @@ import executeLifecycleScript from './util/execute-lifecycle-script.js';
 import * as fs from './util/fs.js';
 import * as constants from './constants.js';
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 const INSTALL_STAGES = ['preinstall', 'install', 'postinstall'];
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -12,11 +12,12 @@ import * as promise from './util/promise.js';
 import {entries} from './util/misc.js';
 import * as fs from './util/fs.js';
 import lockMutex from './util/mutex.js';
+import originalCmdShim from 'cmd-shim';
 
-const invariant = require('invariant');
-const cmdShim = promise.promisify(require('cmd-shim'));
-const semver = require('semver');
-const path = require('path');
+import invariant from 'invariant';
+const cmdShim = promise.promisify(originalCmdShim);
+import semver from 'semver';
+import path from 'path';
 
 type DependencyPairs = Array<{
   dep: Manifest,

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -16,9 +16,9 @@ import * as versionUtil from './util/version.js';
 import * as resolvers from './resolvers/index.js';
 import * as fs from './util/fs.js';
 
-const path = require('path');
-const invariant = require('invariant');
-const semver = require('semver');
+import path from 'path';
+import invariant from 'invariant';
+import semver from 'semver';
 
 type ResolverRegistryNames = $Keys<typeof registryResolvers>;
 

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -11,8 +11,8 @@ import BlockingQueue from './util/blocking-queue.js';
 import Lockfile from './lockfile/wrapper.js';
 import map from './util/map.js';
 
-const invariant = require('invariant');
-const semver = require('semver');
+import invariant from 'invariant';
+import semver from 'semver';
 
 export default class PackageResolver {
   constructor(config: Config, lockfile: Lockfile) {

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -5,8 +5,8 @@ import type Config from '../config.js';
 import type {ConfigRegistries} from './index.js';
 import {removePrefix} from '../util/misc.js';
 
-const objectPath = require('object-path');
-const path = require('path');
+import objectPath from 'object-path';
+import path from 'path';
 
 export type RegistryRequestOptions = {
   method?: RequestMethods,

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -11,10 +11,10 @@ import Registry from './base-registry.js';
 import {addSuffix, removePrefix} from '../util/misc';
 import isRequestToRegistry from './is-request-to-registry.js';
 
-const userHome = require('../util/user-home-dir').default;
-const path = require('path');
-const url = require('url');
-const ini = require('ini');
+import userHome from '../util/user-home-dir';
+import path from 'path';
+import url from 'url';
+import ini from 'ini';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -8,9 +8,9 @@ import stringify from '../lockfile/stringify.js';
 import parse from '../lockfile/parse.js';
 import * as fs from '../util/fs.js';
 
-const userHome = require('../util/user-home-dir').default;
-const path = require('path');
-const pkg: { version: string } = require('../../package.json');
+import userHome from '../util/user-home-dir';
+import path from 'path';
+import {version as yarnVersion} from '../../package.json';
 
 export const DEFAULTS = {
   'version-tag-prefix': 'v',
@@ -27,7 +27,7 @@ export const DEFAULTS = {
   registry: YARN_REGISTRY,
   'strict-ssl': true,
   'user-agent': [
-    `yarn/${pkg.version}`,
+    `yarn/${yarnVersion}`,
     'npm/?',
     `node/${process.version}`,
     process.platform,

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -17,8 +17,8 @@ import {defaultFormatter} from './format.js';
 import * as languages from './lang/index.js';
 import isCI from 'is-ci';
 
-const util = require('util');
-const EventEmitter = require('events').EventEmitter;
+import util from 'util';
+import EventEmitter from 'events';
 
 type Language = $Keys<typeof languages>;
 

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -16,10 +16,10 @@ import {clearLine} from './util.js';
 import {removeSuffix} from '../../util/misc.js';
 import {sortTrees, recurseTree, getFormattedOutput} from './helpers/tree-helper.js';
 
-const {inspect} = require('util');
-const readline = require('readline');
-const chalk = require('chalk');
-const read = require('read');
+import {inspect} from 'util';
+import readline from 'readline';
+import chalk from 'chalk';
+import read from 'read';
 
 type Row = Array<string>;
 

--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -2,8 +2,8 @@
 
 import type {Stdout} from '../types.js';
 
-const readline = require('readline');
-const {supportsColor} = require('chalk');
+import readline from 'readline';
+import {supportsColor} from 'chalk';
 
 const CLEAR_WHOLE_LINE = 0;
 const CLEAR_RIGHT_OF_CURSOR = 1;

--- a/src/reporters/event-reporter.js
+++ b/src/reporters/event-reporter.js
@@ -2,7 +2,7 @@
 
 import JSONReporter from './json-reporter.js';
 
-const {EventEmitter} = require('events');
+import EventEmitter from 'events';
 
 export default class EventReporter extends JSONReporter {
   emit: (type: string, data: mixed) => void;

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -7,8 +7,8 @@ import ExoticResolver from './exotic-resolver.js';
 import * as util from '../../util/misc.js';
 import * as fs from '../../util/fs.js';
 
-const invariant = require('invariant');
-const path = require('path');
+import invariant from 'invariant';
+import path from 'path';
 
 type Dependencies = {
   [key: string]: string

--- a/src/resolvers/exotics/git-resolver.js
+++ b/src/resolvers/exotics/git-resolver.js
@@ -10,7 +10,7 @@ import {registries} from '../../registries/index.js';
 import ExoticResolver from './exotic-resolver.js';
 import Git from '../../util/git.js';
 
-const urlParse = require('url').parse;
+import {parse as urlParse} from 'url';
 
 // we purposefully omit https and http as those are only valid if they end in the .git extension
 const GIT_PROTOCOLS = ['git:', 'git+ssh:', 'git+https:', 'ssh:'];

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -10,7 +10,7 @@ import * as versionUtil from '../../util/version.js';
 import * as crypto from '../../util/crypto.js';
 import * as fs from '../../util/fs.js';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 export default class TarballResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -10,10 +10,10 @@ import map from '../../util/map.js';
 import * as fs from '../../util/fs.js';
 import {YARN_REGISTRY} from '../../constants.js';
 
-const inquirer = require('inquirer');
-const tty = require('tty');
-const invariant = require('invariant');
-const path = require('path');
+import inquirer from 'inquirer';
+import tty from 'tty';
+import invariant from 'invariant';
+import path from 'path';
 
 const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
 

--- a/src/util/blocking-queue.js
+++ b/src/util/blocking-queue.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import map from './map.js';
+import debugFactory from 'debug';
 
-const debug = require('debug')('yarn');
+const debug = debugFactory('yarn');
 
 export default class BlockingQueue {
   constructor(alias: string, maxConcurrency?: number = Infinity) {

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -6,7 +6,7 @@ import BlockingQueue from './blocking-queue.js';
 import {MessageError, SpawnError} from '../errors.js';
 import {promisify} from './promise.js';
 
-const child = require('child_process');
+import child from 'child_process';
 
 export const queue = new BlockingQueue('child', constants.CHILD_CONCURRENCY);
 

--- a/src/util/crypto.js
+++ b/src/util/crypto.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-const crypto = require('crypto');
-const stream = require('stream');
+import crypto from 'crypto';
+import stream from 'stream';
 
 export function hash(content: string, type: string = 'md5'): string {
   return crypto.createHash(type).update(content).digest('hex');

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -8,7 +8,7 @@ import * as child from './child.js';
 import {registries} from '../resolvers/index.js';
 import {fixCmdWinSlashes} from './fix-cmd-win-slashes.js';
 
-const path = require('path');
+import path from 'path';
 
 export type LifecycleReturn = Promise<{
   cwd: string,

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -3,8 +3,8 @@
 import type {WalkFiles} from './fs.js';
 import {removeSuffix} from './misc.js';
 
-const minimatch = require('minimatch');
-const path = require('path');
+import minimatch from 'minimatch';
+import path from 'path';
 
 const WHITESPACE_RE = /^\s+$/;
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -5,10 +5,12 @@ import BlockingQueue from './blocking-queue.js';
 import * as promise from './promise.js';
 import {promisify} from './promise.js';
 import map from './map.js';
+import originalMkdirp from 'mkdirp';
+import originalRimraf from 'rimraf';
 
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
 
 export const lockQueue = new BlockingQueue('fs lock');
 
@@ -20,8 +22,8 @@ export const readdir: (path: string, opts: void) => Promise<Array<string>> = pro
 export const rename: (oldPath: string, newPath: string) => Promise<void> = promisify(fs.rename);
 export const access: (path: string, mode?: number) => Promise<void> = promisify(fs.access);
 export const stat: (path: string) => Promise<fs.Stats> = promisify(fs.stat);
-export const unlink: (path: string) => Promise<void> = promisify(require('rimraf'));
-export const mkdirp: (path: string) => Promise<void> = promisify(require('mkdirp'));
+export const unlink: (path: string) => Promise<void> = promisify(originalRimraf);
+export const mkdirp: (path: string) => Promise<void> = promisify(originalMkdirp);
 export const exists: (path: string) => Promise<boolean> = promisify(fs.exists, true);
 export const lstat: (path: string) => Promise<fs.Stats> = promisify(fs.lstat);
 export const chmod: (path: string, mode: number | string) => Promise<void> = promisify(fs.chmod);
@@ -34,8 +36,8 @@ const fsSymlink: (
   path: string,
   type?: 'dir' | 'file' | 'junction'
 ) => Promise<void> = promisify(fs.symlink);
-const invariant = require('invariant');
-const stripBOM = require('strip-bom');
+import invariant from 'invariant';
+import stripBOM from 'strip-bom';
 
 const noop = () => {};
 

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -9,12 +9,12 @@ import * as child from './child.js';
 import * as fs from './fs.js';
 import map from './map.js';
 
-const invariant = require('invariant');
-const semver = require('semver');
-const StringDecoder = require('string_decoder').StringDecoder;
-const tarFs = require('tar-fs');
-const tarStream = require('tar-stream');
-const url = require('url');
+import invariant from 'invariant';
+import semver from 'semver';
+import {StringDecoder} from 'string_decoder';
+import tarFs from 'tar-fs';
+import tarStream from 'tar-stream';
+import url from 'url';
 import {createWriteStream} from 'fs';
 
 type GitRefs = {

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const _camelCase = require('camelcase');
+import _camelCase from 'camelcase';
 
 export function sortAlpha(a: string, b: string): number {
   // sort alphabetically in a deterministic way

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const os = require('os');
+import os from 'os';
 
 const IGNORE_INTERFACES = ['lo0', 'awdl0', 'bridge0'];
 const LOCAL_IPS = ['127.0.0.1', '::1'];

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -7,9 +7,9 @@ import {hostedGitFragmentToGitUrl} from '../../resolvers/index.js';
 import inferLicense from './infer-license.js';
 import * as fs from '../fs.js';
 
-const semver = require('semver');
-const path = require('path');
-const url = require('url');
+import semver from 'semver';
+import path from 'path';
+import url from 'url';
 
 const LICENSE_RENAMES: { [key: string]: ?string } = {
   'MIT/X11': 'MIT',

--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import validate from './validate.js';
 import fix from './fix.js';
 
-const path = require('path');
+import path from 'path';
 
 export default async function (
   info: Object,

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -2,7 +2,7 @@
 
 import type {PersonObject} from '../../types.js';
 
-const validateLicense = require('validate-npm-package-license');
+import validateLicense from 'validate-npm-package-license';
 
 export function isValidLicense(license: string): boolean {
   return !!license && validateLicense(license).validForNewPackages;

--- a/src/util/normalize-manifest/validate.js
+++ b/src/util/normalize-manifest/validate.js
@@ -5,7 +5,7 @@ import {MessageError} from '../../errors.js';
 import {isValidLicense} from './util.js';
 import typos from './typos.js';
 
-const isBuiltinModule = require('is-builtin-module');
+import isBuiltinModule from 'is-builtin-module';
 
 const strings = [
   'name',

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -8,12 +8,13 @@ import * as network from './network.js';
 import map from '../util/map.js';
 
 import typeof * as RequestModuleT from 'request';
+import request from 'request';
 import type RequestT from 'request';
 
-const RequestCaptureHar = require('request-capture-har');
-const invariant = require('invariant');
-const url = require('url');
-const fs = require('fs');
+import RequestCaptureHar from 'request-capture-har';
+import invariant from 'invariant';
+import url from 'url';
+import fs from 'fs';
 
 const successHosts = map();
 const controlOffline = network.isOffline();
@@ -195,7 +196,6 @@ export default class RequestManager {
 
   _getRequestModule(): RequestModuleT {
     if (!this._requestModule) {
-      const request = require('request');
       if (this.captureHar) {
         this._requestCaptureHar = new RequestCaptureHar(request);
         this._requestModule = this._requestCaptureHar.request.bind(this._requestCaptureHar);

--- a/src/util/stream.js
+++ b/src/util/stream.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-const invariant = require('invariant');
-const stream = require('stream');
-const zlib = require('zlib');
+import invariant from 'invariant';
+import stream from 'stream';
+import zlib from 'zlib';
 
 function hasGzipHeader(chunk: Buffer): boolean {
   return chunk[0] === 0x1F && chunk[1] === 0x8B && chunk[2] === 0x08;

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -2,10 +2,11 @@
 
 import ROOT_USER from './root-user.js';
 
-const path = require('path');
+import os from 'os';
+import path from 'path';
 
 const userHomeDir = (process.platform === 'linux' && ROOT_USER) ?
   path.resolve('/usr/local/share') :
-  require('os').homedir();
+  os.homedir();
 
 export default userHomeDir;


### PR DESCRIPTION
**Summary**
Use ES6 module syntax everywhere, rather than a mix of CommonJS (`require()`) and ES6 modules. Currently there's no difference, but this will allow us to use more advanced optimizations such as tree shaking.

Most of these were find and replace (replace `const ([A-Z0-9_]+) = require\('([^']+)'\);` with `import $1 from '$2';`) with some manual tweaking.

**Test plan**
`yarn run build`, no build errors
`node scripts\build-webpack.js` then run `node "artifacts\yarn-0.24.0-0.js"`, no errors.