### PR TITLE
Allow prerelease versions when checking peer deps

### DIFF
--- a/__tests__/util/semver.js
+++ b/__tests__/util/semver.js
@@ -1,0 +1,53 @@
+/* @flow */
+
+import {satisfiesWithPreleases} from '../../src/util/semver.js';
+
+const semver = require('semver');
+
+describe('satisfiesWithPreleases', () => {
+  it('matches the behavior of node-semver for non-prerelease versions', () => {
+    // true
+    expect(satisfiesWithPreleases('2.0.0', '>=1.0.0'))
+      .toBe(semver.satisfies('2.0.0', '>=1.0.0'));
+    expect(satisfiesWithPreleases('0.1.1', '^0.1.0'))
+      .toBe(semver.satisfies('0.1.1', '^0.1.0'));
+    expect(satisfiesWithPreleases('1.0.1', '~1.0.0'))
+      .toBe(semver.satisfies('1.0.1', '~1.0.0'));
+
+    // false
+    expect(satisfiesWithPreleases('0.2.0', '^0.1.0'))
+      .toBe(semver.satisfies('0.2.0', '^0.1.0'));
+    expect(satisfiesWithPreleases('1.1.0', '~1.0.0'))
+      .toBe(semver.satisfies('1.1.0', '~1.0.0'));
+  });
+
+  it('matches inexact prerelease versions', () => {
+    expect(satisfiesWithPreleases('1.0.0-beta', '>=1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('2.0.0-alpha', '>=1.0.0-beta')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-beta', '^1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-alpha.2', '^1.0.0-alpha.1')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0', '^1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0', '~1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.1-alpha', '~1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('1.1.0-alpha', '^1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('1.1.0-alpha', '^1.0.0-beta')).toBe(true);
+  });
+
+  it('rejects prerelease versions that are too small', () => {
+    expect(satisfiesWithPreleases('1.0.0-alpha', '^1.0.0')).toBe(false);
+    expect(satisfiesWithPreleases('1.0.0-alpha', '>=1.0.0')).toBe(false);
+    expect(satisfiesWithPreleases('1.0.0-alpha', '>=2.0.0-alpha')).toBe(false);
+    expect(satisfiesWithPreleases('0.1.0-alpha', '^0.1.0')).toBe(false);
+  });
+
+  it('follows the semver spec when comparing prerelease versions', () => {
+    // Example from http://semver.org/#spec-item-11
+    expect(satisfiesWithPreleases('1.0.0-alpha.1', '>1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-alpha.beta', '>1.0.0-alpha.1')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-beta', '>1.0.0-alpha.beta')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-beta.2', '>1.0.0-beta')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-beta.11', '>1.0.0-beta.2')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0-rc.1', '>1.0.0-beta.11')).toBe(true);
+    expect(satisfiesWithPreleases('1.0.0', '>1.0.0-rc.1')).toBe(true);
+  });
+});

--- a/__tests__/util/semver.js
+++ b/__tests__/util/semver.js
@@ -40,6 +40,14 @@ describe('satisfiesWithPreleases', () => {
     expect(satisfiesWithPreleases('0.1.0-alpha', '^0.1.0')).toBe(false);
   });
 
+  it('rejects prerelease versions that are too big', () => {
+    expect(satisfiesWithPreleases('2.0.0-alpha', '^1.0.0')).toBe(false);
+    expect(satisfiesWithPreleases('3.0.0-alpha', '^1.0.0')).toBe(false);
+    expect(satisfiesWithPreleases('1.1.0-alpha', '~1.0.0')).toBe(false);
+    expect(satisfiesWithPreleases('1.2.0-alpha', '~1.0.0')).toBe(false);
+    expect(satisfiesWithPreleases('1.0.0-alpha.1', '1.0.0-alpha')).toBe(false);
+  });
+
   it('follows the semver spec when comparing prerelease versions', () => {
     // Example from http://semver.org/#spec-item-11
     expect(satisfiesWithPreleases('1.0.0-alpha.1', '>1.0.0-alpha')).toBe(true);

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -13,10 +13,10 @@ import * as promise from './util/promise.js';
 import {entries} from './util/misc.js';
 import * as fs from './util/fs.js';
 import lockMutex from './util/mutex.js';
+import {satisfiesWithPreleases} from './util/semver.js';
 
 const invariant = require('invariant');
 const cmdShim = promise.promisify(require('cmd-shim'));
-const semver = require('semver');
 const path = require('path');
 
 type DependencyPairs = Array<{
@@ -342,7 +342,7 @@ export default class PackageLinker {
   }
 
   _satisfiesPeerDependency(range: string, version: string): boolean {
-    return range === '*' || semver.satisfies(version, range, this.config.looseSemver);
+    return range === '*' || satisfiesWithPreleases(version, range, this.config.looseSemver);
   }
 
   async init(patterns: Array<string>, linkDuplicates: boolean): Promise<void> {

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -23,7 +23,25 @@ export function satisfiesWithPreleases(version: string, range: string, loose?: b
 
   // A range has multiple sets of comparators. A version must satisfy all comparators in a set
   // and at least one set to satisfy the range.
-  return semverRange.set.some((comparatorSet) =>
-    !comparatorSet.some((comparator) => !comparator.test(semverVersion)),
-  );
+  return semverRange.set.some((comparatorSet) => {
+    // node-semver converts ~ and ^ ranges into pairs of >= and < ranges but the upper bounds don't
+    // properly exclude prerelease versions. For example, "^1.0.0" is converted to ">=1.0.0 <2.0.0",
+    // which includes "2.0.0-pre" since prerelease versions are lower than their non-prerelease
+    // counterparts. As a practical workaround we make upper-bound ranges exclude prereleases and
+    // convert "<2.0.0" to "<2.0.0-0", for example.
+    comparatorSet = comparatorSet.map((comparator) => {
+      if (comparator.operator !== '<' || !comparator.value || comparator.semver.prerelease.length) {
+        return comparator;
+      }
+
+      // "0" is the lowest prerelease version
+      comparator.semver.inc('pre', 0);
+
+      const comparatorString = comparator.operator + comparator.semver.version;
+      // $FlowFixMe: Add a definition for the Comparator class
+      return new semver.Comparator(comparatorString, comparator.loose);
+    });
+
+    return !comparatorSet.some((comparator) => !comparator.test(semverVersion));
+  });
 }

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+const semver = require('semver');
+
+/**
+ * Returns whether the given semver version satisfies the given range. Notably this supports
+ * prerelease versions so that "2.0.0-rc.0" satisfies the range ">=1.0.0", for example.
+ */
+
+export function satisfiesWithPreleases(version: string, range: string, loose?: boolean = false): boolean {
+  let semverRange;
+  try {
+    // $FlowFixMe: Add a definition for the Range class
+    semverRange = new semver.Range(range, loose);
+  } catch (err) {
+    return false;
+  }
+
+  if (!version) {
+    return false;
+  }
+  const semverVersion = new semver.SemVer(version, semverRange.loose);
+
+  // A range has multiple sets of comparators. A version must satisfy all comparators in a set
+  // and at least one set to satisfy the range.
+  return semverRange.set.some((comparatorSet) =>
+    !comparatorSet.some((comparator) => !comparator.test(semverVersion)),
+  );
+}


### PR DESCRIPTION
**Summary**
Uses lower-level APIs in node-semver to allow prerelease versions when checking peer deps. This honors the intent of library authors e.g. when they write a React component that asks for `"react": ">=15.0.0"` they're saying OK to `react@16.0.0` (partly because the React team specifically has said that if you don't have any warnings in version N, then version N+1 should work for you). By extension and modulo bugs, `react@16.0.0-alpha` works too if the user explicitly installs it.

Fixes #2760

**Test plan**
Added unit tests for the new semver utility.

Tested in a real project that uses React 16.0.0-alpha.11 and verified I didn't get any peer dep warnings that usually appear from libraries that ask for `"react": ">=15.0.0"`. Downgraded React to 0.14.0 (too low) and saw peer dep warnings come back as expected.
