### PR TITLE
Fix GitFetcher.fetchFromLocal using wrong hash

### DIFF
--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -92,13 +92,15 @@ export default class GitFetcher extends BaseFetcher {
         .pipe(untarStream)
         .on('finish', () => {
           const expectHash = this.hash;
+          invariant(expectHash, 'Commit hash required');
+
           const actualHash = hashStream.getHash();
 
           // This condition is disabled because "expectHash" actually is the commit hash
           // This is a design issue that we'll need to fix (https://github.com/yarnpkg/yarn/pull/3449)
           if (true || !expectHash || expectHash === actualHash) {
             resolve({
-              hash: actualHash,
+              hash: expectHash,
             });
           } else {
             reject(new SecurityError(this.reporter.lang('fetchBadHash', expectHash, actualHash)));


### PR DESCRIPTION
Found on 0.25.3

Following up #3449

expectHash is used beforehand to generate the cache destination, but actualHash is returned. This causes future cache destination path generation to use the wrong hash, resulting in EOENT errors.

@bestander 

Full story:

PackageFetcher generates `dest` parameter using Config.generateHardModulePath before fetching using expectHash i.e. the commit hash

GitFetcher returns actualHash (i.e. tarball hash) as result of fetch

Some time later updateManifest is called with the fetch result hash (actualHash)

This pollutes the resolved patterns cache (PackageResolver.patterns) with the wrong hash (actualHash)

Future Config.generateHardModulePath calls getResolvedPattern and gets actualHash, (as opposed to expectHash. This causes it to look for the cached package in the wrong directory.