### PR TITLE
Include top-level package.json in engines check

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -412,6 +412,7 @@ export class Install {
       patterns: rawPatterns,
       ignorePatterns,
       workspaceLayout,
+      manifest,
     } = await this.fetchRequestFromCwd();
     let topLevelPatterns: Array<string> = [];
 
@@ -420,6 +421,11 @@ export class Install {
       this.linker.setArtifacts(artifacts);
       this.scripts.setArtifacts(artifacts);
     }
+
+    steps.push(async (curr: number, total: number) => {
+      this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('mag'));
+      await compatibility.checkOne(Object.assign({}, manifest, {_reference: {}}), this.config, false);
+    });
 
     steps.push(async (curr: number, total: number) => {
       this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -422,10 +422,12 @@ export class Install {
       this.scripts.setArtifacts(artifacts);
     }
 
-    steps.push(async (curr: number, total: number) => {
-      this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('mag'));
-      await compatibility.checkOne(Object.assign({}, manifest, {_reference: {}}), this.config, false);
-    });
+    if (!this.flags.ignoreEngines && typeof manifest.engines === 'object') {
+      steps.push(async (curr: number, total: number) => {
+        this.reporter.step(curr, total, this.reporter.lang('checkingManifest'), emoji.get('mag'));
+        await compatibility.checkOne({_reference: {}, ...manifest}, this.config, this.flags.ignoreEngines);
+      });
+    }
 
     steps.push(async (curr: number, total: number) => {
       this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -182,7 +182,7 @@ export default class PackageLinker {
           // after hoisting we end up with this structure
           // root/node_modules/workspace-package(symlink)/node_modules/package-a
           // fs.copy operations can't copy files through a symlink, so all the paths under workspace-package
-          // need to be replaced with a real path, except for the symlink root/node_modules/workspace-package 
+          // need to be replaced with a real path, except for the symlink root/node_modules/workspace-package
           dest = dest.replace(symlink, realpath);
         }
       }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -6,6 +6,7 @@ const messages = {
   folderInSync: 'Folder in sync.',
   nothingToInstall: 'Nothing to install.',
   resolvingPackages: 'Resolving packages',
+  checkingManifest: 'Validating package.json',
   fetchingPackages: 'Fetching packages',
   linkingDependencies: 'Linking dependencies',
   rebuildingPackages: 'Rebuilding all packages',


### PR DESCRIPTION
**Summary**

Add support for enforcing engine versions (especially yarn) at the project level (as opposed to the [sub]dependencies).

This is especially important on large projects to prevent `yarn.lock` churn.

**Test plan**

`yarn test`. Manual verification by setting various versions in `"engines"`.

**TODO**

Needs language translation, and possibly a better log message.