### PR TITLE
Change global prefix directory to `/usr/local` on OS X

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -4,6 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type {Manifest} from '../../types.js';
 import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
+import {OSX_GLOBAL_PREFIX_DIRECTORY} from '../../constants.js';
 import {registries} from '../../registries/index.js';
 import NoopReporter from '../../reporters/base-reporter.js';
 import buildSubCommands from './_build-sub-commands.js';
@@ -76,6 +77,8 @@ function getGlobalPrefix(config: Config, flags: Object): string {
     return String(config.getOption('prefix'));
   } else if (process.env.PREFIX) {
     return process.env.PREFIX;
+  } else if (process.platform === 'darwin') {
+    return OSX_GLOBAL_PREFIX_DIRECTORY;
   } else if (process.platform === 'win32') {
     if (process.env.LOCALAPPDATA) {
       return path.join(process.env.LOCALAPPDATA, 'Yarn', 'bin');

--- a/src/constants.js
+++ b/src/constants.js
@@ -58,6 +58,7 @@ export const MODULE_CACHE_DIRECTORY = getCacheDirectory();
 export const CONFIG_DIRECTORY = getDirectory('config');
 export const LINK_REGISTRY_DIRECTORY = path.join(CONFIG_DIRECTORY, 'link');
 export const GLOBAL_MODULE_DIRECTORY = path.join(CONFIG_DIRECTORY, 'global');
+export const OSX_GLOBAL_PREFIX_DIRECTORY = '/usr/local';
 
 export const META_FOLDER = '.yarn-meta';
 export const INTEGRITY_FILENAME = '.yarn-integrity';


### PR DESCRIPTION
When node is installed from Homebrew, node exists at `/usr/local/Cellar/node/7.10.0/bin/node`

So yarn's global bin directory (`yarn global bin`) becomes: `/usr/local/Cellar/node/7.10.0/bin`

```
$ node -e 'console.log(process.execPath)'
/usr/local/Cellar/node/7.10.0/bin/node
$ yarn global bin
/usr/local/Cellar/node/7.10.0/bin
```

This creates two problems:

1. `/usr/local/Cellar/node/(version)/bin` is not present in `PATH` by default. Users have to modify their profile to extend `PATH` with `yarn global bin`.

2. When node is upgraded, all linked global binaries become inaccessible since `yarn global bin` automatically gets changed to `/usr/local/Cellar/node/(latest-version)` from `/usr/local/Cellar/node/(old-version)`. The global bin directory should remain constant on upgrades.

The fix is to simply use `/usr/local/bin` as the default global bin directory in OS X installations. NPM (`npm --global prefix`) also uses that directory (at least when installed from Homebrew).

This should also fix #1194.

**Alternatives**

1. Instead of all OS X installations, this change can be applied only to installations where node is installed from Homebrew, by checking if `process.execPath` begins with `/usr/local/Cellar`. Although, this issue would still be present with nvm or some other node-installer.

2. Instead of modifying yarn, a patch could be made in the [Yarn formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/yarn.rb) to automatically run `yarn config set prefix /usr/local`. (EDIT: It's not possible atm: https://github.com/Homebrew/homebrew-core/issues/7283#issuecomment-289795136) Other node-installers like nvm will also require similar changes.

3. In the `getGlobalPrefix` function, instead of
```
let prefix = path.dirname(path.dirname(process.execPath)); //=> /usr/local/Cellar/node/7.10.0
```
this could be used:
```
const whichNode = execa.sync('which', ['node']).stdout; //=> /usr/local/bin/node
let prefix = path.dirname(path.dirname(whichNode)); //=> /usr/local
```