### PR TITLE
Add missing await in npm-resolver.js

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -70,7 +70,7 @@ export default class NpmResolver extends RegistryResolver {
 
   async resolveRequest(): Promise<?Manifest> {
     if (this.config.offline) {
-      const res = this.resolveRequestOffline();
+      const res = await this.resolveRequestOffline();
       if (res != null) {
         return res;
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
In the process for figuring out why --prefer-offline is causing a `Couldn't find package "expose-loader" on the "npm" registry.` for us in some cases I noticed a missing await which is probably causing the null check below to be useless.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
