### PR TITLE
Fix: Fix Node 4 by not using `.includes()`

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -141,7 +141,7 @@ export async function executeLifecycleScript(
   // Add global bin folder if it is not present already, as some packages depend
   // on a globally-installed version of node-gyp.
   const globalBin = getGlobalBinFolder(config, {});
-  if (!pathParts.includes(globalBin)) {
+  if (pathParts.indexOf(globalBin) === -1) {
     pathParts.unshift(globalBin);
   }
 


### PR DESCRIPTION
**Summary**

A recent patch introduced `.includes()` which is not supported on Node 4. This patch replaces that with `.indexOf() === -1`

**Test plan**

Make sure TravisCI Node 4 builds pass.