### PR TITLE
Hide Activity/Progress Output in JSONReporter with --no-progress Flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ test/fixtures/**/.fbkpm
 /tmp/
 /__tests__/fixtures/**/_*
 /__tests__/fixtures/request-cache/GET/localhost/.bin
-
+.idea

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -200,6 +200,11 @@ test.concurrent('should install if first arg looks like a flag', async () => {
   expect(stdout[stdout.length - 1]).toEqual('{"type":"success","data":"Saved lockfile."}');
 });
 
+test.concurrent('should not output JSON progress if given --no-progress option', async () => {
+  const stdout = await execCommand('', ['--json', '--no-progress'], 'run-add', true);
+  expect(stdout.length).toEqual(0);
+});
+
 test.concurrent('should interpolate aliases', async () => {
   await expectAnErrorMessage(
     execCommand('i', [], 'run-add', true),

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -201,14 +201,13 @@ test.concurrent('should install if first arg looks like a flag', async () => {
 });
 
 test.concurrent('should not output JSON activity/progress if given --no-progress option', async () => {
+  const activityInfo = ['activityStart', 'activityTick', 'activityEnd'];
+  const progressInfo = ['progressStart', 'progressTick', 'progressFinish'];
   const stdout = await execCommand('', ['--json', '--no-progress'], 'run-add', true);
   stdout.forEach((line) => {
-    expect(line).not.toContain('activityStart');
-    expect(line).not.toContain('activityTick');
-    expect(line).not.toContain('activityEnd');
-    expect(line).not.toContain('progressStart');
-    expect(line).not.toContain('progressTick');
-    expect(line).not.toContain('progressFinish');
+    activityInfo.concat(progressInfo).forEach((info) => {
+      expect(line).not.toContain(info);
+    });
   });
 });
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -200,9 +200,16 @@ test.concurrent('should install if first arg looks like a flag', async () => {
   expect(stdout[stdout.length - 1]).toEqual('{"type":"success","data":"Saved lockfile."}');
 });
 
-test.concurrent('should not output JSON progress if given --no-progress option', async () => {
+test.concurrent('should not output JSON activity/progress if given --no-progress option', async () => {
   const stdout = await execCommand('', ['--json', '--no-progress'], 'run-add', true);
-  expect(stdout.length).toEqual(0);
+  stdout.forEach((line) => {
+    expect(line).not.toContain('activityStart');
+    expect(line).not.toContain('activityTick');
+    expect(line).not.toContain('activityEnd');
+    expect(line).not.toContain('progressStart');
+    expect(line).not.toContain('progressTick');
+    expect(line).not.toContain('progressFinish');
+  });
 });
 
 test.concurrent('should interpolate aliases', async () => {

--- a/__tests__/reporters/__snapshots__/json-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/json-reporter.js.snap
@@ -10,6 +10,13 @@ Object {
 }
 `;
 
+exports[`JSONReporter.activity 2`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
 exports[`JSONReporter.command 1`] = `
 Object {
   "stderr": "",

--- a/__tests__/reporters/__snapshots__/json-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/json-reporter.js.snap
@@ -55,6 +55,13 @@ Object {
 }
 `;
 
+exports[`JSONReporter.progress 2`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
 exports[`JSONReporter.step 1`] = `
 Object {
   "stderr": "",

--- a/__tests__/reporters/json-reporter.js
+++ b/__tests__/reporters/json-reporter.js
@@ -57,6 +57,7 @@ test("JSONReporter.info", async () => {
 
 test("JSONReporter.activity", async () => {
   expect(await getJSONBuff(async function (r): Promise<void> {
+    r.noProgress = false;
     const activity = await r.activity();
     activity.tick("foo");
     activity.tick("bar");
@@ -74,6 +75,7 @@ test("JSONReporter.activity", async () => {
 
 test("JSONReporter.progress", async () => {
   expect(await getJSONBuff(async function (r): Promise<void> {
+    r.noProgress = false;
     const tick = await r.progress(2);
     tick();
     tick();

--- a/__tests__/reporters/json-reporter.js
+++ b/__tests__/reporters/json-reporter.js
@@ -70,4 +70,10 @@ test("JSONReporter.progress", async () => {
     tick();
     tick();
   })).toMatchSnapshot();
+
+  expect(await getJSONBuff(async function (r): Promise<void> {
+    r.noProgress = true;
+    const tick = await r.progress(2);
+    tick();
+  })).toMatchSnapshot();
 });

--- a/__tests__/reporters/json-reporter.js
+++ b/__tests__/reporters/json-reporter.js
@@ -62,6 +62,14 @@ test("JSONReporter.activity", async () => {
     activity.tick("bar");
     activity.end();
   })).toMatchSnapshot();
+
+  expect(await getJSONBuff(async function (r): Promise<void> {
+    r.noProgress = true;
+    const activity = await r.activity();
+    activity.tick("foo");
+    activity.tick("bar");
+    activity.end();
+  })).toMatchSnapshot();
 });
 
 test("JSONReporter.progress", async () => {

--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -155,7 +155,6 @@ export default class JSONReporter extends BaseReporter {
 
       if (current === total) {
         this._dump('progressFinish', {id});
-        this._dump('poop', {id});
       }
     };
   }

--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -79,6 +79,10 @@ export default class JSONReporter extends BaseReporter {
   }
 
   activitySet(total: number, workers: number): ReporterSpinnerSet {
+    if (!this.isTTY || this.noProgress) {
+      return super.activitySet(total, workers);
+    }
+
     const id = this._activityId++;
     this._dump('activitySetStart', {id, total, workers});
 
@@ -113,6 +117,13 @@ export default class JSONReporter extends BaseReporter {
   }
 
   _activity(data: Object): ReporterSpinner {
+    if (!this.isTTY || this.noProgress) {
+      return {
+        tick() {},
+        end() {},
+      };
+    }
+
     const id = this._activityId++;
     this._dump('activityStart', {id, ...data});
 
@@ -128,6 +139,12 @@ export default class JSONReporter extends BaseReporter {
   }
 
   progress(total: number): () => void {
+    if (this.noProgress) {
+      return function() {
+        // noop
+      };
+    }
+
     const id = this._progressId++;
     let current = 0;
     this._dump('progressStart', {id, total});
@@ -138,6 +155,7 @@ export default class JSONReporter extends BaseReporter {
 
       if (current === total) {
         this._dump('progressFinish', {id});
+        this._dump('poop', {id});
       }
     };
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Addresses #3155 by applying the same logic used in the `ConsoleReporter` to hide activity and progress output for the `JSONReporter` when using `--no-progress`.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Originally wanted to be able to generate a list of licenses used in JSON format using `yarn licenses ls --json --no-progress`, but extra output from activity/progress was shown. Discovered that the `JSONReporter` does not contain the same logic to hide activity/progress output as other reporters.

**Test plan**
Automated: `yarn test`
Manual: `yarn [cmd] --json --no-progress`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Before:**
![screenshot_20170414_170617](https://cloud.githubusercontent.com/assets/11700385/25059011/c5042e7e-2134-11e7-8c1e-e8d5c5d3edfc.png)

**After:**
![screenshot_20170414_170636](https://cloud.githubusercontent.com/assets/11700385/25059014/ce43814c-2134-11e7-9b5b-8ccdf8615504.png)

