### PR TITLE
Add a failing test for version conflicts

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -883,3 +883,12 @@ test.concurrent('transitive file: dependencies should work', (): Promise<void> =
     expect(await fs.exists(path.join(config.cwd, 'node_modules', 'b'))).toBe(true);
   });
 });
+
+// Unskip once https://github.com/yarnpkg/yarn/issues/3778 is resolved
+test.skip('unbound transitive dependencies should not conflict with top level dependency', async () => {
+  await runInstall({flat: true}, 'install-conflicts', async config => {
+    expect((await fs.readJson(path.join(config.cwd, 'node_modules', 'left-pad', 'package.json'))).version).toEqual(
+      '1.0.0',
+    );
+  });
+});

--- a/__tests__/fixtures/install/install-conflicts/b/package.json
+++ b/__tests__/fixtures/install/install-conflicts/b/package.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.0.1",
+  "dependencies": {
+    "left-pad": ">=0.0.1"
+  }
+}

--- a/__tests__/fixtures/install/install-conflicts/package.json
+++ b/__tests__/fixtures/install/install-conflicts/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "b": "file:b",
+    "left-pad": "1.0.0"
+  }
+}


### PR DESCRIPTION
**Summary**
This is a failing test to highlight the issue the issue here https://github.com/yarnpkg/yarn/issues/3780 https://github.com/mxmul/yarn_flat_regression

tl;dr:

```
a => b => left-pad@>=0.0.1
a => left-pad@1.0.0
```

yarn fails when doing `--flat` with the following:

```
info Unable to find a suitable version for "left-pad", please choose one by typing one of the numbers below:
  1) "left-pad@>=0.0.1" which resolved to "1.1.3"
  2) "left-pad@1.0.0" which resolved to "1.0.0"
```

(yarn version: 0.27.1)

(this seems to be a regression introduced in 0.27.0, this worked in 0.26.1)

**Test plan**
This is a test only change.

---

This test is currently failing because it's prompting for a resolution, with the following stacktrace
```
(node:23637) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 2)
 FAIL  __tests__/commands/install/integration.js (264.799s)
  ● unbound transitive dependencies should not conflict with top level dependency

    Error: Can't answer a question unless a user TTY
      
      at ConsoleReporter.select (src/reporters/console/console-reporter.js:322:29)
      at src/cli/commands/install.js:932:182
      at next (native)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
      at Promise.F (node_modules/core-js/library/modules/_export.js:35:28)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
      at Install.flatten (src/cli/commands/install.js:933:2215)
      at src/cli/commands/install.js:922:3570
      at next (native)
      Console output:
       warning package.json: No license field
      warning No license field
      [1/4] Resolving packages...
      
      at __tests__/commands/_helpers.js:144:13
      at throw (native)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:30:13
```