### PR TITLE
Use stdout.isTTY instead of tty module

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -9,8 +9,6 @@ import {Add} from './add.js';
 import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 
-const tty = require('tty');
-
 export const requireLockfile = true;
 
 export function setFlags(commander: Object) {
@@ -24,7 +22,7 @@ type InquirerResponses<K, T> = {[key: K]: Array<T>};
 // Prompt user with Inquirer
 async function prompt(choices): Promise<Array<Dependency>> {
   let pageSize;
-  if (process.stdout instanceof tty.WriteStream) {
+  if (process.stdout.isTTY) {
     pageSize = process.stdout.rows - 2;
   }
   const answers: InquirerResponses<'packages', Dependency> = await inquirer.prompt([{

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -11,7 +11,6 @@ import * as fs from '../../util/fs.js';
 import {YARN_REGISTRY} from '../../constants.js';
 
 const inquirer = require('inquirer');
-const tty = require('tty');
 const invariant = require('invariant');
 const path = require('path');
 
@@ -49,7 +48,7 @@ export default class NpmResolver extends RegistryResolver {
       }
       config.reporter.log(config.reporter.lang('couldntFindVersionThatMatchesRange', body.name, range));
       let pageSize;
-      if (process.stdout instanceof tty.WriteStream) {
+      if (process.stdout.isTTY) {
         pageSize = process.stdout.rows - 2;
       }
       const response: {[key: string]: ?string} = await inquirer.prompt([{


### PR DESCRIPTION
Just a small patch to make it more consistent. I noticed `isTTY` is used in some other files but not in the edited two files.