### PR TITLE
Better match npm's SCP vs SSH URL heuristic

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -24,6 +24,12 @@ test('npmUrlToGitUrl', () => {
       hostname: 'github.com',
       repository: 'git://github.com/npm-opam/ocamlfind.git',
     });
+  expect(Git.npmUrlToGitUrl('git+ssh://git@gitlab.mydomain.tld:10202/project-name/my-package.git'))
+    .toEqual({
+      protocol: 'ssh:',
+      hostname: 'gitlab.mydomain.tld',
+      repository: 'ssh://git@gitlab.mydomain.tld:10202/project-name/my-package.git',
+    });
   expect(Git.npmUrlToGitUrl('git+ssh://git@github.com/npm-opam/ocamlfind.git'))
     .toEqual({
       protocol: 'ssh:',

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -58,9 +58,11 @@ export default class Git {
    */
   static npmUrlToGitUrl(npmUrl: string): GitUrl {
     // Special case in npm, where ssh:// prefix is stripped to pass scp-like syntax
-    // which works as remote path only if there are no slashes before ':'
-    const match = npmUrl.match(/^git\+ssh:\/\/((?:[^@:\/]+@)?([^@:\/]+):.*)/);
-    if (match) {
+    // which in git works as remote path only if there are no slashes before ':'.
+    const match = npmUrl.match(/^git\+ssh:\/\/((?:[^@:\/]+@)?([^@:\/]+):([^/]*).*)/);
+    // Additionally, if the host part is digits-only, npm falls back to
+    // interpreting it as an SSH URL with a port number.
+    if (match && /[^0-9]/.test(match[3])) {
       return {
         protocol: 'ssh:',
         hostname: match[2],


### PR DESCRIPTION
Fixes #3146 (related to #1796)

In npm "git+ssh://foo:bar" is an SCP URL (where "bar" is a path), but "git+ssh://foo:123" is an SSH URL (where "123" is a port).
 