### PR TITLE
Update: Make tests great again on Travis CI macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - TEST_TYPE="build-dist"
     - TEST_TYPE="check-lockfile"
     - TEST_TYPE="lint"
-    - TEST_TYPE="test-ci -- -- --maxWorkers 3"
+    - TEST_TYPE="test-ci"
 
 matrix:
   exclude:
@@ -41,15 +41,21 @@ matrix:
   include:
     - os: osx
       node_js: "6"
-      env: TEST_TYPE="test-ci -- -- --maxWorkers 3"
+      env: TEST_TYPE="test-ci"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/bootstrap-env-ubuntu.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install yarn; fi
-  - node --version
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      RAMDISK_SIZE=300;
+      RAMDISK_SECTORS=$(( $RAMDISK_SIZE * 1024 * 1024 / 512 ));
+      RAMDISK=$(hdiutil attach -nomount ram://$RAMDISK_SECTORS);
+      newfs_hfs -v yarn_ramfs $RAMDISK;
+      export TMPDIR="/tmp/ramfs";
+      mkdir -p $TMPDIR;
+      mount -t hfs -o nobrowse $RAMDISK $TMPDIR;
+    fi
 
 os:
   - linux
 
-script: travis_retry yarn $TEST_TYPE
+script: yarn $TEST_TYPE

--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -142,5 +142,7 @@ export async function run<T, R>(
     }
   } catch (err) {
     throw new Error(`${err && err.stack} \nConsole output:\n ${out}`);
+  } finally {
+    await fs.unlink(cwd);
   }
 }

--- a/__tests__/commands/unlink.js
+++ b/__tests__/commands/unlink.js
@@ -8,6 +8,8 @@ import type {CLIFunctionReturn} from '../../src/types.js';
 import mkdir from './../_temp.js';
 import * as fs from '../../src/util/fs.js';
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
+
 const path = require('path');
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'link');
@@ -25,7 +27,7 @@ const runUnlink = buildRun.bind(
   ConsoleReporter,
   fixturesLoc,
   (args, flags, config, reporter): CLIFunctionReturn => {
-    return unlink(config, reporter, flags, args);
+    return link(config, reporter, flags, args).then(unlink.bind(null, config, reporter, flags, args));
   },
 );
 

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -155,6 +155,7 @@ test('ConsoleReporter.select', async () => {
 });
 
 test('ConsoleReporter.progress', async () => {
+  jest.useFakeTimers();
   expect(
     await getConsoleBuff(r => {
       r.noProgress = false; // we need this to override is-ci when running tests on ci

--- a/__tests__/util/blocking-queue.js
+++ b/__tests__/util/blocking-queue.js
@@ -3,6 +3,8 @@
 import BlockingQueue from '../../src/util/blocking-queue.js';
 
 test('max concurrency', async function(): Promise<void> {
+  jest.useFakeTimers();
+
   const queue = new BlockingQueue('test', 5);
   let i = 0;
   let running = 0;
@@ -34,4 +36,6 @@ test('max concurrency', async function(): Promise<void> {
     create(),
     create(),
   ]);
+
+  jest.useRealTimers();
 });

--- a/__tests__/util/promise.js
+++ b/__tests__/util/promise.js
@@ -33,6 +33,7 @@ test('promisify', async function(): Promise<void> {
 });
 
 test('queue', async function(): Promise<void> {
+  jest.useFakeTimers();
   let running = 0;
 
   function create(): Promise<void> {
@@ -53,4 +54,6 @@ test('queue', async function(): Promise<void> {
   });
 
   await promise.queue(Array(10), create, 5);
+
+  jest.useRealTimers();
 });

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
 
 test_script:
   - node --version
-  - yarn test-only -- --maxWorkers 3
+  - node ./node_modules/jest/bin/jest.js --coverage --verbose
 
 artifacts:
   - path: artifacts/*.msi

--- a/package.json
+++ b/package.json
@@ -98,14 +98,13 @@
     "release-branch": "./scripts/release-branch.sh",
     "test": "yarn lint && yarn test-only",
     "test-ci": "yarn build && yarn test-only",
-    "test-only": "jest --coverage --verbose",
+    "test-only": "node --max_old_space_size=4096 ./node_modules/.bin/jest --coverage --verbose",
     "watch": "gulp watch"
   },
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.js"
     ],
-    "timers": "fake",
     "testEnvironment": "node",
     "modulePathIgnorePatterns": [
       "__tests__/fixtures/"


### PR DESCRIPTION
**Summary**

macOS tests on Travis CI keep timing out and they run very slowly. This patch attempts to solve this by doing the following:

- Use ramfs for `__tests__` folder and for `$TMPDIR` for faster file system
- Remove unnecessary `brew update` and `brew install yarn` commands
- Remove unnecessary `--max-workers` argument since all CI VMs have only 2 cores
- Clean up tmp folders per test after they are done
- Fix `link/unlink` test's race condition and previous test case reliance
- Fix `request-manager` timeout tests to be more reliable and finish in under our normal timeout
- Use real timers by default and add necessary `useFakeTimers` calls
- Increase heap size for Linux and OS X to 4 GB since OS X builds were crashing due to limited heap space
- Removes retries from Travis CI

**Test plan**

All tests on all platforms should pass and pass in about 20 minutes max.