### PR TITLE
Fix global module executable path on Windows

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -39,7 +39,7 @@
 				<Environment
 					Id="BinPath"
 					Name="PATH"
-					Value="[LocalAppDataFolder]Yarn\.bin"
+					Value="[LocalAppDataFolder]Yarn\bin"
 					Permanent="no"
 					Part="last"
 					Action="set"

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -77,6 +77,9 @@ function getGlobalPrefix(config: Config, flags: Object): string {
   } else if (process.env.PREFIX) {
     return process.env.PREFIX;
   } else if (process.platform === 'win32') {
+    if (process.env.LOCALAPPDATA) {
+      return path.join(process.env.LOCALAPPDATA, 'Yarn', 'bin');
+    }
     // c:\node\node.exe --> prefix=c:\node\
     return path.dirname(process.execPath);
   } else {


### PR DESCRIPTION
**Summary**
Node.js is almost always installed in `C:\Program Files\Yarn`, which regular users can't write to. However, Yarn defaults to installing the executables for global modules in the Node directory. This means that the out-of-the-box experience for people installing global modules on Windows is totally broken.

It should instead place them in a directory that the user can write to. I'm going with `%LocalAppData\Yarn\bin` (eg. `C:\Users\Daniel\AppData\Local\Yarn\bin`) as it makes the most sense given all the config and cache is already in that directory. I also updated the path in the installer, as the path the installer was using didn't actually exist (`.bin` instead of `bin`).

**Test plan**

Tested `bin\yarn global add webpack`, it placed the files in the right directory:
![](http://ss.dan.cx/2017/04/bin_-_Clover_22-21.48.52.png)

Closes #3055