### PR TITLE
Fix yarn "entrypoint" shell script

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -12,7 +12,7 @@ command_exists() {
 }
 
 if command_exists node; then
-  if [[ "$YARN_FORCE_WINPTY" -eq 1 ]]; then
+  if [ "$YARN_FORCE_WINPTY" = 1 ]; then
     winpty node "$basedir/yarn.js" "$@"
   else
     node "$basedir/yarn.js" "$@"


### PR DESCRIPTION
**Summary**
#3260 PR broke the `bin/yarn` shell script (see issue #3321)
#3338 tried to fix it in a improper way

This way should work.

**Test plan**
I modify my `/usr/bin/yarn` file on my Debian (testing branch) and it fix the error message describe in #3321.
Could be great if someone test this on another platform, but it should be a generic solution.
To test this :
- Install yarn `0.24.x`
- Modify your yarn bin script (location should depends on your distribution) as this PR does.
- Run `yarn -V`. It should work without any error/warning messages from your shell.
