### PR TITLE
Only update Chocolatey and Homebrew for non-RC releases

### DIFF
--- a/jenkins_jobs.groovy
+++ b/jenkins_jobs.groovy
@@ -83,7 +83,9 @@ job('yarn-chocolatey') {
     github 'yarnpkg/yarn', 'master'
   }
   parameters {
+    // Passed from yarn-version job
     stringParam 'YARN_VERSION'
+    booleanParam 'YARN_RC'
   }
   steps {
     powerShell '.\\scripts\\build-chocolatey.ps1 -Publish'
@@ -101,7 +103,9 @@ job('yarn-homebrew') {
     github 'yarnpkg/yarn', 'master'
   }
   parameters {
+    // Passed from yarn-version job
     stringParam 'YARN_VERSION'
+    booleanParam 'YARN_RC'
   }
   steps {
     shell './scripts/update-homebrew.sh'

--- a/scripts/build-chocolatey.ps1
+++ b/scripts/build-chocolatey.ps1
@@ -7,6 +7,11 @@ param(
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
+if ($Env:YARN_RC -eq 'true') {
+  Write-Output 'This is an RC release; Chocolatey will not be updated'
+  Exit
+}
+
 # See if YARN_VERSION was passed in the environment, otherwise get version
 # number from Yarn site
 if ($Env:YARN_VERSION) {

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -3,6 +3,11 @@
 
 set -ex
 
+if [ "$YARN_RC" = "true" ]; then
+  echo 'This is an RC release; Homebrew will not be updated.'
+  exit 0
+fi;
+
 # See if YARN_VERSION was passed in the environment, otherwise get version
 # number from Yarn site
 if [ -z "$YARN_VERSION" ]; then


### PR DESCRIPTION
**Summary**
Updates the Chocolatey and Homebrew builds scripts to quit early if an RC is being built.

**Test plan**
Tested scripts on my computer, and tested Jenkins changes using a test job