### PR TITLE
Support for ~ (home dir) in path configurations

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -1,0 +1,41 @@
+/* @flow */
+
+import NpmRegistry from '../../src/registries/npm-registry.js';
+import {resolve} from 'path';
+import homeDir from '../../src/util/user-home-dir.js';
+
+describe('normalizeConfig', () => {
+  beforeAll(() => {
+    process.env.REPLACE = 'REPLACED';
+  });
+
+  afterAll(() => {
+    delete process.env.REPLACE;
+  });
+
+  test('environment is replaced', () => {
+    const normalized = NpmRegistry.normalizeConfig({username: '[${REPLACE}]'})['username'];
+    expect(normalized).toEqual('[REPLACED]');
+  });
+
+  test("path normalization doesn't affect all options", () => {
+    const normalized = NpmRegistry.normalizeConfig({username: 'foo'})['username'];
+    expect(normalized).toEqual('foo');
+  });
+
+  test('resolve path to current directory', () => {
+    const normalized = NpmRegistry.normalizeConfig({cafile: 'foo'})['cafile'];
+    expect(normalized).toEqual(resolve(process.cwd(), 'foo'));
+  });
+
+  test('resolve path to home directory', () => {
+    const normalized = NpmRegistry.normalizeConfig({cafile: '~/foo'})['cafile'];
+    expect(normalized).toEqual(resolve(homeDir, 'foo'));
+  });
+
+  test('resolve keep path to rooted directory', () => {
+    const rooted = process.platform === 'win32' ? 'C:\\foo' : '/foo';
+    const normalized = NpmRegistry.normalizeConfig({cafile: rooted})['cafile'];
+    expect(normalized).toEqual(rooted);
+  });
+});

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {resolve} from 'path';
+
 const userHome = require('./user-home-dir').default;
 
 export function getPosixPath(path: string): string {
@@ -12,4 +14,13 @@ export function expandPath(path: string): string {
   }
 
   return path;
+}
+
+export function resolveWithHome(path: string): string {
+  const homePattern = process.platform === 'win32' ? /^~(\/|\\)/ : /^~\//;
+  if (path.match(homePattern)) {
+    return resolve(userHome, path.substr(2));
+  }
+
+  return resolve(path);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

This fixes the handling of path that are present in npm configuration (#2930). What's now handled :

* Paths starting with `~/` (Also `~\` on windows) get expanded
* Path that aren't rooted are considered relative to the current directory
* All path are fully resolved

All of this is from npm ( https://github.com/npm/npm/blob/latest/lib/config/core.js#L394 ).
I'm not sure that I like the fact that relative paths are relative to cwd instead of the configuration file where they are found but it's what's npm is doing 😉 

**Motivation**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

My original motivation was to stop having errors when i'm installing `node-sass` on node 8. As versions of `node-sass` that aren't the latest don't include pre-built binaries for node 8 the installer try to use `node-gyp` to build a fresh copy.

This build would work (I have the necessary dev tools) except that `node-gyp` since recently read the `cafile` property and open it. As the cwd for install script is their package, it fail and break most yarn commands.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I added some unit tests tests.

Also verified on the output of an npm module dumping it's environment in it's install script (during `yarn install --verbose`) :

![2017-06-29 16_05_09-vs 2015](https://user-images.githubusercontent.com/131878/27691606-ca19b244-5ce4-11e7-8854-e89b34fc784e.png)

With `.npmrc`:

```
cafile=cafile
prefix=~/.npm-global
```
