### PR TITLE
Change `use_winpty` logic in bin/yarn

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -2,12 +2,9 @@
 argv0=$(echo "$0" | sed -e 's,\\,/,g')
 basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
 
-use_winpty=0
-
 case "$(uname -s)" in
   Linux) basedir=$(dirname "$(readlink -f "$0" || echo "$argv0")");;
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-  MSYS*|MINGW*) use_winpty=1;;
 esac
 
 command_exists() {
@@ -15,7 +12,7 @@ command_exists() {
 }
 
 if command_exists node; then
-  if [ $use_winpty -eq 1 ]; then
+  if [ "$YARN_FORCE_WINPTY" -eq 1 ]; then
     winpty node "$basedir/yarn.js" "$@"
   else
     node "$basedir/yarn.js" "$@"


### PR DESCRIPTION
**Summary**

There used to be issues with Yarn on Windows that required the use of winpty:

- https://github.com/yarnpkg/yarn/issues/743

That fix caused issues down the line when some part of the Windows/Git/Bash toolchain was updated:

- https://github.com/yarnpkg/yarn/issues/2591
- https://github.com/yarnpkg/yarn/issues/2998

This change removes the troublesome auto detection of whether or not winpty is needed and relegates it to the environment variable `YARN_FORCE_WINPTY`

**Test plan**

Simple change of already existing logic. I'm not sure if there are any tests for it, but:

- https://github.com/yarnpkg/yarn/issues/2998#issuecomment-292597818 Working screenshots
- https://github.com/yarnpkg/yarn/issues/2998#issuecomment-291076842 Confirmation that removing the old logic works