### PR TITLE
upgrade flow to 0.48.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,4 +16,4 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.43.0
+^0.48.0

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -478,7 +478,6 @@ test.concurrent('install should be idempotent', (): Promise<void> => {
       expect(await getPackageVersion(config, 'dep-a')).toEqual('1.0.0');
     },
     null,
-    false,
   );
 
   return runInstall({}, 'install-should-be-idempotent', async (config, reporter) => {
@@ -821,15 +820,10 @@ test.concurrent('prunes the offline mirror tarballs after pruning is enabled', (
 test.concurrent('scoped packages remain in offline mirror after pruning is enabled', (): Promise<void> => {
   return runInstall({}, 'prune-offline-mirror-scoped', async (config): Promise<void> => {
     const mirrorPath = 'mirror-for-offline';
-    // Ensure that scoped packages remain mangled and resolvable
-    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/@fakescope-fake-dependency-1.0.1.tgz`))).toEqual(
-      true,
-      'scoped package exists',
-    );
-    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/fake-dependency-1.0.1.tgz`))).toEqual(
-      true,
-      'unscoped package exists',
-    );
+    // scoped package exists
+    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/@fakescope-fake-dependency-1.0.1.tgz`))).toEqual(true);
+    // unscoped package exists
+    expect(await fs.exists(path.join(config.cwd, `${mirrorPath}/fake-dependency-1.0.1.tgz`))).toEqual(true);
   });
 });
 

--- a/__tests__/commands/upgrade.js
+++ b/__tests__/commands/upgrade.js
@@ -174,25 +174,17 @@ test.concurrent('upgrades dependency packages not in registry', (): Promise<void
 
     const lockFileIncludes = sha => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(
-      true,
-      'Lockfile should point to the same yarn-test-git-repo branch.',
-    );
+    // Lockfile should point to the same yarn-test-git-repo branch
+    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(true);
 
-    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(
-      false,
-      'Lockfile should update yarn-test-git-repo SHA.',
-    );
+    // Lockfile should update yarn-test-git-repo SHA
+    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(false);
 
-    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(
-      true,
-      'Lockfile should point to the same e2e-test-repo branch.',
-    );
+    // Lockfile should point to the same e2e-test-repo branch
+    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(true);
 
-    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(
-      true,
-      'Lockfile should keep latest e2e-test-repo SHA.',
-    );
+    // Lockfile should keep latest e2e-test-repo SHA
+    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(true);
   });
 });
 
@@ -204,25 +196,17 @@ test.concurrent('upgrades dev dependency packages not in registry', (): Promise<
 
     const lockFileIncludes = sha => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(
-      true,
-      'Lockfile should point to the same yarn-test-git-repo branch.',
-    );
+    // Lockfile should point to the same yarn-test-git-repo branch
+    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(true);
 
-    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(
-      false,
-      'Lockfile should update yarn-test-git-repo SHA.',
-    );
+    // Lockfile should update yarn-test-git-repo SHA
+    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(false);
 
-    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(
-      true,
-      'Lockfile should point to the same e2e-test-repo branch.',
-    );
+    // Lockfile should point to the same e2e-test-repo branch
+    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(true);
 
-    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(
-      true,
-      'Lockfile should keep latest e2e-test-repo SHA.',
-    );
+    // Lockfile should keep latest e2e-test-repo SHA
+    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(true);
   });
 });
 
@@ -234,25 +218,17 @@ test.concurrent('upgrades optional dependency packages not in registry', (): Pro
 
     const lockFileIncludes = sha => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(
-      true,
-      'Lockfile should point to the same yarn-test-git-repo branch.',
-    );
+    // Lockfile should point to the same yarn-test-git-repo branch
+    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(true);
 
-    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(
-      false,
-      'Lockfile should update yarn-test-git-repo SHA.',
-    );
+    // Lockfile should update yarn-test-git-repo SHA
+    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(false);
 
-    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(
-      true,
-      'Lockfile should point to the same e2e-test-repo branch.',
-    );
+    // Lockfile should point to the same e2e-test-repo branch
+    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(true);
 
-    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(
-      true,
-      'Lockfile should keep latest e2e-test-repo SHA.',
-    );
+    // Lockfile should keep latest e2e-test-repo SHA
+    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(true);
   });
 });
 
@@ -264,25 +240,17 @@ test.concurrent('upgrades peer dependency packages not in registry', (): Promise
 
     const lockFileIncludes = sha => lockfile.includes(`  resolved "${gitRemote}#${sha}"`);
 
-    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(
-      true,
-      'Lockfile should point to the same yarn-test-git-repo branch.',
-    );
+    // Lockfile should point to the same yarn-test-git-repo branch
+    expect(lockfile.includes(`"yarn-test-git-repo@${gitRemote}#master":`)).toEqual(true);
 
-    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(
-      false,
-      'Lockfile should update yarn-test-git-repo SHA.',
-    );
+    // Lockfile should update yarn-test-git-repo SHA
+    expect(lockFileIncludes('d2027157d0c7188fc9ed6a6654325d1e3bf4db40')).toEqual(false);
 
-    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(
-      true,
-      'Lockfile should point to the same e2e-test-repo branch.',
-    );
+    // Lockfile should point to the same e2e-test-repo branch
+    expect(lockfile.includes(`"e2e-test-repo@${gitRemote}#greenkeeper/cross-env-3.1.4":`)).toEqual(true);
 
-    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(
-      true,
-      'Lockfile should keep latest e2e-test-repo SHA.',
-    );
+    // Lockfile should keep latest e2e-test-repo SHA
+    expect(lockFileIncludes('da5940e1ad2b7451c00edffb6e755bf2411fc705')).toEqual(true);
   });
 });
 

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -50,7 +50,7 @@ function createTestFixture(testModules: any = {}): any {
     packageResolver.addPattern(uid, packageManifest);
   });
 
-  const packageHoister = new PackageHoister(config, packageResolver, false);
+  const packageHoister = new PackageHoister(config, packageResolver);
 
   const atPath = function(...installPaths): string {
     const rootPath = config.modulesFolder || path.join(config.cwd, 'node_modules');
@@ -70,35 +70,30 @@ function createTestFixture(testModules: any = {}): any {
   };
 }
 
-beforeEach(function() {
-  jasmine.addMatchers({
-    toContainPackage(): any {
-      return {
-        compare(received, uid, expectedInstallPath): any {
-          let pass: boolean = false;
-          received.forEach(pkg => {
-            const [location: string, hoistManifest: HoistManifest] = pkg;
-            if (location === expectedInstallPath && hoistManifest.pkg._reference.uid === uid) {
-              pass = true;
-            }
-          });
-
-          if (pass) {
-            return {
-              pass: true,
-              message: () => `expected ${received} to not contain package UID ${uid} at path ${expectedInstallPath}`,
-            };
-          } else {
-            return {
-              pass: false,
-              message: () => `expected ${received} to contain package UID ${uid} at path ${expectedInstallPath}`,
-            };
-          }
-        },
-      };
-    },
+const toContainPackage = function(received: any, ...expected: any): JestMatcherResult {
+  const [uid, expectedInstallPath] = expected;
+  let pass: boolean = false;
+  received.forEach(pkg => {
+    const [location: string, hoistManifest: HoistManifest] = pkg;
+    if (location === expectedInstallPath && hoistManifest.pkg._reference.uid === uid) {
+      pass = true;
+    }
   });
-});
+
+  if (pass) {
+    return {
+      pass: true,
+      message: () => `expected ${received} to not contain package UID ${uid} at path ${expectedInstallPath}`,
+    };
+  } else {
+    return {
+      pass: false,
+      message: () => `expected ${received} to contain package UID ${uid} at path ${expectedInstallPath}`,
+    };
+  }
+};
+
+expect.extend({toContainPackage});
 
 test('Produces valid destination paths for scoped modules', () => {
   const expected = path.join(CWD, 'node_modules', '@scoped', 'dep');

--- a/__tests__/util/env-replace.js
+++ b/__tests__/util/env-replace.js
@@ -4,13 +4,13 @@ import envReplace from '../../src/util/env-replace';
 describe('environment variable replacement', () => {
   it('will replace a token that exists in the environment', () => {
     let result = envReplace('test ${a} replacement', {a: 'token'});
-    expect(result).toEqual('test token replacement', `result: ${result}`);
+    expect(result).toEqual('test token replacement');
 
     result = envReplace('${a} replacement', {a: 'token'});
-    expect(result).toEqual('token replacement', `result: ${result}`);
+    expect(result).toEqual('token replacement');
 
     result = envReplace('${a}', {a: 'token'});
-    expect(result).toEqual('token', `result: ${result}`);
+    expect(result).toEqual('token');
   });
 
   it('will not replace a token that does not exist in the environment', () => {
@@ -19,13 +19,13 @@ describe('environment variable replacement', () => {
       envReplace('${a} replacement', {b: 'token'});
     } catch (err) {
       thrown = true;
-      expect(err.message).toEqual('Failed to replace env in config: ${a}', `error message: ${err.message}`);
+      expect(err.message).toEqual('Failed to replace env in config: ${a}');
     }
     expect(thrown).toEqual(true);
   });
 
   it('will not replace a token when a the token-replacement mechanism is prefixed a backslash literal', () => {
     const result = envReplace('\\${a} replacement', {a: 'token'});
-    expect(result).toEqual('\\${a} replacement', `result: ${result}`);
+    expect(result).toEqual('\\${a} replacement');
   });
 });

--- a/__tests__/util/promise.js
+++ b/__tests__/util/promise.js
@@ -32,32 +32,6 @@ test('promisify', async function(): Promise<void> {
   expect(error && error.message).toEqual('yep');
 });
 
-test('promisifyObject', async function(): Promise<void> {
-  const obj = promise.promisifyObject({
-    foo(callback) {
-      callback(null, 'foo');
-    },
-
-    bar(data, callback) {
-      callback(null, data + 'bar');
-    },
-
-    foobar(callback) {
-      callback(new Error('yep'));
-    },
-  });
-
-  expect(await obj.foo()).toBe('foo');
-  expect(await obj.bar('foo')).toBe('foobar');
-  let error;
-  try {
-    await obj.foobar();
-  } catch (e) {
-    error = e;
-  }
-  expect(error && error.message).toEqual('yep');
-});
-
 test('queue', async function(): Promise<void> {
   let running = 0;
 

--- a/flow-typed/npm/jest_v19.x.x_with_custom_matchers.js
+++ b/flow-typed/npm/jest_v19.x.x_with_custom_matchers.js
@@ -1,3 +1,6 @@
+// flow-typed signature: 07da7976dee381abd05d21b890d521b9
+// flow-typed version: fcaf13fb04/jest_v19.x.x/flow_>=v0.33.x
+
 type JestMockFn = {
   (...args: Array<any>): any,
   /**
@@ -74,7 +77,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
-  tick(): void,
+  tick(milliseconds?:number): void,
   uninstall(): void,
 }
 
@@ -187,6 +190,11 @@ type JestExpectType = {
    */
   toHaveBeenCalledWith(...args: Array<any>): void,
   /**
+   * If you have a mock function, you can use .toHaveBeenLastCalledWith to test what
+   * arguments it was last called with.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
    * Check that an object has a .length property and it is set to a certain
    * numeric value.
    */
@@ -222,10 +230,12 @@ type JestExpectType = {
    * matching the most recent snapshot when it is called.
    */
   toThrowErrorMatchingSnapshot(): void,
-  /**
-   * Custom function; need to be backported when updating this file
+
+  /*
+   * Custom matcher defined in yarn
    */
-  toContainPackage(packageName: string, path: string): void;
+
+  toContainPackage(uid: string, expectedInstallPath: string): void
 }
 
 type JestObjectType = {
@@ -248,6 +258,11 @@ type JestObjectType = {
    * An un-hoisted version of enableAutomock
    */
   autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
   /**
    * Resets the state of all mocks. Equivalent to calling .mockReset() on every
    * mocked function.
@@ -290,7 +305,7 @@ type JestObjectType = {
    * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestObjectType,
+  mock(moduleName: string, moduleFactory?: any, options?: Object): JestObjectType,
   /**
    * Resets the module registry - the cache of all required modules. This is
    * useful to isolate modules where local state might conflict between tests.
@@ -343,6 +358,11 @@ type JestObjectType = {
    * Instructs Jest to use the real versions of the standard timer functions.
    */
   useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn,
 }
 
 type JestSpyType = {
@@ -409,12 +429,16 @@ declare var expect: {
   (value: any): JestExpectType,
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: {[name:string]: JestMatcher}): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
   assertions(expectedAssertions: number): void,
   any(value: mixed): JestAsymmetricEqualityType,
   anything(): void,
   arrayContaining(value: Array<mixed>): void,
   objectContaining(value: Object): void,
-  stringMatching(value: string): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void,
 };
 
 // TODO handle return type
@@ -435,7 +459,7 @@ declare var jasmine: {
   arrayContaining(value: Array<mixed>): void,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
+  createSpyObj(baseName: string, methodNames: Array<string>): {[methodName: string]: JestSpyType},
   objectContaining(value: Object): void,
   stringMatching(value: string): void,
-  addMatchers(matcher: Object): void,
 }

--- a/flow-typed/npm/semver_v5.1.x.js
+++ b/flow-typed/npm/semver_v5.1.x.js
@@ -34,32 +34,34 @@ declare module 'semver' {
     prerelease: Array<string | number>,
     build: Array<string>,
     version: string,
+
+    constructor(range: string, loose?: boolean): SemVer | string
   }
 
   // Functions
-  declare function clean(v: string): string | null;
-  declare function valid(v: string): string | null;
-  declare function inc(v: string, release: string): string | null;
-  declare function major(v: string): number;
-  declare function minor(v: string): number;
-  declare function patch(v: string): number;
+  declare function clean(v: string, loose?: boolean): string | null;
+  declare function valid(v: string, loose?: boolean): string | null;
+  declare function inc(v: string, release: string, loose?: boolean): string | null;
+  declare function major(v: string, loose?: boolean): number;
+  declare function minor(v: string, loose?: boolean): number;
+  declare function patch(v: string, loose?: boolean): number;
 
   // Comparison
-  declare function gt(v1: string, v2: string): boolean;
-  declare function gte(v1: string, v2: string): boolean;
-  declare function lt(v1: string, v2: string): boolean;
-  declare function lte(v1: string, v2: string): boolean;
-  declare function eq(v1: string, v2: string): boolean;
-  declare function neq(v1: string, v2: string): boolean;
+  declare function gt(v1: string, v2: string, loose?: boolean): boolean;
+  declare function gte(v1: string, v2: string, loose?: boolean): boolean;
+  declare function lt(v1: string, v2: string, loose?: boolean): boolean;
+  declare function lte(v1: string, v2: string, loose?: boolean): boolean;
+  declare function eq(v1: string, v2: string, loose?: boolean): boolean;
+  declare function neq(v1: string, v2: string, loose?: boolean): boolean;
   declare function cmp(v1: string, comparator: Comparator, v2: string): boolean;
   declare function compare(v1: string, v2: string): -1 | 0 | 1;
   declare function rcompare(v1: string, v2: string): -1 | 0 | 1;
   declare function diff(v1: string, v2: string): ?Release;
 
   // Ranges
-  declare function validRange(r: string): string | null;
-  declare function satisfies(version: string, range: string): boolean;
-  declare function maxSatisfying(versions: Array<string>, range: string): string | null;
+  declare function validRange(r: string, loose?: boolean): string | null;
+  declare function satisfies(version: string, range: string, loose?: boolean): boolean;
+  declare function maxSatisfying(versions: Array<string>, range: string, loose?: boolean): string | null;
   declare function gtr(version: string, range: string): boolean;
   declare function ltr(version: string, range: string): boolean;
   declare function outside(version: string, range: string, hilo: '>' | '<'): boolean;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-flowtype": "^2.32.1",
     "eslint-plugin-react": "^6.7.1",
     "eslint-plugin-yarn-internal": "file:scripts/eslint-rules",
-    "flow-bin": "^0.43.0",
+    "flow-bin": "^0.48.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.0.0",
     "gulp-if": "^2.0.1",

--- a/src/cli/commands/_build-sub-commands.js
+++ b/src/cli/commands/_build-sub-commands.js
@@ -45,7 +45,7 @@ export default function(rootCommandName: string, subCommands: SubCommands, usage
     return Promise.reject(new MessageError(reporter.lang('invalidCommand', subCommandNames.join(', '))));
   }
 
-  function hasWrapper(): boolean {
+  function hasWrapper(commander: Object, args: Array<string>): boolean {
     return true;
   }
 

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -173,7 +173,7 @@ export class Add extends Install {
   }
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object): boolean {
   return true;
 }
 

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -6,11 +6,11 @@ import RegistryYarn from '../../resolvers/registries/yarn-resolver.js';
 
 const path = require('path');
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object): boolean {
   return false;
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
 export function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const binFolder = path.join(config.cwd, config.registries[RegistryYarn.registry].folder, '.bin');

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -15,7 +15,7 @@ const path = require('path');
 export const requireLockfile = false;
 export const noArguments = true;
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object): boolean {
   return true;
 }
 

--- a/src/cli/commands/clean.js
+++ b/src/cli/commands/clean.js
@@ -126,8 +126,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   reporter.info(reporter.lang('cleanSavedSize', Number((removedSize / 1024 / 1024).toFixed(2))));
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object): boolean {
   return true;
 }

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -10,9 +10,9 @@ import * as child from '../../util/child.js';
 import * as fs from '../../util/fs.js';
 import {run as runGlobal} from './global.js';
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/exec.js
+++ b/src/cli/commands/exec.js
@@ -6,9 +6,9 @@ import type {Reporter} from '../../reporters/index.js';
 import * as child from '../../util/child.js';
 import {makeEnv} from '../../util/execute-lifecycle-script.js';
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/generate-lock-entry.js
+++ b/src/cli/commands/generate-lock-entry.js
@@ -6,7 +6,7 @@ import {MessageError} from '../../errors.js';
 import {implodeEntry} from '../../lockfile/wrapper.js';
 import stringify from '../../lockfile/stringify.js';
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return false;
 }
 

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -7,11 +7,11 @@ import type Config from '../../config.js';
 import {sortAlpha, hyphenate} from '../../util/misc.js';
 const chalk = require('chalk');
 
-export function hasWrapper(): boolean {
+export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return false;
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
 export function run(config: Config, reporter: Reporter, commander: Object, args: Array<string>): Promise<void> {
   if (args.length) {

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -294,9 +294,9 @@ export class Import extends Install {
   }
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -36,9 +36,9 @@ function clean(object: any): any {
   }
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -15,7 +15,7 @@ export function setFlags(commander: Object) {
   commander.option('-y, --yes', 'use default options');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -249,7 +249,7 @@ export class Install {
           }
 
           let pattern = name;
-          if (!this.lockfile.getLocked(pattern, true)) {
+          if (!this.lockfile.getLocked(pattern)) {
             // when we use --save we save the dependency to the lockfile with just the name rather than the
             // version combo
             pattern += '@' + depMap[name];
@@ -808,7 +808,7 @@ export class Install {
   maybeOutputUpdate: any;
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -22,11 +22,11 @@ export async function getRegistryFolder(config: Config, name: string): Promise<s
   return path.join(config.cwd, registryFolder);
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   if (args.length) {

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -147,7 +147,7 @@ export function getParent(key: string, treesByKey: Object): Object {
   return treesByKey[parentKey];
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -106,11 +106,11 @@ export async function getToken(config: Config, reporter: Reporter, name: string 
   }
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   await getCredentials(config, reporter);

--- a/src/cli/commands/logout.js
+++ b/src/cli/commands/logout.js
@@ -3,9 +3,9 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -12,7 +12,7 @@ export function setFlags(commander: Object) {
   commander.usage('outdated [packages ...]');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -144,7 +144,7 @@ export function setFlags(commander: Object) {
   commander.option('-f, --filename <filename>', 'filename');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -22,7 +22,7 @@ export function setFlags(commander: Object) {
   commander.option('--tag [tag]', 'tag');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -14,9 +14,9 @@ const path = require('path');
 
 export const requireLockfile = true;
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -16,9 +16,9 @@ function joinArgs(args: Array<string>): string {
   return args.reduce((joinedArgs, arg) => joinedArgs + ' "' + arg.replace(/"/g, '\\"') + '"', '');
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/unlink.js
+++ b/src/cli/commands/unlink.js
@@ -9,9 +9,9 @@ import {getBinFolder as getGlobalBinFolder} from './global';
 
 const path = require('path');
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -17,7 +17,7 @@ export function setFlags(commander: Object) {
   commander.option('-T, --tilde', 'install most recent release with the same minor version');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -14,7 +14,7 @@ export function setFlags(commander: Object) {
   commander.option('--latest', 'upgrade packages to the latest version, ignoring version ranges in package.json');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -24,7 +24,7 @@ export function setFlags(commander: Object) {
   commander.option('--no-git-tag-version', 'no git tag version');
 }
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/versions.js
+++ b/src/cli/commands/versions.js
@@ -5,9 +5,9 @@ import type Config from '../../config.js';
 
 import {version as yarnVersion} from '../../util/yarn-version.js';
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -108,9 +108,9 @@ function getSharedDependencies(hoistManifests: HoistManifestTuples, transitiveKe
   return sharedDependencies;
 }
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/cli/commands/workspace.js
+++ b/src/cli/commands/workspace.js
@@ -7,9 +7,9 @@ import * as child from '../../util/child.js';
 
 const invariant = require('invariant');
 
-export function setFlags() {}
+export function setFlags(commander: Object) {}
 
-export function hasWrapper(): boolean {
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -150,7 +150,6 @@ export default class TarballFetcher extends BaseFetcher {
 
           const handleRequestError = res => {
             if (res.statusCode >= 400) {
-              // $FlowFixMe
               const statusDescription = http.STATUS_CODES[res.statusCode];
               reject(new Error(reporter.lang('requestFailed', `${res.statusCode} ${statusDescription}`)));
             }

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -114,7 +114,7 @@ export function fetch(pkgs: Array<Manifest>, config: Config): Promise<Array<Mani
       }
 
       if (tick) {
-        tick(ref.name);
+        tick();
       }
 
       if (newPkg) {

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -274,7 +274,7 @@ export default class PackageLinker {
 
       onProgress(src: string) {
         if (tick) {
-          tick(src);
+          tick();
         }
       },
     });
@@ -288,7 +288,7 @@ export default class PackageLinker {
 
       onProgress(src: string) {
         if (tick) {
-          tick(src);
+          tick();
         }
       },
     });
@@ -318,7 +318,7 @@ export default class PackageLinker {
         async ([dest, {pkg}]) => {
           const binLoc = path.join(dest, this.config.getFolder(pkg));
           await this.linkBinDependencies(pkg, binLoc);
-          tickBin(dest);
+          tickBin();
         },
         linkBinConcurrency,
       );
@@ -331,7 +331,7 @@ export default class PackageLinker {
           if (pkg.bin && Object.keys(pkg.bin).length) {
             const binLoc = path.join(this.config.cwd, this.config.getFolder(pkg));
             await this.linkSelfDependencies(pkg, dest, binLoc);
-            tickBin(this.config.cwd);
+            tickBin();
           }
         },
         linkBinConcurrency,

--- a/src/reporters/event-reporter.js
+++ b/src/reporters/event-reporter.js
@@ -19,5 +19,4 @@ export default class EventReporter extends JSONReporter {
   }
 }
 
-// $FlowFixMe: need to "inherit" from it
 Object.assign(EventReporter.prototype, EventEmitter.prototype);

--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -42,7 +42,7 @@ export default class JSONReporter extends BaseReporter {
     this._dump('inspect', value);
   }
 
-  footer() {
+  footer(showPeakMemory: boolean) {
     this._dump('finished', this.getTotalTime());
   }
 

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -74,7 +74,6 @@ export default class TarballResolver extends ExoticResolver {
           hash,
         },
         this.config,
-        false,
       );
 
       // fetch file and get it's hash

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -14,7 +14,7 @@ const path = require('path');
 export const lockQueue = new BlockingQueue('fs lock');
 
 export const readFileBuffer = promisify(fs.readFile);
-export const writeFile: (path: string, data: string) => Promise<void> = promisify(fs.writeFile);
+export const writeFile: (path: string, data: string, options?: Object) => Promise<void> = promisify(fs.writeFile);
 export const readlink: (path: string, opts: void) => Promise<string> = promisify(fs.readlink);
 export const realpath: (path: string, opts: void) => Promise<string> = promisify(fs.realpath);
 export const readdir: (path: string, opts: void) => Promise<Array<string>> = promisify(fs.readdir);
@@ -26,8 +26,8 @@ export const mkdirp: (path: string) => Promise<void> = promisify(require('mkdirp
 export const exists: (path: string) => Promise<boolean> = promisify(fs.exists, true);
 export const lstat: (path: string) => Promise<fs.Stats> = promisify(fs.lstat);
 export const chmod: (path: string, mode: number | string) => Promise<void> = promisify(fs.chmod);
-export const link: (path: string) => Promise<fs.Stats> = promisify(fs.link);
-export const glob: (path: string) => Promise<Array<string>> = promisify(globModule);
+export const link: (src: string, dst: string) => Promise<fs.Stats> = promisify(fs.link);
+export const glob: (path: string, options?: Object) => Promise<Array<string>> = promisify(globModule);
 
 const CONCURRENT_QUEUE_ITEMS = 4;
 

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -342,7 +342,6 @@ export default class Git {
               fileContent += decoder.write(buffer);
             });
             stream.on('end', () => {
-              // $FlowFixMe: suppressing this error due to bug https://github.com/facebook/flow/pull/3483
               const remaining: string = decoder.end();
               update(fileContent + remaining);
               next();

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -6,7 +6,7 @@ export function wait(delay: number): Promise<void> {
   });
 }
 
-export function promisify(fn: Function, firstData?: boolean): () => Promise<any> {
+export function promisify(fn: Function, firstData?: boolean): (...args: Array<any>) => Promise<any> {
   return function(...args): Promise<any> {
     return new Promise(function(resolve, reject) {
       args.push(function(err, ...result) {
@@ -31,18 +31,6 @@ export function promisify(fn: Function, firstData?: boolean): () => Promise<any>
       fn.apply(null, args);
     });
   };
-}
-
-export function promisifyObject(obj: {
-  [key: string]: Function,
-}): {
-  [key: string]: () => Promise<any>,
-} {
-  const promisedObj = {};
-  for (const key in obj) {
-    promisedObj[key] = promisify(obj[key]);
-  }
-  return promisedObj;
 }
 
 export function queue<T, U>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,9 +1884,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.43.0:
-  version "0.43.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.43.1.tgz#0733958b448fb8ad4b1576add7e87c31794c81bc"
+flow-bin@^0.48.0:
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.48.0.tgz#72d075143524358db8901525e3c784dc13a7c7ee"
 
 flow-parser@0.45.0:
   version "0.45.0"
@@ -2697,28 +2697,32 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istanbul-api@^1.1.0-alpha.1:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.8.tgz#a844e55c6f9aeee292e7f42942196f60b23dc93e"
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.9.tgz#2827920d380d4286d857d57a2968a841db8a7ec8"
   dependencies:
     async "^2.1.4"
     fileset "^2.0.2"
-    istanbul-lib-coverage "^1.1.0"
-    istanbul-lib-hook "^1.0.6"
-    istanbul-lib-instrument "^1.7.1"
-    istanbul-lib-report "^1.1.0"
-    istanbul-lib-source-maps "^1.2.0"
-    istanbul-reports "^1.1.0"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-hook "^1.0.7"
+    istanbul-lib-instrument "^1.7.2"
+    istanbul-lib-report "^1.1.1"
+    istanbul-lib-source-maps "^1.2.1"
+    istanbul-reports "^1.1.1"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.1.0:
+istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+
+istanbul-lib-coverage@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#caca19decaef3525b5d6331d701f3f3b7ad48528"
 
-istanbul-lib-hook@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.6.tgz#c0866d1e81cf2d5319249510131fc16dee49231f"
+istanbul-lib-hook@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz#dd6607f03076578fe7d6f2a630cf143b49bacddc"
   dependencies:
     append-transform "^0.4.0"
 
@@ -2734,28 +2738,40 @@ istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.7.1:
     istanbul-lib-coverage "^1.1.0"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz#444c4ecca9afa93cf584f56b10f195bf768c0770"
+istanbul-lib-instrument@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz#6014b03d3470fb77638d5802508c255c06312e56"
   dependencies:
-    istanbul-lib-coverage "^1.1.0"
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.13.0"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#f0e55f56655ffa34222080b7a0cd4760e1405fc9"
+  dependencies:
+    istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz#8c7706d497e26feeb6af3e0c28fd5b0669598d0e"
+istanbul-lib-source-maps@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
   dependencies:
     debug "^2.6.3"
-    istanbul-lib-coverage "^1.1.0"
+    istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.0.tgz#1ef3b795889219cfb5fad16365f6ce108d5f8c66"
+istanbul-reports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.1.tgz#042be5c89e175bc3f86523caab29c014e77fee4e"
   dependencies:
     handlebars "^4.0.3"
 
@@ -2902,8 +2918,8 @@ jest-resolve@^19.0.2:
     resolve "^1.2.0"
 
 jest-runtime@^19.0.2:
-  version "19.0.3"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-19.0.3.tgz#a163354ace46910ee33f0282b6bff6b0b87d4330"
+  version "19.0.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-19.0.4.tgz#f167d9f1347752f2027361067926485349fcc245"
   dependencies:
     babel-core "^6.0.0"
     babel-jest "^19.0.0"


### PR DESCRIPTION
**Summary**
After experimenting in https://github.com/yarnpkg/yarn/pull/3652 I understand how to upgrade flow without many breaking changes.

Some info:
- From version v0.46.0 Flow does a strict check of Function Call Arity (https://flow.org/blog/2017/05/07/Strict-Function-Call-Arity/)
- Flow complains when I add a custom matcher in Jest, now I fixed adding the function in the flow definition of jest (I opened an issue flowtype/flow-typed#948)
- the semver definition in flow-typed miss some definitions (https://github.com/flowtype/flow-typed/blob/master/cli/flow-typed/npm/semver_v5.1.x.js). Maybe I will open a pull-request in that repo too.

**Test plan**
The same tests in place.

cc @arcanis @bestander 