### PR TITLE
forward SIGTERM to spawned child processes

### DIFF
--- a/__tests__/util/child.js
+++ b/__tests__/util/child.js
@@ -1,0 +1,74 @@
+/* @flow */
+import {spawn, forwardSignalToSpawnedProcesses} from '../../src/util/child.js';
+
+let mockSpawnedChildren = [];
+
+jest.mock('child_process', () => {
+  class MockedChildProcess {
+    stdout: Object;
+    stderr: Object;
+    receivedSignal: string;
+    exitWithCode: number => void;
+
+    constructor() {
+      this.stdout = {
+        on: () => {},
+      };
+      this.stderr = {
+        on: () => {},
+      };
+    }
+
+    kill(signal) {
+      this.receivedSignal = signal;
+    }
+
+    on(event, handler) {
+      if (event === 'close') {
+        this.exitWithCode = handler;
+      }
+    }
+  }
+
+  const realChildProcess = (require: any).requireActual('child_process');
+
+  realChildProcess.spawn = cmd => {
+    const newChild = new MockedChildProcess();
+    mockSpawnedChildren.push(newChild);
+    return newChild;
+  };
+
+  return realChildProcess;
+});
+
+const expectChildReceivedSignal = (child, signal) => {
+  expect(child.receivedSignal).toEqual(signal);
+};
+
+beforeEach(() => {
+  mockSpawnedChildren = [];
+});
+
+it('should forward signals to all spawned child processes', () => {
+  spawn('foo', []).then(() => {}, () => {});
+  spawn('bar', []).then(() => {}, () => {});
+
+  expect(mockSpawnedChildren.length).toEqual(2);
+
+  forwardSignalToSpawnedProcesses('SIGTERM');
+
+  expectChildReceivedSignal(mockSpawnedChildren[0], 'SIGTERM');
+  expectChildReceivedSignal(mockSpawnedChildren[1], 'SIGTERM');
+});
+
+it('should not attempt to forward signals to children that already terminated', () => {
+  spawn('foo', []).then(() => {}, () => {});
+  spawn('bar', []).then(() => {}, () => {});
+
+  const fooProcess = mockSpawnedChildren[0];
+  fooProcess.exitWithCode(0);
+  forwardSignalToSpawnedProcesses('SIGTERM');
+
+  expectChildReceivedSignal(mockSpawnedChildren[0], undefined);
+  expectChildReceivedSignal(mockSpawnedChildren[1], 'SIGTERM');
+});

--- a/__tests__/util/signal-handler.js
+++ b/__tests__/util/signal-handler.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+import handleSignals from '../../src/util/signal-handler.js';
+
+(process: any).on = jest.fn();
+(process: any).exit = jest.fn();
+
+beforeEach(() => {
+  process.on.mockClear();
+  process.exit.mockClear();
+});
+
+afterAll(() => {
+  process.on.mockRestore();
+  process.exit.mockRestore();
+});
+
+it('should attach a handler for SIGTERM event', () => {
+  handleSignals();
+  expect(process.on.mock.calls[0][0]).toBe('SIGTERM');
+});
+
+it('attached SIGTERM handler should exit with status code 1 when invoked', () => {
+  handleSignals();
+  const sigtermHandler = process.on.mock.calls[0][1];
+  sigtermHandler();
+  expect(process.exit.mock.calls).toEqual([[1]]);
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,6 +9,7 @@ import {MessageError} from '../errors.js';
 import Config from '../config.js';
 import {getRcArgs} from '../rc.js';
 import {version} from '../util/yarn-version.js';
+import handleSignals from '../util/signal-handler.js';
 
 const commander = require('commander');
 const fs = require('fs');
@@ -20,6 +21,7 @@ const onDeath = require('death');
 const path = require('path');
 
 loudRejection();
+handleSignals();
 
 const startArgs = process.argv.slice(0, 2);
 

--- a/src/util/signal-handler.js
+++ b/src/util/signal-handler.js
@@ -1,0 +1,13 @@
+/* @flow */
+import {forwardSignalToSpawnedProcesses} from './child.js';
+
+function forwardSignalAndExit(signal: string) {
+  forwardSignalToSpawnedProcesses(signal);
+  process.exit(1);
+}
+
+export default function handleSignals() {
+  process.on('SIGTERM', () => {
+    forwardSignalAndExit('SIGTERM');
+  });
+}


### PR DESCRIPTION
**Summary**

If yarn receives a SIGTERM signal, it forwards it to all the child processes that it has spawned. This fixes #3424.

module `src/util/child.js` now keeps a reference to every spawned child process until the child exits. it also exports a new function `forwardSignalToSpawnedProcesses()` which sends a signal to all currently held child processes.

new module `src/util/signal-handler.js` exports a single function `handleSignals()` which attaches a SIGTERM listener to the global `process` object that calls `forwardSignalToSpawnedProcesses()`

Currently the `handleSignals()` function is called in `src/cli/index.js`, please let me know if there is a better place for this.

**Test Plan**

Write a script with a long running operation and a SIGTERM handler:

```javascript
//longOperation.js
process.on('SIGTERM', () => {
  console.log('SIGTERM');
  process.exit(1)
});

setInterval(() => {
  console.log('tick')
}, 1000)
```
Add it to a package json as an executable script
```json
+ "longOperation": "node longOperation.js"
```
Run it wth yarn
```
yarn run longOperation
```
In a new terminal run `ps -axu | grep yarn` to find the yarn prcess id. You'll get something like this:

```
gabriel  11880  2.6  0.4 1107924 53612 pts/6   Sl+  05:32   0:00 node bin/yarn.js run longOperation
gabriel  11897  0.0  0.0  13020  2312 pts/4    S+   05:32   0:00 grep yarn
```
Run kill with the yarn process id
```
kill 11880
```

Yarn should be terminated and the `longOperation.js` script should be able to print `SIGTERM` to console before it exits.
