### PR TITLE
Give higher priority to .npmignore over .gitignore

### DIFF
--- a/__tests__/util/filter.js
+++ b/__tests__/util/filter.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {ignoreLinesToRegex} from '../../src/util/filter.js';
+import {ignoreLinesToRegex, filterOverridenGitignores} from '../../src/util/filter.js';
 
 test('ignoreLinesToRegex', () => {
   expect(
@@ -58,5 +58,28 @@ test('ignoreLinesToRegex', () => {
     {base: '.', isNegation: true, pattern: ' D #', regex: /^(?:D #)$/i},
     {base: '.', isNegation: true, pattern: ' E # ', regex: /^(?:E #)$/i},
     {base: '.', isNegation: true, pattern: ' F # # ', regex: /^(?:F # #)$/i},
+  ]);
+});
+
+test('filterOverridenGitignores', () => {
+  expect(
+    filterOverridenGitignores([
+      {relative: '.gitignore', basename: '.gitignore', absolute: '/home/user/p/.gitignore', mtime: 0},
+      {relative: '.npmignore', basename: '.npmignore', absolute: '/home/user/p/.npmignore', mtime: 0},
+      {relative: 'docs', basename: 'lib', absolute: '/home/user/p/docs', mtime: 0},
+      {relative: 'docs/file.txt', basename: 'file.txt', absolute: '/home/user/p/docs/file.txt', mtime: 0},
+      {relative: 'index.js', basename: 'index.js', absolute: '/home/user/p/index.js', mtime: 0},
+      {relative: 'lib', basename: 'lib', absolute: '/home/user/p/lib', mtime: 0},
+      {relative: 'lib/.gitignore', basename: '.gitignore', absolute: '/home/user/p/lib/.gitignore', mtime: 0},
+      {relative: 'lib/index.js', basename: 'index.js', absolute: '/home/user/p/lib/index.js', mtime: 0},
+      {relative: 'README.md', basename: 'README.md', absolute: '/home/user/p/README.md', mtime: 0},
+      {relative: 'src', basename: 'src', absolute: '/home/user/p/src', mtime: 0},
+      {relative: 'src/.yarnignore', basename: '.yarnignore', absolute: '/home/user/p/src/.yarnignore', mtime: 0},
+      {relative: 'src/app.js', basename: 'app.js', absolute: '/home/user/p/src/app.js', mtime: 0},
+    ]),
+  ).toEqual([
+    {relative: '.npmignore', basename: '.npmignore', absolute: '/home/user/p/.npmignore', mtime: 0},
+    {relative: 'lib/.gitignore', basename: '.gitignore', absolute: '/home/user/p/lib/.gitignore', mtime: 0},
+    {relative: 'src/.yarnignore', basename: '.yarnignore', absolute: '/home/user/p/src/.yarnignore', mtime: 0},
   ]);
 });

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -145,3 +145,22 @@ export function ignoreLinesToRegex(lines: Array<string>, base: string = '.'): Ar
       .filter(Boolean)
   );
 }
+
+export function filterOverridenGitignores(files: WalkFiles): WalkFiles {
+  const IGNORE_FILENAMES = ['.yarnignore', '.npmignore', '.gitignore'];
+  const GITIGNORE_NAME = IGNORE_FILENAMES[2];
+  return files.filter(file => IGNORE_FILENAMES.includes(file.basename)).reduce((acc: WalkFiles, file) => {
+    if (file.basename !== GITIGNORE_NAME) {
+      return [...acc, file];
+    } else {
+      //don't include .gitignore if .npmignore or .yarnignore are present
+      const dir = path.dirname(file.absolute);
+      const higherPriorityIgnoreFilePaths = [`${dir}/${IGNORE_FILENAMES[0]}`, `${dir}/${IGNORE_FILENAMES[1]}`];
+      const hasHigherPriorityFiles = files.find(file => higherPriorityIgnoreFilePaths.includes(file.absolute));
+      if (!hasHigherPriorityFiles) {
+        return [...acc, file];
+      }
+    }
+    return acc;
+  }, []);
+}


### PR DESCRIPTION
Here is a solution for #685. I found that the source of the problem is that yarn gives the same priority to `.npmignore` and `.gitignore` while npm does not. According to [npm's developer guide](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package):

> Use a .npmignore file to keep stuff out of your package. If there's no .npmignore file, but there is a .gitignore file, then npm will ignore the stuff matched by the .gitignore file. If you want to include something that is excluded by your .gitignore file, you can create an empty .npmignore file to override it. Like git, npm looks for .npmignore and .gitignore files in all subdirectories of your package, not only the root directory.

In this patch, If `.npmignore` or `.yarnignore` are present in a directory that also contains a `.gitignore`, don't take into account the `.gitignore` when running the `pack` command.

I created a new function `filterOverridenGitignores` in the the `util/filter.js` module that takes a `WalkFiles` object with all the potential package files and returns another `WalkFiles` object only with the relevant dot ignore files (`.npmignore`, `.yarnignore` or `.gitignore`), taking into account the priority rules. This new collection is the used by the `pack` command to create the ignore regexes. 

I have also added a unit test for this function. For a more thorough test just run the `pack` command on any project and compare the contents of the tarball.



