### PR TITLE
Fix: fix e2e yarn output tests after #3536

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -30,19 +30,29 @@ async function execCommand(
   }
 
   return new Promise((resolve, reject) => {
-    exec(`node "${yarnBin}" ${cmd} ${args.join(' ')}`, {cwd: workingDir, env: process.env}, (error, stdout) => {
-      if (error) {
-        reject({error, stdout});
-      } else {
-        const stdoutLines = stdout
-          .toString()
-          .split('\n')
-          .map((line: ?string) => line && line.trim())
-          .filter((line: ?string) => line);
+    exec(
+      `node "${yarnBin}" ${cmd} ${args.join(' ')}`,
+      {
+        cwd: workingDir,
+        env: {
+          ...process.env,
+          YARN_SILENT: 0,
+        },
+      },
+      (error, stdout) => {
+        if (error) {
+          reject({error, stdout});
+        } else {
+          const stdoutLines = stdout
+            .toString()
+            .split('\n')
+            .map((line: ?string) => line && line.trim())
+            .filter((line: ?string) => line);
 
-        resolve(stdoutLines);
-      }
-    });
+          resolve(stdoutLines);
+        }
+      },
+    );
   });
 }
 

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -19,13 +19,23 @@ async function execCommand(cmd: string, packageName: string, env = process.env):
   await fs.copy(srcPackageDir, packageDir, new NoopReporter());
 
   return new Promise((resolve, reject) => {
-    exec(`node "${yarnBin}" ${cmd}`, {cwd: packageDir, env}, (err, stdout) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(stdout.toString());
-      }
-    });
+    exec(
+      `node "${yarnBin}" ${cmd}`,
+      {
+        cwd: packageDir,
+        env: {
+          ...env,
+          YARN_SILENT: 0,
+        },
+      },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stdout.toString());
+        }
+      },
+    );
   });
 }
 


### PR DESCRIPTION
**Summary**

Fixes #3536. Explicitly and programmatically passes `YARN_SILENT=0`
to test runs that checks yarn's output.

**Test plan**

All CI tests and local test runs with yarn 0.27.3 should pass.