### PR TITLE
Pass version number to build-chocolatey and update-homebrew

### DIFF
--- a/jenkins_jobs.groovy
+++ b/jenkins_jobs.groovy
@@ -33,6 +33,17 @@ job('yarn-version') {
       branch 'origin', 'master'
       pushOnlyIfSuccess
     }
+    downstreamParameterized {
+      // Other jobs to run when version number is bumped
+      trigger([
+        'yarn-chocolatey',
+        'yarn-homebrew',
+      ]) {
+        parameters {
+          currentBuild()
+        }
+      }
+    }
     gitHubIssueNotifier {
     }
   }
@@ -71,8 +82,8 @@ job('yarn-chocolatey') {
   scm {
     github 'yarnpkg/yarn', 'master'
   }
-  triggers {
-    upstream 'yarn-version'
+  parameters {
+    stringParam 'YARN_VERSION'
   }
   steps {
     powerShell '.\\scripts\\build-chocolatey.ps1 -Publish'
@@ -80,7 +91,6 @@ job('yarn-chocolatey') {
   publishers {
     gitHubIssueNotifier {
     }
-    mailer 'yarn@dan.cx'
   }
 }
 
@@ -90,8 +100,8 @@ job('yarn-homebrew') {
   scm {
     github 'yarnpkg/yarn', 'master'
   }
-  triggers {
-    upstream 'yarn-version'
+  parameters {
+    stringParam 'YARN_VERSION'
   }
   steps {
     shell './scripts/update-homebrew.sh'
@@ -99,6 +109,5 @@ job('yarn-homebrew') {
   publishers {
     gitHubIssueNotifier {
     }
-    mailer 'yarn@dan.cx'
   }
 }

--- a/scripts/build-chocolatey.ps1
+++ b/scripts/build-chocolatey.ps1
@@ -7,7 +7,15 @@ param(
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
-$latest_version = [String](Invoke-WebRequest -Uri https://yarnpkg.com/latest-version -UseBasicParsing)
+# See if YARN_VERSION was passed in the environment, otherwise get version
+# number from Yarn site
+if ($Env:YARN_VERSION) {
+  $latest_version = $Env:YARN_VERSION
+} else {
+  Write-Output 'Getting Yarn version from https://yarnpkg.com/latest-version'
+  $latest_version = [String](Invoke-WebRequest -Uri https://yarnpkg.com/latest-version -UseBasicParsing)
+}
+
 $latest_chocolatey_version = (Find-Package -Name Yarn).Version
 
 if ([Version]$latest_chocolatey_version -ge [Version]$latest_version) {

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -18,6 +18,9 @@ PATH=$PATH:$HOME/.linuxbrew/bin/
 pushd ~/.linuxbrew/Library/Taps/homebrew/homebrew-core
 #git remote set-url origin https://github.com/Daniel15/homebrew-core # for testing
 git remote set-url origin https://github.com/homebrew/homebrew-core
+git reset --hard HEAD
+git clean -fd
+git fetch --prune origin
 # Remove any existing branch (eg. if the previous attempt failed)
 git branch -D yarn-$version || true
 popd

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -3,7 +3,14 @@
 
 set -ex
 
-version=`curl --fail https://yarnpkg.com/latest-version`
+# See if YARN_VERSION was passed in the environment, otherwise get version
+# number from Yarn site
+if [ -z "$YARN_VERSION" ]; then
+  echo 'Getting Yarn version from https://yarnpkg.com/latest-version'
+  version=`curl --fail https://yarnpkg.com/latest-version`
+else
+  version="$YARN_VERSION"
+fi
 
 # Ensure Linuxbrew is on the PATH
 PATH=$PATH:$HOME/.linuxbrew/bin/


### PR DESCRIPTION
**Summary**
Instead of always grabbing the Yarn version number from yarnpkg.com/latest-version, allow it to be passed in as command line argument. This allows the Homebrew and Chocolatey packages to be rebuilt with the correct version numbers, after the Github release has been performed but before Netlify pushes the site.

**Test plan**
Tested manually in Jenkins by forking the `jenkins_jobs.groovy` into a test project.