### PR TITLE
Chore: Remove unnecessary empty objects from resolver.init calls

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -144,7 +144,7 @@ test('changes the cache directory when bumping the cache version', async () => {
     const lockfile = await Lockfile.fromDirectory(config.cwd);
 
     const resolver = new PackageResolver(config, lockfile);
-    await resolver.init([{pattern: 'is-array', registry: 'npm'}], {});
+    await resolver.init([{pattern: 'is-array', registry: 'npm'}]);
 
     const ref = resolver.getManifests()[0]._reference;
     const cachePath = config.generateHardModulePath(ref, true);

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -42,7 +42,7 @@ function addTest(pattern, registry = 'npm', init: ?(cacheFolder: string) => Prom
     }
 
     const resolver = new PackageResolver(config, lockfile);
-    await resolver.init([{pattern, registry}], {});
+    await resolver.init([{pattern, registry}]);
 
     const ref = resolver.getManifests()[0]._reference;
     const cachePath = config.generateHardModulePath(ref, true);


### PR DESCRIPTION
**Summary**

Follow up to 7515772eabc91b741244a4f19aa34dce0a5dc5f4.

After refactoring #3604 I forgot to remove these empty objects
so now I'm doing it with this diff :)

**Test plan**

Existing tests.