### PR TITLE
Yarn workspaces: running commands from subfolders that don't match glob

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -65,6 +65,15 @@ test.concurrent('adds any new package to the current workspace, but install from
 
     expect(await fs.exists(`${config.cwd}/yarn.lock`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/packages/package-b/yarn.lock`)).toEqual(false);
+
+    await add(await makeConfigFromDirectory(`${config.cwd}/non-packages/package-c`, reporter), reporter, {}, [
+      'isarray',
+    ]);
+
+    expect(await fs.exists(`${config.cwd}/node_modules/isarray`)).toEqual(false);
+    expect(await fs.exists(`${config.cwd}/non-packages/package-c/node_modules/isarray`)).toEqual(true);
+
+    expect(await fs.exists(`${config.cwd}/non-packages/package-c/yarn.lock`)).toEqual(true);
   });
 });
 

--- a/__tests__/fixtures/install/simple-worktree/non-package/package-c/README.md
+++ b/__tests__/fixtures/install/simple-worktree/non-package/package-c/README.md
@@ -1,0 +1,1 @@
+Workspace A

--- a/__tests__/fixtures/install/simple-worktree/non-package/package-c/package.json
+++ b/__tests__/fixtures/install/simple-worktree/non-package/package-c/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-a",
+  "version": "1.0.0",
+  "license": "MIT"
+}

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,7 @@ import map from './util/map.js';
 const detectIndent = require('detect-indent');
 const invariant = require('invariant');
 const path = require('path');
+const micromatch = require('micromatch');
 
 export type ConfigOptions = {
   cwd?: ?string,
@@ -573,9 +574,13 @@ export default class Config {
 
     do {
       const manifest = await this.findManifest(current, true);
-
       if (manifest && manifest.workspaces) {
-        return current;
+        const relativePath = path.relative(current, initial);
+        if (relativePath === '' || micromatch([relativePath], manifest.workspaces).length > 0) {
+          return current;
+        } else {
+          return null;
+        }
       }
 
       previous = current;


### PR DESCRIPTION

This fixes an issue that if you run a Yarn command from any folder that is a subfolder of a workspace it will automatically change CWD to the root.

Before changing CWD the code now checks that workspaces glob matches the original CWD.

**Test plan**

Added test