### PR TITLE
Allow emojis to be force enabled with `--emoji`.

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -65,8 +65,9 @@ commander.option(
   'use a mutex to ensure only one yarn instance is executing',
 );
 commander.option(
-  '--no-emoji',
-  'disable emoji in output',
+  '--emoji',
+  'enable emoji in output',
+  process.platform === 'darwin',
 );
 commander.option(
   '-s, --silent',
@@ -131,7 +132,7 @@ commander.args.shift();
 //
 const Reporter = commander.json ? JSONReporter : ConsoleReporter;
 const reporter = new Reporter({
-  emoji: commander.emoji && process.stdout.isTTY && process.platform === 'darwin',
+  emoji: process.stdout.isTTY && commander.emoji,
   verbose: commander.verbose,
   noProgress: !commander.progress,
   isSilent: commander.silent,


### PR DESCRIPTION
The previous behaviour had a default of enabling emojis for Macs, and
allowed explicitly disabling them.

This PR keeps that default but allows `--emoji` to enable for other
platforms if the user wants to.  `--no-emoji` still works as before, but
due to the way that commander processes "--no-" flags (forcing the
default to true and overwriting the default value given in the `.option`
definition) it was necessary to switch the flag definition from
`--no-emoji` to `--emoji`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Allows users to enable emojis on non-darwin platforms.

Emojis are a nice feature but are explicitly disabled on non-darwin platforms.  There appears to be some interest in having them on other plaforms (see #960) and this allows that by making `--emoji` work as you'd expect (`--no-emoji` and `--emoji` are already accepted, but only `--no-emoji` works).

**Test plan**

On linux

```
# Forcing emojis off
$ node ./lib/cli/index.js --no-emoji
yarn install v0.24.0-0
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.65s.

# Default behaviour; off on non-darwin
$ node ./lib/cli/index.js 
yarn install v0.24.0-0
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.68s.

# Forcing emojis on
$ node ./lib/cli/index.js --emoji
yarn install v0.24.0-0
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.67s.
```

Note that there is a flow type error in this PR related to `process.stdout.isTTY`, however this PR didn't add that check; it seems like it's a flow error that it wasn't already failing (I'm not familiar with flow though, so happy to be corrected here).

Another tweak would be to shift the `process.stdout.isTTY` check into the default value for `commander.emoji`, which would allow users to force emoji output even if `stdout` isn't a TTY - I'm not sure if this is ever desirable, but it's not possible to override at the moment and the change is simple.