### PR TITLE
Fix: Send auth token only when forced or mutating (fixes #1952)

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -65,7 +65,11 @@ export default class NpmRegistry extends Registry {
       },
       opts.headers,
     );
-    if (this.token || (alwaysAuth && isRequestToRegistry(requestUrl, registry, customHostSuffix))) {
+
+    const useAuth =
+      (opts.method !== 'GET' && opts.method !== 'HEAD' && this.token) ||
+      (alwaysAuth && isRequestToRegistry(requestUrl, registry, customHostSuffix));
+    if (useAuth) {
       const authorization = this.getAuth(packageName || pathname);
       if (authorization) {
         headers.authorization = authorization;


### PR DESCRIPTION
**Summary**

Fixes #1952 

Currently, when `this.token` is set, the auth token is always sent,
even with read-only GET and HEAD requests. This seems to be causing
yarn registry to error out. This patch changes the behavior so the
token is only sent with mutating HTTP requests (such as `PUT`) or
when it is forced via `always-auth`.

**Test plan**

TBD. Currently there are no tests for registries and I'm not sure how to start testing them. Any input and direction regarding this would be much appreciated.