### PR TITLE
Add environment variable for yarn cache folder

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -10,8 +10,9 @@ import * as fs from '../../src/util/fs.js';
 import {Install} from '../../src/cli/commands/install.js';
 import Config from '../../src/config.js';
 
-const stream = require('stream');
+const os = require('os');
 const path = require('path');
+const stream = require('stream');
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'install');
 
@@ -49,6 +50,10 @@ export async function getPackageVersion(config: Config, packagePath: string): Pr
   const loc = path.join(config.cwd, `node_modules/${packagePath.replace(/\//g, '/node_modules/')}/package.json`);
   const json = JSON.parse(await fs.readFile(loc));
   return json.version;
+}
+
+export function getTempGlobalFolder(): string {
+  return path.join(os.tmpdir(), `yarn-global-${Math.random()}`);
 }
 
 export async function run<T, R>(
@@ -119,14 +124,18 @@ export async function run<T, R>(
   }
 
   try {
-    const config = await Config.create({
+    const opts = {
       binLinks: !!flags.binLinks,
       cwd,
       globalFolder: path.join(cwd, '.yarn-global'),
       cacheFolder: flags.cacheFolder || path.join(cwd, '.yarn-cache'),
       linkFolder: path.join(cwd, '.yarn-link'),
       production: flags.production,
-    }, reporter);
+    };
+    if (flags.noCache) {
+      delete opts.cacheFolder;
+    }
+    const config = await Config.create(opts, reporter);
 
     const install = await factory(args, flags, config, reporter, lockfile, () => out);
 

--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -3,8 +3,9 @@
 import * as reporters from '../../src/reporters/index.js';
 import * as fs from '../../src/util/fs.js';
 import {run} from '../../src/cli/commands/cache.js';
-import {run as buildRun, runInstall} from './_helpers.js';
+import {getTempGlobalFolder, run as buildRun, runInstall} from './_helpers.js';
 
+const os = require('os');
 const path = require('path');
 const stream = require('stream');
 
@@ -42,9 +43,22 @@ test('ls with scoped package', async (): Promise<void> => {
   });
 });
 
-test('dir', async (): Promise<void> => {
+test('dir, override YARN_CACHE_FOLDER with config', async (): Promise<void> => {
+  // The test harness sets cache folder config by default
   await runCache(['dir'], {}, '', (config, reporter, stdout) => {
     expect(stdout).toContain(JSON.stringify(config.cacheFolder));
+  });
+});
+
+test('dir defaults to YARN_CACHE_FOLDER env var', async (): Promise<void> => {
+  const envCacheFolder = process.env.YARN_CACHE_FOLDER;
+  const tempFolder = getTempGlobalFolder();
+  process.env.YARN_CACHE_FOLDER = tempFolder;
+  await runCache(['dir'], {noCache: true}, '', (config, reporter, stdout) => {
+
+    expect(stdout).toContain(tempFolder);
+    // restore env
+    process.env.YARN_CACHE_FOLDER = envCacheFolder;
   });
 });
 

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -2,7 +2,7 @@
 
 import type {CLIFunctionReturn} from '../../src/types.js';
 import {ConsoleReporter} from '../../src/reporters/index.js';
-import {run as buildRun} from './_helpers.js';
+import {getTempGlobalFolder, run as buildRun} from './_helpers.js';
 import {run as global} from '../../src/cli/commands/global.js';
 import * as fs from '../../src/util/fs.js';
 const isCI = require('is-ci');
@@ -28,10 +28,6 @@ function getGlobalPath(prefix, name): string {
   } else {
     return path.join(prefix, 'bin', name);
   }
-}
-
-function getTempGlobalFolder(): string {
-  return path.join(os.tmpdir(), `yarn-global-${Math.random()}`);
 }
 
 // this test has global folder side effects, run it only in CI

--- a/src/config.js
+++ b/src/config.js
@@ -261,6 +261,7 @@ export default class Config {
     this._cacheRootFolder = String(
       opts.cacheFolder ||
       this.getOption('cache-folder') ||
+      process.env.YARN_CACHE_FOLDER ||
       constants.MODULE_CACHE_DIRECTORY,
     );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Following up from issues #3208 and #1211, I have added configurability for the cache folder via environment variable.

The precedence for config is:

1. Yarn Config
2. Environment Variable `YARN_CACHE_FOLDER` I am open to other naming suggestions. I thought this was the clearest name that reflected its intended usage.
3. Constant settings as determined by `src/constants.js`

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

  - Added a unit test to ensure correct behavior
    - This involved making some changes to the test harness. please let me know if a better testing method is preferred.

Below are some examples as run from a Mac OS X laptop:

```sh
./bin/yarn cache dir
/Users/roger/Library/Caches/Yarn/v1
```

```sh
YARN_CACHE_FOLDER="foo" ./bin/yarn cache dir
foo/v1
```
```sh
$ YARN_CACHE_FOLDER="foo" ./bin/yarn cache dir --cache-folder bar
bar/v1
```

@colinodell @nervo
