### PR TITLE
Add 'project:' dependencies

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -317,13 +317,13 @@ export class Install {
       return false;
     }
     const match = await this.integrityChecker.check(patterns, lockfileCache, this.flags);
-    if (this.flags.frozenLockfile && match.missingPatterns.length > 0) {
+    if (this.flags.frozenLockfile && (match.missingPatterns.length > 0 || match.outOfDate)) {
       throw new MessageError(this.reporter.lang('frozenLockfileError'));
     }
 
     const haveLockfile = await fs.exists(path.join(this.config.cwd, constants.LOCKFILE_FILENAME));
 
-    if (match.integrityMatches && haveLockfile) {
+    if (match.integrityMatches && haveLockfile && !match.outOfDate) {
       this.reporter.success(this.reporter.lang('upToDate'));
       return true;
     }

--- a/src/fetchers/index.js
+++ b/src/fetchers/index.js
@@ -3,21 +3,24 @@
 import BaseFetcher from './base-fetcher.js';
 import CopyFetcher from './copy-fetcher.js';
 import GitFetcher from './git-fetcher.js';
-import TarballFetcher from './tarball-fetcher.js';
+import TarballFetcher, {LocalTarballFetcher} from './tarball-fetcher.js';
 
 export {BaseFetcher as base};
 export {CopyFetcher as copy};
 export {GitFetcher as git};
 export {TarballFetcher as tarball};
+export {LocalTarballFetcher as localTarball};
 
 export type Fetchers =
   | BaseFetcher
   | CopyFetcher
   | GitFetcher
-  | TarballFetcher;
+  | TarballFetcher
+  | LocalTarballFetcher;
 
 export type FetcherNames =
   | 'base'
   | 'copy'
   | 'git'
-  | 'tarball';
+  | 'tarball'
+  | 'localTarball';

--- a/src/resolvers/exotics/project-resolver.js
+++ b/src/resolvers/exotics/project-resolver.js
@@ -1,0 +1,109 @@
+/* @flow */
+
+import type {Manifest} from '../../types.js';
+import type Config from '../../config.js';
+import ExoticResolver from './exotic-resolver.js';
+import {removePrefix} from '../../util/misc.js';
+import * as versionUtil from '../../util/version.js';
+import * as fsUtil from '../../util/fs.js';
+import * as crypto from '../../util/crypto.js';
+const fs = require('fs');
+const path = require('path');
+const tar = require('tar-stream');
+const gunzip = require('gunzip-maybe');
+const stripBOM = require('strip-bom');
+
+// TODO: Move to utils
+const cache = {};
+function hashFile(path: string): Promise<string> {
+  if (path in cache) {
+    return Promise.resolve(cache[path]);
+  }
+  return new Promise((resolve, reject) => {
+    const validateStream = new crypto.HashStream();
+    fs.createReadStream(path)
+      .pipe(validateStream)
+      .on('error', reject)
+      .on('finish', () => {
+        const hash = validateStream.getHash();
+        cache[path] = hash;
+        resolve(hash);
+      });
+  });
+}
+
+// TODO: Move to utils
+function extractPackage(path): Promise<Manifest> {
+  return new Promise((resolve, reject) => {
+    const fstream = fs.createReadStream(path);
+    const chunks = [];
+    fstream
+      .pipe(gunzip())
+      .pipe(tar.extract())
+      .on('entry', (header, stream, next) => {
+        if (header.name.endsWith('/package.json')) {
+          stream.on('data', (data) => chunks.push(data));
+          stream.on('end', () => {
+            const buffer = Buffer.concat(chunks).toString();
+            resolve(JSON.parse(stripBOM(buffer)));
+          });
+        } else {
+          stream.on('end', next);
+        }
+        stream.resume();
+      })
+      .on('error', reject)
+      .on('finish', () => reject(new Error('no package.json found')));
+  });
+}
+
+// TODO: Move to utils/config
+async function resolveWorkspacePath(config: Config, fragment: string): Promise<string> {
+  const location = versionUtil.explodeHashedUrl(removePrefix(fragment, 'project:'));
+  const workspace = await fsUtil.find('.yarn.project', config.cwd);
+  if (workspace === false) {
+    throw new Error('no .yarn.project found');
+  }
+  return path.resolve(path.dirname(workspace), location.url);
+}
+
+export default class PackResolver extends ExoticResolver {
+
+  static protocol = 'project';
+
+  static async isOutdated(resolved: ?string, config: Config): Promise<boolean> {
+    if (resolved == null) {
+      return true;
+    }
+    if (resolved.startsWith('project:')) {
+      const version = versionUtil.explodeHashedUrl(resolved);
+      const artifact = await resolveWorkspacePath(config, resolved);
+      const hash = await hashFile(artifact);
+      return hash !== version.hash;
+    }
+    return false;
+  }
+
+  async resolve(): Promise<Manifest> {
+    const artifact = await resolveWorkspacePath(this.config, this.fragment);
+
+    // calculate the hash of the file
+    const hash = await hashFile(artifact);
+
+    // check if the file matches the hash in the lock file
+    const shrunk = this.request.getLocked('localTarball');
+    if (shrunk && shrunk._remote.hash === hash && !shrunk._remote.reference.startsWith('project:')) {
+      return shrunk;
+    }
+    const pkg = await extractPackage(artifact);
+    pkg._uid = hash;
+    pkg._remote = {
+      type: 'localTarball',
+      resolved: `${this.fragment}#${hash}`,
+      hash: null,
+      registry: this.registry,
+      reference: artifact,
+    };
+    return pkg;
+  }
+}

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -35,6 +35,10 @@ export default class TarballResolver extends ExoticResolver {
       return true;
     }
 
+    if (pattern.startsWith('project:')) {
+      return false;
+    }
+
     // local file reference - ignore patterns with names
     if (pattern.indexOf('@') < 0) {
       if (pattern.endsWith('.tgz') || pattern.endsWith('.tar.gz')) {

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -17,6 +17,7 @@ import ExoticFile from './exotics/file-resolver.js';
 import ExoticGitLab from './exotics/gitlab-resolver.js';
 import ExoticGist from './exotics/gist-resolver.js';
 import ExoticBitbucket from './exotics/bitbucket-resolver.js';
+import ExoticProject from './exotics/project-resolver.js';
 
 export const exotics = {
   git: ExoticGit,
@@ -26,6 +27,7 @@ export const exotics = {
   gitlab: ExoticGitLab,
   gist: ExoticGist,
   bitbucket: ExoticBitbucket,
+  project: ExoticProject,
 };
 
 //


### PR DESCRIPTION
This is a proof of concept for https://github.com/yarnpkg/rfcs/pull/59

Allows specifying a .tgz file as a project dependency. These will be resolved against the workspace directory (a parent directory containing a .yarn.workspace file) instead of the current directory.