### PR TITLE
Better use of English in `why` output

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -188,7 +188,7 @@ const messages = {
   whyDiskSizeWithout: 'Disk size without dependencies: $0',
   whyDiskSizeUnique: 'Disk size with unique dependencies: $0',
   whyDiskSizeTransitive: 'Disk size with transitive dependencies: $0',
-  whySharedDependencies: 'Amount of shared dependencies: $0',
+  whySharedDependencies: 'Number of shared dependencies: $0',
   whyHoistedTo: `Has been hoisted to $0`,
 
   whyHoistedFromSimple: `This module exists because it's hoisted from $0.`,


### PR DESCRIPTION
**Summary**

Just a small wording tidy up,

Original:
> Amount of shared dependencies: $0

Update:
> Number of shared dependencies: $0

**Test plan**

```
yarn why [PACKAGE_NAME]
...
info Number of shared dependencies: 11
...
```