### PR TITLE
Delay resolving patterns to existing versions until all final version…

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -757,3 +757,14 @@ test.concurrent('bailout should work with --production flag too', (): Promise<vo
     expect(await fs.exists(path.join(config.cwd, 'node_modules', 'left-pad', 'index.js'))).toBe(false);
   });
 });
+
+test.concurrent('package version resolve should be deterministic', (): Promise<void> => {
+  // Scenario:
+  // graceful-fs will install two versions, from @4.1.10 and @^4.1.11. The pattern @^4.1.2 would sometimes resolve
+  // to 4.1.10, if @^4.1.11 hadn't been processed before. Otherwise it would resolve to the result of @^4.1.11.
+  // Run an independent install and check, and see they have different results for @^4.1.2 - won't always see
+  // the bug, but its the best we can do without creating mock registry with controlled timing of responses.
+  return runInstall({}, 'install-deterministic-versions', async (config, reporter) => {
+    await check(config, reporter, {integrity: true}, []);
+  });
+});

--- a/__tests__/fixtures/install/install-deterministic-versions/package.json
+++ b/__tests__/fixtures/install/install-deterministic-versions/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "graceful-fs": "4.1.10",
+    "write-file-atomic": "1.3.1",
+    "path-type": "1.1.0"
+  }
+}

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -235,6 +235,9 @@ class ImportPackageResolver extends PackageResolver {
     deps = this.next;
     this.next = [];
     if (!deps.length) {
+      // all required package versions have been discovered, so now packages that
+      // resolved to existing versions can be resolved to their best available version
+      this.resolvePackagesWithExistingVersions();
       return;
     }
     await this.findAll(deps);

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -27,6 +27,7 @@ export default class PackageResolver {
     this.reporter = config.reporter;
     this.lockfile = lockfile;
     this.config = config;
+    this.delayedResolveQueue = [];
   }
 
   // whether the dependency graph will be flattened
@@ -77,6 +78,10 @@ export default class PackageResolver {
 
   // environment specific config methods and options
   config: Config;
+
+  // list of packages need to be resolved later (they found a matching version in the
+  // resolver, but better matches can still arrive later in the resolve process)
+  delayedResolveQueue: Array<{ req: PackageRequest, info: Manifest }>;
 
   /**
    * TODO description
@@ -474,7 +479,32 @@ export default class PackageResolver {
     //
     await Promise.all(deps.map((req): Promise<void> => this.find(req)));
 
+    // all required package versions have been discovered, so now packages that
+    // resolved to existing versions can be resolved to their best available version
+    this.resolvePackagesWithExistingVersions();
+
     activity.end();
     this.activity = null;
+  }
+
+  /**
+    * Called by the package requester for packages that this resolver already had
+    * a matching version for. Delay the resolve, because better matches can still be
+    * discovered.
+    */
+
+  reportPackageWithExistingVersion(req: PackageRequest, info: Manifest) {
+    this.delayedResolveQueue.push({req, info});
+  }
+
+  /**
+    * Executes the resolve to existing versions for packages after the find process,
+    * when all versions that are going to be used have been discovered.
+    */
+
+  resolvePackagesWithExistingVersions() {
+    for (const {req, info} of this.delayedResolveQueue) {
+      req.resolveToExistingVersion(info);
+    }
   }
 }


### PR DESCRIPTION
…s are known. Fixes #3466

**Summary**

When PackageRequester has retrieved the version information for a pattern, it queries the package resolver for the current best match for its pattern. If it finds one, it immediately resolves to that version.

This can cause indeterminism. If we have requests for graceful-fs@4.1.10, graceful-fs@^4.1.2 and graceful-fs@^4.1.11, the following can happen.
1. graceful-fs@4.1.10 resolves first, to 4.1.10
2. graceful-fs@^4.1.2 resolves next, finds 4.1.10, resolves to that.
3. graceful-fs@^4.1.11 resolves last to 4.1.11.

In a different order, the following can happen:
1. graceful-fs@4.1.10 resolves first, to 4.1.10
2. graceful-fs@^4.1.11 resolves next to 4.1.11.
3. graceful-fs@^4.1.2 resolves last, finds 4.1.11, resolves to that.

This PR reworks the package-requester to store requests that match an existing version with the resolver. When the resolver has processed all other patterns, it then resolves those stored requests. These requests will then always find the best version.

**Test plan**
Added a test that installs and checks the package.json from #3466. This test isn't deterministic, but if the error is present it should find it now and then. I have run the test a few time without the fix and seen it fail. The whole testsuite runs without error.

**Risks**
I have adjusted the default package resolver and the resolver from import.js, a risk is that I have overlooked other (less well-tested) paths.