### PR TITLE
Fixed failure to set proxy during redirects

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -427,7 +427,7 @@ export default class RequestManager {
 
     req.on('error', onError);
 
-    // make sure request is re-evaluating proxy based on redirect uri
+    // make sure request is re-evaluating proxy based on redirect uri (#2683)
     req.on('redirect', () => {
       delete req.proxy;
     });

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -427,6 +427,11 @@ export default class RequestManager {
 
     req.on('error', onError);
 
+    // make sure request is re-evaluating proxy based on redirect uri
+    req.on('redirect', () => {
+      delete req.proxy;
+    });
+
     const queue = params.queue;
     if (queue) {
       req.on('data', queue.stillActive.bind(queue));


### PR DESCRIPTION
**Summary**
I have a scenario where a request is being made to an internal company server (no proxy) which redirects to an external server (proxy needed). The consecutive request is also being done without a proxy.

An example is how Microsoft TFS handles npm-feeds, see https://www.visualstudio.com/en-us/docs/package/npm/upstream-sources#caching (Internet requirements). Normally, TFS is installed on-prem (no proxy needed) but will redirect to npmjs.org (proxy needed).

Also - see https://github.com/request/request/issues/2683.

**Test plan**
Connect to a TFS repo behind a corporate firewall, which requires a client proxy to get internet access. Request a package that has never been cached in TFS. Before this change, the request is failing. After the change (testing with a new package that has never been cached before), the request goes through.
