### PR TITLE
Allow tildes (~) in any path as a placeholder for the home directory

### DIFF
--- a/__tests__/util/fs.js
+++ b/__tests__/util/fs.js
@@ -1,6 +1,10 @@
 /* @flow */
 
-import {fileDatesEqual} from '../../src/util/fs.js';
+jest.mock('../../src/util/user-home-dir.js', () => ({
+  default: '/home/foo',
+}));
+
+import {fileDatesEqual, expandPath} from '../../src/util/fs.js';
 
 describe('fileDatesEqual', () => {
   const realPlatform = process.platform;
@@ -24,7 +28,15 @@ describe('fileDatesEqual', () => {
       expect(fileDatesEqual(new Date(1491393700834), new Date(1491393798834))).toBeFalsy();
       expect(fileDatesEqual(new Date(1491393798000), new Date(1491393798835))).toBeFalsy();
     });
+
+    test('Paths get expanded', () => {
+      expect(expandPath('~/bar/baz/q')).toEqual('/home/foo/bar/baz/q');
+      expect(expandPath('  ~/bar/baz')).toEqual('/home/foo/bar/baz');
+      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
+      expect(expandPath('~/~/bar/baz')).toEqual('/home/foo/~/bar/baz');
+    });
   });
+
   describe('win32', () => {
     beforeAll(() => {
       process.platform = 'win32';
@@ -47,6 +59,13 @@ describe('fileDatesEqual', () => {
     test('Milliseconds are ignored when one date has zero milliseconds', () => {
       expect(fileDatesEqual(new Date(1491393798000), new Date(1491393798835))).toBeTruthy();
       expect(fileDatesEqual(new Date(1491393798834), new Date(1491393798000))).toBeTruthy();
+    });
+
+    test('Paths never get expanded', () => {
+      expect(expandPath('~/bar/baz/q')).toEqual('~/bar/baz/q');
+      expect(expandPath('  ~/bar/baz')).toEqual('  ~/bar/baz');
+      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
+      expect(expandPath('~/~/bar/baz')).toEqual('~/~/bar/baz');
     });
   });
 });

--- a/__tests__/util/fs.js
+++ b/__tests__/util/fs.js
@@ -1,10 +1,6 @@
 /* @flow */
 
-jest.mock('../../src/util/user-home-dir.js', () => ({
-  default: '/home/foo',
-}));
-
-import {fileDatesEqual, expandPath} from '../../src/util/fs.js';
+import {fileDatesEqual} from '../../src/util/fs.js';
 
 describe('fileDatesEqual', () => {
   const realPlatform = process.platform;
@@ -27,13 +23,6 @@ describe('fileDatesEqual', () => {
       expect(fileDatesEqual(new Date(1491393798834), new Date(1491393798835))).toBeFalsy();
       expect(fileDatesEqual(new Date(1491393700834), new Date(1491393798834))).toBeFalsy();
       expect(fileDatesEqual(new Date(1491393798000), new Date(1491393798835))).toBeFalsy();
-    });
-
-    test('Paths get expanded', () => {
-      expect(expandPath('~/bar/baz/q')).toEqual('/home/foo/bar/baz/q');
-      expect(expandPath('  ~/bar/baz')).toEqual('/home/foo/bar/baz');
-      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
-      expect(expandPath('~/~/bar/baz')).toEqual('/home/foo/~/bar/baz');
     });
   });
 
@@ -59,13 +48,6 @@ describe('fileDatesEqual', () => {
     test('Milliseconds are ignored when one date has zero milliseconds', () => {
       expect(fileDatesEqual(new Date(1491393798000), new Date(1491393798835))).toBeTruthy();
       expect(fileDatesEqual(new Date(1491393798834), new Date(1491393798000))).toBeTruthy();
-    });
-
-    test('Paths never get expanded', () => {
-      expect(expandPath('~/bar/baz/q')).toEqual('~/bar/baz/q');
-      expect(expandPath('  ~/bar/baz')).toEqual('  ~/bar/baz');
-      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
-      expect(expandPath('~/~/bar/baz')).toEqual('~/~/bar/baz');
     });
   });
 });

--- a/__tests__/util/path.js
+++ b/__tests__/util/path.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+jest.mock('../../src/util/user-home-dir.js', () => ({
+  default: '/home/foo',
+}));
+
+import {expandPath} from '../../src/util/path.js';
+
+describe('fileDatesEqual', () => {
+  const realPlatform = process.platform;
+
+  describe('!win32', () => {
+    beforeAll(() => {
+      process.platform = 'notWin32';
+    });
+
+    afterAll(() => {
+      process.platform = realPlatform;
+    });
+
+    test('Paths get expanded', () => {
+      expect(expandPath('~/bar/baz/q')).toEqual('/home/foo/bar/baz/q');
+      expect(expandPath('  ~/bar/baz')).toEqual('/home/foo/bar/baz');
+      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
+      expect(expandPath('~/~/bar/baz')).toEqual('/home/foo/~/bar/baz');
+    });
+  });
+
+  describe('win32', () => {
+    beforeAll(() => {
+      process.platform = 'win32';
+    });
+
+    afterAll(() => {
+      process.platform = realPlatform;
+    });
+
+    test('Paths never get expanded', () => {
+      expect(expandPath('~/bar/baz/q')).toEqual('~/bar/baz/q');
+      expect(expandPath('  ~/bar/baz')).toEqual('  ~/bar/baz');
+      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
+      expect(expandPath('~/~/bar/baz')).toEqual('~/~/bar/baz');
+    });
+  });
+});

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -9,8 +9,7 @@ import {MessageError} from '../../errors.js';
 
 const zlib = require('zlib');
 const path = require('path');
-const tar = require('tar-fs');
-const fs2 = require('fs');
+const tarFs = require('tar-fs');
 
 const IGNORE_FILENAMES = ['.yarnignore', '.npmignore', '.gitignore'];
 
@@ -111,11 +110,11 @@ export async function pack(config: Config, dir: string): Promise<stream$Duplex> 
   // apply filters
   sortFilter(files, filters, keepFiles, possibleKeepFiles, ignoredFiles);
 
-  const packer = tar.pack(config.cwd, {
+  const packer = tarFs.pack(fs.expandPath(config.cwd), {
     ignore: name => {
       const relative = path.relative(config.cwd, name);
       // Don't ignore directories, since we need to recurse inside them to check for unignored files.
-      if (fs2.lstatSync(name).isDirectory()) {
+      if (fs.lstatSync(name).isDirectory()) {
         const isParentOfKeptFile = Array.from(keepFiles).some(name => !path.relative(relative, name).startsWith('..'));
         return !isParentOfKeptFile;
       }
@@ -159,7 +158,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const stream = await pack(config, config.cwd);
 
   await new Promise((resolve, reject) => {
-    stream.pipe(fs2.createWriteStream(filename));
+    stream.pipe(fs.createWriteStream(filename));
     stream.on('error', reject);
     stream.on('close', resolve);
   });

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -4,6 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import type {IgnoreFilter} from '../../util/filter.js';
 import * as fs from '../../util/fs.js';
+import {expandPath} from '../../util/path.js';
 import {sortFilter, ignoreLinesToRegex} from '../../util/filter.js';
 import {MessageError} from '../../errors.js';
 
@@ -110,7 +111,7 @@ export async function pack(config: Config, dir: string): Promise<stream$Duplex> 
   // apply filters
   sortFilter(files, filters, keepFiles, possibleKeepFiles, ignoredFiles);
 
-  const packer = tarFs.pack(fs.expandPath(config.cwd), {
+  const packer = tarFs.pack(expandPath(config.cwd), {
     ignore: name => {
       const relative = path.relative(config.cwd, name);
       // Don't ignore directories, since we need to recurse inside them to check for unignored files.

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -14,7 +14,6 @@ import {has2xxResponse} from '../../util/misc.js';
 const invariant = require('invariant');
 const crypto = require('crypto');
 const url = require('url');
-const fs2 = require('fs');
 
 export function setFlags(commander: Object) {
   versionSetFlags(commander);
@@ -40,7 +39,7 @@ async function publish(config: Config, pkg: any, flags: Object, dir: string): Pr
   if (stat.isDirectory()) {
     stream = await pack(config, dir);
   } else if (stat.isFile()) {
-    stream = fs2.createReadStream(dir);
+    stream = fs.createReadStream(dir);
   } else {
     throw new Error("Don't know how to handle this file type");
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -4,6 +4,7 @@ import {ConsoleReporter, JSONReporter} from '../reporters/index.js';
 import {registries, registryNames} from '../registries/index.js';
 import commands from './commands/index.js';
 import * as constants from '../constants.js';
+import * as fs from '../util/fs.js';
 import * as network from '../util/network.js';
 import {MessageError} from '../errors.js';
 import Config from '../config.js';
@@ -11,7 +12,6 @@ import {getRcArgs} from '../rc.js';
 import {version} from '../util/yarn-version.js';
 
 const commander = require('commander');
-const fs = require('fs');
 const invariant = require('invariant');
 const lockfile = require('proper-lockfile');
 const loudRejection = require('loud-rejection');

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import {SecurityError, MessageError} from '../errors.js';
+import {expandPath} from '../util/path.js';
 import type {FetchedOverride} from '../types.js';
 import BaseFetcher from './base-fetcher.js';
 import Git from '../util/git.js';
@@ -77,7 +78,7 @@ export default class GitFetcher extends BaseFetcher {
     }
 
     return new Promise((resolve, reject) => {
-      const untarStream = tarFs.extract(fs.expandPath(this.dest), {
+      const untarStream = tarFs.extract(expandPath(this.dest), {
         dmode: 0o555, // all dirs should be readable
         fmode: 0o444, // all files should be readable
         chown: false, // don't chown. just leave as it is

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -4,14 +4,13 @@ import {SecurityError, MessageError} from '../errors.js';
 import type {FetchedOverride} from '../types.js';
 import BaseFetcher from './base-fetcher.js';
 import Git from '../util/git.js';
-import * as fsUtil from '../util/fs.js';
+import * as fs from '../util/fs.js';
 import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
 
 const tarFs = require('tar-fs');
 const url = require('url');
 const path = require('path');
-const fs = require('fs');
 
 const invariant = require('invariant');
 
@@ -24,15 +23,15 @@ export default class GitFetcher extends BaseFetcher {
     const tarballModernMirrorPath = this.getTarballMirrorPath();
     const tarballCachePath = this.getTarballCachePath();
 
-    if (tarballLegacyMirrorPath != null && (await fsUtil.exists(tarballLegacyMirrorPath))) {
+    if (tarballLegacyMirrorPath != null && (await fs.exists(tarballLegacyMirrorPath))) {
       return true;
     }
 
-    if (tarballModernMirrorPath != null && (await fsUtil.exists(tarballModernMirrorPath))) {
+    if (tarballModernMirrorPath != null && (await fs.exists(tarballModernMirrorPath))) {
       return true;
     }
 
-    if (await fsUtil.exists(tarballCachePath)) {
+    if (await fs.exists(tarballCachePath)) {
       return true;
     }
 
@@ -65,20 +64,20 @@ export default class GitFetcher extends BaseFetcher {
     const tarballCachePath = this.getTarballCachePath();
 
     const tarballMirrorPath = tarballModernMirrorPath &&
-      !await fsUtil.exists(tarballModernMirrorPath) &&
+      !await fs.exists(tarballModernMirrorPath) &&
       tarballLegacyMirrorPath &&
-      (await fsUtil.exists(tarballLegacyMirrorPath))
+      (await fs.exists(tarballLegacyMirrorPath))
       ? tarballLegacyMirrorPath
       : tarballModernMirrorPath;
 
     const tarballPath = override || tarballMirrorPath || tarballCachePath;
 
-    if (!tarballPath || !await fsUtil.exists(tarballPath)) {
+    if (!tarballPath || !await fs.exists(tarballPath)) {
       throw new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarballPath));
     }
 
     return new Promise((resolve, reject) => {
-      const untarStream = tarFs.extract(this.dest, {
+      const untarStream = tarFs.extract(fs.expandPath(this.dest), {
         dmode: 0o555, // all dirs should be readable
         fmode: 0o444, // all files should be readable
         chown: false, // don't chown. just leave as it is

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -2,6 +2,7 @@
 
 import http from 'http';
 import {SecurityError, MessageError} from '../errors.js';
+import {expandPath} from '../util/path.js';
 import type {FetchedOverride} from '../types.js';
 import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
@@ -75,7 +76,7 @@ export default class TarballFetcher extends BaseFetcher {
   } {
     const validateStream = new crypto.HashStream();
     const extractorStream = gunzip();
-    const untarStream = tarFs.extract(fs.expandPath(this.dest), {
+    const untarStream = tarFs.extract(expandPath(this.dest), {
       strip: 1,
       dmode: 0o555, // all dirs should be readable
       fmode: 0o444, // all files should be readable

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -5,13 +5,12 @@ import {SecurityError, MessageError} from '../errors.js';
 import type {FetchedOverride} from '../types.js';
 import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
+import * as fs from '../util/fs.js';
 import BaseFetcher from './base-fetcher.js';
-import * as fsUtil from '../util/fs.js';
 
 const path = require('path');
 const tarFs = require('tar-fs');
 const url = require('url');
-const fs = require('fs');
 const stream = require('stream');
 const gunzip = require('gunzip-maybe');
 
@@ -24,9 +23,9 @@ export default class TarballFetcher extends BaseFetcher {
       return;
     }
 
-    if (!await fsUtil.exists(tarballMirrorPath) && (await fsUtil.exists(tarballCachePath))) {
+    if (!await fs.exists(tarballMirrorPath) && (await fs.exists(tarballCachePath))) {
       // The tarball doesn't exists in the offline cache but does in the cache; we import it to the mirror
-      await fsUtil.copy(tarballCachePath, tarballMirrorPath, this.reporter);
+      await fs.copy(tarballCachePath, tarballMirrorPath, this.reporter);
     }
   }
 
@@ -34,11 +33,11 @@ export default class TarballFetcher extends BaseFetcher {
     const tarballMirrorPath = this.getTarballMirrorPath();
     const tarballCachePath = this.getTarballCachePath();
 
-    if (tarballMirrorPath != null && (await fsUtil.exists(tarballMirrorPath))) {
+    if (tarballMirrorPath != null && (await fs.exists(tarballMirrorPath))) {
       return true;
     }
 
-    if (await fsUtil.exists(tarballCachePath)) {
+    if (await fs.exists(tarballCachePath)) {
       return true;
     }
 
@@ -76,7 +75,7 @@ export default class TarballFetcher extends BaseFetcher {
   } {
     const validateStream = new crypto.HashStream();
     const extractorStream = gunzip();
-    const untarStream = tarFs.extract(this.dest, {
+    const untarStream = tarFs.extract(fs.expandPath(this.dest), {
       strip: 1,
       dmode: 0o555, // all dirs should be readable
       fmode: 0o444, // all files should be readable
@@ -114,7 +113,7 @@ export default class TarballFetcher extends BaseFetcher {
 
     const tarballPath = path.resolve(this.config.cwd, override || tarballMirrorPath || tarballCachePath);
 
-    if (!tarballPath || !await fsUtil.exists(tarballPath)) {
+    if (!tarballPath || !await fs.exists(tarballPath)) {
       throw new MessageError(this.config.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarballPath));
     }
 

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -73,7 +73,7 @@ export default class PackageResolver {
 
   // list of packages need to be resolved later (they found a matching version in the
   // resolver, but better matches can still arrive later in the resolve process)
-  delayedResolveQueue: Array<{ req: PackageRequest, info: Manifest }>;
+  delayedResolveQueue: Array<{req: PackageRequest, info: Manifest}>;
 
   /**
    * TODO description

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const globModule = require('glob');
 const os = require('os');
 const path = require('path');
+const expandPath = require('./path').expandPath;
 
 export const lockQueue = new BlockingQueue('fs lock');
 
@@ -820,14 +821,6 @@ export async function makeTempDir(prefix?: string): Promise<string> {
   await unlink(dir);
   await mkdirp(dir);
   return dir;
-}
-
-export function expandPath(path: string): string {
-  if (process.platform !== 'win32') {
-    path = path.replace(/^\s*~(?=$|\/|\\)/, userHome);
-  }
-
-  return path;
 }
 
 function expandPathArg(method: Function): any {

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -4,6 +4,7 @@ import type Config from '../config.js';
 import type {Reporter} from '../reporters/index.js';
 import {MessageError, SecurityError} from '../errors.js';
 import {removeSuffix} from './misc.js';
+import {expandPath} from './path.js';
 import * as crypto from './crypto.js';
 import * as child from './child.js';
 import * as fs from './fs.js';
@@ -45,7 +46,7 @@ export default class Git {
     this.hash = hash;
     this.ref = hash;
     this.gitUrl = gitUrl;
-    this.cwd = fs.expandPath(this.config.getTemp(crypto.hash(this.gitUrl.repository)));
+    this.cwd = expandPath(this.config.getTemp(crypto.hash(this.gitUrl.repository)));
   }
 
   supportsArchive: boolean;
@@ -239,7 +240,7 @@ export default class Git {
   async _cloneViaRemoteArchive(dest: string): Promise<void> {
     await child.spawn('git', ['archive', `--remote=${this.gitUrl.repository}`, this.ref], {
       process(proc, update, reject, done) {
-        const extractor = tarFs.extract(fs.expandPath(dest), {
+        const extractor = tarFs.extract(expandPath(dest), {
           dmode: 0o555, // all dirs should be readable
           fmode: 0o444, // all files should be readable
         });
@@ -256,7 +257,7 @@ export default class Git {
     await child.spawn('git', ['archive', this.hash], {
       cwd: this.cwd,
       process(proc, resolve, reject, done) {
-        const extractor = tarFs.extract(fs.expandPath(dest), {
+        const extractor = tarFs.extract(expandPath(dest), {
           dmode: 0o555, // all dirs should be readable
           fmode: 0o444, // all files should be readable
         });

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -45,7 +45,7 @@ export default class Git {
     this.hash = hash;
     this.ref = hash;
     this.gitUrl = gitUrl;
-    this.cwd = this.config.getTemp(crypto.hash(this.gitUrl.repository));
+    this.cwd = fs.expandPath(this.config.getTemp(crypto.hash(this.gitUrl.repository)));
   }
 
   supportsArchive: boolean;
@@ -239,7 +239,7 @@ export default class Git {
   async _cloneViaRemoteArchive(dest: string): Promise<void> {
     await child.spawn('git', ['archive', `--remote=${this.gitUrl.repository}`, this.ref], {
       process(proc, update, reject, done) {
-        const extractor = tarFs.extract(dest, {
+        const extractor = tarFs.extract(fs.expandPath(dest), {
           dmode: 0o555, // all dirs should be readable
           fmode: 0o444, // all files should be readable
         });
@@ -256,7 +256,7 @@ export default class Git {
     await child.spawn('git', ['archive', this.hash], {
       cwd: this.cwd,
       process(proc, resolve, reject, done) {
-        const extractor = tarFs.extract(dest, {
+        const extractor = tarFs.extract(fs.expandPath(dest), {
           dmode: 0o555, // all dirs should be readable
           fmode: 0o444, // all files should be readable
         });

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+const userHome = require('./user-home-dir').default;
+
+export function expandPath(path: string): string {
+  if (process.platform !== 'win32') {
+    path = path.replace(/^\s*~(?=$|\/|\\)/, userHome);
+  }
+
+  return path;
+}

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -4,6 +4,7 @@ import type {Reporter} from '../reporters/index.js';
 import {MessageError} from '../errors.js';
 import BlockingQueue from './blocking-queue.js';
 import * as constants from '../constants.js';
+import * as fs from '../util/fs.js';
 import * as network from './network.js';
 import map from '../util/map.js';
 
@@ -13,7 +14,6 @@ import type RequestT from 'request';
 const RequestCaptureHar = require('request-capture-har');
 const invariant = require('invariant');
 const url = require('url');
-const fs = require('fs');
 
 const successHosts = map();
 const controlOffline = network.isOffline();


### PR DESCRIPTION
**Summary**

Tildes (`~`) were not correctly processed by Yarn when setting up the cache directory. Instead of expanding it to the home folder, it was creating a folder called `~` on the current directory where the command was executed.

The fix included proxying all `fs` calls through our custom module (`src/util/fs.js`), and expand each and every path we get through it. In places where this was not possible (e.g. external modules which accept paths, like `tar-fs`, an extra method called `fs.expandPath` is used just before calling them. Path expansion does not happen on Windows platforms.

Overridding the native `fs` module seemed way too risky and could lead to confusion.

**Test plan**

* Change your cache folder to point to something that includes the tilde; for example `~/foo`. Be sure to quote this, otherwise, your shell will automatically expand it.
* Open your `.yarnrc` to make sure path was correctly changed.
* Install any package, or perform any `yarn install` over an existing package.
* You should not see any folder called `~` on your current directory. Instead, you should have a new `foo` folder on your home directory, which contains all cached artifacts.