### PR TITLE
Add retry on 5xx errors. Fixes #2849

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -14,3 +14,12 @@ export class SecurityError extends MessageError {}
 export class SpawnError extends MessageError {
   EXIT_CODE: number;
 }
+
+export class ResponseError extends Error {
+  constructor(msg: string, responseCode: number) {
+    super(msg);
+    this.responseCode = responseCode;
+  }
+
+  responseCode: number;
+}

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -1,12 +1,13 @@
 /* @flow */
 
 import http from 'http';
-import {SecurityError, MessageError} from '../errors.js';
+import {SecurityError, MessageError, ResponseError} from '../errors.js';
 import type {FetchedOverride} from '../types.js';
 import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
 import BaseFetcher from './base-fetcher.js';
 import * as fsUtil from '../util/fs.js';
+import {sleep} from '../util/misc.js';
 
 const path = require('path');
 const tarFs = require('tar-fs');
@@ -130,48 +131,66 @@ export default class TarballFetcher extends BaseFetcher {
     });
   }
 
-  fetchFromExternal(): Promise<FetchedOverride> {
+  async fetchFromExternal(): Promise<FetchedOverride> {
     const registry = this.config.registries[this.registry];
 
-    return registry.request(
-      this.reference,
-      {
-        headers: {
-          'Accept-Encoding': 'gzip',
-          Accept: 'application/octet-stream',
-        },
-        buffer: true,
-        process: (req, resolve, reject) => {
-          const {reporter} = this.config;
-          // should we save this to the offline cache?
-          const tarballMirrorPath = this.getTarballMirrorPath();
-          const tarballCachePath = this.getTarballCachePath();
+    let retriesRemaining = 2;
+    do {
+      try {
+        return await registry.request(
+          this.reference,
+          {
+            headers: {
+              'Accept-Encoding': 'gzip',
+              Accept: 'application/octet-stream',
+            },
+            buffer: true,
+            process: (req, resolve, reject) => {
+              // should we save this to the offline cache?
+              const {reporter} = this.config;
+              const tarballMirrorPath = this.getTarballMirrorPath();
+              const tarballCachePath = this.getTarballCachePath();
 
-          const {validateStream, extractorStream} = this.createExtractor(resolve, reject);
+              const {validateStream, extractorStream} = this.createExtractor(resolve, reject);
 
-          const handleRequestError = res => {
-            if (res.statusCode >= 400) {
-              const statusDescription = http.STATUS_CODES[res.statusCode];
-              reject(new Error(reporter.lang('requestFailed', `${res.statusCode} ${statusDescription}`)));
-            }
-          };
+              req.on('response', res => {
+                if (res.statusCode >= 400) {
+                  const statusDescription = http.STATUS_CODES[res.statusCode];
+                  reject(
+                    new ResponseError(
+                      reporter.lang('requestFailed', `${res.statusCode} ${statusDescription}`),
+                      res.statusCode,
+                    ),
+                  );
+                }
+              });
+              req.pipe(validateStream);
 
-          req.on('response', handleRequestError);
-          req.pipe(validateStream);
+              if (tarballMirrorPath) {
+                validateStream.pipe(fs.createWriteStream(tarballMirrorPath)).on('error', reject);
+              }
 
-          if (tarballMirrorPath) {
-            validateStream.pipe(fs.createWriteStream(tarballMirrorPath)).on('error', reject);
-          }
+              if (tarballCachePath) {
+                validateStream.pipe(fs.createWriteStream(tarballCachePath)).on('error', reject);
+              }
 
-          if (tarballCachePath) {
-            validateStream.pipe(fs.createWriteStream(tarballCachePath)).on('error', reject);
-          }
-
-          validateStream.pipe(extractorStream).on('error', reject);
-        },
-      },
-      this.packageName,
-    );
+              validateStream.pipe(extractorStream).on('error', reject);
+            },
+          },
+          this.packageName,
+        );
+      } catch (err) {
+        if (err instanceof ResponseError && err.responseCode >= 500 && retriesRemaining > 1) {
+          retriesRemaining--;
+          this.reporter.warn(this.reporter.lang('retryOnInternalServerError'));
+          await sleep(3000);
+        } else {
+          throw err;
+        }
+      }
+    } while (retriesRemaining > 0);
+    // Unreachable code, this is just to make Flow happy
+    throw new Error('Ran out of retries!');
   }
 
   async _fetch(): Promise<FetchedOverride> {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -264,6 +264,7 @@ const messages = {
   errorDecompressingTarball: '$0. Error decompressing $1, it appears to be corrupt.',
   updateInstalling: 'Installing $0...',
   hostedGitResolveError: 'Error connecting to repository. Please, check the url.',
+  retryOnInternalServerError: 'There appears to be trouble with our server. Retrying...',
 
   unknownFetcherFor: 'Unknown fetcher for $0',
 

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -78,3 +78,9 @@ export function compareSortedArrays<T>(array1: Array<T>, array2: Array<T>): bool
   }
   return true;
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
This is not a very elegant solution but it will do the job for now.

During fetching tarball for any **5xx** errors, it will show `warning There appears to be trouble with our server. Retrying...` and try again after `3000ms`. If it fails again then it will show the error like before.

**Future Work**
Refactor `RequestManager` to add support for retry.

I spent some time trying to refactor `RequestManager`, but it will take some time and effort to finish it.  And, since `RequestManager` is a very important part of **Yarn**. So, it is important that it doesn't degrade the speed after refactor.