### PR TITLE
Update: Save a call when checking for links

### DIFF
--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -10,13 +10,17 @@ import {runInstall} from '../_helpers.js';
 
 async function linkAt(config, ...relativePath): Promise<string> {
   const joinedPath = path.join(config.cwd, ...relativePath);
-  const stat = await fs.lstat(joinedPath);
-  if (stat.isSymbolicLink()) {
+  try {
     const linkPath = await fs.readlink(joinedPath);
     return linkPath;
-  } else {
-    const contents = await fs.readFile(joinedPath);
-    return /node" +"\$basedir\/([^"]*\.js)"/.exec(contents)[1];
+  } catch (err) {
+    if (err.code === 'EINVAL') {
+      // Means this is not a link
+      const contents = await fs.readFile(joinedPath);
+      return /node" +"\$basedir\/([^"]*\.js)"/.exec(contents)[1];
+    } else {
+      throw err;
+    }
   }
 }
 

--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -14,7 +14,7 @@ async function linkAt(config, ...relativePath): Promise<string> {
     const linkPath = await fs.readlink(joinedPath);
     return linkPath;
   } catch (err) {
-    if (err.code === 'EINVAL') {
+    if (err.code === 'EINVAL' || err.code === 'UNKNOWN') {
       // Means this is not a link
       const contents = await fs.readFile(joinedPath);
       return /node" +"\$basedir\/([^"]*\.js)"/.exec(contents)[1];


### PR DESCRIPTION
**Summary**

`fs.readlink` already makes an internal call to `fs.lstat` so rely
on the `EINVAL` error it throws instead of checking if the path is
a link or not via `lstat`.

**Test plan**

Existing tests.