### PR TITLE
modify git ref parsing to not error on non-matching lines

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -86,5 +86,32 @@ test('secureGitUrl', async function (): Promise<void> {
   gitURL = await Git.secureGitUrl(Git.npmUrlToGitUrl('git://github.com/yarnpkg/yarn.git'), '', reporter);
   expect(gitURL.repository).toEqual('https://github.com/yarnpkg/yarn.git');
 
-},
-);
+});
+
+test('parseRefs', () => {
+  expect(Git.parseRefs(`64b2c0cee9e829f73c5ad32b8cc8cb6f3bec65bb refs/tags/v4.2.2`))
+    .toMatchObject({
+      'v4.2.2': '64b2c0cee9e829f73c5ad32b8cc8cb6f3bec65bb',
+    });
+
+  expect(Git.parseRefs(`ebeb6eafceb61dd08441ffe086c77eb472842494  refs/tags/v0.21.0
+70e76d174b0c7d001d2cd608a16c94498496e92d  refs/tags/v0.21.0^{}
+de43f4a993d1e08cd930ee22ecb2bac727f53449  refs/tags/v0.21.0-pre`))
+    .toMatchObject({
+      'v0.21.0': '70e76d174b0c7d001d2cd608a16c94498496e92d',
+      'v0.21.0-pre': 'de43f4a993d1e08cd930ee22ecb2bac727f53449',
+    });
+
+  expect(Git.parseRefs(`**********
+This is a custom response header
+  as described in: https://github.com/yarnpkg/yarn/issues/3325
+**********
+
+ebeb6eafceb61dd08441ffe086c77eb472842494  refs/tags/v0.21.0
+70e76d174b0c7d001d2cd608a16c94498496e92d  refs/tags/v0.21.0^{}
+de43f4a993d1e08cd930ee22ecb2bac727f53449  refs/tags/v0.21.0-pre`))
+    .toMatchObject({
+      'v0.21.0': '70e76d174b0c7d001d2cd608a16c94498496e92d',
+      'v0.21.0-pre': 'de43f4a993d1e08cd930ee22ecb2bac727f53449',
+    });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #3325 

Modified the parsing of Git ref lines to check it against a regexp before assuming the input line is a reference.
Since I was now using a regexp, I also use capture groups to extract the tag name and sha hash, insted of hte old implementation that was using string splits.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Added unit tests for `Git.parseRefs()` to `__tests__/util/git.js`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
