### PR TITLE
Use tar-fs instead of tar-stream in `yarn pack` (and fix packed emojis)

### DIFF
--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -9,7 +9,7 @@ import {MessageError} from '../../errors.js';
 
 const zlib = require('zlib');
 const path = require('path');
-const tar = require('tar-stream');
+const tar = require('tar-fs');
 const fs2 = require('fs');
 
 const IGNORE_FILENAMES = [
@@ -53,18 +53,6 @@ const NEVER_IGNORE = ignoreLinesToRegex([
   '!/+(license|licence)*',
   '!/+(changes|changelog|history)*',
 ]);
-
-function addEntry(packer: any, entry: Object, buffer?: ?Buffer): Promise<void> {
-  return new Promise((resolve, reject) => {
-    packer.entry(entry, buffer, function(err) {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
-  });
-}
 
 export async function pack(config: Config, dir: string): Promise<stream$Duplex> {
   const pkg = await config.readRootManifest();
@@ -126,46 +114,18 @@ export async function pack(config: Config, dir: string): Promise<stream$Duplex> 
   // apply filters
   sortFilter(files, filters, keepFiles, possibleKeepFiles, ignoredFiles);
 
-  const packer = tar.pack();
-  const compressor = packer.pipe(new zlib.Gzip());
-
-  await addEntry(packer, {
-    name: 'package',
-    type: 'directory',
+  const packer = tar.pack(config.cwd, {
+    ignore: (name) => !keepFiles.has(path.relative(config.cwd, name)),
+    map: (header) => {
+      const suffix = header.name === '.' ? '' : `/${header.name}`;
+      header.name = `package${suffix}`;
+      delete header.uid;
+      delete header.gid;
+      return header;
+    },
   });
 
-  for (const name of keepFiles) {
-    const loc = path.join(config.cwd, name);
-    const stat = await fs.lstat(loc);
-
-    let type: ?string;
-    let buffer: ?Buffer;
-    let linkname: ?string;
-    if (stat.isDirectory()) {
-      type = 'directory';
-    } else if (stat.isFile()) {
-      buffer = await fs.readFileRaw(loc);
-      type = 'file';
-    } else if (stat.isSymbolicLink()) {
-      type = 'symlink';
-      linkname = await fs.readlink(loc);
-    } else {
-      throw new Error();
-    }
-
-    const entry = {
-      name: `package/${name}`,
-      size: stat.size,
-      mode: stat.mode,
-      mtime: stat.mtime,
-      type,
-      linkname,
-    };
-
-    await addEntry(packer, entry, buffer);
-  }
-
-  packer.finalize();
+  const compressor = packer.pipe(new zlib.Gzip());
 
   return compressor;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This lets tar-fs do the [header construction] for us.

[header construction]: https://github.com/mafintosh/tar-fs/blob/b79d82a79c5e21f6187462d7daaba1fc03cdd1de/index.js#L101-L127


**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I tested this by comparing the output of this command before and after
the change:

    ./bin/yarn.js pack >/dev/null && tar tvf yarn-v0.24.0-0.tgz | sort && wc -c < yarn-v0.24.0-0.tgz && rm *tgz

Here's the diff between the outputs:

```diff
diff --git a/before.txt b/after.txt
index 5e7f370e..5565a808 100644
--- a/before.txt
+++ b/after.txt
@@ -7,13 +7,13 @@
 -rw-r--r--  0 0      0         657 Mar  4 07:19 package/Dockerfile.dev
 -rw-r--r--  0 0      0        1346 Mar  4 07:19 package/LICENSE
 -rw-r--r--  0 0      0        1789 Apr 17 15:10 package/jenkins_jobs.groovy
--rw-r--r--  0 0      0        3061 Mar  4 07:19 package/README.md
--rw-r--r--  0 0      0        3438 Apr 17 16:18 package/package.json
+-rw-r--r--  0 0      0        3057 Mar  4 07:19 package/README.md
+-rw-r--r--  0 0      0        3430 Apr 17 16:18 package/package.json
 -rwxr-xr-x  0 0      0          42 Mar  4 07:19 package/bin/yarnpkg
 -rwxr-xr-x  0 0      0         172 Mar  4 07:19 package/bin/node-gyp-bin/node-gyp
 -rwxr-xr-x  0 0      0         906 Mar  4 07:19 package/bin/yarn
 -rwxr-xr-x  0 0      0         929 Apr 10 15:59 package/bin/yarn.js
 drwxr-xr-x  0 0      0           0 Apr 10 15:59 package/bin
 drwxr-xr-x  0 0      0           0 Apr 17 17:04 package
 drwxr-xr-x  0 0      0           0 Mar  4 07:19 package/bin/node-gyp-bin
-    6206
+    6177
```

I extracted the tarballs into `./package-master` and `./package-feature`,
then diffed them to find that this change has the side effect of
fixing emojis in the tarball. You can see examples of the broken emoji
here:

* https://unpkg.com/yarn@0.22.0/package.json
* https://unpkg.com/yarn@0.22.0/README.md

```diff
diff --git a/package-master/README.md b/package-feature/README.md
index aabfc24f..6aff13d8 100644
--- a/package-master/README.md
+++ b/package-feature/README.md
@@ -30,7 +30,7 @@
 * **Network Performance.** Yarn efficiently queues up requests and avoids request waterfalls in order to maximize network utilization.
 * **Network Resilience.** A single request failing won't cause an install to fail. Requests are retried upon failure.
 * **Flat Mode.** Yarn resolves mismatched versions of dependencies to a single version to avoid creating duplicates.
-* **More emojis.** ð
+* **More emojis.** 🐈

 ## Installing Yarn

diff --git a/package-master/package.json b/package-feature/package.json
index c89ad7a6..8e7e3bc7 100644
--- a/package-master/package.json
+++ b/package-feature/package.json
@@ -4,7 +4,7 @@
   "version": "0.24.0-0",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
-  "description": "ð¦ð Fast, reliable, and secure dependency management.",
+  "description": "📦🐈 Fast, reliable, and secure dependency management.",
   "dependencies": {
     "babel-runtime": "^6.0.0",
     "bytes": "^2.4.0",
```