### PR TITLE
feat(config): use XDG config specification

### DIFF
--- a/end_to_end_tests/data/run-yarn-test.sh
+++ b/end_to_end_tests/data/run-yarn-test.sh
@@ -12,6 +12,11 @@ fail_with_log() {
   exit $exitcode
 }
 
+check_config() {
+  XDG_CONFIG_HOME=~/config_path yarn config get $1 > config_output
+  echo $2 | diff config_output - || fail_with_log
+}
+
 cd /tmp
 mkdir yarntest
 cd yarntest
@@ -23,3 +28,12 @@ yarn --version || fail_with_log
 rm -rf ~/.cache/yarn
 
 yarn add react || fail_with_log
+
+# Ensure that we follow the xdg spec
+mkdir ~/config_path
+echo "foo bar" > ~/config_path
+check_config foo bar
+
+# Ensure that compatibility with the old config format is maintained
+echo "bar baz" >> ~/.yarnrc
+check_config bar baz

--- a/src/constants.js
+++ b/src/constants.js
@@ -55,7 +55,9 @@ function getCacheDirectory(): string {
 }
 
 export const MODULE_CACHE_DIRECTORY = getCacheDirectory();
-export const CONFIG_DIRECTORY = getDirectory('config');
+export const CONFIG_DIRECTORY = process.env.XDG_CONFIG_HOME
+  ? path.join(process.env.XDG_CONFIG_HOME, 'yarn')
+  : getDirectory('config');
 export const LINK_REGISTRY_DIRECTORY = path.join(CONFIG_DIRECTORY, 'link');
 export const GLOBAL_MODULE_DIRECTORY = path.join(CONFIG_DIRECTORY, 'global');
 

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -2,6 +2,7 @@
 
 import {readFileSync} from 'fs';
 import {basename, dirname, join} from 'path';
+import {CONFIG_DIRECTORY} from '../constants.js';
 
 const etc = '/etc';
 const isWin = process.platform === 'win32';
@@ -49,6 +50,7 @@ export function findRc(name: string, parser: Function): Object {
   }
 
   if (home) {
+    addConfigPath(CONFIG_DIRECTORY, `${name}rc`);
     addConfigPath(home, '.config', name, 'config');
     addConfigPath(home, '.config', name);
     addConfigPath(home, `.${name}`, 'config');


### PR DESCRIPTION
As per [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), prioritise the environment variable `$XDG_CONFIG_PATH` when possible, and use `$HOME/.config/` as a fallback.

Backward-compatibility is handled to avoid unnecessary breakage, this is a first step towards full compliance with the spec.

Related to #2334 (But only solves part of it)