### PR TITLE
Fix ".bin" not linked when preparing a git dependency

### DIFF
--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -83,7 +83,7 @@ test('GitFetcher.fetch with prepare script', async () => {
     {
       type: 'git',
       reference: 'https://github.com/Volune/test-js-git-repo',
-      hash: '96e838bcc908ed424666b4b04efe802fd4c8bccd',
+      hash: '0e56593e326069ed4bcec8126bb48a1891215c57',
       registry: 'npm',
     },
     (await Config.create()),
@@ -95,6 +95,8 @@ test('GitFetcher.fetch with prepare script', async () => {
   expect(dependencyName).toBe('beeper');
   // The file "prepare.js" is not in "files" list
   expect(await fs.exists(path.join(dir, 'prepare.js'))).toBe(false);
+  // Check the dependency with a bin script was correctly executed
+  expect(await fs.exists(path.join(dir, 'testscript.output.txt'))).toBe(true);
   // Check executed lifecycle scripts
   expect(await fs.exists(path.join(dir, 'generated', 'preinstall'))).toBe(true);
   expect(await fs.exists(path.join(dir, 'generated', 'install'))).toBe(true);

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -161,6 +161,7 @@ export default class GitFetcher extends BaseFetcher {
     const [prepareConfig, prepareLockFile] = await Promise.all([
       Config.create(
         {
+          binLinks: true,
           cwd: prepareDirectory,
           disablePrepublish: true,
         },


### PR DESCRIPTION
**Summary**

Fix installation issue reported by @sammarks in yarnpkg/yarn#3553
> - I have `package-a` that depends on `package-b` (through a git URL as package-b is not published to a registry).
> - `package-a` and `package-b` both use Babel (listed in devDependencies in both).
> - `package-b`'s prepare script is: `babel --optional runtime src -d dist`
> 
> When installing the dependencies of package-a, I get an error message: `babel: command not found`

**Test plan**

Improved test in `__test__/fetchers.js` (Updated test dependency Volune/test-js-git-repo@1958040dbfb461f32f43ac5a6f319880b9c448ea and Volune/test-js-git-repo@c455e0cb000917f4362ee4c792e8a4636a291f89)