### PR TITLE
Enhancement: slightly optimize how we update status from running scripts

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -10,6 +10,7 @@ import {registries} from '../resolvers/index.js';
 import {fixCmdWinSlashes} from './fix-cmd-win-slashes.js';
 import {run as globalRun, getBinFolder as getGlobalBinFolder} from '../cli/commands/global.js';
 
+const invariant = require('invariant');
 const path = require('path');
 
 export type LifecycleReturn = Promise<{
@@ -175,14 +176,14 @@ export async function executeLifecycleScript(
 
   let updateProgress;
   if (spinner) {
-    const ticker = spinner.tick.bind(spinner);
     updateProgress = data => {
       const dataStr = data
         .toString() // turn buffer into string
         .trim(); // trim whitespace
 
+      invariant(spinner && spinner.tick, 'We should have spinner and its ticker here');
       if (dataStr) {
-        ticker(
+        spinner.tick(
           dataStr
             // Only get the last line
             .substr(dataStr.lastIndexOf('\n') + 1)


### PR DESCRIPTION
**Summary**

This patch does two minor optimizations:

1. Do not even have a handler for data updates if we don't have a
   spinner. This avoids noop calls to a handler that just returns
   if we don't have a spinner.
2. Optimize getting the last available line from the buffer.
   Instead of using `.split()` and `.pop()` it uses `.lastIndexOf()`
   and `.substr()` to locate and extract the last line.

**Test plan**

Existing tests, behavior should not change.