### PR TITLE
Remove .includes for node 4 compatibility

### DIFF
--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -347,7 +347,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         const rootDep = packagePath[0];
         const packageName = packagePath[1] || packageJson.name;
 
-        const bundledDep = bundledDeps[rootDep] && bundledDeps[rootDep].includes(packageName);
+        const bundledDep = bundledDeps[rootDep] && bundledDeps[rootDep].indexOf(packageName) !== -1;
         if (
           !bundledDep &&
           (packageJson.version === depPkg.version ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Bug fix. Remove use of `.includes` for node 4 compatibility.

**Test plan**

`yarn check` no longer fails.

Fixes https://github.com/yarnpkg/yarn/issues/3591