### PR TITLE
Fix `yarn pack` to always include the file in the "main" field

### DIFF
--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -130,7 +130,7 @@ test.concurrent('pack should include mandatory files not listed in files array i
       path.join(cwd, 'files-include-mandatory-v1.0.0.tgz'),
       path.join(cwd, 'files-include-mandatory-v1.0.0'),
     );
-    const expected = ['package.json', 'readme.md', 'license', 'changelog'];
+    const expected = ['package.json', 'index.js', 'readme.md', 'license', 'changelog'];
     expected.forEach((filename) => {
       expect(files.indexOf(filename)).toBeGreaterThanOrEqual(0);
     });

--- a/__tests__/fixtures/pack/files-include-mandatory/package.json
+++ b/__tests__/fixtures/pack/files-include-mandatory/package.json
@@ -3,5 +3,5 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "files": ["index.js", "a.js", "b.js"]
+  "files": ["a.js", "b.js"]
 }

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -68,13 +68,16 @@ function addEntry(packer: any, entry: Object, buffer?: ?Buffer): Promise<void> {
 
 export async function pack(config: Config, dir: string): Promise<stream$Duplex> {
   const pkg = await config.readRootManifest();
-  const {bundledDependencies, files: onlyFiles} = pkg;
+  const {bundledDependencies, main, files: onlyFiles} = pkg;
 
   // inlude required files
   let filters: Array<IgnoreFilter> = NEVER_IGNORE.slice();
   // include default filters unless `files` is used
   if (!onlyFiles) {
     filters = filters.concat(DEFAULT_IGNORE);
+  }
+  if (main) {
+    filters = filters.concat(ignoreLinesToRegex(['!/' + main]));
   }
 
   // include bundledDependencies

--- a/src/types.js
+++ b/src/types.js
@@ -120,6 +120,7 @@ export type Manifest = {
 
   deprecated?: string,
   files?: Array<string>,
+  main?: string,
 };
 
 //


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This is for compatibility with npm, which [specifies] that:

> Certain files are always included, regardless of settings:
> * package.json
> * README
> * CHANGES / CHANGELOG / HISTORY
> * LICENSE / LICENCE
> * NOTICE
> * The file in the "main" field

[specifies]: https://docs.npmjs.com/files/package.json#files

**Test plan**

I changed the `files-include-mandatory` test to exclude "index.js" from
`files`, and ensure that it still gets included, since it is the `main`
file.