### PR TITLE
Fixes 3598

### DIFF
--- a/__tests__/commands/install/workspaces-install.js
+++ b/__tests__/commands/install/workspaces-install.js
@@ -191,6 +191,14 @@ test.concurrent('install should not install dev dependencies of workspaces in pr
   });
 });
 
+// https://github.com/yarnpkg/yarn/issues/3598
+test.concurrent('install should work correctly for workspaces that have similar names', (): Promise<void> => {
+  return runInstall({production: true}, 'workspaces-install-names-issue', async (config): Promise<void> => {
+    expect(await fs.exists(path.join(config.cwd, 'packages', 'jest', 'package.json'))).toBe(true);
+    expect(await fs.exists(path.join(config.cwd, 'packages', 'jest-cli', 'package.json'))).toBe(true);
+  });
+});
+
 test.concurrent('check command should work', (): Promise<void> => {
   return runInstall({checkFiles: true}, 'workspaces-install-basic', async (config, reporter): Promise<void> => {
     // check command + integrity check

--- a/__tests__/fixtures/install/workspaces-install-names-issue/.yarnrc
+++ b/__tests__/fixtures/install/workspaces-install-names-issue/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental true

--- a/__tests__/fixtures/install/workspaces-install-names-issue/package.json
+++ b/__tests__/fixtures/install/workspaces-install-names-issue/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-project",
+  "private": true,
+  "dependencies": {
+    "jest": "^1.0.0",
+    "jest-cli": "^1.0.0"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__tests__/fixtures/install/workspaces-install-names-issue/packages/jest-cli/package.json
+++ b/__tests__/fixtures/install/workspaces-install-names-issue/packages/jest-cli/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "jest-cli",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/__tests__/fixtures/install/workspaces-install-names-issue/packages/jest/package.json
+++ b/__tests__/fixtures/install/workspaces-install-names-issue/packages/jest/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "jest",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -179,7 +179,7 @@ export default class PackageLinker {
 
       // fs copy can't copy through a symlink, so we replace those with real paths to workpsaces
       for (const [symlink, realpath] of symlinkPaths.entries()) {
-        if (dest !== symlink && dest.indexOf(symlink) === 0) {
+        if (dest.indexOf(symlink + path.sep) === 0) {
           dest = dest.replace(symlink, realpath);
         }
       }


### PR DESCRIPTION

**Summary**

Fixes #3598 

Fixed a very naive condition that matched workspaces `jest-cli` as a subpath of workspace `jest`.

**Test plan**

Added test + tested that workspaces install correctly for jest.