### PR TITLE
Fix: inherit env variables from process when calling Git

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -32,7 +32,12 @@ const supportsArchiveCache: {[key: string]: boolean} = map({
 });
 
 // Suppress any password prompts since we run these in the background
-const env = {GIT_ASKPASS: '', GIT_TERMINAL_PROMPT: 0, GIT_SSH_COMMAND: 'ssh -oBatchMode=yes'};
+const env = {
+  ...process.env,
+  GIT_ASKPASS: '',
+  GIT_TERMINAL_PROMPT: 0,
+  GIT_SSH_COMMAND: 'ssh -oBatchMode=yes',
+};
 
 // This regex is designed to match output from git of the style:
 //   ebeb6eafceb61dd08441ffe086c77eb472842494  refs/tags/v0.21.0


### PR DESCRIPTION
**Summary**

Fixes #3742.

With #3633 we started overriding the default `env` map that was passed
to `git` calls. It defaulted to `process.env` and since the option is
a whitelist, now it is only the ones we wanted to add, instead of
`process.env` + the additions. This patch fixes the problem by spreading
`process.env` before the new values.

Relevant part from Node docs:

https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
>Use env to specify environment variables that will be visible to the new process, the default is process.env.

**Test plan**

Manual verification for t19705486. We should have automated tests for this
so I'll start working on them. Just want the fix our first.