### PR TITLE
Add scripts-prepend-node-path flag

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -66,6 +66,7 @@ commander.option('--no-progress', 'disable progress bar');
 commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
 commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
 commander.option('--non-interactive', 'do not show interactive prompts');
+commander.option('--scripts-prepend-node-path [bool]', 'prepend the node executable dir to the PATH in scripts');
 
 // get command name
 let commandName: string = args.shift() || 'install';
@@ -305,6 +306,8 @@ config
     networkConcurrency: commander.networkConcurrency,
     networkTimeout: commander.networkTimeout,
     nonInteractive: commander.nonInteractive,
+    scriptsPrependNodePath: commander.scriptsPrependNodePath,
+
     commandName: commandName === 'run' ? commander.args[0] : commandName,
   })
   .then(() => {

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,7 @@ export type ConfigOptions = {
   childConcurrency?: number,
   networkTimeout?: number,
   nonInteractive?: boolean,
+  scriptsPrependNodePath?: boolean,
 
   // Loosely compare semver for invalid cases like "0.01.0"
   looseSemver?: ?boolean,

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -150,6 +150,10 @@ export async function executeLifecycleScript(
 
   await checkForGypIfNeeded(config, cmd, pathParts);
 
+  if (config.scriptsPrependNodePath) {
+    pathParts.unshift(path.join(path.dirname(process.execPath)));
+  }
+
   // join path back together
   env[constants.ENV_PATH_KEY] = pathParts.join(path.delimiter);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

We package up the `node` interpreter and `yarn` into a distributable application and obscure the fact that we use `node` under the hood.  This leads to problems when trying to build binary packages because `node` is not in the path which causes `node-gyp` to fail.

Previously we were using npm and when we switched from 3 to 4 we had to add `--scripts-prepend-node-path=true` in order to have `node` added to the `PATH` variable.  We could not find a suitable flag for yarn so we hack in `node` into the `PATH` before utilizing `yarn`, but it would be nice if this were available as part of `yarn` itself.

Could you review this PR and let me know what changes are necessary.  One thing I would like feedback on is that the [npm config](https://docs.npmjs.com/misc/config) takes a Type: Boolean, "auto" or "warn-only" which I am not sure how that would it in the `yarn` config code.  Let me know if I should pass through a string instead of bool so I can handle `auto` & `warn-only` cases, or if I should just handle boolean.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I was planning on writing tests for my changes to `execute-lifecycle-script.js` but could not find a suitable place to do so, where would you recommend me adding tests?  I did test by hand and here are the results of my tests follow.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
-> % ~/src/github.com/ransombriggs/yarn/bin/yarn --scripts-prepend-node-path=false
yarn install v0.26.0-0
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
[1/1] ⠂ snappy
error /Users/rbriggs/src/github.com/heroku/heroku-kafka-jsplugin/node_modules/snappy: Command failed.
Exit code: 127
Command: sh
Arguments: -c ./node_modules/.bin/node-gyp rebuild
Directory: /Users/rbriggs/src/github.com/heroku/heroku-kafka-jsplugin/node_modules/snappy
Output:
env: node: No such file or directory
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
-> % ~/src/github.com/ransombriggs/yarn/bin/yarn --scripts-prepend-node-path=true 
yarn install v0.26.0-0
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 2.14s.
```