### PR TITLE
Chore: prefer async/await to `then`

### DIFF
--- a/__tests__/commands/unlink.js
+++ b/__tests__/commands/unlink.js
@@ -26,8 +26,9 @@ const runUnlink = buildRun.bind(
   null,
   ConsoleReporter,
   fixturesLoc,
-  (args, flags, config, reporter): CLIFunctionReturn => {
-    return link(config, reporter, flags, args).then(unlink.bind(null, config, reporter, flags, args));
+  async (args, flags, config, reporter): CLIFunctionReturn => {
+    await link(config, reporter, flags, args);
+    return unlink(config, reporter, flags, args);
   },
 );
 


### PR DESCRIPTION
**Summary**

Follow up to #3667. Uses `async`/`await` instead of `.then()` in
`unlink` tests.

**Test plan**

Tests should pass as usual.