### PR TITLE
yarn publish not ready for CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -49,7 +49,8 @@ deployment:
       # Only NPM is handled here - All other release files are handled in a webhook.
       - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - ./scripts/set-installation-method.js "`pwd`/package.json" npm
-      - yarn publish --tag rc
+      # https://github.com/yarnpkg/yarn/issues/610, need to make yarn publish noninteractive
+      - npm publish --tag rc
 
 notify:
   webhooks:


### PR DESCRIPTION
Until #610 is fixed we have to use npm publish on CI