### PR TITLE
Fix support for private git repos when using shorted repo syntax and lock file exists

### DIFF
--- a/__tests__/package-request.js
+++ b/__tests__/package-request.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+import PackageRequest from '../src/package-request.js';
+import * as reporters from '../src/reporters/index.js';
+import PackageResolver from '../src/package-resolver.js';
+import Lockfile from '../src/lockfile/wrapper.js';
+import Config from '../src/config.js';
+
+async function prepareRequest(pattern, version, resolved): Object {
+  const privateDepCache = {[pattern]: {version, resolved}};
+  const lockfile = new Lockfile(privateDepCache);
+  const reporter = new reporters.NoopReporter({});
+  const depRequestPattern = {
+    pattern,
+    registry: 'npm',
+    hint: null,
+    optional: false,
+  };
+  const config = await Config.create({}, reporter);
+  const resolver = new PackageResolver(config, lockfile);
+  const request = new PackageRequest(depRequestPattern, resolver);
+
+  return {request, reporter};
+}
+
+test('Produce valid remote type for a git private dep', async () => {
+  const {request, reporter} = await prepareRequest(
+    'private-dep@github:yarnpkg/private-dep#1.0.0',
+    '1.0.0',
+    'git+ssh://git@github.com/yarnpkg/private-dep.git#d6c57894210c52be02da7859dbb5205feb85d8b0'
+  );
+
+  expect(request.getLocked('git')._remote.type).toBe('git');
+  expect(request.getLocked('tarball')._remote.type).toBe('git');
+
+  await reporter.close();
+});
+
+test('Produce valid remote type for a git public dep', async () => {
+  const {request, reporter} = await prepareRequest(
+    'public-dep@yarnpkg/public-dep#1fde368',
+    '1.0.0',
+    'https://codeload.github.com/yarnpkg/public-dep/tar.gz/1fde368'
+  );
+
+  expect(request.getLocked('git')._remote.type).toBe('git');
+  expect(request.getLocked('tarball')._remote.type).toBe('tarball');
+
+  await reporter.close();
+});

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -75,6 +75,8 @@ export default class PackageRequest {
 
     if (shrunk && shrunk.resolved) {
       const resolvedParts = versionUtil.explodeHashedUrl(shrunk.resolved);
+      // If it's a private git url set remote to 'git'.
+      const preferredRemoteType = resolvedParts.url.startsWith('git+ssh://') ? 'git' : remoteType;
 
       return {
         name: shrunk.name,
@@ -82,7 +84,7 @@ export default class PackageRequest {
         _uid: shrunk.uid,
         _remote: {
           resolved: shrunk.resolved,
-          type: remoteType,
+          type: preferredRemoteType,
           reference: resolvedParts.url,
           hash: resolvedParts.hash,
           registry: shrunk.registry,


### PR DESCRIPTION
> Description based on https://github.com/yarnpkg/yarn/issues/573#issuecomment-301674068

https://github.com/yarnpkg/yarn/pull/2992 added support for private git repos when using shorted repo syntax (this landed on v0.24.0).

The generation for the first time of a `yarn.lock` file works well, but then with a yarn.lock file if you try `rm -rf node_modules && yarn` fails with this error:
```sh
error An unexpected error occurred: "Invalid protocol: git+ssh:".
```
That error comes from https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/request.js#L455  and I think it's because yarn tries to use the tarball fetcher instead of the git fetcher.

The offline feature/fix added recently makes the git resolver defaults to the tarball to avoid http calls https://github.com/yarnpkg/yarn/pull/3000/files
Returning the git shrunk instead of the tarball if is possible seems to fix the issue.