### PR TITLE
fs: do bulk file reads to optimize cache extraction

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -520,39 +520,32 @@ export async function copyBulk(
       }
 
       const cleanup = () => delete currentlyWriting[data.dest];
-      return (currentlyWriting[data.dest] = new Promise((resolve, reject) => {
-        const readStream = fs.createReadStream(data.src);
-        const writeStream = fs.createWriteStream(data.dest, {mode: data.mode});
-
-        reporter.verbose(reporter.lang('verboseFileCopy', data.src, data.dest));
-
-        readStream.on('error', reject);
-        writeStream.on('error', reject);
-
-        writeStream.on('open', function() {
-          readStream.pipe(writeStream);
-        });
-
-        writeStream.once('close', function() {
-          fs.utimes(data.dest, data.atime, data.mtime, function(err) {
-            if (err) {
-              reject(err);
-            } else {
-              events.onProgress(data.dest);
-              cleanup();
-              resolve();
-            }
-          });
-        });
-      })
-        .then(arg => {
-          cleanup();
-          return arg;
+      reporter.verbose(reporter.lang('verboseFileCopy', data.src, data.dest));
+      return (currentlyWriting[data.dest] = readFile(data.src)
+        .then(d => {
+          return writeFile(data.dest, d, {mode: data.mode});
         })
-        .catch(arg => {
-          cleanup();
-          throw arg;
-        }));
+        .then(() => {
+          return new Promise((resolve, reject) => {
+            fs.utimes(data.dest, data.atime, data.mtime, err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          });
+        })
+        .then(
+          () => {
+            events.onProgress(data.dest);
+            cleanup();
+          },
+          err => {
+            cleanup();
+            throw err;
+          },
+        ));
     },
     CONCURRENT_QUEUE_ITEMS,
   );

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -521,7 +521,7 @@ export async function copyBulk(
 
       const cleanup = () => delete currentlyWriting[data.dest];
       reporter.verbose(reporter.lang('verboseFileCopy', data.src, data.dest));
-      return (currentlyWriting[data.dest] = readFile(data.src)
+      return (currentlyWriting[data.dest] = readFileBuffer(data.src)
         .then(d => {
           return writeFile(data.dest, d, {mode: data.mode});
         })


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<img width="721" alt="screen shot 2017-05-30 at 13 54 18" src="https://cloud.githubusercontent.com/assets/17535/26604535/84674c50-453f-11e7-8a1f-39fda680d8a3.png">

This patch boosts cache extraction by ~2x+ by letting node
do more parallelization work. This makes nearly all of the file copy
stuff be done by the C++ code with minimal boundary-crossing (at least
compared to node streams).

Streams in node.js are ~3x slower, specially for small files,
than just doing fs.writeFile/readFile, because of this boundary. This
is something Yarn might want to take into account in other places.

The reason this is OK is because pretty much any files this would
handle would fit neatly into memory (any npm packages MUST fit
into memory by definition, because of the way npm@<5 does extracts).

If you really want to make doubleplus sure to minimize memory usage,
you could do an fs.stat to find the file size and then do heuristics
to only use streams for files bigger than <X>MB.

**Test plan**

I guess I should probably spend more time on making sure this passes the test suite, but it's a pretty benign patch, imo 👍 

