### PR TITLE
Revert "Update: add regression tests for Git.spawn env issues"

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -1,9 +1,6 @@
 /* @flow */
 
-jest.mock('../../src/util/child.js');
-
 import Git from '../../src/util/git.js';
-import {spawn} from '../../src/util/child.js';
 import {NoopReporter} from '../../src/reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
@@ -79,10 +76,6 @@ test('secureGitUrl', async function(): Promise<void> {
   const reporter = new NoopReporter();
 
   let hasException = false;
-  (Git: any).repoExists = jest.fn();
-  Git.repoExists.mockImplementation(() => Promise.resolve(true)).mockImplementationOnce(() => {
-    throw new Error('Non-existent repo!');
-  });
   try {
     await Git.secureGitUrl(Git.npmUrlToGitUrl('http://fake-fake-fake-fake.com/123.git'), '', reporter);
   } catch (e) {
@@ -126,18 +119,5 @@ de43f4a993d1e08cd930ee22ecb2bac727f53449  refs/tags/v0.21.0-pre`),
   ).toMatchObject({
     'v0.21.0': '70e76d174b0c7d001d2cd608a16c94498496e92d',
     'v0.21.0-pre': 'de43f4a993d1e08cd930ee22ecb2bac727f53449',
-  });
-});
-
-test('spawn', () => {
-  const spawnMock = (spawn: any).mock;
-
-  Git.spawn(['status']);
-
-  expect(spawnMock.calls[0][2].env).toMatchObject({
-    ...process.env,
-    GIT_ASKPASS: '',
-    GIT_TERMINAL_PROMPT: 0,
-    GIT_SSH_COMMAND: 'ssh -oBatchMode=yes',
   });
 });

--- a/src/util/__mocks__/child.js
+++ b/src/util/__mocks__/child.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-const realChild = (require: any).requireActual('./child.js');
-
-realChild.spawn = jest.fn(() => Promise.resolve(''));
-
-module.exports = realChild;


### PR DESCRIPTION
Reverts yarnpkg/yarn#3759, see comments for reasons

- mock leaks into source code when built
- jest complains about seeing the mock twice 