### PR TITLE
Use yarn instead of npm everywhere is possible ...

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
 
 test_script:
   - node --version
-  - npm run test-only -- --maxWorkers 3
+  - yarn test-only -- --maxWorkers 3
 
 artifacts:
   - path: artifacts/*.msi

--- a/circle.yml
+++ b/circle.yml
@@ -49,7 +49,7 @@ deployment:
       # Only NPM is handled here - All other release files are handled in a webhook.
       - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - ./scripts/set-installation-method.js "`pwd`/package.json" npm
-      - npm publish --tag rc
+      - yarn publish --tag rc
 
 notify:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "yarnpkg": "./bin/yarn.js"
   },
   "scripts": {
-    "test": "npm run lint && npm run test-only",
-    "test-ci": "npm run build && npm run test-only",
+    "test": "yarn lint && yarn test-only",
+    "test-ci": "yarn build && yarn test-only",
     "check-lockfile": "./scripts/check-lockfile.sh",
     "build": "gulp build",
     "watch": "gulp watch",

--- a/scripts/build-dist-debug.sh
+++ b/scripts/build-dist-debug.sh
@@ -6,8 +6,8 @@ set -ex
 # potentially be useful for debugging purposes, but it's more bloated than the
 # regular distribution.
 
-npm run build
-npm pack
+yarn build
+yarn pack
 rm -rf dist-debug
 mkdir dist-debug
 mkdir -p artifacts
@@ -18,7 +18,7 @@ umask 0022 # Ensure permissions are correct (0755 for dirs, 0644 for files)
 tar -xzf pack.tgz --strip 1
 rm -rf pack.tgz
 # Change this to "yarn install --production" once #1115 is fixed
-npm install --production
+yarn install --production
 ../scripts/set-installation-method.js $(readlink -f package.json) tar
 cd ..
 

--- a/scripts/check-lockfile.sh
+++ b/scripts/check-lockfile.sh
@@ -5,7 +5,7 @@ set -ex
 DIR="TEMP_LOCKFILE_CHECK"
 
 # build yarn
-npm run build
+yarn build
 
 # create temp directory
 rm -rf $DIR

--- a/scripts/trim-mirror-test-packages.js
+++ b/scripts/trim-mirror-test-packages.js
@@ -24,7 +24,7 @@ for (let file of files) {
   delete packageJson.scripts;
   delete packageJson.bin;
   JSON.stringify(packageJson, null, 4).to('package.json');
-  exec('npm pack');
+  exec('yarn pack');
   mv(file, '..');
   cd('..');
   rm('-rf', [folder, 'trimmed-package']);


### PR DESCRIPTION
… aka Eating your own dog food

**Summary**
This should fix https://github.com/yarnpkg/yarn/issues/153 but the real purpose of this pull request is understand if there are parts/commands that maybe don't fully work and in some way it forces developers to use npm instead of yarn.

**Test Plan**
There are a lot of tests, but I am not totally confident on this PR, please double check it before breaking things maybe infrastructurally.
