### PR TITLE
Add command to output json format of lockfile

### DIFF
--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -16,6 +16,7 @@ import * as init from './init.js'; export {init};
 import * as install from './install.js'; export {install};
 import * as licenses from './licenses.js'; export {licenses};
 import * as link from './link.js'; export {link};
+import * as lockfileJson from './lockfile-json'; export {lockfileJson};
 import * as login from './login.js'; export {login};
 import * as logout from './logout.js'; export {logout};
 import * as list from './list.js'; export {list};

--- a/src/cli/commands/lockfile-json.js
+++ b/src/cli/commands/lockfile-json.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import * as constants from '../../constants.js';
+import type {Reporter} from '../../reporters/index.js';
+import type Config from '../../config.js';
+import Parse from '../../lockfile/parse.js';
+
+const path = require('path');
+const fs = require('fs');
+
+export function hasWrapper() {}
+
+export function run(
+  config: Config,
+  reporter: Reporter,
+  flags: Object,
+  args: Array<string>,
+): Promise<void> {
+  const rawLockfile = fs.readFileSync(path.join(config.cwd, constants.LOCKFILE_FILENAME));
+  const lockfile = Parse(rawLockfile.toString());
+  console.log(lockfile);
+  return Promise.resolve();
+}

--- a/src/cli/commands/lockfile-json.js
+++ b/src/cli/commands/lockfile-json.js
@@ -8,8 +8,6 @@ import Parse from '../../lockfile/parse.js';
 const path = require('path');
 const fs = require('fs');
 
-export function hasWrapper() {}
-
 export function run(
   config: Config,
   reporter: Reporter,


### PR DESCRIPTION
Original request: #3152 

**Summary**
This pr hooks into the existing lockfile parser and makes the data available through a new yarn argument (`lockfile-json`). This new argument will make it easier for users that want to be able to parse the lockfile and see what's being installed without having to write or rely on 3rd party lockfile parsers.

**Test plan**
Manual: `yarn lockfile-json`

Example:
<img width="1000" alt="screen shot 2017-04-15 at 3 34 17 am" src="https://cloud.githubusercontent.com/assets/1575003/25062969/9ab2522e-218c-11e7-8f10-2635533dfda1.png">

