### PR TITLE
Fixed concurrnet unpacks into the same folder

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -93,6 +93,7 @@ const messages = {
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
   frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
   fileWriteError: 'Could not write file $0: $1',
+  multiplePackagesCantUnpackInSameDestination: 'Pattern $0 is trying to unpack in the same destination $1 as pattern $2. This could result in a non deterministic behavior, skipping.',
 
   yarnOutdated: "Your current version of Yarn is out of date. The latest version is $0 while you're on $1.",
   yarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',


### PR DESCRIPTION
**Summary**

This is a mitigation for issue #2629.
In some cases two different packages could end up unpacking into the same cache folder.
Example https://github.com/yarnpkg/yarn/issues/2629#issuecomment-282745896, package typescript is downloaded twice because yarn.lock has inconsistent entries.
This change prevents more than one package to be unpacked into the same cache folder.

This is not a final fix for #2629, there is a more specific bug in resolver that causes this internal inconsistency but I think fetcher should check that every package will be extracted in a unique folder anyway.

**Test plan**

- I'll add a unit test in the next PR when I'll be fixing the reason for the same package having 2 downloads
- Manual test plan
1. Check out https://github.com/yarnpkg/yarn/issues/2629#issuecomment-282745896
2. yarn install
```
yarn install v0.24.0-0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning Pattern ["@angular/core@^2.0.0"] is trying to unpack in the same destination "/Users/bestander/Library/Caches/Yarn/v1/npm-@angular/core-4.0.0-rc.1-7f87b7696b407476e45d6d3c1880a50d5afbb6e3" as pattern ["@angular/core@4.0.0-rc.1","@angular/core@>=2.3.1 <5.0.0 || >=4.0.0-beta <5.0.0"]. This could result in a non deterministic behavior, skipping.
warning Pattern ["typescript@>=2.0.0 <2.2.0"] is trying to unpack in the same destination "/Users/bestander/Library/Caches/Yarn/v1/npm-typescript-2.2.1-4862b662b988a4c8ff691cc7969622d24db76ae9" as pattern ["typescript@2.2.1","typescript@>=2.1.4"]. This could result in a non deterministic behavior, skipping.
[3/4] 🔗  Linking dependencies...
warning "@angular/flex-layout@2.0.0-rc.1" has incorrect peer dependency "@angular/common@^2.2.3".
warning "@angular/flex-layout@2.0.0-rc.1" has incorrect peer dependency "@angular/core@^2.2.3".
warning "@angular/material@2.0.0-beta.2" has incorrect peer dependency "@angular/core@^2.3.0".
warning "@angular/material@2.0.0-beta.2" has incorrect peer dependency "@angular/common@^2.3.0".
warning "@angular/material@2.0.0-beta.2" has incorrect peer dependency "@angular/http@^2.3.0".
warning "@ngrx/effects@2.0.0" has incorrect peer dependency "@angular/core@^2.0.0".
warning "@ngrx/store@2.2.1" has incorrect peer dependency "@angular/core@^2.0.0".
warning "angular2-notifications@0.4.53" has incorrect peer dependency "@angular/core@^2.1.2".
warning "angular2-notifications@0.4.53" has incorrect peer dependency "@angular/common@^2.1.2".
warning "angular2-notifications@0.4.53" has incorrect peer dependency "@angular/platform-browser@^2.1.1".
warning "ng2-translate@5.0.0" has incorrect peer dependency "@angular/core@^2.0.0".
warning "ng2-translate@5.0.0" has incorrect peer dependency "@angular/http@^2.0.0".
warning "redux-batched-actions@0.1.5" has unmet peer dependency "redux@>=1.0.0".
[4/4] 📃  Building fresh packages...
✨  Done in 6.16s.
```

