### PR TITLE
use fcopy for faster file copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "death": "^1.0.0",
     "debug": "^2.2.0",
     "detect-indent": "^5.0.0",
+    "fcopy": "^0.0.7",
     "gunzip-maybe": "^1.4.0",
     "ini": "^1.3.4",
     "inquirer": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,6 +1695,12 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fcopy@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/fcopy/-/fcopy-0.0.7.tgz#bad8c8f1d256f1bae65e4165334bae58b1d190c2"
+  dependencies:
+    nan "^2.6.2"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3280,6 +3286,10 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
 nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+
+nan@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
 natives@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
#### (this is not something that should be merged now, needs more testing)

I dug up my old uv_sendfile code and thought it could be interesting to make a little package out of it (https://github.com/sciolist/fcopy) and see what impact it would have on yarn.

### My test setup:
  - yarn in offline mode
  - yarn.lock exists, node_modules is empty
  - windows defender disabled
  - node v7.8.0
  - [package.json with about 100 deps, 42k files, 200mb](https://github.com/sciolist/fcopy/blob/c0ded8b82bbaa3f4cdb0a67e951eb3f8b0f97fb7/perf/project/alottafiles/package.json)
  - each test ran 10 times

### Results

| Platform | avg speed v0.24 (master) | avg speed with fcopy lib |
| - | - | - |
| FreeBSD | 32s | 9s |
| Ubuntu | 30s | 9s |
| Os x | 32s | 10s |
| Windows | 68s | 32s |

I've ran diffs on the output and worked with it a bit today without noticing any differences or issues, but, I wouldn't be surprised if there are some.. particularly on other bsds.