### PR TITLE
Disables the hash check for git repositories

### DIFF
--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -91,15 +91,20 @@ export default class GitFetcher extends BaseFetcher {
         .pipe(hashStream)
         .pipe(untarStream)
         .on('finish', () => {
+
           const expectHash = this.hash;
           const actualHash = hashStream.getHash();
-          if (!expectHash || expectHash === actualHash) {
+
+          // This condition is disabled because "expectHash" actually is the commit hash
+          // This is a design issue that we'll need to fix (https://github.com/yarnpkg/yarn/pull/3449)
+          if (true || !expectHash || expectHash === actualHash) {
             resolve({
               hash: actualHash,
             });
           } else {
             reject(new SecurityError(this.reporter.lang('fetchBadHash', expectHash, actualHash)));
           }
+
         })
         .on('error', function(err) {
           reject(new MessageError(this.reporter.lang('fetchErrorCorrupt', err.message, tarballPath)));


### PR DESCRIPTION
Because `this.hash` is equal to the commit hash inside the git fetcher, we have nothing against which compare the tarball hash. Fixing this will require fixing the lockfile structure (discussion [here](https://github.com/yarnpkg/rfcs/pull/64)), so in the meantime it's better to just disable this check.

Note that it wasn't a problem before 0.23, because until we merged #51 the offline `resolved` entry only contained the tarball name, which conveniently didn't included the hash. Since there was no hash, no check was made.