### PR TITLE
Bugfix help command

### DIFF
--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -5,6 +5,8 @@ import * as constants from '../../constants.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {sortAlpha, hyphenate} from '../../util/misc.js';
+import unsupportedAliases from '../unsupported-aliases.js';
+import aliases from '../aliases';
 const chalk = require('chalk');
 
 export function hasWrapper(): boolean {
@@ -41,11 +43,14 @@ export function run(config: Config, reporter: Reporter, commander: Object, args:
     const getDocsLink = name => `${constants.YARN_DOCS}${name || ''}`;
     console.log('  Commands:\n');
     for (const name of Object.keys(commands).sort(sortAlpha)) {
-      if (commands[name].useless) {
+      if (commands[name].useless || !!unsupportedAliases[name] || Object.values(aliases).includes(name)) {
         continue;
       }
-
-      console.log(`    - ${hyphenate(name)}`);
+      if(!!aliases[name]) {
+        console.log(`    - ${hyphenate(name)}  alias: ${aliases[name]}`);
+      }
+      else 
+        console.log(`    - ${hyphenate(name)}`);
     }
     console.log('\n  Run `' + chalk.bold('yarn help COMMAND') + '` for more information on specific commands.');
     console.log('  Visit ' + chalk.bold(getDocsLink()) + ' to learn more about Yarn.\n');

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -43,7 +43,11 @@ export function run(config: Config, reporter: Reporter, commander: Object, args:
     const getDocsLink = name => `${constants.YARN_DOCS}${name || ''}`;
     console.log('  Commands:\n');
     for (const name of Object.keys(commands).sort(sortAlpha)) {
-      if (commands[name].useless || unsupportedAliases[name] || Object.keys(aliases).map(key => aliases[key]).indexOf(name) > -1) {
+      if (
+        commands[name].useless ||
+        unsupportedAliases[name] ||
+        Object.keys(aliases).map(key => aliases[key]).indexOf(name) > -1
+      ) {
         continue;
       }
       if (aliases[name]) {

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -43,11 +43,11 @@ export function run(config: Config, reporter: Reporter, commander: Object, args:
     const getDocsLink = name => `${constants.YARN_DOCS}${name || ''}`;
     console.log('  Commands:\n');
     for (const name of Object.keys(commands).sort(sortAlpha)) {
-      if (commands[name].useless || unsupportedAliases[name] || Object.values(aliases).includes(name)) {
+      if (commands[name].useless || unsupportedAliases[name] || Object.keys(aliases).map(key => aliases[key]).indexOf(name) > -1) {
         continue;
       }
       if (aliases[name]) {
-        console.log(`    - ${hyphenate(name)}  alias: ${aliases[name]}`);
+        console.log(`    - ${hyphenate(name)} / ${aliases[name]}`);
       } else {
         console.log(`    - ${hyphenate(name)}`);
       }

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -43,14 +43,14 @@ export function run(config: Config, reporter: Reporter, commander: Object, args:
     const getDocsLink = name => `${constants.YARN_DOCS}${name || ''}`;
     console.log('  Commands:\n');
     for (const name of Object.keys(commands).sort(sortAlpha)) {
-      if (commands[name].useless || !!unsupportedAliases[name] || Object.values(aliases).includes(name)) {
+      if (commands[name].useless || unsupportedAliases[name] || Object.values(aliases).includes(name)) {
         continue;
       }
-      if(!!aliases[name]) {
+      if (aliases[name]) {
         console.log(`    - ${hyphenate(name)}  alias: ${aliases[name]}`);
-      }
-      else 
+      } else {
         console.log(`    - ${hyphenate(name)}`);
+      }
     }
     console.log('\n  Run `' + chalk.bold('yarn help COMMAND') + '` for more information on specific commands.');
     console.log('  Visit ' + chalk.bold(getDocsLink()) + ' to learn more about Yarn.\n');


### PR DESCRIPTION
**Summary** - Bug Fix
This PR fixes #3559 

The code removes unsupported aliases from the output list of help command and also prints out the supported alias (if there is any) for the command in the same row. For clarification, please have a look at the command `generate-lock-entry` and `upgrade-interactive` in the output below, you should be able to see the alias of the commands in the same line.

**Output with this fix**
```
Usage: yarn [command] [flags]

  Options:

    -h, --help                          output usage information
    -V, --version                       output the version number
    --verbose                           output verbose messages on internal operations
    --offline                           trigger an error if any required dependencies are not available in local cache
    --prefer-offline                    use network only if dependencies are not available in local cache
    --strict-semver                     
    --json                              
    --ignore-scripts                    don't run lifecycle scripts
    --har                               save HAR output of network traffic
    --ignore-platform                   ignore platform checks
    --ignore-engines                    ignore engines check
    --ignore-optional                   ignore optional dependencies
    --force                             install and build packages even if they were built before, overwrite lockfile
    --skip-integrity-check              run install without checking if node_modules is installed
    --check-files                       install will verify file tree of packages for consistency
    --no-bin-links                      don't generate bin links when setting up packages
    --flat                              only allow one version of a package
    --prod, --production [prod]         
    --no-lockfile                       don't read or generate a lockfile
    --pure-lockfile                     don't generate a lockfile
    --frozen-lockfile                   don't generate a lockfile and fail if an update is needed
    --link-duplicates                   create hardlinks to the repeated modules in node_modules
    --global-folder <path>              specify a custom folder to store global packages
    --modules-folder <path>             rather than installing modules into the node_modules folder relative to the cwd, output them here
    --cache-folder <path>               specify a custom folder to store the yarn cache
    --mutex <type>[:specifier]          use a mutex to ensure only one yarn instance is executing
    --emoji                             enable emoji in output
    -s, --silent                        skip Yarn console logs, other types of logs (script output) will be printed
    --proxy <host>                      
    --https-proxy <host>                
    --no-progress                       disable progress bar
    --network-concurrency <number>      maximum number of concurrent network requests
    --network-timeout <milliseconds>    TCP timeout for network requests
    --non-interactive                   do not show interactive prompts
    --scripts-prepend-node-path [bool]  prepend the node executable dir to the PATH in scripts

  Commands:

    - access
    - add
    - bin
    - cache
    - check
    - clean
    - config
    - create
    - exec
    - generate-lock-entry  alias: generateLockEntry
    - global
    - help
    - import
    - info
    - init
    - install
    - licenses
    - link
    - list
    - login
    - logout
    - outdated
    - owner
    - pack
    - publish
    - remove
    - run
    - tag
    - team
    - unlink
    - upgrade
    - upgrade-interactive  alias: upgradeInteractive
    - version
    - versions
    - why
    - workspace

  Run `yarn help COMMAND` for more information on specific commands.
  Visit https://yarnpkg.com/en/docs/cli/ to learn more about Yarn.
```