### PR TITLE
Optimize async functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "flowtype/space-after-type-colon": [2, "always"],
     "flowtype/require-return-type": [2, "always", {"excludeArrowFunctions": true}],
     "no-async-without-await/no-async-without-await": 2,
+    "no-return-await": "error",
     "sort-keys": "off"
   }
 }

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -35,8 +35,8 @@ function getTempGlobalFolder(): string {
   return path.join(os.tmpdir(), `yarn-global-${Math.random()}`);
 }
 
-async function createTempGlobalFolder(): Promise<string> {
-  return await mkdir('yarn-global');
+function createTempGlobalFolder(): Promise<string> {
+  return mkdir('yarn-global');
 }
 
 async function createTempPrefixFolder(): Promise<string> {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -110,6 +110,6 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       .then(answer => runCommand(answer.split(' ')), () => reporter.error(reporter.lang('commandNotSpecified')));
     return Promise.resolve();
   } else {
-    return await runCommand(args);
+    return runCommand(args);
   }
 }

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -109,7 +109,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       if (deps.length) {
         reporter.info(reporter.lang('updateInstalling', getNameFromHint(hint)));
         const add = new Add(deps, flags, config, reporter, lockfile);
-        return await add.init();
+        return add.init();
       }
       return Promise.resolve();
     }, Promise.resolve());

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -45,9 +45,9 @@ export async function setVersion(
     throw new MessageError(reporter.lang('invalidVersionArgument', NEW_VERSION_FLAG));
   }
 
-  async function runLifecycle(lifecycle: string): Promise<void> {
+  function runLifecycle(lifecycle: string): Promise<void> {
     if (scripts[lifecycle]) {
-      return await execCommand(lifecycle, config, scripts[lifecycle], config.cwd);
+      return execCommand(lifecycle, config, scripts[lifecycle], config.cwd);
     }
 
     return Promise.resolve();

--- a/src/config.js
+++ b/src/config.js
@@ -586,9 +586,9 @@ export default class Config {
    * of a syntax error.
    */
 
-  async readJson(loc: string, factory: (filename: string) => Promise<Object> = fs.readJson): Promise<Object> {
+  readJson(loc: string, factory: (filename: string) => Promise<Object> = fs.readJson): Promise<Object> {
     try {
-      return await factory(loc);
+      return factory(loc);
     } catch (err) {
       if (err instanceof SyntaxError) {
         throw new MessageError(this.reporter.lang('jsonError', loc, err.message));

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -181,13 +181,13 @@ export default class TarballFetcher extends BaseFetcher {
       : urlParse.pathname ? urlParse.pathname.match(/^(?:\.{1,2})?[\\\/]/) : false;
 
     if (isFilePath) {
-      return await this.fetchFromLocal(this.reference);
+      return this.fetchFromLocal(this.reference);
     }
 
     if (await this.getLocalAvailabilityStatus()) {
-      return await this.fetchFromLocal();
+      return this.fetchFromLocal();
     } else {
-      return await this.fetchFromExternal();
+      return this.fetchFromExternal();
     }
   }
 }

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -51,7 +51,7 @@ export default class PackageFetcher {
     await fs.unlink(dest);
 
     try {
-      return await fetcher.fetch();
+      return fetcher.fetch();
     } catch (err) {
       try {
         await fs.unlink(dest);

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -215,12 +215,12 @@ export default class PackageRequest {
    * the registry.
    */
 
-  async findVersionInfo(): Promise<Manifest> {
+  findVersionInfo(): Promise<Manifest> {
     const exoticResolver = PackageRequest.getExoticResolver(this.pattern);
     if (exoticResolver) {
-      return await this.findExoticVersionInfo(exoticResolver, this.pattern);
+      return this.findExoticVersionInfo(exoticResolver, this.pattern);
     } else {
-      return await this.findVersionOnRegistry(this.pattern);
+      return this.findVersionOnRegistry(this.pattern);
     }
   }
 

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -136,7 +136,7 @@ export default class HostedGitResolver extends ExoticResolver {
     }
 
     const refs = Git.parseRefs(out);
-    return await client.setRef(refs);
+    return client.setRef(refs);
   }
 
   async resolveOverHTTP(url: string): Promise<Manifest> {
@@ -212,7 +212,7 @@ export default class HostedGitResolver extends ExoticResolver {
     // archive and tarball unarchiving. The HTTP API is only available for public repos
     // though.
     if (await this.hasHTTPCapability(httpBaseUrl)) {
-      return await this.resolveOverHTTP(httpUrl);
+      return this.resolveOverHTTP(httpUrl);
     }
 
     // If the url is accessible over git archive then we should immediately delegate to
@@ -225,10 +225,10 @@ export default class HostedGitResolver extends ExoticResolver {
     if (await Git.hasArchiveCapability(sshGitUrl)) {
       const archiveClient = new Git(this.config, sshGitUrl, this.hash);
       const commit = await archiveClient.init();
-      return await this.fork(GitResolver, true, `${sshUrl}#${commit}`);
+      return this.fork(GitResolver, true, `${sshUrl}#${commit}`);
     }
 
     // fallback to the plain git resolver
-    return await this.fork(GitResolver, true, sshUrl);
+    return this.fork(GitResolver, true, sshUrl);
   }
 }

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -79,7 +79,7 @@ export default class NpmResolver extends RegistryResolver {
     const body = await this.config.registries.npm.request(NpmRegistry.escapeName(this.name));
 
     if (body) {
-      return await NpmResolver.findVersionInRegistryResponse(this.config, this.range, body, this.request);
+      return NpmResolver.findVersionInRegistryResponse(this.config, this.range, body, this.request);
     } else {
       return null;
     }

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -381,13 +381,13 @@ export default class Git {
       await this.fetch();
     }
 
-    return await this.setRefRemote();
+    return this.setRefRemote();
   }
 
   async setRefRemote(): Promise<string> {
     const stdout = await child.spawn('git', ['ls-remote', '--tags', '--heads', this.gitUrl.repository]);
     const refs = Git.parseRefs(stdout);
-    return await this.setRef(refs);
+    return this.setRef(refs);
   }
 
   /**


### PR DESCRIPTION
* Add lint rule `no-return-await`

* Replace redundant `return await` calls with `return`

* Convert async functions which no longer have `await` calls to normal functions

Similar to #352