### PR TITLE
Don't use .includes for compatibility with Node 4

### DIFF
--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -203,7 +203,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const normalized = path.normalize(relative).split(path.sep);
     return normalized.filter(p => p !== 'node_modules').reduce((result, part) => {
       const length = result.length;
-      if (length && result[length - 1].startsWith('@') && !result[length - 1].includes(path.sep)) {
+      if (length && result[length - 1].startsWith('@') && result[length - 1].indexOf(path.sep) < 0) {
         result[length - 1] += path.sep + part;
       } else {
         result.push(part);

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -144,7 +144,7 @@ export default class PackageRequest {
   }
 
   async normalizeRange(pattern: string): Promise<string> {
-    if (pattern.includes(':') || pattern.includes('@') || PackageRequest.getExoticResolver(pattern)) {
+    if (pattern.indexOf(':') >= 0 || pattern.indexOf('@') >= 0 || PackageRequest.getExoticResolver(pattern)) {
       return Promise.resolve(pattern);
     }
 

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -141,7 +141,7 @@ export async function executeLifecycleScript(
   // Add global bin folder if it is not present already, as some packages depend
   // on a globally-installed version of node-gyp.
   const globalBin = getGlobalBinFolder(config, {});
-  if (!pathParts.includes(globalBin)) {
+  if (pathParts.indexOf(globalBin) < 0) {
     pathParts.unshift(globalBin);
   }
 

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -149,14 +149,14 @@ export function ignoreLinesToRegex(lines: Array<string>, base: string = '.'): Ar
 export function filterOverridenGitignores(files: WalkFiles): WalkFiles {
   const IGNORE_FILENAMES = ['.yarnignore', '.npmignore', '.gitignore'];
   const GITIGNORE_NAME = IGNORE_FILENAMES[2];
-  return files.filter(file => IGNORE_FILENAMES.includes(file.basename)).reduce((acc: WalkFiles, file) => {
+  return files.filter(file => IGNORE_FILENAMES.indexOf(file.basename) >= 0).reduce((acc: WalkFiles, file) => {
     if (file.basename !== GITIGNORE_NAME) {
       return [...acc, file];
     } else {
       //don't include .gitignore if .npmignore or .yarnignore are present
       const dir = path.dirname(file.absolute);
       const higherPriorityIgnoreFilePaths = [`${dir}/${IGNORE_FILENAMES[0]}`, `${dir}/${IGNORE_FILENAMES[1]}`];
-      const hasHigherPriorityFiles = files.find(file => higherPriorityIgnoreFilePaths.includes(file.absolute));
+      const hasHigherPriorityFiles = files.find(file => higherPriorityIgnoreFilePaths.indexOf(file.absolute) >= 0);
       if (!hasHigherPriorityFiles) {
         return [...acc, file];
       }


### PR DESCRIPTION
**Summary**

Several tests fail on Node 4 because of the use of `Array.prototype.includes`

**Test plan**

Existing tests on Node 4
