### PR TITLE
Use skipIntegrityCheck instead of skipIntegrity in licenses command

### DIFF
--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -16,7 +16,7 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
 
 async function getManifests(config: Config, flags: Object): Promise<Array<Manifest>> {
   const lockfile = await Lockfile.fromDirectory(config.cwd);
-  const install = new Install({skipIntegrity: true, ...flags}, config, new NoopReporter(), lockfile);
+  const install = new Install({skipIntegrityCheck: true, ...flags}, config, new NoopReporter(), lockfile);
   await install.hydrate(true, true);
 
   let manifests = install.resolver.getManifests();


### PR DESCRIPTION
In https://github.com/yarnpkg/yarn/pull/3238 I noticed that we changed the skipIntegrity flag in skipIntegrityCheck (this is the commit https://github.com/yarnpkg/yarn/commit/bd8e326668aa1deac07b53bb9b9d93daf172c070)

**Test plan**
I have no idea how to test it; right now I don't have time to see this part. Let's park here for now.
