### PR TITLE
Removes invalid chars in evn var names

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -79,7 +79,11 @@ export async function makeEnv(
         if (cleanVal.indexOf('\n') >= 0) {
           cleanVal = JSON.stringify(cleanVal);
         }
-        env[`npm_package_${key}`] = cleanVal;
+
+        //replacing invalid chars with underscore
+        const cleanKey = key.replace(/[^a-zA-Z0-9_]/g, '_');
+
+        env[`npm_package_${cleanKey}`] = cleanVal;
       }
     }
   }


### PR DESCRIPTION
**Summary** - Bug Fix
This PR fixes #3562 
The code replaces all the invalid characters in the variable names by underscores to match the env variable names introduced by npm. This will eventually allow scripts to be cross-compatible between npm and yarn.

I have tested it using the following:
Node v8.1.2
macOS Sierra 10.12.5