### PR TITLE
Use `.every` instead of `.filter().length === 0` pattern

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -662,13 +662,11 @@ export class Install {
       this.scripts.getArtifacts(),
     );
 
-    const lockFileHasAllPatterns = patterns.filter(p => !this.lockfile.getLocked(p)).length === 0;
-    const resolverPatternsAreSameAsInLockfile =
-      Object.keys(lockfileBasedOnResolver).filter(pattern => {
-        const manifest = this.lockfile.getLocked(pattern);
-        return !manifest || manifest.resolved !== lockfileBasedOnResolver[pattern].resolved;
-      }).length === 0;
-
+    const lockFileHasAllPatterns = patterns.every(p => this.lockfile.getLocked(p));
+    const resolverPatternsAreSameAsInLockfile = Object.keys(lockfileBasedOnResolver).every(pattern => {
+      const manifest = this.lockfile.getLocked(pattern);
+      return manifest && manifest.resolved === lockfileBasedOnResolver[pattern].resolved;
+    });
     // remove command is followed by install with force, lockfile will be rewritten in any case then
     if (lockFileHasAllPatterns && resolverPatternsAreSameAsInLockfile && patterns.length && !this.flags.force) {
       return;


### PR DESCRIPTION
**Summary**

When checking lockfile patterns and resolved patterns, we were using `.filter(!expr).length === 0` pattern, I guess due to Node < 4 support in the past. Since we have `.every(expr)` now, this patch uses that and comes with a slight performance boost due to the short-circuiting nature of `every()` on top of readability.

**Test plan**

Existing tests.