### PR TITLE
Put build artifact tracking in integrity file

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -52,9 +52,9 @@ test.concurrent('properly find and save build artifacts', async () => {
   await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
     const cacheFolder = path.join(config.cacheFolder, 'npm-dummy-0.0.0');
 
-    expect(
-      (await fs.readJson(path.join(cacheFolder, constants.METADATA_FILENAME))).artifacts,
-    ).toEqual(
+    const integrity = await fs.readJson(path.join(config.cwd, 'node_modules', constants.INTEGRITY_FILENAME));
+
+    expect(integrity.artifacts['dummy@0.0.0']).toEqual(
       ['dummy', path.join('dummy', 'dummy.txt'), 'dummy.txt'],
     );
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -329,6 +329,12 @@ export class Install {
       return true;
     }
 
+    const {artifacts} = match;
+    if (artifacts) {
+      this.linker.setArtifacts(artifacts);
+      this.scripts.setArtifacts(artifacts);
+    }
+
     return false;
   }
 
@@ -603,7 +609,7 @@ export class Install {
     }
 
     // write integrity hash
-    await this.integrityChecker.save(patterns, lockfileBasedOnResolver, this.flags, this.resolver.usedRegistries);
+    await this.integrityChecker.save(patterns, lockfileBasedOnResolver, this.flags, this.resolver.usedRegistries, this.scripts.getArtifacts());
 
     const lockFileHasAllPatterns = patterns.filter((p) => !this.lockfile.getLocked(p)).length === 0;
     const resolverPatternsAreSameAsInLockfile = Object.keys(lockfileBasedOnResolver)

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -609,7 +609,13 @@ export class Install {
     }
 
     // write integrity hash
-    await this.integrityChecker.save(patterns, lockfileBasedOnResolver, this.flags, this.resolver.usedRegistries, this.scripts.getArtifacts());
+    await this.integrityChecker.save(
+      patterns,
+      lockfileBasedOnResolver,
+      this.flags,
+      this.resolver.usedRegistries,
+      this.scripts.getArtifacts(),
+    );
 
     const lockFileHasAllPatterns = patterns.filter((p) => !this.lockfile.getLocked(p)).length === 0;
     const resolverPatternsAreSameAsInLockfile = Object.keys(lockfileBasedOnResolver)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This moves build artifact tracking away from the cache metadata and into the integrity file.

I suspect this should fix #1981 as the cause seems to be that they restore `node_modules` and not Yarn's internal cache.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Existing tests.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
