### PR TITLE
Ensure that every command has setFlags and hasWrapper functions

### DIFF
--- a/src/cli/commands/_build-sub-commands.js
+++ b/src/cli/commands/_build-sub-commands.js
@@ -13,6 +13,7 @@ type SubCommands =  {
 type Return = {
   run: CLIFunction,
   setFlags: (commander: Object) => void,
+  hasWrapper: (commander: Object, Array<string>) => boolean,
   examples: Array<string>,
 };
 
@@ -49,9 +50,13 @@ export default function(rootCommandName: string, subCommands: SubCommands, usage
     return Promise.reject(new MessageError(reporter.lang('invalidCommand', subCommandNames.join(', '))));
   }
 
+  function hasWrapper(): boolean {
+    return true;
+  }
+
   const examples = usage.map((cmd: string): string => {
     return `${rootCommandName} ${cmd}`;
   });
 
-  return {run, setFlags, examples};
+  return {run, setFlags, hasWrapper, examples};
 }

--- a/src/cli/commands/_useless.js
+++ b/src/cli/commands/_useless.js
@@ -8,5 +8,7 @@ export default function(message: string): { run: Function, useless: boolean } {
     run() {
       throw new MessageError(message);
     },
+    setFlags: () => {},
+    hasWrapper: () => true,
   };
 }

--- a/src/cli/commands/access.js
+++ b/src/cli/commands/access.js
@@ -2,7 +2,7 @@
 
 import buildSubCommands from './_build-sub-commands.js';
 
-export const {run, setFlags} = buildSubCommands('access', {
+export const {run, setFlags, hasWrapper, examples} = buildSubCommands('access', {
   public(): Promise<void> {
     return Promise.reject(new Error('TODO'));
   },

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -181,6 +181,10 @@ export class Add extends Install {
   }
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export function setFlags(commander: Object) {
   commander.usage('add [packages ...] [flags]');
   commander.option('-D, --dev', 'save package to your `devDependencies`');

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -8,6 +8,8 @@ const path = require('path');
 
 export function hasWrapper() {}
 
+export function setFlags() {}
+
 export function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -6,7 +6,9 @@ import RegistryYarn from '../../resolvers/registries/yarn-resolver.js';
 
 const path = require('path');
 
-export function hasWrapper() {}
+export function hasWrapper(): boolean {
+  return false;
+}
 
 export function setFlags() {}
 

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -12,7 +12,7 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] !== 'dir';
 }
 
-export const {run, setFlags} = buildSubCommands('cache', {
+export const {run, setFlags, examples} = buildSubCommands('cache', {
   async ls(
     config: Config,
     reporter: Reporter,

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -14,6 +14,10 @@ const path = require('path');
 export const requireLockfile = false;
 export const noArguments = true;
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export function setFlags(commander: Object) {
   commander.option('--integrity');
   commander.option('--verify-tree');

--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -127,3 +127,5 @@ export async function run(
   reporter.info(reporter.lang('cleanRemovedFiles', removedFiles));
   reporter.info(reporter.lang('cleanSavedSize', Number((removedSize / 1024 / 1024).toFixed(2))));
 }
+
+export function setFlags() {}

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -9,7 +9,7 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] !== 'get';
 }
 
-export const {run, setFlags} = buildSubCommands('config', {
+export const {run, setFlags, examples} = buildSubCommands('config', {
   async set(
     config: Config,
     reporter: Reporter,

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -11,6 +11,8 @@ export function hasWrapper(): boolean {
   return false;
 }
 
+export function setFlags() {}
+
 export function run(
   config: Config,
   reporter: Reporter,
@@ -27,10 +29,7 @@ export function run(
       const command = commands[commandName];
 
       if (command) {
-        if (typeof command.setFlags === 'function') {
-          command.setFlags(commander);
-        }
-
+        command.setFlags(commander);
         const examples: Array<string> = (command && command.examples) || [];
         if (examples.length) {
           commander.on('--help', () => {

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -293,6 +293,10 @@ export class Import extends Install {
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -291,6 +291,8 @@ export class Import extends Install {
   }
 }
 
+export function setFlags() {}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -36,6 +36,8 @@ function clean(object: any): any {
   }
 }
 
+export function setFlags() {}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -38,6 +38,10 @@ function clean(object: any): any {
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -15,6 +15,10 @@ export function setFlags(commander: Object) {
   commander.option('-y, --yes', 'use default options');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -734,6 +734,10 @@ export class Install {
   maybeOutputUpdate: any;
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export function setFlags(commander: Object) {
   commander.usage('install [flags]');
   commander.option('-g, --global', 'DEPRECATED');

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -47,7 +47,7 @@ async function getManifests(config: Config, flags: Object): Promise<Array<Manife
   return manifests;
 }
 
-export const {run, setFlags} = buildSubCommands('licenses', {
+export const {run, setFlags, examples} = buildSubCommands('licenses', {
   async ls(
     config: Config,
     reporter: Reporter,

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -22,6 +22,10 @@ export async function getRegistryFolder(config: Config, name: string): Promise<s
   return path.join(config.cwd, registryFolder);
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export function setFlags() {}
 
 export async function run(

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -22,6 +22,8 @@ export async function getRegistryFolder(config: Config, name: string): Promise<s
   return path.join(config.cwd, registryFolder);
 }
 
+export function setFlags() {}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -147,6 +147,10 @@ export function getParent(key: string, treesByKey: Object) : Object {
   return treesByKey[parentKey];
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export function setFlags(commander: Object) {
   commander.option('--depth [depth]', 'Limit the depth of the shown dependencies');
 }

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -102,6 +102,10 @@ export async function getToken(config: Config, reporter: Reporter, name: string 
   }
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export function setFlags() {}
 
 export async function run(

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -102,6 +102,8 @@ export async function getToken(config: Config, reporter: Reporter, name: string 
   }
 }
 
+export function setFlags() {}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/logout.js
+++ b/src/cli/commands/logout.js
@@ -3,6 +3,8 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 
+export function setFlags() {}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/logout.js
+++ b/src/cli/commands/logout.js
@@ -5,6 +5,10 @@ import type Config from '../../config.js';
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -12,6 +12,10 @@ export function setFlags(commander: Object) {
   commander.usage('outdated [packages ...]');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -83,7 +83,7 @@ export async function mutate(
   }
 }
 
-export const {run, setFlags} = buildSubCommands('owner', {
+export const {run, setFlags, hasWrapper, examples} = buildSubCommands('owner', {
   add(
     config: Config,
     reporter: Reporter,

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -174,6 +174,10 @@ export function setFlags(commander: Object) {
   commander.option('-f, --filename <filename>', 'filename');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -22,6 +22,10 @@ export function setFlags(commander: Object) {
   commander.option('--tag [tag]', 'tag');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 async function publish(
   config: Config,
   pkg: any,

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -14,6 +14,8 @@ const path = require('path');
 
 export const requireLockfile = true;
 
+export function setFlags() {}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -24,6 +24,10 @@ function sanitizedArgs(args: Array<string>): Array<string> {
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -22,6 +22,8 @@ function sanitizedArgs(args: Array<string>): Array<string> {
   return newArgs;
 }
 
+export function setFlags() {}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -28,7 +28,7 @@ export async function getName(args: Array<string>, config: Config): Promise<stri
   }
 }
 
-export const {run, setFlags, examples} = buildSubCommands('tag', {
+export const {run, setFlags, hasWrapper, examples} = buildSubCommands('tag', {
   async add(
     config: Config,
     reporter: Reporter,

--- a/src/cli/commands/team.js
+++ b/src/cli/commands/team.js
@@ -103,7 +103,7 @@ function wrapRequiredUser(callback: CLIFunctionWithParts): CLIFunction {
   }, true);
 }
 
-export const {run, setFlags} = buildSubCommands('team', {
+export const {run, setFlags, hasWrapper, examples} = buildSubCommands('team', {
   create: wrapRequiredTeam(async function(
     parts: TeamParts,
     config: Config,

--- a/src/cli/commands/unlink.js
+++ b/src/cli/commands/unlink.js
@@ -9,6 +9,8 @@ import {getBinFolder as getGlobalBinFolder} from './global';
 
 const path = require('path');
 
+export function setFlags() {}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/unlink.js
+++ b/src/cli/commands/unlink.js
@@ -11,6 +11,10 @@ const path = require('path');
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -19,6 +19,10 @@ export function setFlags(commander: Object) {
   commander.option('-T, --tilde', 'install most recent release with the same minor version');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 type InquirerResponses<K, T> = {[key: K]: Array<T>};
 
 // Prompt user with Inquirer

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -11,6 +11,10 @@ export function setFlags(commander: Object) {
   commander.usage('upgrade [flags]');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export const requireLockfile = true;
 
 export async function run(

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -24,6 +24,10 @@ export function setFlags(commander: Object) {
   commander.option('--no-git-tag-version', 'no git tag version');
 }
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function setVersion(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/versions.js
+++ b/src/cli/commands/versions.js
@@ -5,6 +5,8 @@ import type Config from '../../config.js';
 
 const YARN_VERSION = require('../../../package.json').version;
 
+export function setFlags() {}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/versions.js
+++ b/src/cli/commands/versions.js
@@ -7,6 +7,10 @@ const YARN_VERSION = require('../../../package.json').version;
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
  config: Config,
  reporter: Reporter,

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -123,6 +123,10 @@ function getSharedDependencies(
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -121,6 +121,8 @@ function getSharedDependencies(
   return sharedDependencies;
 }
 
+export function setFlags() {}
+
 export async function run(
   config: Config,
   reporter: Reporter,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -31,6 +31,7 @@ for (const key in aliases) {
       throw new MessageError(`Did you mean \`yarn ${aliases[key]}\`?`);
     },
     setFlags: () => {},
+    hasWrapper: () => true,
   };
 }
 
@@ -145,10 +146,7 @@ console.assert(commander.args[0] === 'this-arg-will-get-stripped-later');
 commander.args.shift();
 
 //
-let Reporter = ConsoleReporter;
-if (commander.json) {
-  Reporter = JSONReporter;
-}
+const Reporter = commander.json ? JSONReporter : ConsoleReporter;
 const reporter = new Reporter({
   emoji: commander.emoji && process.stdout.isTTY && process.platform === 'darwin',
   verbose: commander.verbose,
@@ -159,15 +157,8 @@ const reporter = new Reporter({
 reporter.initPeakMemoryCounter();
 
 const config = new Config(reporter);
+const outputWrapper = !commander.json && command.hasWrapper(commander, commander.args);
 
-// print header
-let outputWrapper = true;
-if (typeof command.hasWrapper === 'function') {
-  outputWrapper = command.hasWrapper(commander, commander.args);
-}
-if (commander.json) {
-  outputWrapper = false;
-}
 if (outputWrapper) {
   reporter.header(commandName, pkg);
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -30,6 +30,7 @@ for (const key in aliases) {
     run(config: Config, reporter: ConsoleReporter | JSONReporter): Promise<void> {
       throw new MessageError(`Did you mean \`yarn ${aliases[key]}\`?`);
     },
+    setFlags: () => {},
   };
 }
 
@@ -127,10 +128,7 @@ if (!command) {
   command = commands.run;
 }
 
-if (command && typeof command.setFlags === 'function') {
-  command.setFlags(commander);
-}
-
+command.setFlags(commander);
 commander.parse([
   ...startArgs,
   // we use this for https://github.com/tj/commander.js/issues/346, otherwise


### PR DESCRIPTION
**Summary**
This pull request is a simplified version of https://github.com/yarnpkg/yarn/pull/2810 and maybe for some ways better because it prefers composition over inheritance and it is less invasive right now.
There are two commits that ensure that we always have setFlags and hasWrapper functions.
This is the first step to move some responsabilities from the index towards the command classes.

**Test plan**
For what I see every command is covered, but let me know if I have to cover something.
