### PR TITLE
remove duplication in __tests__/commands/pack.js

### DIFF
--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -1,82 +1,27 @@
 /* @flow */
-import type {Reporter} from '../../src/reporters/index.js';
-
 import * as fs from '../../src/util/fs.js';
 import {run as pack} from '../../src/cli/commands/pack.js';
-import * as reporters from '../../src/reporters/index.js';
-import Config from '../../src/config.js';
+import {ConsoleReporter} from '../../src/reporters/index.js';
+import {run as buildRun} from './_helpers.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 const path = require('path');
-const os = require('os');
-const stream = require('stream');
 
 const zlib = require('zlib');
 const tarFs = require('tar-fs');
 const fs2 = require('fs');
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'pack');
-
-export function runPack(
-  flags: Object,
-  name: string,
-  checkArchive?: ?(config: Config) => ?Promise<void>,
-): Promise<void> {
-  return run(() => {
-    return pack;
-  }, flags, path.join(fixturesLoc, name), checkArchive);
-}
-
-export async function run(
-  factory: () => (config: Config, reporter: Reporter, flags: Object, args: Array<string>) => Promise<void>,
-  flags: Object,
-  dir: string,
-  checkArchive: ?(config: Config) => ?Promise<void>,
-): Promise<void> {
-  let out = '';
-  const stdout = new stream.Writable({
-    decodeStrings: false,
-    write(data, encoding, cb) {
-      out += data;
-      cb();
-    },
-  });
-
-  const reporter = new reporters.ConsoleReporter({stdout, stderr: stdout});
-
-  const tmpRoot = path.join(
-    os.tmpdir(),
-    `yarn-${path.basename(dir)}-${Math.random()}`,
-  );
-
-  await fs.unlink(tmpRoot);
-  const cwd = path.join(tmpRoot, 'cwd');
-  await fs.copy(dir, cwd, reporter);
-
-  for (const {basename, absolute} of await fs.walk(cwd)) {
-    if (basename.toLowerCase() === '.ds_store') {
-      await fs.unlink(absolute);
-    }
-  }
-
-  try {
-    const config = await Config.create({
-      cwd,
-      globalFolder: path.join(tmpRoot, '.yarn/.global'),
-      cacheFolder: path.join(tmpRoot, '.yarn'),
-      linkFolder: path.join(tmpRoot, '.yarn/.link'),
-    }, reporter);
-
-    await pack(config, reporter, flags, []);
-
-    if (checkArchive) {
-      await checkArchive(config);
-    }
-  } catch (err) {
-    throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
-  }
-}
+const runPack = buildRun.bind(
+  null,
+  ConsoleReporter,
+  fixturesLoc,
+  async (args, flags, config, reporter, lockfile, getStdout): Promise<string> => {
+    await pack(config, reporter, flags, args);
+    return getStdout();
+  },
+);
 
 export async function getFilesFromArchive(source, destination): Promise<Array<string>> {
   const unzip = new Promise((resolve, reject) => {
@@ -97,7 +42,7 @@ export async function getFilesFromArchive(source, destination): Promise<Array<st
 }
 
 test.concurrent('pack should work with a minimal example', (): Promise<void> => {
-  return runPack({}, 'minimal', async (config): Promise<void> => {
+  return runPack([], {}, 'minimal', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'pack-minimal-test-v1.0.0.tgz'),
@@ -109,7 +54,7 @@ test.concurrent('pack should work with a minimal example', (): Promise<void> => 
 });
 
 test.concurrent('pack should include all files listed in the files array', (): Promise<void> => {
-  return runPack({}, 'files-include', async (config): Promise<void> => {
+  return runPack([], {}, 'files-include', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'files-include-v1.0.0.tgz'),
@@ -128,7 +73,7 @@ test.concurrent('pack should include all files listed in the files array', (): P
 
 test.concurrent('pack should include mandatory files not listed in files array if files not empty',
 (): Promise<void> => {
-  return runPack({}, 'files-include-mandatory', async (config): Promise<void> => {
+  return runPack([], {}, 'files-include-mandatory', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'files-include-mandatory-v1.0.0.tgz'),
@@ -142,7 +87,7 @@ test.concurrent('pack should include mandatory files not listed in files array i
 });
 
 test.concurrent('pack should exclude mandatory files from ignored directories', (): Promise<void> => {
-  return runPack({}, 'exclude-mandatory-files-from-ignored-directories', async (config): Promise<void> => {
+  return runPack([], {}, 'exclude-mandatory-files-from-ignored-directories', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'exclude-mandatory-files-from-ignored-directories-v1.0.0.tgz'),
@@ -156,7 +101,7 @@ test.concurrent('pack should exclude mandatory files from ignored directories', 
 
 test.concurrent('pack should exclude all other files if files array is not empty',
 (): Promise<void> => {
-  return runPack({}, 'files-exclude', async (config): Promise<void> => {
+  return runPack([], {}, 'files-exclude', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'files-exclude-v1.0.0.tgz'),
@@ -171,7 +116,7 @@ test.concurrent('pack should exclude all other files if files array is not empty
 
 test.concurrent('pack should exclude all dotflies if not in files and files not empty',
 (): Promise<void> => {
-  return runPack({}, 'files-exclude-dotfile', async (config): Promise<void> => {
+  return runPack([], {}, 'files-exclude-dotfile', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'files-exclude-dotfile-v1.0.0.tgz'),
@@ -183,7 +128,7 @@ test.concurrent('pack should exclude all dotflies if not in files and files not 
 
 test.concurrent('pack should exclude all files in dot-directories if not in files and files not empty ',
 (): Promise<void> => {
-  return runPack({}, 'files-exclude-dotdir', async (config): Promise<void> => {
+  return runPack([], {}, 'files-exclude-dotdir', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(
       path.join(cwd, 'files-exclude-dotdir-v1.0.0.tgz'),


### PR DESCRIPTION
**Summary**

In this file we had a run function very similar to the function present in https://github.com/yarnpkg/yarn/blob/master/__tests__/commands/_helpers.js#L54

**Test plan**

We have a lot of tests for the pack command. Everything seems ok.

cc @bestander @arcanis 
