### PR TITLE
Do not test new version with pkg.version

### DIFF
--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -39,6 +39,14 @@ test('run version with no arguments and --new-version flag', (): Promise<void> =
   });
 });
 
+test('run version with no arguments, --new-version flag where version is same as pkg.version', (): Promise<void> => {
+  return runRun([], {newVersion, gitTagVersion}, 'no-args-same-version', async(config, reporter): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+
+    expect(pkg.version).toEqual(newVersion);
+  });
+});
+
 test('run version and make sure all lifecycle steps are executed', (): Promise<void> => {
   return runRun([], {newVersion, gitTagVersion}, 'no-args', async(config): ?Promise<void> => {
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));

--- a/__tests__/fixtures/version/no-args-same-version/package.json
+++ b/__tests__/fixtures/version/no-args-same-version/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.0.0",
+  "license": "BSD-2-Clause",
+  "scripts": {
+    "preversion": "echo preversion",
+    "version": "echo version",
+    "postversion": "echo postversion"
+  }
+}

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -90,7 +90,9 @@ export async function setVersion(
   invariant(newVersion, 'expected new version');
 
   if (newVersion === pkg.version) {
-    throw new MessageError(reporter.lang('publishSame'));
+    return function(): Promise<void> {
+      return Promise.resolve();
+    };
   }
 
   await runLifecycle('preversion');

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -218,7 +218,6 @@ const messages = {
   incorrectCredentials: 'Incorrect username or password.',
   clearedCredentials: 'Cleared login credentials.',
 
-  publishSame: 'New version is the same as the current version.',
   publishFail: "Couldn't publish package.",
   publishPrivate: 'Package marked as private, not publishing.',
   published: 'Published.',


### PR DESCRIPTION
See issue 3011 for details. Leave it to npm registry to validate the version number.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Motivation is to make it work with the way how I deploy my videomail-client library at
https://github.com/binarykitchen/videomail-client/blob/develop/bin/release.sh

There I am already bumping to the new version in package.json before publishing it with yarn to npm.

**Test plan**

1. Manually increment version in a random package.json
2. Run `yarn publish --new-version with that new version`
3. Yarn won't complain anymore that the new version is the same.
4. It will be up to the npm registry whether to accept that version or not.
