### PR TITLE
Fixes resolution concurrency problem

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -344,7 +344,10 @@ export default class PackageRequest {
       }
     }
 
-    await Promise.all(promises);
+    for (const promise of promises) {
+      await promise;
+    }
+
     ref.addDependencies(deps);
 
     // Now that we have all dependencies, it's safe to propagate optional

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -471,7 +471,10 @@ export default class PackageResolver {
     this.frozen = Boolean(isFrozen);
     this.workspaceLayout = workspaceLayout;
     const activity = (this.activity = this.reporter.activity());
-    await Promise.all(deps.map((req): Promise<void> => this.find(req)));
+
+    for (const req of deps) {
+      await this.find(req);
+    }
 
     // all required package versions have been discovered, so now packages that
     // resolved to existing versions can be resolved to their best available version


### PR DESCRIPTION
Should fix #3023 for sure, possibly #3364, #3490, and #3489 as well.

Two notes:

- I thought this would make perfs worse by a large factor, but actually it barely had any impact at all, **even when running without lockfile**. On a project requiring react-native, react, react-dom and webpack, over a hundred tries, it went from Avg:11s to Avg:12s overall.

- I tried to write an integration test, but unfortunately couldn't automatically reproduce from inside the test environment #3023 - for some reason I always ended up getting 2.7.5 instead of the bogus 2.8.0 :( However, I was able to systematically reproduce it manually, so I'm confident that this PR should fix this issue. 