### PR TITLE
Fixies for running with artifactory 4.14.1

### DIFF
--- a/__tests__/registries/is-request-to-registry.js
+++ b/__tests__/registries/is-request-to-registry.js
@@ -20,14 +20,14 @@ test('isRequestToRegistry functional test', () => {
   )).toBe(true);
 
   expect(isRequestToRegistry(
-      'https://foo.bar/foo/bar/baz',
-      'https://foo.bar:443/foo/',
-    )).toBe(true);
+    'https://foo.bar/foo/bar/baz',
+    'https://foo.bar:443/foo/',
+  )).toBe(true);
 
   expect(isRequestToRegistry(
     'http://foo.bar:80/foo/bar/baz',
     'https://foo.bar/foo/',
-  )).toBe(false);
+  )).toBe(true);
 
   expect(isRequestToRegistry(
     'http://foo.bar/blah/whatever/something',
@@ -43,4 +43,9 @@ test('isRequestToRegistry functional test', () => {
     'https://foo.bar:1337/foo/bar/baz',
     'https://foo.bar/foo/',
   )).toBe(false);
+
+  expect(isRequestToRegistry(
+    'http://foo.bar/foo/bar/baz',
+    'https://foo.bar/foo/bar/baz',
+  )).toBe(true);
 });

--- a/src/registries/is-request-to-registry.js
+++ b/src/registries/is-request-to-registry.js
@@ -10,19 +10,17 @@ export default function isRequestToRegistry(requestUrl: string, registry: string
   const requestPath = requestParsed.path || '';
   const registryPath = registryParsed.path || '';
 
-  return (requestParsed.protocol === registryParsed.protocol) &&
-        (requestParsed.hostname === registryParsed.hostname) &&
+  return (requestParsed.hostname === registryParsed.hostname) &&
         (requestPort === registryPort) &&
         requestPath.startsWith(registryPath);
 }
 
 function getPortOrDefaultPort(port: ?string, protocol: ?string): ?string {
-  const defaultPort = !port;
-  if (defaultPort && protocol === 'https:') {
-    return '443';
+  if (protocol === 'https:' && port === '443') {
+    return null;
   }
-  if (defaultPort && protocol === 'http:') {
-    return '80';
+  if (protocol === 'http:' && port === '80') {
+    return null;
   }
   return port;
 }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -58,7 +58,7 @@ export default class NpmRegistry extends Registry {
       || removePrefix(requestUrl, registry)[0] === '@';
 
     const headers = Object.assign({
-      'Accept': 'application/vnd.npm.install-v1+json',
+      'Accept': 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*',
     }, opts.headers);
     if (this.token || (alwaysAuth && isRequestToRegistry(requestUrl, registry))) {
       const authorization = this.getAuth(pathname);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This will help solving #521 

I use a private NPM registry hosted via Artifactory v4.14.1 and I was having some issues.

The first one is that apparently this version of Artifactory still does not support the `application/vnd.npm.install-v1+json` header implemented on #3112. To fix that, I noted by reading [npm docs](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md) that we can add a fallback to `application/json`.

This allowed yarn to correctly download metadata from artifactory. Then, I had another problem, with the `isRequestToRegistry` function implemented on #2598. The problem was that although I do specify `https://myartifactory` for my registy, some dependencies gets the `https` replaced with `http` by yarn, preventing it from sending the authentication header. I don't know why this happens, maybe its artifactory itself telling yarn to use http (I've noted it happens on public dependencies)

So, I've modified the function `isRequestToRegistry` to understand that `https://myartifactory` and `http://myartifactory` is still the same registry.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I've added extra test cases to `isRequestToRegistry functional test`, maybe some snapshots testing needs to be changed for the `vnd.npm` header, but they gave no errors on my machine.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Cheers!