### PR TITLE
accept 1ms difference in filedates as equal on windows

### DIFF
--- a/__tests__/util/fs.js
+++ b/__tests__/util/fs.js
@@ -39,7 +39,8 @@ describe('fileDatesEqual', () => {
     });
 
     test('Different dates differ', () => {
-      expect(fileDatesEqual(new Date(1491393798834), new Date(1491393798835))).toBeFalsy();
+      expect(fileDatesEqual(new Date(1491393798834), new Date(1491393798835))).toBeTruthy();
+      expect(fileDatesEqual(new Date(1491393798834), new Date(1491393798836))).toBeFalsy();
       expect(fileDatesEqual(new Date(1491393700834), new Date(1491393798834))).toBeFalsy();
     });
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -88,6 +88,14 @@ export const fileDatesEqual = (a: Date, b: Date) => {
     return aTime === bTime;
   }
 
+  // See https://github.com/nodejs/node/pull/12607
+  // Submillisecond times from stat and utimes are truncated on Windows,
+  // causing a file with mtime 8.0079998 and 8.0081144 to become 8.007 and 8.008
+  // and making it impossible to update these files to their correct timestamps.
+  if (Math.abs(aTime - bTime) <= 1) {
+    return true;
+  }
+
   const aTimeSec = Math.floor(aTime / 1000);
   const bTimeSec = Math.floor(bTime / 1000);
 


### PR DESCRIPTION
There's an issue in node (https://github.com/nodejs/node/pull/12607) with submillisecond truncation of file mtimes on Windows, which makes yarns fileDatesEqual test fail on any file that's affected by the bug. This causes many identical files to appear changed causing unneeded re-copying on every yarn command.

You can run this to reproduce the issue:
```js
var fs = require('fs');
var targetMTime = new Date('2017-04-08T17:59:38.008Z');

fs.writeFileSync("./file1", "");
fs.utimesSync("./file1", targetMTime, targetMTime);

var actualMTime = fs.statSync("./file1").mtime;

console.log(actualMTime); // 2017-04-08T17:59:38.007Z
console.log(actualMTime.getTime() === targetMTime.getTime()); // false
```

In my test projects this issue affects in the area of 10% of files, so in a project with 50000 files in node_modules you get roughly 5000 extra file copies per yarn command.