### PR TITLE
Added a list sub-command for the yarn global command. Added unit test.

### DIFF
--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -115,6 +115,18 @@ test.concurrent('ls', async (): Promise<void> => {
   });
 });
 
+test.concurrent('list', async (): Promise<void> => {
+  const tmpGlobalFolder = await createTempGlobalFolder();
+  const tmpPrefixFolder = await createTempPrefixFolder();
+  const flags = {globalFolder: tmpGlobalFolder, prefix: tmpPrefixFolder};
+  return runGlobal(['add', 'react-native-cli'], flags, 'add-with-prefix-flag', () => {})
+  .then(() => {
+    return runGlobal(['list'], flags, 'add-with-prefix-flag', (config, reporter, install, getStdout) => {
+      expect(getStdout()).toContain('react-native-cli');
+    });
+  });
+});
+
 test.concurrent('upgrade', async (): Promise<void> => {
   const tmpGlobalFolder = await createTempGlobalFolder();
   const tmpPrefixFolder = await createTempPrefixFolder();


### PR DESCRIPTION
This involved moving the list function out of the buildSubCommands so it could be called from ls & list.

Calling global ls will display a warning that global ls is deprecated and to use global list.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Changed the `yarn global ls` command to `yarn global list` to be inline with the non-global command, as per #3003.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tests were updated to ensure that the output of `yarn global ls` and `yarn global list` produced the same results. Running `yarn run test` verified the new test passed.
