### PR TITLE
Interpolate env variables in config

### DIFF
--- a/__tests__/commands/config.js
+++ b/__tests__/commands/config.js
@@ -5,6 +5,7 @@ import * as reporters from '../../src/reporters/index.js';
 import * as configCmd from '../../src/cli/commands/config.js';
 import {run as buildRun} from './_helpers.js';
 import * as fs from '../../src/util/fs.js';
+import userHome from '../../src/util/user-home-dir';
 
 const path = require('path');
 
@@ -57,5 +58,11 @@ test('set value "false" to an option', (): Promise<void> => {
 test('set value "true" to an option', (): Promise<void> => {
   return runConfig(['set', 'strict-ssl', 'true'], {}, '', config => {
     expect(config.registries.yarn.homeConfig['strict-ssl']).toBe(true);
+  });
+});
+
+test('can interpolate ~ into user\'s local home path', (): Promise<void> => {
+  return runConfig(['set', 'cafile', '~/foo'], {}, '', config => {
+    expect(config.registries.yarn.getOption('cafile')).toBe(`${userHome}/foo`);
   });
 });

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -67,6 +67,10 @@ export default class YarnRegistry extends NpmRegistry {
       val = DEFAULTS[key];
     }
 
+    if (typeof val === 'string') {
+      val = val.replace(/^\~/, userHome);
+    }
+
     return val;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This is a bug fix/enhancements from issues reported in https://github.com/yarnpkg/yarn/issues/2877, https://github.com/yarnpkg/yarn/issues/2930, and others that rely on path configurations with home variable `~`.

<img width="233" alt="screen shot 2017-06-04 at 3 25 59 pm" src="https://cloud.githubusercontent.com/assets/18429494/26765879/271bea84-493a-11e7-9298-239d0c0c3347.png">

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test to config test file
