### PR TITLE
added check on response code on publish cli command to accomodate add…

### DIFF
--- a/__tests__/util/misc.js
+++ b/__tests__/util/misc.js
@@ -21,3 +21,8 @@ test('sortAlpha', () => {
     'foo@~6.8.x',
   ]);
 });
+
+test('has2xxResponse', () => {
+  const response = {responseCode: 200};
+  expect(misc.has2xxResponse(response)).toEqual(true);
+});

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -9,6 +9,7 @@ import {setVersion, setFlags as versionSetFlags} from './version.js';
 import * as fs from '../../util/fs.js';
 import {pack} from './pack.js';
 import {getToken} from './login.js';
+import {has2xxResponse} from '../../util/misc.js';
 
 const invariant = require('invariant');
 const crypto = require('crypto');
@@ -101,7 +102,7 @@ async function publish(
     body: root,
   });
 
-  if (res != null && res.success) {
+  if (res !== null && has2xxResponse(res)) {
     await config.executeLifecycleScript('publish');
     await config.executeLifecycleScript('postpublish');
   } else {

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -2,6 +2,10 @@
 
 const _camelCase = require('camelcase');
 
+export function has2xxResponse(res: Object): boolean {
+  return res.responseCode >= 200 && res.responseCode < 300;
+}
+
 export function sortAlpha(a: string, b: string): number {
   // sort alphabetically in a deterministic way
   const shortLen = Math.min(a.length, b.length);


### PR DESCRIPTION
…itional registries

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->



<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is based on the following closed PR https://github.com/yarnpkg/yarn/pull/1417
When working with Artifactory, the original implementation was dependent on the response body from the npm public registry. Following that original PR, checking the response code seemed to be a general enough approach to accomodate both.

Also I noticed that this exact response checking logic was found elsewhere in the codebase. If desired, I could migrate them over to this.

**Test plan**
I added a simple method to misc.js to check the response code of the response object, but when I was looking at the code, it looks like the publish.js cli command has very little test coverage, at least from what I was able to figure out.

If adding additional test coverage to the publish.js file is necessary, I would love to assist in that effort, as the projects im working with currently are trying to migrate completely to yarn, but this one defect is preventing us from completing that and extra test coverage would help us complete the migration with confidence.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
