### PR TITLE
Added --ignore-scripts flag to integrity check

### DIFF
--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -147,6 +147,20 @@ async (): Promise<void> => {
   });
 });
 
+test.concurrent('--integrity should fail if --ignore-scripts is changed',
+  async (): Promise<void> => {
+    await runInstall({ignoreScripts: true}, path.join('..', 'check', 'integrity-lock-check'),
+      async (config, reporter): Promise<void> => {
+        let thrown = false;
+        try {
+          await checkCmd.run(config, reporter, {integrity: true, ignoreScripts: false}, []);
+        } catch (e) {
+          thrown = true;
+        }
+        expect(thrown).toEqual(true);
+      });
+  });
+
 test.concurrent('when switching to --check-files install should rebuild integrity file',
 async (): Promise<void> => {
   await runInstall({}, path.join('..', 'check', 'integrity-lock-check'), async (config, reporter): Promise<void> => {

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -140,6 +140,9 @@ export default class InstallationIntegrityChecker {
     if (flags.flat) {
       result.flags.push('flat');
     }
+    if (flags.ignoreScripts) {
+      result.flags.push('ignoreScripts');
+    }
 
     if (this.config.production) {
       result.flags.push('production');


### PR DESCRIPTION
**Summary**

--ignore-scripts affects the underlying node_modules and should be factored in integrity check

**Test plan**

- added test
- manual
```
bestander-mbp:left-pad bestander$ yarn install --ignore-scripts
yarn install v0.24.0-0
warning No license field
[1/4] 🔍  Resolving packages...
warning Integrity check: Flags don't match
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
warning Ignored scripts due to flag.
✨  Done in 0.55s.

bestander-mbp:left-pad bestander$ yarn check --integrity
yarn check v0.24.0-0
warning No license field
warning Integrity check: Flags don't match
error Integrity check failed
error Found 1 errors.
info Visit https://yarnpkg.com/en/docs/cli/check for documentation about this command.

bestander-mbp:left-pad bestander$ yarn check --integrity --ignore-scripts
yarn check v0.24.0-0
warning No license field
success Folder in sync.
✨  Done in 0.06s.
```