### PR TITLE
Rename upgrade-interactive help option

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -13,8 +13,8 @@ export const requireLockfile = true;
 
 export function setFlags(commander: Object) {
   commander.usage('upgrade-interactive');
-  commander.option('-E, --exact', 'install exact version');
-  commander.option('-T, --tilde', 'install most recent release with the same minor version');
+  commander.option('-E, --exact', 'upgrade to most recent release with exact version');
+  commander.option('-T, --tilde', 'upgrade to most recent release with patch version');
 }
 
 export function hasWrapper(): boolean {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Tilde in semver refers to patched version, not minor version. The behavior of command is still correct, this only changes the wording of the help option.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
checked the help menu in CLI with `yarn upgrade-interactive -h`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
