### PR TITLE
Move inquirer code to console reporter

### DIFF
--- a/__tests__/reporters/base-reporter.js
+++ b/__tests__/reporters/base-reporter.js
@@ -119,3 +119,15 @@ test('BaseReporter.termstrings', () => {
   const expected = '"\u001b[2mjsprim#\u001b[22mjson-schema" not installed';
   expect(reporter.lang('packageNotInstalled', '\u001b[2mjsprim#\u001b[22mjson-schema')).toEqual(expected);
 });
+
+test('BaseReporter.prompt', async () => {
+  const reporter = new BaseReporter();
+  let error;
+  try {
+    await reporter.prompt('', []);
+  } catch (e) {
+    error = e;
+  }
+  expect(error).not.toBeUndefined();
+  reporter.close();
+});

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -9,8 +9,6 @@ import {Add} from './add.js';
 import {Install} from './install.js';
 import Lockfile from '../../lockfile/wrapper.js';
 
-const tty = require('tty');
-
 export const requireLockfile = true;
 
 export function setFlags(commander: Object) {
@@ -21,25 +19,6 @@ export function setFlags(commander: Object) {
 
 export function hasWrapper(): boolean {
   return true;
-}
-
-type InquirerResponses<K, T> = {[key: K]: Array<T>};
-
-// Prompt user with Inquirer
-async function prompt(choices): Promise<Array<Dependency>> {
-  let pageSize;
-  if (process.stdout instanceof tty.WriteStream) {
-    pageSize = process.stdout.rows - 2;
-  }
-  const answers: InquirerResponses<'packages', Dependency> = await inquirer.prompt([{
-    name: 'packages',
-    type: 'checkbox',
-    message: 'Choose which packages to update.',
-    choices,
-    pageSize,
-    validate: (answer) => !!answer.length || 'You must choose at least one package.',
-  }]);
-  return answers.packages;
 }
 
 export async function run(
@@ -109,13 +88,21 @@ export async function run(
       (ys, y) => ys.concat(Array.isArray(y) ? flatten(y) : y), [],
   );
 
-  const choices = Object.keys(groupedDeps).map((key) => [
+  const choices = flatten(Object.keys(groupedDeps).map((key) => [
     new inquirer.Separator(reporter.format.bold.underline.green(key)),
     groupedDeps[key],
     new inquirer.Separator(' '),
-  ]);
+  ]));
 
-  const answers = await prompt(flatten(choices));
+  const answers: Array<Dependency> = await reporter.prompt(
+    'Choose which packages to update.',
+    choices,
+    {
+      name: 'packages',
+      type: 'checkbox',
+      validate: (answer) => !!answer.length || 'You must choose at least one package.',
+    },
+  );
 
   const getName = ({name}) => name;
   const isHint = (x) => ({hint}) => hint === x;

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -10,6 +10,7 @@ import type {
   Package,
   ReporterSpinner,
   QuestionOptions,
+  PromptOptions,
 } from './types.js';
 import type {LanguageKeys} from './lang/en.js';
 import type {Formatter} from './format.js';
@@ -258,5 +259,12 @@ export default class BaseReporter {
   // utility function to disable progress bar
   disableProgress() {
     this.noProgress = true;
+  }
+
+  //
+  prompt<T>(
+    message: string, choices: Array<*>, options?: PromptOptions = {},
+  ): Promise<Array<T>> {
+    return Promise.reject(new Error('Not implemented'));
   }
 }

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -7,6 +7,7 @@ import type {
   ReporterSpinner,
   ReporterSelectOption,
   QuestionOptions,
+  PromptOptions,
 } from '../types.js';
 import type {FormatKeys} from '../format.js';
 import BaseReporter from '../base-reporter.js';
@@ -15,13 +16,16 @@ import Spinner from './spinner-progress.js';
 import {clearLine} from './util.js';
 import {removeSuffix} from '../../util/misc.js';
 import {sortTrees, recurseTree, getFormattedOutput} from './helpers/tree-helper.js';
+import inquirer from 'inquirer';
 
 const {inspect} = require('util');
 const readline = require('readline');
 const chalk = require('chalk');
 const read = require('read');
+const tty = require('tty');
 
 type Row = Array<string>;
+type InquirerResponses<K, T> = {[key: K]: Array<T>};
 
 export default class ConsoleReporter extends BaseReporter {
   constructor(opts: Object) {
@@ -379,5 +383,25 @@ export default class ConsoleReporter extends BaseReporter {
     return function() {
       bar.tick();
     };
+  }
+
+  async prompt<T>(
+    message: string, choices: Array<*>, options?: PromptOptions = {},
+  ): Promise<Array<T>> {
+    if (!process.stdout.isTTY) {
+      return Promise.reject(new Error("Can't answer a question unless a user TTY"));
+    }
+
+    let pageSize;
+    if (process.stdout instanceof tty.WriteStream) {
+      pageSize = process.stdout.rows - 2;
+    }
+
+    const {name = 'prompt', type = 'input', validate} = options;
+    const answers: InquirerResponses<string, T> = await inquirer.prompt([{
+      name, type, message, choices, pageSize, validate,
+    }]);
+
+    return answers[name];
   }
 }

--- a/src/reporters/noop-reporter.js
+++ b/src/reporters/noop-reporter.js
@@ -10,6 +10,7 @@ import type {
     Package,
     ReporterSpinner,
     QuestionOptions,
+    PromptOptions,
 } from './types.js';
 import type {LanguageKeys} from './lang/en.js';
 import type {Formatter} from './format.js';
@@ -78,5 +79,11 @@ export default class NoopReporter extends BaseReporter {
 
   disableProgress() {
     this.noProgress = true;
+  }
+
+  prompt<T>(
+    message: string, choices: Array<*>, options?: PromptOptions = {},
+  ): Promise<Array<T>> {
+    return Promise.reject(new Error('Not implemented'));
   }
 }

--- a/src/reporters/types.js
+++ b/src/reporters/types.js
@@ -47,3 +47,12 @@ export type QuestionOptions = {
   password?: boolean,
   required?: boolean,
 };
+
+export type InquirerPromptTypes = 'list' | 'rawlist' | 'expand' |
+  'checkbox' | 'confirm' | 'input' | 'password' | 'editor';
+
+export type PromptOptions = {
+  name?: string,
+  type?: InquirerPromptTypes,
+  validate?: (input: string | Array<string>) => (boolean | string),
+};


### PR DESCRIPTION
This is a long time due.

When I first wrote it I had no idea about the rest of the yarn codebase. Later I realized it would be a better idea to move this inside the reporter. Then we can easily use this in other parts of our codebase.

**Future Wok**
* Update Inquirer flow type.
* ~~Fix *press double `ctrl+c` to get out of interactive mode*~~ (done)