### PR TITLE
extract the reporter out of integrity checker

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -65,7 +65,7 @@ export async function run<T, R>(
   args: Array<string>,
   flags: Object,
   name: string | { source: string, cwd: string },
-  checkInstalled: ?(config: Config, reporter: R, install: T) => ?Promise<void>,
+  checkInstalled: ?(config: Config, reporter: R, install: T, getStdout: () => string) => ?Promise<void>,
   beforeInstall: ?(cwd: string) => ?Promise<void>,
 ): Promise<void> {
   let out = '';
@@ -131,7 +131,7 @@ export async function run<T, R>(
     const install = await factory(args, flags, config, reporter, lockfile, () => out);
 
     if (checkInstalled) {
-      await checkInstalled(config, reporter, install);
+      await checkInstalled(config, reporter, install, () => out);
     }
   } catch (err) {
     throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -241,10 +241,11 @@ async (): Promise<void> => {
 });
 
 test.concurrent('--integrity should fail if integrity file have different linkedModules', async (): Promise<void> => {
-  await runInstall({}, path.join('..', 'check', 'integrity-lock-check'), async (config, reporter, install, getStdout): Promise<void> => {
+  await runInstall({}, path.join('..', 'check', 'integrity-lock-check'),
+  async (config, reporter, install, getStdout): Promise<void> => {
     const integrityFilePath = path.join(config.cwd, 'node_modules', '.yarn-integrity');
     const integrityFile = JSON.parse(await fs.readFile(integrityFilePath));
-    integrityFile.linkedModules.push("aLinkedModule");
+    integrityFile.linkedModules.push('aLinkedModule');
     await fs.writeFile(integrityFilePath, JSON.stringify(integrityFile, null, 2));
 
     let thrown = false;

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -239,3 +239,21 @@ async (): Promise<void> => {
 
   });
 });
+
+test.concurrent('--integrity should fail if integrity file have different linkedModules', async (): Promise<void> => {
+  await runInstall({}, path.join('..', 'check', 'integrity-lock-check'), async (config, reporter, install, getStdout): Promise<void> => {
+    const integrityFilePath = path.join(config.cwd, 'node_modules', '.yarn-integrity');
+    const integrityFile = JSON.parse(await fs.readFile(integrityFilePath));
+    integrityFile.linkedModules.push("aLinkedModule");
+    await fs.writeFile(integrityFilePath, JSON.stringify(integrityFile, null, 2));
+
+    let thrown = false;
+    try {
+      await checkCmd.run(config, reporter, {integrity: true}, []);
+    } catch (e) {
+      thrown = true;
+    }
+    expect(thrown).toEqual(true);
+    expect(getStdout()).toContain('Integrity check: Linked modules don\'t match');
+  });
+});

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -171,7 +171,7 @@ async function integrityHashCheck(
     reportError('noIntegrityFile');
   }
   if (!match.integrityMatches) {
-    reportError(reasons[match.whyIntegrityMatchesFailed]);
+    reporter.warn(reporter.lang(reasons[match.whyIntegrityMatchesFailed]));
     reportError('integrityCheckFailed');
   }
 

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -152,7 +152,6 @@ async function integrityHashCheck(
     'FILES_MISSING': 'integrityFailedFilesMissing',
     'LOCKFILE_DONT_MATCH': 'integrityLockfilesDontMatch',
     'FLAGS_DONT_MATCH': 'integrityFlagsDontMatch',
-    'PATTERNS_DONT_MATCH': 'integrityPatternsDontMatch',
     'LINKED_MODULES_DONT_MATCH': 'integrityCheckLinkedModulesDontMatch',
   };
   const integrityChecker = new InstallationIntegrityChecker(config);

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -148,7 +148,7 @@ async function integrityHashCheck(
     errCount++;
   }
   const reasons = {
-    'EXPECTED_MISSING': 'integrityFailedExpectedMissing',
+    'EXPECTED_IS_NOT_A_JSON': 'integrityFailedExpectedIsNotAJSON',
     'FILES_MISSING': 'integrityFailedFilesMissing',
     'LOCKFILE_DONT_MATCH': 'integrityLockfilesDontMatch',
     'FLAGS_DONT_MATCH': 'integrityFlagsDontMatch',
@@ -170,7 +170,7 @@ async function integrityHashCheck(
   if (match.integrityFileMissing) {
     reportError('noIntegrityFile');
   }
-  if (!match.integrityMatches) {
+  if (match.integrityMatches === false) {
     reporter.warn(reporter.lang(reasons[match.whyIntegrityMatchesFailed]));
     reportError('integrityCheckFailed');
   }

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -147,7 +147,15 @@ async function integrityHashCheck(
     reporter.error(reporter.lang(msg, ...vars));
     errCount++;
   }
-  const integrityChecker = new InstallationIntegrityChecker(config, reporter);
+  const reasons = {
+    'EXPECTED_MISSING': 'integrityFailedExpectedMissing',
+    'FILES_MISSING': 'integrityFailedFilesMissing',
+    'LOCKFILE_DONT_MATCH': 'integrityLockfilesDontMatch',
+    'FLAGS_DONT_MATCH': 'integrityFlagsDontMatch',
+    'PATTERNS_DONT_MATCH': 'integrityPatternsDontMatch',
+    'LINKED_MODULES_DONT_MATCH': 'integrityCheckLinkedModulesDontMatch',
+  };
+  const integrityChecker = new InstallationIntegrityChecker(config);
 
   const lockfile = await Lockfile.fromDirectory(config.cwd);
   const install = new Install(flags, config, reporter, lockfile);
@@ -163,6 +171,7 @@ async function integrityHashCheck(
     reportError('noIntegrityFile');
   }
   if (!match.integrityMatches) {
+    reportError(reasons[match.whyIntegrityMatchesFailed]);
     reportError('integrityCheckFailed');
   }
 

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -3,6 +3,7 @@
 import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
 import InstallationIntegrityChecker from '../../integrity-checker.js';
+import {integrityErrors} from '../../integrity-checker.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import type {Reporter} from '../../reporters/index.js';
 import * as fs from '../../util/fs.js';
@@ -147,13 +148,6 @@ async function integrityHashCheck(
     reporter.error(reporter.lang(msg, ...vars));
     errCount++;
   }
-  const reasons = {
-    'EXPECTED_IS_NOT_A_JSON': 'integrityFailedExpectedIsNotAJSON',
-    'FILES_MISSING': 'integrityFailedFilesMissing',
-    'LOCKFILE_DONT_MATCH': 'integrityLockfilesDontMatch',
-    'FLAGS_DONT_MATCH': 'integrityFlagsDontMatch',
-    'LINKED_MODULES_DONT_MATCH': 'integrityCheckLinkedModulesDontMatch',
-  };
   const integrityChecker = new InstallationIntegrityChecker(config);
 
   const lockfile = await Lockfile.fromDirectory(config.cwd);
@@ -170,7 +164,7 @@ async function integrityHashCheck(
     reportError('noIntegrityFile');
   }
   if (match.integrityMatches === false) {
-    reporter.warn(reporter.lang(reasons[match.whyIntegrityMatchesFailed]));
+    reporter.warn(reporter.lang(integrityErrors[match.integrityError]));
     reportError('integrityCheckFailed');
   }
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -172,7 +172,7 @@ export class Install {
 
     this.resolver = new PackageResolver(config, lockfile);
     this.fetcher = new PackageFetcher(config, this.resolver);
-    this.integrityChecker = new InstallationIntegrityChecker(config, this.reporter);
+    this.integrityChecker = new InstallationIntegrityChecker(config);
     this.compatibility = new PackageCompatibility(config, this.resolver, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
     this.scripts = new PackageInstallScripts(config, this.resolver, this.flags.force);

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -178,7 +178,7 @@ export default class InstallationIntegrityChecker {
     checkFiles: boolean,
     locationFolder: string): Promise<string> {
     if (!expected) {
-      return Promise.resolve('EXPECTED_MISSING');
+      return Promise.resolve('EXPECTED_IS_NOT_A_JSON');
     }
     if (!compareSortedArrays(actual.linkedModules, expected.linkedModules)) {
       return Promise.resolve('LINKED_MODULES_DONT_MATCH');

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -183,9 +183,6 @@ export default class InstallationIntegrityChecker {
     if (!compareSortedArrays(actual.linkedModules, expected.linkedModules)) {
       return Promise.resolve('LINKED_MODULES_DONT_MATCH');
     }
-    if (!compareSortedArrays(actual.topLevelPatters, expected.topLevelPatters)) {
-      return Promise.resolve('PATTERNS_DONT_MATCH');
-    }
     if (!compareSortedArrays(actual.flags, expected.flags)) {
       return Promise.resolve('FLAGS_DONT_MATCH');
     }

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -291,5 +291,4 @@ export default class InstallationIntegrityChecker {
       await fs.unlink(loc.locationPath);
     }
   }
-
 }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -256,7 +256,6 @@ const messages = {
   noIntegrityFile: 'Couldn\'t find an integrity file',
   integrityFailedExpectedIsNotAJSON: 'Integrity check: integrity file is not a json',
   integrityCheckLinkedModulesDontMatch: 'Integrity check: Linked modules don\'t match',
-  integrityPatternsDontMatch: 'Integrity check: Patterns don\'t match',
   integrityFlagsDontMatch: 'Integrity check: Flags don\'t match',
   integrityLockfilesDontMatch: 'Integrity check: Lock files don\'t match',
   integrityFailedFilesMissing: 'Integrity check: Files are missing',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -254,6 +254,7 @@ const messages = {
   lockfileNotContainPattern: 'Lockfile does not contain pattern: $0',
   integrityCheckFailed: 'Integrity check failed',
   noIntegrityFile: 'Couldn\'t find an integrity file',
+  integrityFailedExpectedIsNotAJSON: 'Integrity check: integrity file is not a json',
   integrityCheckLinkedModulesDontMatch: 'Integrity check: Linked modules don\'t match',
   integrityPatternsDontMatch: 'Integrity check: Patterns don\'t match',
   integrityFlagsDontMatch: 'Integrity check: Flags don\'t match',


### PR DESCRIPTION
**Summary**
Integrity-checker should not have side effects and we should reporting warning only in the check command.

**Todo list**
- [x] add some testing for the check command
- [x] Right now I report an error with the reason why integrity matches failed in the check command, this is incorrect, I should use a warning

**Test plan**
See above.