### PR TITLE
Allow to clean named package from cache

### DIFF
--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -70,3 +70,23 @@ test('clean', async (): Promise<void> => {
     expect(files.length).toEqual(0);
   });
 });
+
+test('clean with package name', async (): Promise<void> => {
+  await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
+    let files = await fs.readdir(config.cacheFolder);
+    expect(files.length).toEqual(3);
+
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+
+    await run(config, reporter, {}, ['clean', 'unknownname']);
+    expect(await fs.exists(config.cacheFolder)).toBeTruthy();
+    files = await fs.readdir(config.cacheFolder);
+    expect(files.length).toEqual(3); // Nothing deleted
+
+    await run(config, reporter, {}, ['clean', 'dummy']);
+    expect(await fs.exists(config.cacheFolder)).toBeTruthy();
+    files = await fs.readdir(config.cacheFolder);
+    expect(files.length).toEqual(1); // Only .tmp folder left
+  });
+});

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -50,14 +50,60 @@ export const {run, setFlags, examples} = buildSubCommands('cache', {
   },
 
   async clean(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    async function getPackageCachefolders(
+      packageName,
+      parentDir = config.cacheFolder,
+      metadataFile = METADATA_FILENAME,
+    ): Promise<Array<string>> {
+      const folders = await fs.readdir(parentDir);
+      const packageFolders = [];
+
+      for (const folder of folders) {
+        if (folder[0] === '.') {
+          continue;
+        }
+
+        const loc = path.join(config.cacheFolder, parentDir.replace(config.cacheFolder, ''), folder);
+        // Check if this is a scoped package
+        if (!await fs.exists(path.join(loc, metadataFile))) {
+          // If so, recurrently read scoped packages metadata
+          packageFolders.push(...(await getPackageCachefolders(packageName, loc)));
+        } else {
+          const {package: manifest} = await config.readPackageMetadata(loc);
+          if (packageName === manifest.name) {
+            packageFolders.push(loc);
+          }
+        }
+      }
+
+      return packageFolders;
+    }
+
     if (config.cacheFolder) {
       const activity = reporter.activity();
 
-      await fs.unlink(config._cacheRootFolder);
-      await fs.mkdirp(config.cacheFolder);
+      if (args.length > 0) {
+        // Clear named package from cache
+        const folders = await getPackageCachefolders(args[0]);
 
-      activity.end();
-      reporter.success(reporter.lang('clearedCache'));
+        if (folders.length === 0) {
+          activity.end();
+          reporter.warn(reporter.lang('couldntClearPackageFromCache', args[0]));
+          return;
+        }
+
+        for (const folder of folders) {
+          await fs.unlink(folder);
+        }
+        activity.end();
+        reporter.success(reporter.lang('clearedPackageFromCache', args[0]));
+      } else {
+        // Clear all cache
+        await fs.unlink(config._cacheRootFolder);
+        await fs.mkdirp(config.cacheFolder);
+        activity.end();
+        reporter.success(reporter.lang('clearedCache'));
+      }
     }
   },
 });

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -19,6 +19,8 @@ const messages = {
   waitingInstance: 'Waiting for the other yarn instance to finish',
   offlineRetrying: 'There appears to be trouble with your network connection. Retrying...',
   clearedCache: 'Cleared cache.',
+  couldntClearPackageFromCache: "Couldn't clear package $0 from cache",
+  clearedPackageFromCache: 'Cleared package $0 from cache',
   packWroteTarball: 'Wrote tarball to $0.',
 
   manifestPotentialTypo: 'Potential typo $0, did you mean $1?',


### PR DESCRIPTION
**Summary**

This minor feature is described in #3324 . It introduce an optional argument to existing `yarn cache clean` command.

The usage become : `yarn cache clean [package_name]`

For example, `yarn cache clean yargs` will remove all versions of `yargs` from cache (_if exists in cache folder, otherwise will display a warning message_)

**Motivations**

Default behaviour is to clean all the cache. But for some reasons, you may need to only clean a single package from cache.

**Test plan**

I added a test in `__tests__/commands/cache.js`.
