### PR TITLE
use close instead of finish event for file copy completion

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -515,7 +515,7 @@ export async function copyBulk(
         readStream.pipe(writeStream);
       });
 
-      writeStream.once('finish', function() {
+      writeStream.once('close', function() {
         fs.utimes(data.dest, data.atime, data.mtime, function(err) {
           if (err) {
             reject(err);


### PR DESCRIPTION
Currently performance of yarn on Windows with Windows Defender is not great, especially for large projects. One of the causes of this is fs.copyBulk invoking fs.utimes prior to closing the file being copied.

Windows updates a files mtime when its handle closes, so if yarns utime call completes before the os has had time to actually close the file, yarns times will be overwritten. Windows Defender makes this issue far more noticeable since it runs its scan before the handle is closed causing nearly every file to lose yarns mtime. The end result is that most files in node_modules will be recopied on every single yarn command if Windows Defender is enabled. (If WD is disabled the issue remains, but it does stabilize as yarn gets lucky and updates mtimes after windows.)

By using the close event of writeStream rather than finish, the utimes-call occurs after Windows has had time to wrap things up.