### PR TITLE
Correctly handle installationMethod when using bundled build

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -21,6 +21,7 @@ import {clean} from './clean.js';
 import * as constants from '../../constants.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
+import {version as YARN_VERSION, installationMethod as YARN_INSTALL_METHOD} from '../../util/yarn-version.js';
 
 const invariant = require('invariant');
 const semver = require('semver');
@@ -28,7 +29,6 @@ const emoji = require('node-emoji');
 const isCI = require('is-ci');
 const path = require('path');
 
-const {version: YARN_VERSION, installationMethod: YARN_INSTALL_METHOD} = require('../../../package.json');
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
 export type InstallCwdRequest = {

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import type {InstallationMethod} from '../../util/yarn-version.js';
 import type {Reporter} from '../../reporters/index.js';
 import type {ReporterSelectOption} from '../../reporters/types.js';
 import type {Manifest, DependencyRequestPatterns} from '../../types.js';
@@ -21,7 +22,7 @@ import {clean} from './clean.js';
 import * as constants from '../../constants.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
-import {version as YARN_VERSION, installationMethod as YARN_INSTALL_METHOD} from '../../util/yarn-version.js';
+import {version as YARN_VERSION, getInstallationMethod} from '../../util/yarn-version.js';
 
 const invariant = require('invariant');
 const semver = require('semver');
@@ -66,41 +67,41 @@ type Flags = {
  * Try and detect the installation method for Yarn and provide a command to update it with.
  */
 
-function getUpdateCommand(): ?string {
-  if (YARN_INSTALL_METHOD === 'tar') {
+function getUpdateCommand(installationMethod: InstallationMethod): ?string {
+  if (installationMethod === 'tar') {
     return `curl -o- -L ${constants.YARN_INSTALLER_SH} | bash`;
   }
 
-  if (YARN_INSTALL_METHOD === 'homebrew') {
+  if (installationMethod === 'homebrew') {
     return 'brew upgrade yarn';
   }
 
-  if (YARN_INSTALL_METHOD === 'deb') {
+  if (installationMethod === 'deb') {
     return 'sudo apt-get update && sudo apt-get install yarn';
   }
 
-  if (YARN_INSTALL_METHOD === 'rpm') {
+  if (installationMethod === 'rpm') {
     return 'sudo yum install yarn';
   }
 
-  if (YARN_INSTALL_METHOD === 'npm') {
+  if (installationMethod === 'npm') {
     return 'npm upgrade --global yarn';
   }
 
-  if (YARN_INSTALL_METHOD === 'chocolatey') {
+  if (installationMethod === 'chocolatey') {
     return 'choco upgrade yarn';
   }
 
-  if (YARN_INSTALL_METHOD === 'apk') {
+  if (installationMethod === 'apk') {
     return 'apk update && apk add -u yarn';
   }
 
   return null;
 }
 
-function getUpdateInstaller(): ?string {
+function getUpdateInstaller(installationMethod: InstallationMethod): ?string {
   // Windows
-  if (YARN_INSTALL_METHOD === 'msi') {
+  if (installationMethod === 'msi') {
     return constants.YARN_INSTALLER_MSI;
   }
 
@@ -460,6 +461,7 @@ export class Install {
     for (const step of steps) {
       const stepResult = await step(++currentStep, steps.length);
       if (stepResult && stepResult.bailout) {
+        this.maybeOutputUpdate();
         return flattenedTopLevelPatterns;
       }
     }
@@ -727,15 +729,16 @@ export class Install {
     });
 
     if (semver.gt(latestVersion, YARN_VERSION)) {
+      const installationMethod = await getInstallationMethod();
       this.maybeOutputUpdate = () => {
         this.reporter.warn(this.reporter.lang('yarnOutdated', latestVersion, YARN_VERSION));
 
-        const command = getUpdateCommand();
+        const command = getUpdateCommand(installationMethod);
         if (command) {
           this.reporter.info(this.reporter.lang('yarnOutdatedCommand'));
           this.reporter.command(command);
         } else {
-          const installer = getUpdateInstaller();
+          const installer = getUpdateInstaller(installationMethod);
           if (installer) {
             this.reporter.info(this.reporter.lang('yarnOutdatedInstaller', installer));
           }

--- a/src/cli/commands/versions.js
+++ b/src/cli/commands/versions.js
@@ -3,7 +3,7 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 
-const YARN_VERSION = require('../../../package.json').version;
+import {version as yarnVersion} from '../../util/yarn-version.js';
 
 export function setFlags() {}
 
@@ -17,7 +17,7 @@ export async function run(
  flags: Object,
  args: Array<string>,
 ): Promise<void> {
-  const versions: {[name: string]: string} = {yarn: YARN_VERSION};
+  const versions: {[name: string]: string} = {yarn: yarnVersion};
 
   const pkg = await config.maybeReadManifest(config.cwd);
   if (pkg && pkg.name && pkg.version) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -8,6 +8,7 @@ import * as network from '../util/network.js';
 import {MessageError} from '../errors.js';
 import Config from '../config.js';
 import {getRcArgs} from '../rc.js';
+import {version} from '../util/yarn-version.js';
 
 const commander = require('commander');
 const fs = require('fs');
@@ -17,7 +18,6 @@ const loudRejection = require('loud-rejection');
 const net = require('net');
 const onDeath = require('death');
 const path = require('path');
-const pkg = require('../../package.json');
 
 loudRejection();
 
@@ -29,7 +29,7 @@ const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length 
 const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
 // set global options
-commander.version(pkg.version);
+commander.version(version);
 commander.usage('[command] [flags]');
 commander.option('--verbose', 'output verbose messages on internal operations');
 commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
@@ -143,7 +143,7 @@ const config = new Config(reporter);
 const outputWrapper = !commander.json && command.hasWrapper(commander, commander.args);
 
 if (outputWrapper) {
-  reporter.header(commandName, pkg);
+  reporter.header(commandName, {name: 'Yarn', version});
 }
 
 if (command.noArguments && commander.args.length) {
@@ -259,7 +259,7 @@ function onUnexpectedError(err: Error) {
   const log = [];
   log.push(`Arguments: ${indent(process.argv.join(' '))}`);
   log.push(`PATH: ${indent(process.env.PATH || 'undefined')}`);
-  log.push(`Yarn version: ${indent(pkg.version)}`);
+  log.push(`Yarn version: ${indent(version)}`);
   log.push(`Node version: ${indent(process.versions.node)}`);
   log.push(`Platform: ${indent(process.platform + ' ' + process.arch)}`);
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -143,7 +143,7 @@ const config = new Config(reporter);
 const outputWrapper = !commander.json && command.hasWrapper(commander, commander.args);
 
 if (outputWrapper) {
-  reporter.header(commandName, {name: 'Yarn', version});
+  reporter.header(commandName, {name: 'yarn', version});
 }
 
 if (command.noArguments && commander.args.length) {

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -7,12 +7,13 @@ import type Config from './config.js';
 import {MessageError} from './errors.js';
 import map from './util/map.js';
 import {entries} from './util/misc.js';
+import {version as yarnVersion} from './util/yarn-version.js';
 
 const invariant = require('invariant');
 const semver = require('semver');
 
 const VERSIONS = Object.assign({}, process.versions, {
-  yarn: require('../package.json').version,
+  yarn: yarnVersion,
 });
 
 function isValid(items: Array<string>, actual: string): boolean {

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -8,10 +8,10 @@ import NpmRegistry from './npm-registry.js';
 import stringify from '../lockfile/stringify.js';
 import parse from '../lockfile/parse.js';
 import * as fs from '../util/fs.js';
+import {version} from '../util/yarn-version.js';
 
 const userHome = require('../util/user-home-dir').default;
 const path = require('path');
-const pkg: { version: string } = require('../../package.json');
 
 export const DEFAULTS = {
   'version-tag-prefix': 'v',
@@ -28,7 +28,7 @@ export const DEFAULTS = {
   registry: YARN_REGISTRY,
   'strict-ssl': true,
   'user-agent': [
-    `yarn/${pkg.version}`,
+    `yarn/${version}`,
     'npm/?',
     `node/${process.version}`,
     process.platform,

--- a/src/util/yarn-version.js
+++ b/src/util/yarn-version.js
@@ -1,0 +1,28 @@
+/**
+ * Determines the current version of Yarn itself.
+ * @flow
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+function getVersion(): {version: string, installationMethod: string} {
+  // This will be bundled directly in the .js file for production builds
+  const data = require('../../package.json');
+
+  // If there's a package.json in the parent directory, it could have an
+  // override for the installation method, so we should prefer that over
+  // whatever was originally in Yarn's package.json. This is the case with
+  // systems such as Homebrew, which take the tarball and modify the
+  // installation method so we're aware of the fact that Yarn was installed via
+  // Homebrew (so things like update notifications can point out the correct
+  // command to upgrade).
+  const manifestPath = path.join(__dirname, '..', 'package.json');
+  if (fs.existsSync(manifestPath)) {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    data.installationMethod = manifest.installationMethod;
+  }
+  return data;
+}
+
+export const {version, installationMethod} = getVersion();

--- a/src/util/yarn-version.js
+++ b/src/util/yarn-version.js
@@ -47,4 +47,5 @@ export type InstallationMethod =
   | 'msi'
   | 'chocolatey'
   | 'apk'
+  | 'npm'
   | 'unknown';


### PR DESCRIPTION
**Summary**
We do `require('package.json')` in a few places to get the version number and installation method of Yarn. In the Webpack build, this is embedded within the JS file itself. While this works fine for the version number (as that's constant), the installation methods can be different even with an identical build of Yarn. For example, Homebrew takes our tarball and then patches the `installationMethod` in `package.json` so we can tell that Yarn was installed via Homebrew. Using `require('package.json')` in this case won't reflect the update as it's only seeing package.json at the time of build (rather than at runtime).

Instead, we need to actually read the `package.json` file to check for the installationMethod at runtime. This looks in the parent directory (`../package.json`) due to the directory structure:
```
\package.json  <--- This is the file we want
\lib
  \yarn-cli.js <--- This is where the code is
\bin
  \yarn
  \yarn.cmd
```

**Test plan**
`.\bin\yarn --version`, ensure it says `0.24.0-0`
`.\bin\yarn install`. ensure heading says "Yarn install v0.24.0-0"
`.\bin\yarn versions`, ensure 
`.\scripts\build-webpack.js` then do all the same tests with `.\artifacts\yarn-0.24.0.js`

Closes #3085