### PR TITLE
Use /bin/bash in shebang

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 argv0=$(echo "$0" | sed -e 's,\\,/,g')
 basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
 


### PR DESCRIPTION
**Summary**
Use `/bin/bash` as the shebang, as the script may use Bash-specific features.

**Test plan**
Run `yarn` with `/bin/sh` symlinked to `/bin/dash` and ensure it still works.

Closes #3321