### PR TITLE
Fix bin path on Windows, fixes #2565

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -39,7 +39,7 @@
 				<Environment
 					Id="BinPath"
 					Name="PATH"
-					Value="[LocalAppDataFolder]Yarn\.bin"
+					Value="[LocalAppDataFolder]Yarn\config\global\node_modules\.bin"
 					Permanent="no"
 					Part="last"
 					Action="set"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`yarn global add (package name)` installs a package on `%LOCALAPPDATA%\Yarn\config\global\node_modules\.bin` but the installer adds wrong path. This PR fixes it.

**Test plan**

No test, can you help me if a test for this is required?
