### PR TITLE
Add explicit check for tarball files in mirror files directory

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -718,7 +718,7 @@ test.concurrent('should install if symlink source does not exist', async (): Pro
   await runInstall({}, 'relative-symlinks-work', () => {});
 });
 
-test.concurrent('prunes the offline mirror after pruning is enabled', (): Promise<void> => {
+test.concurrent('prunes the offline mirror tarballs after pruning is enabled', (): Promise<void> => {
   return runInstall({}, 'prune-offline-mirror', async (config): Promise<void> => {
     const mirrorPath = 'mirror-for-offline';
     // Scenario:
@@ -728,6 +728,7 @@ test.concurrent('prunes the offline mirror after pruning is enabled', (): Promis
     // so the next install should remove dep-a-1.0.0.tgz and dep-b-1.0.0.tgz.
     expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-a-1.0.0.tgz`))).toEqual(false);
     expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/dep-b-1.0.0.tgz`))).toEqual(false);
+    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/dummy.txt`))).toEqual(true);
   });
 });
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -614,10 +614,11 @@ export class Install {
       }
     }
 
-    const mirrorTarballs = await fs.walk(mirror);
-    for (const tarball of mirrorTarballs) {
-      if (!requiredTarballs.has(tarball.basename)) {
-        await fs.unlink(tarball.absolute);
+    const mirrorFiles = await fs.walk(mirror);
+    for (const file of mirrorFiles) {
+      const isTarball = path.extname(file.basename) === '.tgz';
+      if (isTarball && !requiredTarballs.has(file.basename)) {
+        await fs.unlink(file.absolute);
       }
     }
   }


### PR DESCRIPTION
**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR is a bug fix from https://github.com/yarnpkg/yarn/issues/3435
The issue was that files that weren't tarballs (.git, for example) were also removed since they weren't present in the lockfile.

**Test plan**
I've stepped through the STRs from the original bug report
1) Set `yarn config set yarn-offline-mirror ./npm-packages-offline-cache` and `yarn config set yarn-offline-mirror-pruning true`
2) Create a git repo inside of packages-cache
3) Run `yarn remove` on an installed dependency
4) Check that the git repo still exists, unlike previous behavior
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
