### PR TITLE
Run install and pack when fetching git dependencies with a prepare script

### DIFF
--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -50,7 +50,10 @@ const NEVER_IGNORE = ignoreLinesToRegex([
   '!/+(changes|changelog|history)*',
 ]);
 
-export async function pack(config: Config, dir: string): Promise<stream$Duplex> {
+export async function packTarball(
+  config: Config,
+  {mapHeader}: {mapHeader?: Object => Object} = {},
+): Promise<stream$Duplex> {
   const pkg = await config.readRootManifest();
   const {bundledDependencies, main, files: onlyFiles} = pkg;
 
@@ -125,10 +128,15 @@ export async function pack(config: Config, dir: string): Promise<stream$Duplex> 
       header.name = `package${suffix}`;
       delete header.uid;
       delete header.gid;
-      return header;
+      return mapHeader ? mapHeader(header) : header;
     },
   });
 
+  return packer;
+}
+
+export async function pack(config: Config, dir: string): Promise<stream$Duplex> {
+  const packer = await packTarball(config);
   const compressor = packer.pipe(new zlib.Gzip());
 
   return compressor;

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ export type ConfigOptions = {
   ignoreEngines?: boolean,
   cafile?: ?string,
   production?: boolean,
+  disablePrepublish?: boolean,
   binLinks?: boolean,
   networkConcurrency?: number,
   childConcurrency?: number,
@@ -143,6 +144,8 @@ export default class Config {
   ignoreScripts: boolean;
 
   production: boolean;
+
+  disablePrepublish: boolean;
 
   nonInteractive: boolean;
 
@@ -327,6 +330,8 @@ export default class Config {
 
     this.ignorePlatform = !!opts.ignorePlatform;
     this.ignoreScripts = !!opts.ignoreScripts;
+
+    this.disablePrepublish = !!opts.disablePrepublish;
 
     this.nonInteractive = !!opts.nonInteractive;
 


### PR DESCRIPTION
Implement a new behaviour in `GitFetcher` to fix #2875 and match the new behaviour of npm 5 regarding git dependencies:
- If the git repository's package.json does not contain a _prepare_ script, no change of behaviour
- If the git repository's package.json contains a _prepare_ script:
  - clone the repository in a new temporary folder
  - run `install` command in that folder, excluding the _prepublish_ script
  - run `pack` command and use the content of the generated tarball as result of GitFetcher
  - remove the temporary folder

(@zkat please let me know if you think it differs from npm)

----
At the moment, I open the PR mostly for review and comments. The PR still lacks documentation of the new behaviour.

Some implementation details:
- There is a new boolean `config.gitDependency` to disable the _prepublish_ script
- The tarball generated if there is a prepare script uses the `pack` code. That means all the files are in a `package/` folder. If generated from `git archive`, there are no `package/` folder. To differentiate during the tarball extraction, when I generate a tarball from the `pack` command, I add a parameter in the header of the first file.
- The `tarballMirrorPath` filename does not have extension. The `tarballCachePath` filename has extension `tgz`, but the content does not seem gzipped. I did not change these points.
- The `git archive` may be run multiple times for one fetch. I replicated this behaviour, running the `pack` command multiple times. I did so to ensure a better error handling with minimal work. I think both cases can be optimised.

I added only one test. I'm thinking of improving it to ensure the _prepublish_ script is not run.
I'm not sure what other tests are worth adding, while staying in the scope of this PR. (I don't want to fix all git-fetcher issues here).
By the way, if yarn supports a "git+file://" protocol, that would be useful for testing.