### PR TITLE
Partially revert #2657 to fix add command test

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -218,6 +218,12 @@ async function buildActionsForCopy(
           if (srcFiles.indexOf(file) < 0) {
             const loc = path.join(dest, file);
             possibleExtraneous.add(loc);
+
+            if ((await lstat(loc)).isDirectory()) {
+              for (const file of await readdir(loc)) {
+                possibleExtraneous.add(path.join(loc, file));
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Adds back a few lines that were removed in #2657 that apparently caused the `command add` test to fail. cc @bestander @arcanis 