### PR TITLE
Make package-compatibility and package-fetcher stateless

### DIFF
--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -314,11 +314,13 @@ test.concurrent('--integrity --check-files should not die on broken symlinks', a
   );
 });
 
-test.concurrent('should ignore bundled dependencies',
-async (): Promise<void> => {
-  await runInstall({}, path.join('..', 'check', 'bundled-dep-check'),
-  async (config, reporter, install, getStdout): Promise<void> => {
-    await checkCmd.run(config, reporter, {}, []);
-    expect(getStdout().indexOf('warning')).toEqual(-1);
-  });
+test.concurrent('should ignore bundled dependencies', async (): Promise<void> => {
+  await runInstall(
+    {},
+    path.join('..', 'check', 'bundled-dep-check'),
+    async (config, reporter, install, getStdout): Promise<void> => {
+      await checkCmd.run(config, reporter, {}, []);
+      expect(getStdout().indexOf('warning')).toEqual(-1);
+    },
+  );
 });

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -83,7 +83,7 @@ test('changes the cache directory when bumping the cache version', async () => {
     const resolver = new PackageResolver(config, lockfile);
     await resolver.init([{pattern: 'is-array', registry: 'npm'}]);
 
-    const ref = resolver.getPackageReferences()[0];
+    const ref = resolver.getManifests()[0]._reference;
     const cachePath = config.generateHardModulePath(ref, true);
 
     await fs.writeFile(path.join(cachePath, 'yarn.test'), 'YARN TEST');

--- a/__tests__/package-request.js
+++ b/__tests__/package-request.js
@@ -27,7 +27,7 @@ test('Produce valid remote type for a git private dep', async () => {
   const {request, reporter} = await prepareRequest(
     'private-dep@github:yarnpkg/private-dep#1.0.0',
     '1.0.0',
-    'git+ssh://git@github.com/yarnpkg/private-dep.git#d6c57894210c52be02da7859dbb5205feb85d8b0'
+    'git+ssh://git@github.com/yarnpkg/private-dep.git#d6c57894210c52be02da7859dbb5205feb85d8b0',
   );
 
   expect(request.getLocked('git')._remote.type).toBe('git');
@@ -40,7 +40,7 @@ test('Produce valid remote type for a git public dep', async () => {
   const {request, reporter} = await prepareRequest(
     'public-dep@yarnpkg/public-dep#1fde368',
     '1.0.0',
-    'https://codeload.github.com/yarnpkg/public-dep/tar.gz/1fde368'
+    'https://codeload.github.com/yarnpkg/public-dep/tar.gz/1fde368',
   );
 
   expect(request.getLocked('git')._remote.type).toBe('git');

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -44,7 +44,7 @@ function addTest(pattern, registry = 'npm', init: ?(cacheFolder: string) => Prom
     const resolver = new PackageResolver(config, lockfile);
     await resolver.init([{pattern, registry}]);
 
-    const ref = resolver.getPackageReferences()[0];
+    const ref = resolver.getManifests()[0]._reference;
     const cachePath = config.generateHardModulePath(ref, true);
     expect(cachePath).toMatch(cachePathRe);
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "build-dist": "bash ./scripts/build-dist.sh",
     "build-win-installer": "scripts\\build-windows-installer.bat",
     "check-lockfile": "./scripts/check-lockfile.sh",
-    "lint": "yarn run prettier && eslint . && flow check",
+    "lint": "yarn run lint-prettier && eslint . && flow check",
     "lint-prettier": "node scripts/prettier.js lint",
     "prettier": "node scripts/prettier.js write",
     "release-branch": "./scripts/release-branch.sh",

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -328,9 +328,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         const packageName = packagePath[1] || packageJson.name;
 
         const bundledDep = bundledDeps[rootDep] && bundledDeps[rootDep].includes(packageName);
-        if (!bundledDep && (packageJson.version === depPkg.version ||
-        (semver.satisfies(packageJson.version, range, config.looseSemver) &&
-          semver.gt(packageJson.version, depPkg.version, config.looseSemver)))
+        if (
+          !bundledDep &&
+          (packageJson.version === depPkg.version ||
+            (semver.satisfies(packageJson.version, range, config.looseSemver) &&
+              semver.gt(packageJson.version, depPkg.version, config.looseSemver)))
         ) {
           reporter.warn(
             reporter.lang(

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -268,7 +268,7 @@ export class Import extends Install {
     super(flags, config, reporter, lockfile);
     this.resolver = new ImportPackageResolver(this.config, this.lockfile);
     this.fetcher = new PackageFetcher(config, this.resolver);
-    this.compatibility = new PackageCompatibility(config, this.resolver, this.flags.ignoreEngines);
+    this.compatibility = new PackageCompatibility(config, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
   }
 
@@ -280,7 +280,7 @@ export class Import extends Install {
     const {requests, patterns, manifest} = await this.fetchRequestFromCwd();
     await this.resolver.init(requests, this.flags.flat, manifest.name);
     await this.fetcher.init();
-    await this.compatibility.init();
+    await this.compatibility.checkEvery(this.resolver.getManifests());
     await this.linker.resolvePeerModules();
     await this.saveLockfileAndIntegrity(patterns);
     return patterns;

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -15,7 +15,7 @@ import PackageResolver from '../../package-resolver.js';
 import PackageRequest from '../../package-request.js';
 import PackageFetcher from '../../package-fetcher.js';
 import PackageLinker from '../../package-linker.js';
-import checkCompatibility from '../../package-compatibility.js';
+import * as compatibility from '../../package-compatibility.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import * as fs from '../../util/fs.js';
 import * as util from '../../util/misc.js';
@@ -280,7 +280,7 @@ export class Import extends Install {
     await this.resolver.init(requests, this.flags.flat, manifest.name);
     const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
     this.resolver.updateManifests(manifests);
-    await checkCompatibility(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
+    await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     await this.linker.resolvePeerModules();
     await this.saveLockfileAndIntegrity(patterns);
     return patterns;

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -15,7 +15,7 @@ import PackageResolver from '../../package-resolver.js';
 import PackageRequest from '../../package-request.js';
 import PackageFetcher from '../../package-fetcher.js';
 import PackageLinker from '../../package-linker.js';
-import PackageCompatibility from '../../package-compatibility.js';
+import checkCompatibility from '../../package-compatibility.js';
 import Lockfile from '../../lockfile/wrapper.js';
 import * as fs from '../../util/fs.js';
 import * as util from '../../util/misc.js';
@@ -268,7 +268,6 @@ export class Import extends Install {
     super(flags, config, reporter, lockfile);
     this.resolver = new ImportPackageResolver(this.config, this.lockfile);
     this.fetcher = new PackageFetcher(config);
-    this.compatibility = new PackageCompatibility(config, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
   }
 
@@ -281,7 +280,7 @@ export class Import extends Install {
     await this.resolver.init(requests, this.flags.flat, manifest.name);
     const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
     this.resolver.updateManifests(manifests);
-    await this.compatibility.checkEvery(this.resolver.getManifests());
+    await checkCompatibility(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     await this.linker.resolvePeerModules();
     await this.saveLockfileAndIntegrity(patterns);
     return patterns;

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -267,7 +267,7 @@ export class Import extends Install {
   constructor(flags: Object, config: Config, reporter: Reporter, lockfile: Lockfile) {
     super(flags, config, reporter, lockfile);
     this.resolver = new ImportPackageResolver(this.config, this.lockfile);
-    this.fetcher = new PackageFetcher(config, this.resolver);
+    this.fetcher = new PackageFetcher(config);
     this.compatibility = new PackageCompatibility(config, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
   }
@@ -279,7 +279,8 @@ export class Import extends Install {
     await verifyTreeCheck(this.config, this.reporter, {}, []);
     const {requests, patterns, manifest} = await this.fetchRequestFromCwd();
     await this.resolver.init(requests, this.flags.flat, manifest.name);
-    await this.fetcher.init();
+    const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
+    this.resolver.updateManifests(manifests);
     await this.compatibility.checkEvery(this.resolver.getManifests());
     await this.linker.resolvePeerModules();
     await this.saveLockfileAndIntegrity(patterns);

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -255,7 +255,6 @@ class ImportPackageResolver extends PackageResolver {
     this.flat = isFlat;
     this.rootName = rootName || this.rootName;
     const activity = (this.activity = this.reporter.activity());
-    this.seedPatterns = deps.map((dep): string => dep.pattern);
     await this.findAll(deps);
     this.resetOptional();
     activity.end();

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -13,7 +13,7 @@ import GitResolver from '../../resolvers/exotics/git-resolver.js';
 import FileResolver from '../../resolvers/exotics/file-resolver.js';
 import PackageResolver from '../../package-resolver.js';
 import PackageRequest from '../../package-request.js';
-import PackageFetcher from '../../package-fetcher.js';
+import * as fetcher from '../../package-fetcher.js';
 import PackageLinker from '../../package-linker.js';
 import * as compatibility from '../../package-compatibility.js';
 import Lockfile from '../../lockfile/wrapper.js';
@@ -267,7 +267,6 @@ export class Import extends Install {
   constructor(flags: Object, config: Config, reporter: Reporter, lockfile: Lockfile) {
     super(flags, config, reporter, lockfile);
     this.resolver = new ImportPackageResolver(this.config, this.lockfile);
-    this.fetcher = new PackageFetcher(config);
     this.linker = new PackageLinker(config, this.resolver);
   }
 
@@ -278,7 +277,7 @@ export class Import extends Install {
     await verifyTreeCheck(this.config, this.reporter, {}, []);
     const {requests, patterns, manifest} = await this.fetchRequestFromCwd();
     await this.resolver.init(requests, this.flags.flat, manifest.name);
-    const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
+    const manifests : Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
     this.resolver.updateManifests(manifests);
     await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     await this.linker.resolvePeerModules();

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -227,7 +227,7 @@ class ImportPackageResolver extends PackageResolver {
       this.activity.tick(req.pattern);
     }
     const request = new ImportPackageRequest(req, this);
-    await request.find();
+    await request.find(false);
   }
 
   async findAll(deps: DependencyRequestPatterns): Promise<void> {

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -276,7 +276,7 @@ export class Import extends Install {
     await verifyTreeCheck(this.config, this.reporter, {}, []);
     const {requests, patterns, manifest} = await this.fetchRequestFromCwd();
     await this.resolver.init(requests, this.flags.flat, manifest.name);
-    const manifests : Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
+    const manifests: Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
     this.resolver.updateManifests(manifests);
     await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     await this.linker.resolvePeerModules();

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -13,7 +13,7 @@ import Lockfile from '../../lockfile/wrapper.js';
 import lockStringify from '../../lockfile/stringify.js';
 import PackageFetcher from '../../package-fetcher.js';
 import PackageInstallScripts from '../../package-install-scripts.js';
-import checkCompatibility from '../../package-compatibility.js';
+import * as compatibility from '../../package-compatibility.js';
 import PackageResolver from '../../package-resolver.js';
 import PackageLinker from '../../package-linker.js';
 import PackageRequest from '../../package-request.js';
@@ -428,7 +428,7 @@ export class Install {
       this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
       const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
       this.resolver.updateManifests(manifests);
-      await checkCompatibility(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
+      await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     });
 
     steps.push(async (curr: number, total: number) => {
@@ -688,7 +688,7 @@ export class Install {
       // fetch packages, should hit cache most of the time
       const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
       this.resolver.updateManifests(manifests);
-      await checkCompatibility(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
+      await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
 
       // expand minimal manifests
       for (const manifest of this.resolver.getManifests()) {

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -167,7 +167,7 @@ export class Install {
     this.flags = normalizeFlags(config, flags);
 
     this.resolver = new PackageResolver(config, lockfile);
-    this.fetcher = new PackageFetcher(config, this.resolver);
+    this.fetcher = new PackageFetcher(config);
     this.integrityChecker = new InstallationIntegrityChecker(config);
     this.compatibility = new PackageCompatibility(config, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
@@ -428,7 +428,8 @@ export class Install {
     steps.push(async (curr: number, total: number) => {
       this.markIgnored(ignorePatterns);
       this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
-      await this.fetcher.init();
+      const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
+      this.resolver.updateManifests(manifests);
       await this.compatibility.checkEvery(this.resolver.getManifests());
     });
 
@@ -687,7 +688,8 @@ export class Install {
 
     if (fetch) {
       // fetch packages, should hit cache most of the time
-      await this.fetcher.init();
+      const manifests : Array<Manifest> = await this.fetcher.init(this.resolver.getManifests());
+      this.resolver.updateManifests(manifests);
       await this.compatibility.checkEvery(this.resolver.getManifests());
 
       // expand minimal manifests

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -424,7 +424,7 @@ export class Install {
     steps.push(async (curr: number, total: number) => {
       this.markIgnored(ignorePatterns);
       this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
-      const manifests : Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
+      const manifests: Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
       this.resolver.updateManifests(manifests);
       await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     });
@@ -684,7 +684,7 @@ export class Install {
 
     if (fetch) {
       // fetch packages, should hit cache most of the time
-      const manifests : Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
+      const manifests: Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
       this.resolver.updateManifests(manifests);
       await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -169,7 +169,7 @@ export class Install {
     this.resolver = new PackageResolver(config, lockfile);
     this.fetcher = new PackageFetcher(config, this.resolver);
     this.integrityChecker = new InstallationIntegrityChecker(config);
-    this.compatibility = new PackageCompatibility(config, this.resolver, this.flags.ignoreEngines);
+    this.compatibility = new PackageCompatibility(config, this.flags.ignoreEngines);
     this.linker = new PackageLinker(config, this.resolver);
     this.scripts = new PackageInstallScripts(config, this.resolver, this.flags.force);
   }
@@ -429,7 +429,7 @@ export class Install {
       this.markIgnored(ignorePatterns);
       this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
       await this.fetcher.init();
-      await this.compatibility.init();
+      await this.compatibility.checkEvery(this.resolver.getManifests());
     });
 
     steps.push(async (curr: number, total: number) => {
@@ -688,7 +688,7 @@ export class Install {
     if (fetch) {
       // fetch packages, should hit cache most of the time
       await this.fetcher.init();
-      await this.compatibility.init();
+      await this.compatibility.checkEvery(this.resolver.getManifests());
 
       // expand minimal manifests
       for (const manifest of this.resolver.getManifests()) {

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -91,7 +91,6 @@ export default class GitFetcher extends BaseFetcher {
         .pipe(hashStream)
         .pipe(untarStream)
         .on('finish', () => {
-
           const expectHash = this.hash;
           const actualHash = hashStream.getHash();
 
@@ -104,7 +103,6 @@ export default class GitFetcher extends BaseFetcher {
           } else {
             reject(new SecurityError(this.reporter.lang('fetchBadHash', expectHash, actualHash)));
           }
-
         })
         .on('error', function(err) {
           reject(new MessageError(this.reporter.lang('fetchErrorCorrupt', err.message, tarballPath)));

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -120,19 +120,14 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
     }
   };
 
-  const invalidPlatform = !config.ignorePlatform &&
-    Array.isArray(info.os) &&
-    info.os.length > 0 &&
-    !isValidPlatform(info.os);
+  const invalidPlatform =
+    !config.ignorePlatform && Array.isArray(info.os) && info.os.length > 0 && !isValidPlatform(info.os);
 
   if (invalidPlatform) {
     pushError(reporter.lang('incompatibleOS', process.platform));
   }
 
-  const invalidCpu = !config.ignorePlatform &&
-    Array.isArray(info.cpu) &&
-    info.cpu.length > 0 &&
-    !isValidArch(info.cpu);
+  const invalidCpu = !config.ignorePlatform && Array.isArray(info.cpu) && info.cpu.length > 0 && !isValidArch(info.cpu);
 
   if (invalidCpu) {
     pushError(reporter.lang('incompatibleCPU', process.arch));

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import type PackageResolver from './package-resolver.js';
 import type {Reporter} from './reporters/index.js';
 import type {Manifest} from './types.js';
 import type Config from './config.js';
@@ -90,14 +89,12 @@ export function testEngine(name: string, range: string, versions: Versions, loos
 }
 
 export default class PackageCompatibility {
-  constructor(config: Config, resolver: PackageResolver, ignoreEngines: boolean) {
+  constructor(config: Config, ignoreEngines: boolean) {
     this.reporter = config.reporter;
-    this.resolver = resolver;
     this.config = config;
     this.ignoreEngines = ignoreEngines;
   }
 
-  resolver: PackageResolver;
   reporter: Reporter;
   config: Config;
   ignoreEngines: boolean;
@@ -177,8 +174,7 @@ export default class PackageCompatibility {
     }
   }
 
-  init(): Promise<void> {
-    const infos = this.resolver.getManifests();
+  checkEvery(infos: Array<Manifest>): Promise<void> {
     for (const info of infos) {
       this.check(info);
     }

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -18,7 +18,8 @@ async function fetchCache(dest: string, fetcher: Fetchers, config: Config): Prom
     dest,
     cached: true,
   };
-} 
+}
+
 async function fetchOne(ref: PackageReference, config: Config): Promise<FetchedMetadata> {
   const dest = config.generateHardModulePath(ref);
 
@@ -37,7 +38,7 @@ async function fetchOne(ref: PackageReference, config: Config): Promise<FetchedM
   await fs.unlink(dest);
 
   try {
-    return await fetcher.fetch();
+    return fetcher.fetch();
   } catch (err) {
     try {
       await fs.unlink(dest);

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -62,7 +62,7 @@ async function maybeFetchOne(ref: PackageReference, config: Config): Promise<?Fe
   }
 }
 
-export async function fetch(pkgs: Array<Manifest>, config: Config): Promise<Array<Manifest>> {
+export function fetch(pkgs: Array<Manifest>, config: Config): Promise<Array<Manifest>> {
   const pkgsPerDest: Map<string, PackageReference> = new Map();
   pkgs = pkgs.filter(pkg => {
     const ref = pkg._reference;
@@ -82,7 +82,7 @@ export async function fetch(pkgs: Array<Manifest>, config: Config): Promise<Arra
   });
   const tick = config.reporter.progress(pkgs.length);
 
-  return await promise.queue(
+  return promise.queue(
     pkgs,
     async pkg => {
       const ref = pkg._reference;

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -2,7 +2,6 @@
 
 import type {FetchedMetadata, Manifest} from './types.js';
 import type {Fetchers} from './fetchers/index.js';
-import type {Reporter} from './reporters/index.js';
 import type PackageReference from './package-reference.js';
 import type Config from './config.js';
 import {MessageError} from './errors.js';
@@ -10,119 +9,108 @@ import * as fetchers from './fetchers/index.js';
 import * as fs from './util/fs.js';
 import * as promise from './util/promise.js';
 
-export default class PackageFetcher {
-  constructor(config: Config) {
-    this.reporter = config.reporter;
-    this.config = config;
+async function fetchCache(dest: string, fetcher: Fetchers, config: Config): Promise<FetchedMetadata> {
+  const {hash, package: pkg} = await config.readPackageMetadata(dest);
+  await fetcher.setupMirrorFromCache();
+  return {
+    package: pkg,
+    hash,
+    dest,
+    cached: true,
+  };
+} 
+async function fetchOne(ref: PackageReference, config: Config): Promise<FetchedMetadata> {
+  const dest = config.generateHardModulePath(ref);
+
+  const remote = ref.remote;
+  const Fetcher = fetchers[remote.type];
+  if (!Fetcher) {
+    throw new MessageError(config.reporter.lang('unknownFetcherFor', remote.type));
   }
 
-  reporter: Reporter;
-  config: Config;
-
-  async fetchCache(dest: string, fetcher: Fetchers): Promise<FetchedMetadata> {
-    const {hash, package: pkg} = await this.config.readPackageMetadata(dest);
-    await fetcher.setupMirrorFromCache();
-    return {
-      package: pkg,
-      hash,
-      dest,
-      cached: true,
-    };
+  const fetcher = new Fetcher(dest, remote, config);
+  if (await config.isValidModuleDest(dest)) {
+    return fetchCache(dest, fetcher, config);
   }
 
-  async fetch(ref: PackageReference): Promise<FetchedMetadata> {
-    const dest = this.config.generateHardModulePath(ref);
+  // remove as the module may be invalid
+  await fs.unlink(dest);
 
-    const remote = ref.remote;
-    const Fetcher = fetchers[remote.type];
-    if (!Fetcher) {
-      throw new MessageError(this.reporter.lang('unknownFetcherFor', remote.type));
-    }
-
-    const fetcher = new Fetcher(dest, remote, this.config);
-    if (await this.config.isValidModuleDest(dest)) {
-      return this.fetchCache(dest, fetcher);
-    }
-
-    // remove as the module may be invalid
-    await fs.unlink(dest);
-
+  try {
+    return await fetcher.fetch();
+  } catch (err) {
     try {
-      return fetcher.fetch();
-    } catch (err) {
-      try {
-        await fs.unlink(dest);
-      } catch (err2) {
-        // what do?
-      }
+      await fs.unlink(dest);
+    } catch (err2) {
+      // what do?
+    }
+    throw err;
+  }
+}
+
+async function maybeFetchOne(ref: PackageReference, config: Config): Promise<?FetchedMetadata> {
+  try {
+    return await fetchOne(ref, config);
+  } catch (err) {
+    if (ref.optional) {
+      config.reporter.error(err.message);
+      return null;
+    } else {
       throw err;
     }
   }
+}
 
-  async maybeFetch(ref: PackageReference): Promise<?FetchedMetadata> {
-    try {
-      return await this.fetch(ref);
-    } catch (err) {
-      if (ref.optional) {
-        this.reporter.error(err.message);
-        return null;
-      } else {
-        throw err;
+export async function fetch(pkgs: Array<Manifest>, config: Config): Promise<Array<Manifest>> {
+  const pkgsPerDest: Map<string, PackageReference> = new Map();
+  pkgs = pkgs.filter(pkg => {
+    const ref = pkg._reference;
+    if (!ref) {
+      return false;
+    }
+    const dest = config.generateHardModulePath(ref);
+    const otherPkg = pkgsPerDest.get(dest);
+    if (otherPkg) {
+      config.reporter.warn(
+        config.reporter.lang('multiplePackagesCantUnpackInSameDestination', ref.patterns, dest, otherPkg.patterns),
+      );
+      return false;
+    }
+    pkgsPerDest.set(dest, ref);
+    return true;
+  });
+  const tick = config.reporter.progress(pkgs.length);
+
+  return await promise.queue(pkgs, async pkg => {
+    const ref = pkg._reference;
+    if (!ref) {
+      return pkg;
+    }
+
+    const res = await maybeFetchOne(ref, config);
+    let newPkg;
+
+    if (res) {
+      newPkg = res.package;
+
+      // update with new remote
+      // but only if there was a hash previously as the tarball fetcher does not provide a hash.
+      if (ref.remote.hash) {
+        ref.remote.hash = res.hash;
       }
     }
-  }
 
-  async init(pkgs: Array<Manifest>): Promise<Array<Manifest>> {
-    const pkgsPerDest: Map<string, PackageReference> = new Map();
-    pkgs = pkgs.filter(pkg => {
-      const ref = pkg._reference;
-      if (!ref) {
-        return false;
-      }
-      const dest = this.config.generateHardModulePath(ref);
-      const otherPkg = pkgsPerDest.get(dest);
-      if (otherPkg) {
-        this.reporter.warn(
-          this.reporter.lang('multiplePackagesCantUnpackInSameDestination', ref.patterns, dest, otherPkg.patterns),
-        );
-        return false;
-      }
-      pkgsPerDest.set(dest, ref);
-      return true;
-    });
-    const tick = this.reporter.progress(pkgs.length);
+    if (tick) {
+      tick(ref.name);
+    }
 
-    return await promise.queue(pkgs, async pkg => {
-      const ref = pkg._reference;
-      if (!ref) {
-        return pkg;
-      }
+    if (newPkg) {
+      newPkg._reference = ref;
+      newPkg._remote = ref.remote;
+      newPkg.name = pkg.name;
+      return newPkg;
+    }
 
-      const res = await this.maybeFetch(ref);
-      let newPkg;
-
-        if (res) {
-          newPkg = res.package;
-
-          // update with new remote
-          // but only if there was a hash previously as the tarball fetcher does not provide a hash.
-          if (ref.remote.hash) {
-            ref.remote.hash = res.hash;
-          }
-        }
-
-      if (tick) {
-        tick(ref.name);
-      }
-
-      if (newPkg) {
-        newPkg._reference = ref;
-        newPkg._remote = ref.remote;
-        newPkg.name = pkg.name;
-        return newPkg;
-      }
-
-      return pkg;
-    }, this.config.networkConcurrency);
-  }
+    return pkg;
+  }, config.networkConcurrency);
 }

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -108,6 +108,7 @@ export async function fetch(pkgs: Array<Manifest>, config: Config): Promise<Arra
       newPkg._reference = ref;
       newPkg._remote = ref.remote;
       newPkg.name = pkg.name;
+      newPkg.fresh = pkg.fresh;
       return newPkg;
     }
 

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -229,14 +229,15 @@ export default class PackageRequest {
   /**
    * TODO description
    */
-
-  async find(): Promise<void> {
+  async find(fresh: boolean): Promise<void> {
     // find version info for this package pattern
     const info: ?Manifest = await this.findVersionInfo();
+
     if (!info) {
       throw new MessageError(this.reporter.lang('unknownPackage', this.pattern));
     }
 
+    info.fresh = fresh;
     cleanDependencies(info, false, this.reporter, () => {
       // swallow warnings
     });

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -281,7 +281,8 @@ export default class PackageResolver {
 
     invariant(
       collapseToReference && collapseToManifest && collapseToPattern,
-      `Couldn't find package manifest for ${human}`);
+      `Couldn't find package manifest for ${human}`,
+    );
 
     for (const pattern of patterns) {
       // don't touch the pattern we're collapsing to

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -286,30 +286,30 @@ export default class PackageResolver {
         break;
       }
     }
+
     invariant(
       collapseToReference && collapseToManifest && collapseToPattern,
-      `Couldn't find package manifest for ${human}`,
-    );
+      `Couldn't find package manifest for ${human}`);
 
-for (const pattern of patterns) {
-  // don't touch the pattern we're collapsing to
-  if (pattern === collapseToPattern) {
-    continue;
-  }
+    for (const pattern of patterns) {
+      // don't touch the pattern we're collapsing to
+      if (pattern === collapseToPattern) {
+        continue;
+      }
 
-  // remove this pattern
-  const ref = this.getStrictResolvedPattern(pattern)._reference;
-  invariant(ref, 'expected package reference');
-  const refPatterns = ref.patterns.slice();
-  ref.prune();
+      // remove this pattern
+      const ref = this.getStrictResolvedPattern(pattern)._reference;
+      invariant(ref, 'expected package reference');
+      const refPatterns = ref.patterns.slice();
+      ref.prune();
 
-  // add pattern to the manifest we're collapsing to
-  for (const pattern of refPatterns) {
-    collapseToReference.addPattern(pattern, collapseToManifest);
-  }
-}
+      // add pattern to the manifest we're collapsing to
+      for (const pattern of refPatterns) {
+        collapseToReference.addPattern(pattern, collapseToManifest);
+      }
+    }
 
-return collapseToPattern;
+    return collapseToPattern;
   }
 
   /**

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -52,10 +52,6 @@ export default class PackageResolver {
   // TODO
   fetchingQueue: BlockingQueue;
 
-  // these are patterns that the package resolver was seeded with. these are required in
-  // order to resolve top level peerDependencies
-  seedPatterns: Array<string>;
-
   // manages and throttles json api http requests
   requestManager: RequestManager;
 
@@ -455,16 +451,8 @@ export default class PackageResolver {
 
   async init(deps: DependencyRequestPatterns, isFlat: boolean): Promise<void> {
     this.flat = isFlat;
-
-    //
     const activity = (this.activity = this.reporter.activity());
-
-    //
-    this.seedPatterns = deps.map((dep): string => dep.pattern);
-
-    //
     await Promise.all(deps.map((req): Promise<void> => this.find(req)));
-
     activity.end();
     this.activity = null;
   }

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -86,10 +86,6 @@ export default class PackageResolver {
     return this.newPatterns.indexOf(pattern) >= 0;
   }
 
-  /**
-   * TODO description
-   */
-
   updateManifest(ref: PackageReference, newPkg: Manifest): Promise<void> {
     // inherit fields
     const oldPkg = this.patterns[ref.patterns[0]];
@@ -100,6 +96,18 @@ export default class PackageResolver {
     // update patterns
     for (const pattern of ref.patterns) {
       this.patterns[pattern] = newPkg;
+    }
+
+    return Promise.resolve();
+  }
+
+  updateManifests(newPkgs: Array<Manifest>): Promise<void> {
+    for (const newPkg of newPkgs) {
+      if (newPkg._reference) {
+        for (const pattern of newPkg._reference.patterns) {
+          this.patterns[pattern] = newPkg;
+        }
+      }
     }
 
     return Promise.resolve();
@@ -223,23 +231,6 @@ export default class PackageResolver {
   }
 
   /**
-   * Get a flat list of all package references.
-   */
-
-  getPackageReferences(): Array<PackageReference> {
-    const refs = [];
-
-    for (const manifest of this.getManifests()) {
-      const ref = manifest._reference;
-      if (ref) {
-        refs.push(ref);
-      }
-    }
-
-    return refs;
-  }
-
-  /**
    * Get a flat list of all package info.
    */
 
@@ -300,25 +291,25 @@ export default class PackageResolver {
       `Couldn't find package manifest for ${human}`,
     );
 
-    for (const pattern of patterns) {
-      // don't touch the pattern we're collapsing to
-      if (pattern === collapseToPattern) {
-        continue;
-      }
+for (const pattern of patterns) {
+  // don't touch the pattern we're collapsing to
+  if (pattern === collapseToPattern) {
+    continue;
+  }
 
-      // remove this pattern
-      const ref = this.getStrictResolvedPattern(pattern)._reference;
-      invariant(ref, 'expected package reference');
-      const refPatterns = ref.patterns.slice();
-      ref.prune();
+  // remove this pattern
+  const ref = this.getStrictResolvedPattern(pattern)._reference;
+  invariant(ref, 'expected package reference');
+  const refPatterns = ref.patterns.slice();
+  ref.prune();
 
-      // add pattern to the manifest we're collapsing to
-      for (const pattern of refPatterns) {
-        collapseToReference.addPattern(pattern, collapseToManifest);
-      }
-    }
+  // add pattern to the manifest we're collapsing to
+  for (const pattern of refPatterns) {
+    collapseToReference.addPattern(pattern, collapseToManifest);
+  }
+}
 
-    return collapseToPattern;
+return collapseToPattern;
   }
 
   /**

--- a/src/types.js
+++ b/src/types.js
@@ -125,6 +125,8 @@ export type Manifest = {
   main?: string,
 
   workspaces?: Array<string>,
+
+  fresh?: boolean
 };
 
 //

--- a/src/types.js
+++ b/src/types.js
@@ -126,7 +126,10 @@ export type Manifest = {
 
   workspaces?: Array<string>,
 
-  fresh?: boolean
+  // This flag is true when we add a new package with `yarn add <mypackage>`.
+  // We need to preserve the flag because we print a list of new packages in
+  // the end of the add command
+  fresh?: boolean,
 };
 
 //


### PR DESCRIPTION
**Summary**
Make package-compatibility and package-fetcher stateless and indipendent from package-resolver.
I made some ugly choices, but imho the road towards https://github.com/yarnpkg/yarn/issues/2918 is open :D (I hope this merge it will not close that issue).
I think it is important to be incremental as possible because I am touching the core O.o
Big Pro: now we can time every part and maybe introduce some unit tests :)

**Test plan**
Tests are green, before made every change I carefully check if every line were covered indirectly from tests.
