### PR TITLE
Add legend colors 3454

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -88,6 +88,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   );
 
   try {
+    const red = reporter.format.red('<red>');
+    const yellow = reporter.format.yellow('<yellow>');   
+    reporter.info(reporter.lang('legendColorsForUpgradeInteractive', red, yellow));
+
     const answers: Array<Dependency> = await reporter.prompt('Choose which packages to update.', choices, {
       name: 'packages',
       type: 'checkbox',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -93,7 +93,7 @@ const messages = {
   jsonError: 'Error parsing JSON at $0, $1.',
   noFilePermission: "We don't have permissions to touch the file $0.",
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
-  legendColorsForUpgradeInteractive: 'Hello world',
+  legendColorsForUpgradeInteractive: 'Color legend : \n $0    : Patch Update Backward-compatible bug fixes \n $1 : Minor Update backward-compatibles features',
   frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
   fileWriteError: 'Could not write file $0: $1',
   multiplePackagesCantUnpackInSameDestination: 'Pattern $0 is trying to unpack in the same destination $1 as pattern $2. This could result in a non deterministic behavior, skipping.',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -93,6 +93,7 @@ const messages = {
   jsonError: 'Error parsing JSON at $0, $1.',
   noFilePermission: "We don't have permissions to touch the file $0.",
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
+  legendColorsForUpgradeInteractive: 'Hello world',
   frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
   fileWriteError: 'Could not write file $0: $1',
   multiplePackagesCantUnpackInSameDestination: 'Pattern $0 is trying to unpack in the same destination $1 as pattern $2. This could result in a non deterministic behavior, skipping.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
As mentionned in #3454, this PR explains the color legend when using the `upgrade-interactive` command. 
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
cd-charles@CDCHARLESW764 MINGW64 ~/Documents/workspace/angular2-test (master)
$ yarn upgrade-interactive
yarn upgrade-interactive v0.26.0-0
info Color legend :
 "<red>"    : Patch Update Backward-compatible bug fixes
 "<yellow>" : Minor Update backward-compatibles features
? Choose which packages to update. (Press <space> to select, <a> to toggle all, <i> to inverse selection)
```

