### PR TITLE
Use "-v" to display version number instead of "-V"

### DIFF
--- a/__tests__/commands/install/lockfiles.js
+++ b/__tests__/commands/install/lockfiles.js
@@ -44,15 +44,13 @@ test.concurrent("writes new lockfile if existing one isn't satisfied", async ():
   });
 });
 
-test.concurrent('writes a lockfile even when there are no dependencies', (): Promise<void> => {
-  // https://github.com/yarnpkg/yarn/issues/679
+test.concurrent("doesn't write a lockfile when there are no dependencies", (): Promise<void> => {
   return runInstall({}, 'install-without-dependencies', async config => {
     const lockfileExists = await fs.exists(path.join(config.cwd, 'yarn.lock'));
     const installedDepFiles = await fs.walk(path.join(config.cwd, 'node_modules'));
 
-    expect(lockfileExists).toEqual(true);
-    // 1 for integrity file (located in node_modules)
-    expect(installedDepFiles).toHaveLength(1);
+    expect(lockfileExists).toEqual(false);
+    expect(installedDepFiles).toHaveLength(0);
   });
 });
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -198,7 +198,7 @@ test.concurrent('should install if no args', async () => {
 
 test.concurrent('should install if first arg looks like a flag', async () => {
   const stdout = await execCommand('--json', [], 'run-add', true);
-  expect(stdout[stdout.length - 1]).toEqual('{"type":"success","data":"Saved lockfile."}');
+  expect(stdout[stdout.length - 1]).toEqual('{"type":"info","data":"Lockfile not saved, no dependencies."}');
 });
 
 test.concurrent('should not output JSON activity/progress if given --no-progress option', async () => {

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -502,7 +502,12 @@ export class Install {
     }
 
     // fin!
-    await this.saveLockfileAndIntegrity(topLevelPatterns, workspaceLayout);
+    // The second condition is to make sure lockfile can be updated when running `remove` command.
+    if (topLevelPatterns.length || (await fs.exists(path.join(this.config.cwd, constants.LOCKFILE_FILENAME)))) {
+      await this.saveLockfileAndIntegrity(topLevelPatterns, workspaceLayout);
+    } else {
+      this.reporter.info(this.reporter.lang('notSavedLockfileNoDependencies'));
+    }
     this.maybeOutputUpdate();
     this.config.requestManager.clearCache();
     return flattenedTopLevelPatterns;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -29,7 +29,7 @@ const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length 
 const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
 // set global options
-commander.version(version);
+commander.version(version, '--version');
 commander.usage('[command] [flags]');
 commander.option('--verbose', 'output verbose messages on internal operations');
 commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -182,6 +182,8 @@ const messages = {
   foundWarnings: 'Found $0 warnings.',
   foundErrors: 'Found $0 errors.',
 
+  notSavedLockfileNoDependencies: 'Lockfile not saved, no dependencies.',
+
   savedLockfile: 'Saved lockfile.',
   noRequiredLockfile: 'No lockfile in this directory. Run `yarn install` to generate one.',
   noLockfileFound: 'No lockfile found.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Before, we run `yarn -V` or `yarn --version` to display version number of Yarn. But we are used to using `-v` to display it, like running `node -v` and `npm -v`.
Maybe caused by [commander.js](https://github.com/tj/commander.js), flags of command for displaying version number cannot be `'-v, -V, --version'`. In other word, we cannot run `yarn -V` to display version number any more.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Just run `yarn -v`. Note that do **NOT** use `yarn -V` any more.
```
$ yarn -v
0.25.0-0
$ yarn --version
0.25.0-0
```