### PR TITLE
Auto detect and merge lockfile conflicts

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -35,7 +35,7 @@ export async function createLockfile(dir: string): Promise<Lockfile> {
 
   if (await fs.exists(lockfileLoc)) {
     const rawLockfile = await fs.readFile(lockfileLoc);
-    lockfile = parse(rawLockfile);
+    lockfile = parse(rawLockfile).object;
   }
 
   return new Lockfile(lockfile);

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -330,7 +330,7 @@ test.concurrent('add with offline mirror', (): Promise<void> => {
     ).toBeGreaterThanOrEqual(0);
 
     const rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
-    const lockfile = parse(rawLockfile);
+    const {object: lockfile} = parse(rawLockfile);
 
     expect(lockfile['is-array@^1.0.1']['resolved']).toEqual(
       'https://registry.yarnpkg.com/is-array/-/is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a',
@@ -393,7 +393,7 @@ test.concurrent('install with --save and without offline mirror', (): Promise<vo
     ).toEqual(-1);
 
     const rawLockfile = await fs.readFile(path.join(config.cwd, constants.LOCKFILE_FILENAME));
-    const lockfile = parse(rawLockfile);
+    const {object: lockfile} = parse(rawLockfile);
 
     expect(lockfile['is-array@^1.0.1']['resolved']).toMatch(
       /https:\/\/registry\.yarnpkg\.com\/is-array\/-\/is-array-1\.0\.1\.tgz#[a-f0-9]+/,

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -642,7 +642,7 @@ test.concurrent('offline mirror can be enabled from parent dir', (): Promise<voi
   };
   return runInstall({}, fixture, async (config, reporter) => {
     const rawLockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    const lockfile = parse(rawLockfile);
+    const {object: lockfile} = parse(rawLockfile);
     expect(lockfile['mime-types@2.1.14'].resolved).toEqual(
       'https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee',
     );
@@ -657,7 +657,7 @@ test.concurrent('offline mirror can be enabled from parent dir, with merging of 
   };
   return runInstall({}, fixture, async (config, reporter) => {
     const rawLockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    const lockfile = parse(rawLockfile);
+    const {object: lockfile} = parse(rawLockfile);
     expect(lockfile['mime-types@2.1.14'].resolved).toEqual(
       'https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee',
     );
@@ -672,7 +672,7 @@ test.concurrent('offline mirror can be disabled locally', (): Promise<void> => {
   };
   return runInstall({}, fixture, async (config, reporter) => {
     const rawLockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    const lockfile = parse(rawLockfile);
+    const {object: lockfile} = parse(rawLockfile);
     expect(lockfile['mime-types@2.1.14'].resolved).toEqual(
       'https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee',
     );

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -194,7 +194,7 @@ test('Lockfile.getLockfile (sorting)', () => {
   expect(actual).toEqual(expected);
 });
 
-test('parse merge conflicts', () => {
+test('parse single merge conflict', () => {
   const file = `
 a:
   no "yes"
@@ -219,6 +219,41 @@ d:
   expect(object.d.yes).toEqual('no');
 });
 
+test('parse multiple merge conflicts', () => {
+  const file = `
+a:
+  no "yes"
+
+<<<<<<< HEAD
+b:
+  foo "bar"
+=======
+c:
+  bar "foo"
+>>>>>>> branch-a
+
+d:
+  yes "no"
+
+<<<<<<< HEAD
+e:
+  foo "bar"
+=======
+f:
+  bar "foo"
+>>>>>>> branch-b
+`;
+
+  const {type, object} = parse(file);
+  expect(type).toEqual('merge');
+  expect(object.a.no).toEqual('yes');
+  expect(object.b.foo).toEqual('bar');
+  expect(object.c.bar).toEqual('foo');
+  expect(object.d.yes).toEqual('no');
+  expect(object.e.foo).toEqual('bar');
+  expect(object.f.bar).toEqual('foo');
+});
+
 test('parse merge conflict fail', () => {
   const file = `
 <<<<<<< HEAD
@@ -233,4 +268,25 @@ c:
   const {type, object} = parse(file);
   expect(type).toEqual('conflict');
   expect(Object.keys(object).length).toEqual(0);
+});
+
+test('discards common ancestors in merge conflicts', () => {
+  const file = `
+<<<<<<< HEAD
+b:
+  foo "bar"
+||||||| common ancestor
+d:
+  yes "no"
+=======
+c:
+  bar "foo"
+>>>>>>> branch-a
+`;
+
+  const {type, object} = parse(file);
+  expect(type).toEqual('merge');
+  expect(object.b.foo).toEqual('bar');
+  expect(object.c.bar).toEqual('foo');
+  expect(object.d).toBe(undefined);
 });

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -213,10 +213,12 @@ d:
 
   const {type, object} = parse(file);
   expect(type).toEqual('merge');
-  expect(object.a.no).toEqual('yes');
-  expect(object.b.foo).toEqual('bar');
-  expect(object.c.bar).toEqual('foo');
-  expect(object.d.yes).toEqual('no');
+  expect(object).toEqual({
+    a: {no: 'yes'},
+    b: {foo: 'bar'},
+    c: {bar: 'foo'},
+    d: {yes: 'no'},
+  });
 });
 
 test('parse multiple merge conflicts', () => {
@@ -246,12 +248,14 @@ f:
 
   const {type, object} = parse(file);
   expect(type).toEqual('merge');
-  expect(object.a.no).toEqual('yes');
-  expect(object.b.foo).toEqual('bar');
-  expect(object.c.bar).toEqual('foo');
-  expect(object.d.yes).toEqual('no');
-  expect(object.e.foo).toEqual('bar');
-  expect(object.f.bar).toEqual('foo');
+  expect(object).toEqual({
+    a: {no: 'yes'},
+    b: {foo: 'bar'},
+    c: {bar: 'foo'},
+    d: {yes: 'no'},
+    e: {foo: 'bar'},
+    f: {bar: 'foo'},
+  });
 });
 
 test('parse merge conflict fail', () => {
@@ -286,7 +290,9 @@ c:
 
   const {type, object} = parse(file);
   expect(type).toEqual('merge');
-  expect(object.b.foo).toEqual('bar');
-  expect(object.c.bar).toEqual('foo');
+  expect(object).toEqual({
+    b: {foo: 'bar'},
+    c: {bar: 'foo'},
+  });
   expect(object.d).toBe(undefined);
 });

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -314,9 +314,10 @@ export class Parser {
   }
 }
 
-const MERGE_CONFLICT_START = '<<<<<<<';
-const MERGE_CONFLICT_SEP = '=======';
+const MERGE_CONFLICT_ANCESTOR = '|||||||';
 const MERGE_CONFLICT_END = '>>>>>>>';
+const MERGE_CONFLICT_SEP = '=======';
+const MERGE_CONFLICT_START = '<<<<<<<';
 
 /**
  * Extract the two versions of the lockfile from a merge conflict.
@@ -325,6 +326,7 @@ const MERGE_CONFLICT_END = '>>>>>>>';
 export function extractConflictVariants(str: string): Array<string> {
   const variants: Array<Array<string>> = [[], []];
   const lines = str.split(/\n/g);
+  let skip = false;
 
   while (lines.length) {
     const line = lines.shift();
@@ -333,7 +335,11 @@ export function extractConflictVariants(str: string): Array<string> {
       while (lines.length) {
         const line = lines.shift();
         if (line === MERGE_CONFLICT_SEP) {
+          skip = false;
           break;
+        } else if (skip || line.startsWith(MERGE_CONFLICT_ANCESTOR)) {
+          skip = true;
+          continue;
         } else {
           variants[0].push(line);
         }

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -337,25 +337,25 @@ function extractConflictVariants(str: string): [string, string] {
     if (line.startsWith(MERGE_CONFLICT_START)) {
       // get the first variant
       while (lines.length) {
-        const line = lines.shift();
-        if (line === MERGE_CONFLICT_SEP) {
+        const conflictLine = lines.shift();
+        if (conflictLine === MERGE_CONFLICT_SEP) {
           skip = false;
           break;
-        } else if (skip || line.startsWith(MERGE_CONFLICT_ANCESTOR)) {
+        } else if (skip || conflictLine.startsWith(MERGE_CONFLICT_ANCESTOR)) {
           skip = true;
           continue;
         } else {
-          variants[0].push(line);
+          variants[0].push(conflictLine);
         }
       }
 
       // get the second variant
       while (lines.length) {
-        const line = lines.shift();
-        if (line.startsWith(MERGE_CONFLICT_END)) {
+        const conflictLine = lines.shift();
+        if (conflictLine.startsWith(MERGE_CONFLICT_END)) {
           break;
         } else {
-          variants[1].push(line);
+          variants[1].push(conflictLine);
         }
       }
     } else {
@@ -371,7 +371,7 @@ function extractConflictVariants(str: string): [string, string] {
  * Check if a lockfile has merge conflicts.
  */
 function hasMergeConflicts(str: string): boolean {
-  return str.includes(MERGE_CONFLICT_START);
+  return str.includes(MERGE_CONFLICT_START) && str.includes(MERGE_CONFLICT_SEP) && str.includes(MERGE_CONFLICT_END);
 }
 
 /**

--- a/src/lockfile/wrapper.js
+++ b/src/lockfile/wrapper.js
@@ -95,7 +95,17 @@ export default class Lockfile {
 
     if (await fs.exists(lockfileLoc)) {
       rawLockfile = await fs.readFile(lockfileLoc);
-      lockfile = parse(rawLockfile, lockfileLoc);
+      const lockResult = parse(rawLockfile, lockfileLoc);
+
+      if (reporter) {
+        if (lockResult.type === 'merge') {
+          reporter.info(reporter.lang('lockfileMerged'));
+        } else if (lockResult.type === 'conflict') {
+          reporter.warn(reporter.lang('lockfileConflict'));
+        }
+      }
+
+      lockfile = lockResult.object;
     } else {
       if (reporter) {
         reporter.info(reporter.lang('noLockfileFound'));

--- a/src/rc.js
+++ b/src/rc.js
@@ -12,7 +12,7 @@ let rcArgsCache;
 
 const buildRcConf = () =>
   rcUtil.findRc('yarn', (fileText, filePath) => {
-    const values = parse(fileText, 'yarnrc');
+    const {object: values} = parse(fileText, 'yarnrc');
     const keys = Object.keys(values);
 
     for (const key of keys) {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -12,7 +12,6 @@ import envReplace from '../util/env-replace.js';
 import Registry from './base-registry.js';
 import {addSuffix} from '../util/misc';
 import {getPosixPath, resolveWithHome} from '../util/path';
-import isRequestToRegistry from './is-request-to-registry.js';
 
 const userHome = require('../util/user-home-dir').default;
 const path = require('path');

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -72,7 +72,7 @@ export default class YarnRegistry extends NpmRegistry {
 
   async loadConfig(): Promise<void> {
     for (const [isHome, loc, file] of await this.getPossibleConfigLocations('.yarnrc', this.reporter)) {
-      const config = parse(file, loc);
+      const {object: config} = parse(file, loc);
 
       if (isHome) {
         this.homeConfig = config;

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -83,6 +83,9 @@ const messages = {
   shrinkwrapWarning:
     'npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.',
   lockfileOutdated: 'Outdated lockfile. Please run `yarn install` and try again.',
+  lockfileMerged: 'Merge conflict detected in yarn.lock and successfully merged.',
+  lockfileConflict:
+    'A merge conflict was found in yarn.lock but it could not be successfully merged, regenerating yarn.lock from scratch.',
   ignoredScripts: 'Ignored scripts due to flag.',
   missingAddDependencies: 'Missing list of packages to add to your project.',
   yesWarning:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Git merge conflicts are common with `yarn.lock`. This PR allows you to run `yarn` to automatically merge the two versions of `yarn.lock` which will run Yarn and regenerate a new lockfile.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Added tests.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
