### PR TITLE
add a check that same file is not copied twice

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -163,6 +163,7 @@ async function buildActionsForCopy(
     const {src, dest, type} = data;
     const onFresh = data.onFresh || noop;
     const onDone = data.onDone || noop;
+    invariant(!files.has(dest), `The same file ${dest} can't be copied twice in one bulk copy`);
     files.add(dest);
 
     if (type === 'symlink') {


### PR DESCRIPTION

**Summary**

If the same file is copied twice during a bulk copy then we have a problem in out recursive logic.
Added an invariant to make sure we don't make extra IO operation.

**Test plan**

all tests pass