### PR TITLE
Ref #2938 - Remove warning spam during install with file mutex

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -217,7 +217,7 @@ const runEventuallyWithFile = (mutexFilename: ?string, isFirstTime?: boolean): P
           reporter.warn(reporter.lang('waitingInstance'));
         }
         setTimeout(() => {
-          ok(runEventuallyWithFile(mutexFilename, isFirstTime));
+          ok(runEventuallyWithFile(mutexFilename, false));
         }, 200); // do not starve the CPU
       } else {
         onDeath(() => {


### PR DESCRIPTION
**Summary**
Installing with `--mutex file:` option spams the output with warnings of:
```
warning Waiting for the other yarn instance to finish
```

It should only display once.  Fixes #2938.

**Test plan**
Not sure this is necessary.