### PR TITLE
Fix for #3506 - Use setFresh method for determining fresh install 

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -293,6 +293,7 @@ export default class PackageRequest {
     const ref = new PackageReference(this, info, remote);
     ref.addPattern(this.pattern, info);
     ref.addOptional(this.optional);
+    ref.setFresh(fresh);
     info._reference = ref;
     info._remote = remote;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is a fix for https://github.com/yarnpkg/yarn/issues/3506
The root cause of the issue was that after an initial installation method that didn't generate a lockfile, e.g.`--pure-lockfile` or `--no-lockfile`, the second install skipped packages w/pre and post install scripts because [this line](https://github.com/yarnpkg/yarn/blob/master/src/package-install-scripts.js#L137-L139) returned false, even though fresh was being correctly passed [here](https://github.com/yarnpkg/yarn/blob/master/src/package-resolver.js#L455). It turns out `fresh` attribute wasn't being hydrated correctly, so this diff fixes that.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Existing tests, and tested that the pre and post-install scripts get executed correctly after `yarn --pure-lockfile` command. Not sure how else to test, since it's just setting a property on the object.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
<img width="427" alt="screen shot 2017-06-18 at 6 54 59 pm" src="https://user-images.githubusercontent.com/18429494/27266658-b5cefdde-5457-11e7-9e2a-d7f6cde20d2c.png">


