### PR TITLE
fixes #3767 - silencing Yarn when running in jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,10 +95,11 @@
     "lint": "yarn run lint-prettier && eslint . && flow check",
     "lint-prettier": "node scripts/prettier.js lint",
     "prettier": "node scripts/prettier.js write",
+    "jest": "YARN_SILENT=0 node ./node_modules/.bin/jest",
     "release-branch": "./scripts/release-branch.sh",
     "test": "yarn lint && yarn test-only",
     "test-ci": "yarn build && yarn test-only",
-    "test-only": "node --max_old_space_size=4096 ./node_modules/.bin/jest --coverage --verbose",
+    "test-only": "node --max_old_space_size=4096 YARN_SILENT=0 ./node_modules/.bin/jest --coverage --verbose",
     "watch": "gulp watch"
   },
   "jest": {


### PR DESCRIPTION
**Summary**
fixes #3767 which was caused by #3536

**to cherry-pick into 0.27-stable**

The reason why it fails - when you run `yarn run test-ci` current Yarn binary will set env var  `YARN_SILENT=1` and then invoke jest passing process.env.
Later jest would run some tests in Yarn repo that check for output of Yarn commands but they are silenced and fail.

Apparently it affects only tests that are invoked via `yarn run` command and that test yarn's output.
I suppose that only Yarn repository tests for Yarn output and is invoked via Yarn run command so I just override `YARN_SILENT` in the run commands that invoke jest.

Otherwise we might revert automatic silencing #3536 and educate users to silence manually.

The logic is this now

`yarn run` => sets YARN_SILENT = 1 => `finds command in package.json ` => overrides YARN_SILENT = 0 => e2e tests run not silenced.

**Test plan**

- yarn build
- `./bin/yarn run jest`