### PR TITLE
Added support for more git URL formats

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -41,6 +41,26 @@ test('npmUrlToGitUrl', () => {
     hostname: 'scp-host-nickname',
     repository: 'user@scp-host-nickname:npm-opam/ocamlfind.git',
   });
+  expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind.git#v1.2.3')).toEqual({
+    protocol: 'ssh:',
+    hostname: 'github.com',
+    repository: 'ssh://git@github.com/npm-opam/ocamlfind.git#v1.2.3',
+  });
+  expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind#v1.2.3')).toEqual({
+    protocol: 'ssh:',
+    hostname: 'github.com',
+    repository: 'ssh://git@github.com/npm-opam/ocamlfind#v1.2.3',
+  });
+  expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind.git')).toEqual({
+    protocol: 'ssh:',
+    hostname: 'github.com',
+    repository: 'ssh://git@github.com/npm-opam/ocamlfind.git',
+  });
+  expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind')).toEqual({
+    protocol: 'ssh:',
+    hostname: 'github.com',
+    repository: 'ssh://git@github.com/npm-opam/ocamlfind',
+  });
 });
 
 test('isCommitHash', () => {

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -62,6 +62,9 @@ export default class Git {
    * git "URLs" also allow an alternative scp-like syntax, so they're not standard URLs.
    */
   static npmUrlToGitUrl(npmUrl: string): GitUrl {
+    // Expand shortened format first if needed
+    npmUrl = npmUrl.replace(/^github:/, 'git+ssh://git@github.com/');
+
     // Special case in npm, where ssh:// prefix is stripped to pass scp-like syntax
     // which in git works as remote path only if there are no slashes before ':'.
     const match = npmUrl.match(/^git\+ssh:\/\/((?:[^@:\/]+@)?([^@:\/]+):([^/]*).*)/);


### PR DESCRIPTION
**Summary**

After recent work on fixing the private shortened git URL formats I've noticed there are still some that do not work.

For example this URL format works:

    github:thedumbterminal/test-private-node-module

But this format does not:

    github:thedumbterminal/test-private-node-module.git

This work fixes this.

**Test plan**

Create a new directory with the following `package.json`:

```json
{
  "name": "1",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
   "grunt-gemnasium": "github:thedumbterminal/grunt-gemnasium.git"
  }
}
```

Without this fix you will get the following error:

```
ssh: Could not resolve hostname github: nodename nor servname provided, or not known
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
(Notice the error: `Could not resolve hostname github` which is incorrect)

With this fix you will able to install these modules as it will switch to ssh auth.
