### PR TITLE
Make `yarn run` only add global path to env if it is not present already

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -138,9 +138,12 @@ export async function executeLifecycleScript(
     path.join(path.dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'node-gyp-bin'),
   );
 
-  // Add global bin folder, as some packages depend on a globally-installed
-  // version of node-gyp.
-  pathParts.unshift(getGlobalBinFolder(config, {}));
+  // Add global bin folder if it is not present already, as some packages depend
+  // on a globally-installed version of node-gyp.
+  const globalBin = getGlobalBinFolder(config, {});
+  if (!pathParts.includes(globalBin)) {
+    pathParts.unshift(globalBin);
+  }
 
   // add .bin folders to PATH
   for (const registry of Object.keys(registries)) {


### PR DESCRIPTION
**Summary**

If the global path is present already, prepending it should not be necessary
and might change the order of path entries. This can break
applications that rely on the correct order of path entries, like
rbenv.

fixes #3636

**Test plan**

Should not be needed here, really small code change.
