### PR TITLE
Color fix

### DIFF
--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -13,6 +13,7 @@ const stream = require('stream');
 require('chalk').enabled = true;
 require('chalk').supportsColor = true;
 require('chalk').styles.blue.open = '\u001b[34m';
+require('chalk').styles.bold.close = '\u001b[22m';
 
 test('ConsoleReporter.step', async () => {
   expect(

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -27,6 +27,11 @@ const tty = require('tty');
 type Row = Array<string>;
 type InquirerResponses<K, T> = {[key: K]: Array<T>};
 
+// fixes bold on windows
+if (process.platform === 'win32' && process.env.TERM && !/^xterm/i.test(process.env.TERM)) {
+  chalk.styles.bold.close += '\u001b[m';
+}
+
 export default class ConsoleReporter extends BaseReporter {
   constructor(opts: Object) {
     super(opts);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR resets the console style after using bold, because the new windows console does not support the ansi escape codes ^[[21m and ^[[22m. This would fix  #2724 

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Only one test case had to be fixed. :)
