### PR TITLE
Add hasWrapper function in clean and remove command

### DIFF
--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -129,3 +129,7 @@ export async function run(
 }
 
 export function setFlags() {}
+
+export function hasWrapper(): boolean {
+  return true;
+}

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -16,6 +16,10 @@ export const requireLockfile = true;
 
 export function setFlags() {}
 
+export function hasWrapper(): boolean {
+  return true;
+}
+
 export async function run(
   config: Config,
   reporter: Reporter,


### PR DESCRIPTION
@arcanis sorry I totally forgot to inform you that clean and remove command miss a hasWrapper function.
This should fix both commands after https://github.com/yarnpkg/yarn/pull/3105

Let mw know,
cheers,
Simon
