### PR TITLE
Fix npm command

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -85,7 +85,7 @@ function getUpdateCommand(installationMethod: InstallationMethod): ?string {
   }
 
   if (installationMethod === 'npm') {
-    return 'npm upgrade --global yarn';
+    return 'npm update --global yarn';
   }
 
   if (installationMethod === 'chocolatey') {


### PR DESCRIPTION
'update' instead of 'upgrade'

**Summary**

If your yarn version is out of date, you get prompted to remedy this by running 'npm upgrade...' which results in an error.  Using 'npm update...' instead works as expected.

**Test plan**

Run on a machine with an older version of yarn.  Should be able to follow on-screen instructions and update to latest version without errors.
