### PR TITLE
feat-fix(pkg): restore partial export of internal APIs

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -30,4 +30,4 @@ var mkdirp = require('mkdirp');
 var constants = require('../lib-legacy/constants');
 mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
 
-module.exports = require(path);
+module.exports = process.env.YARN_AS_LIB ? require(path).library : require(path).default();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,6 +9,7 @@ import {MessageError} from '../errors.js';
 import Config from '../config.js';
 import {getRcArgs} from '../rc.js';
 import {version} from '../util/yarn-version.js';
+import * as yarn from '../index.js';
 
 const commander = require('commander');
 const fs = require('fs');
@@ -19,349 +20,355 @@ const net = require('net');
 const onDeath = require('death');
 const path = require('path');
 
-loudRejection();
+export default function cli() {
+  loudRejection();
 
-const startArgs = process.argv.slice(0, 2);
+  const startArgs = process.argv.slice(0, 2);
 
-// ignore all arguments after a --
-const doubleDashIndex = process.argv.findIndex(element => element === '--');
-const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
-const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
+  // ignore all arguments after a --
+  const doubleDashIndex = process.argv.findIndex(element => element === '--');
+  const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
+  const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
 
-// set global options
-commander.version(version);
-commander.usage('[command] [flags]');
-commander.option('--verbose', 'output verbose messages on internal operations');
-commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
-commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
-commander.option('--strict-semver');
-commander.option('--json', '');
-commander.option('--ignore-scripts', "don't run lifecycle scripts");
-commander.option('--har', 'save HAR output of network traffic');
-commander.option('--ignore-platform', 'ignore platform checks');
-commander.option('--ignore-engines', 'ignore engines check');
-commander.option('--ignore-optional', 'ignore optional dependencies');
-commander.option('--force', 'install and build packages even if they were built before, overwrite lockfile');
-commander.option('--skip-integrity-check', 'run install without checking if node_modules is installed');
-commander.option('--check-files', 'install will verify file tree of packages for consistency');
-commander.option('--no-bin-links', "don't generate bin links when setting up packages");
-commander.option('--flat', 'only allow one version of a package');
-commander.option('--prod, --production [prod]', '');
-commander.option('--no-lockfile', "don't read or generate a lockfile");
-commander.option('--pure-lockfile', "don't generate a lockfile");
-commander.option('--frozen-lockfile', "don't generate a lockfile and fail if an update is needed");
-commander.option('--link-duplicates', 'create hardlinks to the repeated modules in node_modules');
-commander.option('--global-folder <path>', 'specify a custom folder to store global packages');
-commander.option(
-  '--modules-folder <path>',
-  'rather than installing modules into the node_modules folder relative to the cwd, output them here',
-);
-commander.option(
-  '--cache-folder <path>',
-  'specify a custom folder to store the yarn cache',
-);
-commander.option(
-  '--mutex <type>[:specifier]',
-  'use a mutex to ensure only one yarn instance is executing',
-);
-commander.option(
-  '--emoji',
-  'enable emoji in output',
-  process.platform === 'darwin',
-);
-commander.option(
-  '-s, --silent',
-  'skip Yarn console logs, other types of logs (script output) will be printed',
-);
-commander.option('--proxy <host>', '');
-commander.option('--https-proxy <host>', '');
-commander.option(
-  '--no-progress',
-  'disable progress bar',
-);
-commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
-commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
-commander.option('--non-interactive', 'do not show interactive prompts');
+  // set global options
+  commander.version(version);
+  commander.usage('[command] [flags]');
+  commander.option('--verbose', 'output verbose messages on internal operations');
+  commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
+  commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
+  commander.option('--strict-semver');
+  commander.option('--json', '');
+  commander.option('--ignore-scripts', "don't run lifecycle scripts");
+  commander.option('--har', 'save HAR output of network traffic');
+  commander.option('--ignore-platform', 'ignore platform checks');
+  commander.option('--ignore-engines', 'ignore engines check');
+  commander.option('--ignore-optional', 'ignore optional dependencies');
+  commander.option('--force', 'install and build packages even if they were built before, overwrite lockfile');
+  commander.option('--skip-integrity-check', 'run install without checking if node_modules is installed');
+  commander.option('--check-files', 'install will verify file tree of packages for consistency');
+  commander.option('--no-bin-links', "don't generate bin links when setting up packages");
+  commander.option('--flat', 'only allow one version of a package');
+  commander.option('--prod, --production [prod]', '');
+  commander.option('--no-lockfile', "don't read or generate a lockfile");
+  commander.option('--pure-lockfile', "don't generate a lockfile");
+  commander.option('--frozen-lockfile', "don't generate a lockfile and fail if an update is needed");
+  commander.option('--link-duplicates', 'create hardlinks to the repeated modules in node_modules');
+  commander.option('--global-folder <path>', 'specify a custom folder to store global packages');
+  commander.option(
+    '--modules-folder <path>',
+    'rather than installing modules into the node_modules folder relative to the cwd, output them here',
+  );
+  commander.option(
+    '--cache-folder <path>',
+    'specify a custom folder to store the yarn cache',
+  );
+  commander.option(
+    '--mutex <type>[:specifier]',
+    'use a mutex to ensure only one yarn instance is executing',
+  );
+  commander.option(
+    '--emoji',
+    'enable emoji in output',
+    process.platform === 'darwin',
+  );
+  commander.option(
+    '-s, --silent',
+    'skip Yarn console logs, other types of logs (script output) will be printed',
+  );
+  commander.option('--proxy <host>', '');
+  commander.option('--https-proxy <host>', '');
+  commander.option(
+    '--no-progress',
+    'disable progress bar',
+  );
+  commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
+  commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
+  commander.option('--non-interactive', 'do not show interactive prompts');
 
 
-// get command name
-let commandName: string = args.shift() || 'install';
+  // get command name
+  let commandName: string = args.shift() || 'install';
 
-if (commandName === '--help' || commandName === '-h') {
-  commandName = 'help';
-}
+  if (commandName === '--help' || commandName === '-h') {
+    commandName = 'help';
+  }
 
-if (args.indexOf('--help') >= 0 || args.indexOf('-h') >= 0) {
-  args.unshift(commandName);
-  commandName = 'help';
-}
+  if (args.indexOf('--help') >= 0 || args.indexOf('-h') >= 0) {
+    args.unshift(commandName);
+    commandName = 'help';
+  }
 
-// if no args or command name looks like a flag then set default to `install`
-if (commandName[0] === '-') {
-  args.unshift(commandName);
-  commandName = 'install';
-}
+  // if no args or command name looks like a flag then set default to `install`
+  if (commandName[0] === '-') {
+    args.unshift(commandName);
+    commandName = 'install';
+  }
 
-let command;
-if (Object.prototype.hasOwnProperty.call(commands, commandName)) {
-  command = commands[commandName];
-}
+  let command;
+  if (Object.prototype.hasOwnProperty.call(commands, commandName)) {
+    command = commands[commandName];
+  }
 
-// if command is not recognized, then set default to `run`
-if (!command) {
-  args.unshift(commandName);
-  command = commands.run;
-}
+  // if command is not recognized, then set default to `run`
+  if (!command) {
+    args.unshift(commandName);
+    command = commands.run;
+  }
 
-command.setFlags(commander);
-commander.parse([
-  ...startArgs,
-  // we use this for https://github.com/tj/commander.js/issues/346, otherwise
-  // it will strip some args that match with any options
-  'this-arg-will-get-stripped-later',
-  ...getRcArgs(commandName),
-  ...args,
-]);
-commander.args = commander.args.concat(endArgs);
+  command.setFlags(commander);
+  commander.parse([
+    ...startArgs,
+    // we use this for https://github.com/tj/commander.js/issues/346, otherwise
+    // it will strip some args that match with any options
+    'this-arg-will-get-stripped-later',
+    ...getRcArgs(commandName),
+    ...args,
+  ]);
+  commander.args = commander.args.concat(endArgs);
 
-// we strip cmd
-console.assert(commander.args.length >= 1);
-console.assert(commander.args[0] === 'this-arg-will-get-stripped-later');
-commander.args.shift();
+  // we strip cmd
+  console.assert(commander.args.length >= 1);
+  console.assert(commander.args[0] === 'this-arg-will-get-stripped-later');
+  commander.args.shift();
 
-//
-const Reporter = commander.json ? JSONReporter : ConsoleReporter;
-const reporter = new Reporter({
-  emoji: process.stdout.isTTY && commander.emoji,
-  verbose: commander.verbose,
-  noProgress: !commander.progress,
-  isSilent: commander.silent,
-});
-
-reporter.initPeakMemoryCounter();
-
-const config = new Config(reporter);
-const outputWrapper = !commander.json && command.hasWrapper(commander, commander.args);
-
-if (outputWrapper) {
-  reporter.header(commandName, {name: 'yarn', version});
-}
-
-if (command.noArguments && commander.args.length) {
-  reporter.error(reporter.lang('noArguments'));
-  reporter.info(command.getDocsInfo);
-  process.exit(1);
-}
-
-//
-if (commander.yes) {
-  reporter.warn(reporter.lang('yesWarning'));
-}
-
-//
-if (!commander.offline && network.isOffline()) {
-  reporter.warn(reporter.lang('networkWarning'));
-}
-
-//
-if (command.requireLockfile && !fs.existsSync(path.join(config.cwd, constants.LOCKFILE_FILENAME))) {
-  reporter.error(reporter.lang('noRequiredLockfile'));
-  process.exit(1);
-}
-
-//
-const run = (): Promise<void> => {
-  invariant(command, 'missing command');
-  return command.run(config, reporter, commander, commander.args).then(() => {
-    reporter.close();
-    if (outputWrapper) {
-      reporter.footer(false);
-    }
+  //
+  const Reporter = commander.json ? JSONReporter : ConsoleReporter;
+  const reporter = new Reporter({
+    emoji: process.stdout.isTTY && commander.emoji,
+    verbose: commander.verbose,
+    noProgress: !commander.progress,
+    isSilent: commander.silent,
   });
-};
 
-//
-const runEventuallyWithFile = (mutexFilename: ?string, isFirstTime?: boolean): Promise<void> => {
-  return new Promise(ok => {
-    const lockFilename = mutexFilename || path.join(config.cwd, constants.SINGLE_INSTANCE_FILENAME);
-    lockfile.lock(lockFilename, {realpath: false}, (err: mixed, release: () => void) => {
-      if (err) {
-        if (isFirstTime) {
-          reporter.warn(reporter.lang('waitingInstance'));
-        }
-        setTimeout(() => {
-          ok(runEventuallyWithFile(mutexFilename, false));
-        }, 200); // do not starve the CPU
-      } else {
-        onDeath(() => {
-          process.exit(1);
-        });
-        ok(run().then(release));
+  reporter.initPeakMemoryCounter();
+
+  const config = new Config(reporter);
+  const outputWrapper = !commander.json && command.hasWrapper(commander, commander.args);
+
+  if (outputWrapper) {
+    reporter.header(commandName, {name: 'yarn', version});
+  }
+
+  if (command.noArguments && commander.args.length) {
+    reporter.error(reporter.lang('noArguments'));
+    reporter.info(command.getDocsInfo);
+    process.exit(1);
+  }
+
+  //
+  if (commander.yes) {
+    reporter.warn(reporter.lang('yesWarning'));
+  }
+
+  //
+  if (!commander.offline && network.isOffline()) {
+    reporter.warn(reporter.lang('networkWarning'));
+  }
+
+  //
+  if (command.requireLockfile && !fs.existsSync(path.join(config.cwd, constants.LOCKFILE_FILENAME))) {
+    reporter.error(reporter.lang('noRequiredLockfile'));
+    process.exit(1);
+  }
+
+  //
+  const run = (): Promise<void> => {
+    invariant(command, 'missing command');
+    return command.run(config, reporter, commander, commander.args).then(() => {
+      reporter.close();
+      if (outputWrapper) {
+        reporter.footer(false);
       }
     });
-  });
-};
+  };
 
-//
-const runEventuallyWithNetwork = (mutexPort: ?string): Promise<void> => {
-  return new Promise(ok => {
-    const connectionOptions = {
-      port: +mutexPort || constants.SINGLE_INSTANCE_PORT,
-    };
+  //
+  const runEventuallyWithFile = (mutexFilename: ?string, isFirstTime?: boolean): Promise<void> => {
+    return new Promise(ok => {
+      const lockFilename = mutexFilename || path.join(config.cwd, constants.SINGLE_INSTANCE_FILENAME);
+      lockfile.lock(lockFilename, {realpath: false}, (err: mixed, release: () => void) => {
+        if (err) {
+          if (isFirstTime) {
+            reporter.warn(reporter.lang('waitingInstance'));
+          }
+          setTimeout(() => {
+            ok(runEventuallyWithFile(mutexFilename, false));
+          }, 200); // do not starve the CPU
+        } else {
+          onDeath(() => {
+            process.exit(1);
+          });
+          ok(run().then(release));
+        }
+      });
+    });
+  };
 
-    const server = net.createServer();
+  //
+  const runEventuallyWithNetwork = (mutexPort: ?string): Promise<void> => {
+    return new Promise(ok => {
+      const connectionOptions = {
+        port: +mutexPort || constants.SINGLE_INSTANCE_PORT,
+      };
 
-    server.on('error', () => {
-      // another Yarn instance exists, let's connect to it to know when it dies.
-      reporter.warn(reporter.lang('waitingInstance'));
-      const socket = net.createConnection(connectionOptions);
+      const server = net.createServer();
 
-      socket
-        .on('connect', () => {
-          // Allow the program to exit if this is the only active server in the event system.
-          socket.unref();
-        })
-        .on('close', (hadError?: boolean) => {
-          // the `close` event gets always called after the `error` event
-          if (!hadError) {
+      server.on('error', () => {
+        // another Yarn instance exists, let's connect to it to know when it dies.
+        reporter.warn(reporter.lang('waitingInstance'));
+        const socket = net.createConnection(connectionOptions);
+
+        socket
+          .on('connect', () => {
+            // Allow the program to exit if this is the only active server in the event system.
+            socket.unref();
+          })
+          .on('close', (hadError?: boolean) => {
+            // the `close` event gets always called after the `error` event
+            if (!hadError) {
+              process.nextTick(() => {
+                ok(runEventuallyWithNetwork(mutexPort));
+              });
+            }
+          })
+          .on('error', () => {
+            // No server to listen to ? Let's retry to become the next server then.
             process.nextTick(() => {
               ok(runEventuallyWithNetwork(mutexPort));
             });
-          }
-        })
-        .on('error', () => {
-          // No server to listen to ? Let's retry to become the next server then.
-          process.nextTick(() => {
-            ok(runEventuallyWithNetwork(mutexPort));
           });
-        });
+      });
+
+      const onServerEnd = (): Promise<void> => {
+        server.close();
+        return Promise.resolve();
+      };
+
+      // open the server and continue only if succeed.
+      server.listen(connectionOptions, () => {
+        // ensure the server gets closed properly on SIGNALS.
+        onDeath(onServerEnd);
+
+        ok(run().then(onServerEnd));
+      });
     });
-
-    const onServerEnd = (): Promise<void> => {
-      server.close();
-      return Promise.resolve();
-    };
-
-    // open the server and continue only if succeed.
-    server.listen(connectionOptions, () => {
-      // ensure the server gets closed properly on SIGNALS.
-      onDeath(onServerEnd);
-
-      ok(run().then(onServerEnd));
-    });
-  });
-};
-
-function onUnexpectedError(err: Error) {
-  function indent(str: string): string {
-    return '\n  ' + str.trim().split('\n').join('\n  ');
-  }
-
-  const log = [];
-  log.push(`Arguments: ${indent(process.argv.join(' '))}`);
-  log.push(`PATH: ${indent(process.env.PATH || 'undefined')}`);
-  log.push(`Yarn version: ${indent(version)}`);
-  log.push(`Node version: ${indent(process.versions.node)}`);
-  log.push(`Platform: ${indent(process.platform + ' ' + process.arch)}`);
-
-  // add manifests
-  for (const registryName of registryNames) {
-    const possibleLoc = path.join(config.cwd, registries[registryName].filename);
-    const manifest = fs.existsSync(possibleLoc) ? fs.readFileSync(possibleLoc, 'utf8') : 'No manifest';
-    log.push(`${registryName} manifest: ${indent(manifest)}`);
-  }
-
-  // lockfile
-  const lockLoc = path.join(config.cwd, constants.LOCKFILE_FILENAME);
-  const lockfile = fs.existsSync(lockLoc) ? fs.readFileSync(lockLoc, 'utf8') : 'No lockfile';
-  log.push(`Lockfile: ${indent(lockfile)}`);
-
-  log.push(`Trace: ${indent(err.stack)}`);
-
-  const errorReportLoc = writeErrorReport(log);
-
-  reporter.error(reporter.lang('unexpectedError', err.message));
-
-  if (errorReportLoc) {
-    reporter.info(reporter.lang('bugReport', errorReportLoc));
-  }
-}
-
-function writeErrorReport(log) : ?string {
-  const errorReportLoc = config.enableMetaFolder
-    ? path.join(config.cwd, constants.META_FOLDER, 'yarn-error.log')
-    : path.join(config.cwd, 'yarn-error.log');
-
-  try {
-    fs.writeFileSync(errorReportLoc, log.join('\n\n') + '\n');
-  } catch (err) {
-    reporter.error(reporter.lang('fileWriteError', errorReportLoc, err.message));
-    return undefined;
-  }
-
-  return errorReportLoc;
-}
-
-config.init({
-  binLinks: commander.binLinks,
-  modulesFolder: commander.modulesFolder,
-  globalFolder: commander.globalFolder,
-  cacheFolder: commander.cacheFolder,
-  preferOffline: commander.preferOffline,
-  captureHar: commander.har,
-  ignorePlatform: commander.ignorePlatform,
-  ignoreEngines: commander.ignoreEngines,
-  ignoreScripts: commander.ignoreScripts,
-  offline: commander.preferOffline || commander.offline,
-  looseSemver: !commander.strictSemver,
-  production: commander.production,
-  httpProxy: commander.proxy,
-  httpsProxy: commander.httpsProxy,
-  networkConcurrency: commander.networkConcurrency,
-  nonInteractive: commander.nonInteractive,
-  commandName: commandName === 'run' ? commander.args[0] : commandName,
-}).then(() => {
-  // option "no-progress" stored in yarn config
-  const noProgressConfig = config.registries.yarn.getOption('no-progress');
-
-  if (noProgressConfig) {
-    reporter.disableProgress();
-  }
-
-  const exit = () => {
-    process.exit(0);
   };
-  // verbose logs outputs process.uptime() with this line we can sync uptime to absolute time on the computer
-  reporter.verbose(`current time: ${new Date().toISOString()}`);
 
-  const mutex: mixed = commander.mutex;
-  if (mutex && typeof mutex === 'string') {
-    const parts = mutex.split(':');
-    const mutexType = parts.shift();
-    const mutexSpecifier = parts.join(':');
-
-    if (mutexType === 'file') {
-      return runEventuallyWithFile(mutexSpecifier, true).then(exit);
-    } else if (mutexType === 'network') {
-      return runEventuallyWithNetwork(mutexSpecifier).then(exit);
-    } else {
-      throw new MessageError(`Unknown single instance type ${mutexType}`);
+  function onUnexpectedError(err: Error) {
+    function indent(str: string): string {
+      return '\n  ' + str.trim().split('\n').join('\n  ');
     }
-  } else {
-    return run().then(exit);
-  }
-}).catch((err: Error) => {
-  reporter.verbose(err.stack);
 
-  if (err instanceof MessageError) {
-    reporter.error(err.message);
-  } else {
-    onUnexpectedError(err);
+    const log = [];
+    log.push(`Arguments: ${indent(process.argv.join(' '))}`);
+    log.push(`PATH: ${indent(process.env.PATH || 'undefined')}`);
+    log.push(`Yarn version: ${indent(version)}`);
+    log.push(`Node version: ${indent(process.versions.node)}`);
+    log.push(`Platform: ${indent(process.platform + ' ' + process.arch)}`);
+
+    // add manifests
+    for (const registryName of registryNames) {
+      const possibleLoc = path.join(config.cwd, registries[registryName].filename);
+      const manifest = fs.existsSync(possibleLoc) ? fs.readFileSync(possibleLoc, 'utf8') : 'No manifest';
+      log.push(`${registryName} manifest: ${indent(manifest)}`);
+    }
+
+    // lockfile
+    const lockLoc = path.join(config.cwd, constants.LOCKFILE_FILENAME);
+    const lockfile = fs.existsSync(lockLoc) ? fs.readFileSync(lockLoc, 'utf8') : 'No lockfile';
+    log.push(`Lockfile: ${indent(lockfile)}`);
+
+    log.push(`Trace: ${indent(err.stack)}`);
+
+    const errorReportLoc = writeErrorReport(log);
+
+    reporter.error(reporter.lang('unexpectedError', err.message));
+
+    if (errorReportLoc) {
+      reporter.info(reporter.lang('bugReport', errorReportLoc));
+    }
   }
 
-  if (commands[commandName]) {
-    reporter.info(commands[commandName].getDocsInfo);
+  function writeErrorReport(log) : ?string {
+    const errorReportLoc = config.enableMetaFolder
+      ? path.join(config.cwd, constants.META_FOLDER, 'yarn-error.log')
+      : path.join(config.cwd, 'yarn-error.log');
+
+    try {
+      fs.writeFileSync(errorReportLoc, log.join('\n\n') + '\n');
+    } catch (err) {
+      reporter.error(reporter.lang('fileWriteError', errorReportLoc, err.message));
+      return undefined;
+    }
+
+    return errorReportLoc;
   }
 
-  process.exit(1);
-});
+  config.init({
+    binLinks: commander.binLinks,
+    modulesFolder: commander.modulesFolder,
+    globalFolder: commander.globalFolder,
+    cacheFolder: commander.cacheFolder,
+    preferOffline: commander.preferOffline,
+    captureHar: commander.har,
+    ignorePlatform: commander.ignorePlatform,
+    ignoreEngines: commander.ignoreEngines,
+    ignoreScripts: commander.ignoreScripts,
+    offline: commander.preferOffline || commander.offline,
+    looseSemver: !commander.strictSemver,
+    production: commander.production,
+    httpProxy: commander.proxy,
+    httpsProxy: commander.httpsProxy,
+    networkConcurrency: commander.networkConcurrency,
+    nonInteractive: commander.nonInteractive,
+    commandName: commandName === 'run' ? commander.args[0] : commandName,
+  }).then(() => {
+    // option "no-progress" stored in yarn config
+    const noProgressConfig = config.registries.yarn.getOption('no-progress');
+
+    if (noProgressConfig) {
+      reporter.disableProgress();
+    }
+
+    const exit = () => {
+      process.exit(0);
+    };
+    // verbose logs outputs process.uptime() with this line we can sync uptime to absolute time on the computer
+    reporter.verbose(`current time: ${new Date().toISOString()}`);
+
+    const mutex: mixed = commander.mutex;
+    if (mutex && typeof mutex === 'string') {
+      const parts = mutex.split(':');
+      const mutexType = parts.shift();
+      const mutexSpecifier = parts.join(':');
+
+      if (mutexType === 'file') {
+        return runEventuallyWithFile(mutexSpecifier, true).then(exit);
+      } else if (mutexType === 'network') {
+        return runEventuallyWithNetwork(mutexSpecifier).then(exit);
+      } else {
+        throw new MessageError(`Unknown single instance type ${mutexType}`);
+      }
+    } else {
+      return run().then(exit);
+    }
+  }).catch((err: Error) => {
+    reporter.verbose(err.stack);
+
+    if (err instanceof MessageError) {
+      reporter.error(err.message);
+    } else {
+      onUnexpectedError(err);
+    }
+
+    if (commands[commandName]) {
+      reporter.info(commands[commandName].getDocsInfo);
+    }
+
+    process.exit(1);
+  });
+}
+
+// hang library exposure off of the CLI as this is our only entry point
+// into the bundled script
+export const library = yarn;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,12 @@
+/* @flow */
+import * as constants from './constants';
+import parse from './lockfile/parse';
+import {version} from './util/yarn-version.js';
+
+export default {
+  constants,
+  lockfile: {
+    parse,
+  },
+  version,
+};


### PR DESCRIPTION
**Summary**

# problem statement

- yarn@24 bundles the CLI, removing entry points & usability from the tool.
  - for instance, i wrote [parse-yarn-lock](https://www.npmjs.com/package/parse-yarn-lock), which (used to) use `yarn`'s very own [lockfile parser](https://github.com/yarnpkg/yarn/blob/master/src/lockfile/parse.js), to be used for a variety of reasons.  in version 24, the parser is now bundled, and cut off from external access.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In my described use case, it is logical to use the _very same parser_ rather than an independent parser.  There's no value in duplicate tooling, and integrity/quality of the operation can suffer if using an alternative.  Some may challenge that exposing such functionality is out of scope for this project.  However, I would argue that exposing internals is a big enabler and comes with a very low cost + cost-of-ownership.

# solution

- incrementally expose some internal APIs so `yarn` can be used programmatically.  `YARN_AS_LIB` tells the entry point to expose the library by default, vs executing the CLI.

**Test plan**

- an integration test could be done to call into the library from a shell, although im not seeing such test code in `__tests__` ATM, and i figured core maintainers would have a preference on how to execute such a test.

# review

**review with `?w=1` in the URL such that github more cleanly displays the very few changes.  https://github.com/yarnpkg/yarn/pull/3397/files?w=1**

![yarn-as-lib mov](https://cloud.githubusercontent.com/assets/1003261/26028300/7a7053ec-37d2-11e7-81c7-ba70561c39bc.gif)

