### PR TITLE
Allow tilde to be used in config paths, expanding it to $HOME

### DIFF
--- a/__tests__/util/path.js
+++ b/__tests__/util/path.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+jest.mock('../../src/util/user-home-dir.js', () => ({
+  default: '/home/foo',
+}));
+
+import {expandPath} from '../../src/util/path.js';
+
+describe('fileDatesEqual', () => {
+  const realPlatform = process.platform;
+
+  describe('!win32', () => {
+    beforeAll(() => {
+      process.platform = 'notWin32';
+    });
+
+    afterAll(() => {
+      process.platform = realPlatform;
+    });
+
+    test('Paths get expanded', () => {
+      expect(expandPath('~/bar/baz/q')).toEqual('/home/foo/bar/baz/q');
+      expect(expandPath('  ~/bar/baz')).toEqual('/home/foo/bar/baz');
+      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
+      expect(expandPath('~/~/bar/baz')).toEqual('/home/foo/~/bar/baz');
+    });
+  });
+
+  describe('win32', () => {
+    beforeAll(() => {
+      process.platform = 'win32';
+    });
+
+    afterAll(() => {
+      process.platform = realPlatform;
+    });
+
+    test('Paths never get expanded', () => {
+      expect(expandPath('~/bar/baz/q')).toEqual('~/bar/baz/q');
+      expect(expandPath('  ~/bar/baz')).toEqual('  ~/bar/baz');
+      expect(expandPath('./~/bar/baz')).toEqual('./~/bar/baz');
+      expect(expandPath('~/~/bar/baz')).toEqual('~/~/bar/baz');
+    });
+  });
+});

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -26,7 +26,7 @@ export const {run, setFlags, examples} = buildSubCommands('config', {
       return false;
     }
 
-    reporter.log(String(config.getOption(args[0])));
+    reporter.log(String(config.getOption(args[0], false)));
     return true;
   },
 

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ import type {Reporter} from './reporters/index.js';
 import type {Manifest, PackageRemote} from './types.js';
 import type PackageReference from './package-reference.js';
 import {execFromManifest} from './util/execute-lifecycle-script.js';
+import {expandPath} from './util/path.js';
 import normalizeManifest from './util/normalize-manifest/index.js';
 import {MessageError} from './errors.js';
 import * as fs from './util/fs.js';
@@ -180,8 +181,14 @@ export default class Config {
    * Get a config option from our yarn config.
    */
 
-  getOption(key: string): mixed {
-    return this.registries.yarn.getOption(key);
+  getOption(key: string, expand: boolean = true): mixed {
+    const value = this.registries.yarn.getOption(key);
+
+    if (expand && (typeof value === 'string')) {
+      return expandPath(value);
+    }
+
+    return value;
   }
 
   /**

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+const userHome = require('./user-home-dir').default;
+
+export function expandPath(path: string): string {
+  if (process.platform !== 'win32') {
+    path = path.replace(/^\s*~(?=$|\/|\\)/, userHome);
+  }
+
+  return path;
+}


### PR DESCRIPTION
**Summary**

Tildes (`~`) were not correctly processed by Yarn when setting up the cache directory. Instead of expanding it to the home folder, it was creating a folder called `~` on the current directory where the command was executed.

The fix included proxying all `fs` calls through our custom module (`src/util/fs.js`), and expand each and every path we get through it. In places where this was not possible (e.g. external modules which accept paths, like `tar-fs`, an extra method called `fs.expandPath` is used just before calling them. Path expansion does not happen on Windows platforms.

Overridding the native `fs` module seemed way too risky and could lead to confusion.

**Test plan**

* Change your cache folder to point to something that includes the tilde; for example `~/foo`. Be sure to quote this, otherwise, your shell will automatically expand it.
* Open your `.yarnrc` to make sure path was correctly changed.
* Install any package, or perform any `yarn install` over an existing package.
* You should not see any folder called `~` on your current directory. Instead, you should have a new `foo` folder on your home directory, which contains all cached artifacts.