### PR TITLE
symlink the metadeps with binaries into the topmost node_modules/.bin

### DIFF
--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -277,8 +277,12 @@ export default class PackageLinker {
     if (this.config.binLinks) {
       const tickBin = this.reporter.progress(flatTree.length);
       await promise.queue(flatTree, async ([dest, {pkg}]) => {
+        // symlink bin script to package module
         const binLoc = path.join(dest, this.config.getFolder(pkg));
         await this.linkBinDependencies(pkg, binLoc);
+
+        // symlink bin script to root module folder so that these scripts are available in npm run $PATH
+        await this.linkBinDependencies(pkg, this.config.getFolder(pkg));
         tickBin(dest);
       }, 4);
     }


### PR DESCRIPTION
**Issue** #3059 

**Summary**
When running yarn install on a dependency tree with a nested child dependency that exposes a CLI binary, the CLI bin is not symlinked into node_modules/.bin as expected. Current behavior of yarn is to symlink the script to parent module's .bin folder.

``` Current Behavior
$ git clone https://github.com/probablyup/sample_repo_a.git
$ cd sample_repo_a
$ yarn install
yarn install v0.21.3
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
✨  Done in 16.16s.
$ ls node_modules/.bin
ls: node_modules/.bin: No such file or directory
$ ls node_modules/sample_repo_b/node_modules/.bin/
eslint
```
This pull request adds the functionality to symlink the binaries/scripts in both locations; current yarn behavior as well as symlink to root node_modules folder.

**Test plan**
1. Checkout https://github.com/probablyup/sample_repo_a.git
2. Install dependencies using yarn
3. A symlink to node_modules/eslint/bin/eslint.js should be created in node_modules/.bin. This is npm's behavior.

```
$ git clone https://github.com/probablyup/sample_repo_a.git
$ cd sample_repo_a

$ yarn install
yarn install v0.21.3
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
✨  Done in 12.99s.

$ ls -al node_modules/.bin/
total 64
drwxr-xr-x   10 snagi  users   340 Apr 28 16:19 .
drwxr-xr-x  139 snagi  users  4726 Apr 28 16:19 ..
lrwxr-xr-x    1 snagi  users    41 Apr 28 16:19 acorn -> ../acorn-jsx/node_modules/acorn/bin/acorn
lrwxr-xr-x    1 snagi  users    23 Apr 28 16:19 eslint -> ../eslint/bin/eslint.js
lrwxr-xr-x    1 snagi  users    25 Apr 28 16:19 esparse -> ../esprima/bin/esparse.js
lrwxr-xr-x    1 snagi  users    28 Apr 28 16:19 esvalidate -> ../esprima/bin/esvalidate.js
lrwxr-xr-x    1 snagi  users    25 Apr 28 16:19 js-yaml -> ../js-yaml/bin/js-yaml.js
lrwxr-xr-x    1 snagi  users    20 Apr 28 16:19 mkdirp -> ../mkdirp/bin/cmd.js
lrwxr-xr-x    1 snagi  users    16 Apr 28 16:19 rimraf -> ../rimraf/bin.js
lrwxr-xr-x    1 snagi  users    19 Apr 28 16:19 shjs -> ../shelljs/bin/shjs

$ ls -al node_modules/sample_repo_b/node_modules/.bin/
total 8
drwxr-xr-x    3 snagi  users  102 Apr 28 16:19 .
drwxr-xr-x    3 snagi  users  102 Apr 28 16:19 ..
lrwxr-xr-x    1 snagi  users   29 Apr 28 16:19 eslint -> ../../../eslint/bin/eslint.js
```