### PR TITLE
[PoC] Use worker-farm during linking phase.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "tar-stream": "^1.5.2",
     "uuid": "^3.0.1",
     "v8-compile-cache": "^1.1.0",
-    "validate-npm-package-license": "^3.0.1"
+    "validate-npm-package-license": "^3.0.1",
+    "worker-farm": "^1.3.1"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/src/util/copy-worker.js
+++ b/src/util/copy-worker.js
@@ -1,0 +1,60 @@
+/* @flow */
+
+import * as fs from 'fs';
+
+type SerializableError = {|
+ message: string,
+ stack: ?string,
+ type: 'Error',
+|};
+type WorkerMessage = {
+  atime: number,
+  dest: string,
+  mode: number,
+  mtime: number,
+  src: string,
+  type: string,
+};
+type WorkerCallback = (error: ?SerializableError, data: ?string) => void;
+
+const formatError = (error: string | Error): SerializableError => {
+  if (typeof error === 'string') {
+    return {
+      message: error,
+      stack: null,
+      type: 'Error',
+    };
+  }
+
+  return {
+    message: error.message,
+    stack: error.stack,
+    type: 'Error',
+  };
+};
+
+module.exports = (data: WorkerMessage, callback: WorkerCallback): void => {
+  try {
+    const readStream = fs.createReadStream(data.src);
+    const writeStream = fs.createWriteStream(data.dest, {mode: data.mode});
+
+    readStream.on('error', (error) => callback(error));
+    writeStream.on('error', (error) => callback(error));
+
+    writeStream.on('open', () => {
+      readStream.pipe(writeStream);
+    });
+
+    writeStream.once('close', () => {
+      fs.utimes(data.dest, data.atime, data.mtime, (error) => {
+        if (error) {
+          callback(formatError(error));
+        } else {
+          callback(null, 'done');
+        }
+      });
+    });
+  } catch (error) {
+    callback(formatError(error));
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,20 +257,7 @@ babel-eslint@^6.1.2:
     lodash.assign "^4.0.0"
     lodash.pickby "^4.0.0"
 
-babel-generator@^6.18.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.23.0.tgz#6b8edab956ef3116f79d8c84c5a3c05f32a74bc5"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-babel-generator@^6.24.1:
+babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
   dependencies:
@@ -735,17 +722,7 @@ babel-runtime@^6.0.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.22.0, babel-template@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.22.0, babel-template@^6.23.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -755,21 +732,7 @@ babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.0.20, babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0:
-  version "6.23.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.24.1:
+babel-traverse@^6.0.20, babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -783,16 +746,7 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.0.19, babel-types@^6.18.0, babel-types@^6.22.0, babel-types@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.24.1:
+babel-types@^6.0.19, babel-types@^6.18.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:


### PR DESCRIPTION
**Summary**

I'm hacking and I figured I'll try to see if I can make the linking phase faster. With worker-farm, I'm getting a quite consistent ~10% win in the linking phase when installing react-native. However, it also comes with a bunch of downsides – it makes it harder to use the single file build as well as on CI systems this kind of stuff usually leads to trouble (from experience with Jest).

**Test plan**

#yolo