### PR TITLE
Refactor and optimize `bin/yarn.js`

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -9,12 +9,12 @@ var semver = require('semver');
 var ver = process.versions.node;
 ver = ver.split('-')[0]; // explode and truncate tag from version #511
 
-var path = null;
+var dirPath = null;
 
 if (semver.satisfies(ver, '>=5.0.0')) {
-  path = '../lib/cli/index.js';
+  dirPath = '../lib';
 } else if (semver.satisfies(ver, '>=4.0.0')) {
-  path = '../lib-legacy/cli/index.js';
+  dirPath = '../lib-legacy';
 } else {
   console.log(require('chalk').red('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.'));
   process.exit(1);
@@ -27,7 +27,7 @@ if (semver.satisfies(ver, '>=5.7.0')) {
 
 // ensure cache directory exists
 var mkdirp = require('mkdirp');
-var constants = require('../lib-legacy/constants');
+var constants = require(dirPath + '/constants');
 mkdirp.sync(constants.MODULE_CACHE_DIRECTORY);
 
-module.exports = require(path);
+module.exports = require(dirPath + '/cli');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,34 +14,39 @@ const fs = require('fs');
 
 const babelRc = JSON.parse(fs.readFileSync(path.join(__dirname, '.babelrc'), 'utf8'));
 
-function build(lib, opts) {
-  return gulp.src('src/**/*')
-    .pipe(plumber({
-      errorHandler(err) {
-        gutil.log(err.stack);
-      },
-    }))
-    .pipe(newer(lib))
-    .pipe(gulpif(argv.sourcemaps, sourcemaps.init()))
-    .pipe(babel(opts))
-    .pipe(gulpif(argv.sourcemaps, sourcemaps.write('.')))
-    .pipe(gulp.dest(lib));
-}
+const build = (lib, opts) =>
+  gulp.src('src/**/*')
+      .pipe(plumber({
+        errorHandler(err) {
+          gutil.log(err.stack);
+        },
+      }))
+      .pipe(newer(lib))
+      .pipe(gulpif(argv.sourcemaps, sourcemaps.init()))
+      .pipe(babel(opts))
+      .pipe(gulpif(argv.sourcemaps, sourcemaps.write('.')))
+      .pipe(gulp.dest(lib));
 
 gulp.task('default', ['build']);
 
 gulp.task('build', ['build-modern', 'build-legacy']);
 
-gulp.task('build-modern', () => {
-  return build('lib', babelRc.env.node5);
-});
+gulp.task('build-modern', () =>
+  build('lib', babelRc.env.node5)
+);
 
-gulp.task('build-legacy', () => {
-  return build('lib-legacy', babelRc.env['pre-node5']);
-});
+gulp.task('build-legacy', () =>
+  build('lib-legacy', babelRc.env['pre-node5'])
+);
 
 gulp.task('watch', ['build'], () => {
   watch('src/**/*', () => {
     gulp.start('build');
+  });
+});
+
+gulp.task('watch-modern', ['build-modern'], () => {
+  watch('src/**/*', () => {
+    gulp.start('build-modern');
   });
 });


### PR DESCRIPTION
* Running `bin/yarn.js` failed if `lib-legacy` wasn't built. Most developers run node v4+ and don't need/want to build the legacy files while developing for yarn. This PR also adds a gulp command `watch-modern`.

* Requiring files from the `lib-legacy` directory in node v4+ environments resulted in loading some modules from disk twice, once from `lib-legacy` and once from `lib`.
For example, previously, `constants.js` was loaded from the `lib-legacy` directory when `require('../lib-legacy/constants')` was called and later again from the `lib` directory when `require(path)` was called. Any module that was required by `constants.js` directly or indirectly, were all loaded twice.
