### PR TITLE
Strip 'file:' from the path before checking with path.isAbsolute()

### DIFF
--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -103,7 +103,7 @@ export default class FileResolver extends ExoticResolver {
     let temp = section;
 
     for (const [k, v] of util.entries(section)) {
-      if (typeof v === 'string' && v.startsWith('file:') && !path.isAbsolute(v)) {
+      if (typeof v === 'string' && v.startsWith('file:') && !path.isAbsolute(v.substring(5))) {
         if (temp === section) {
           temp = Object.assign({}, section);
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
`path.isAbsolute()` will always return `false` when the path is prefixed with `file:`

I came across the issue when adding local packages using absolute paths using the `file:` protocol. 

`file:` dependencies of a `file:` dependency will erroneously have their paths modified so yarn tries to locate them relative to the parent instead of using their absolute path.

**Test plan**

Take, for example, 3 packages.

**package-1**
```
{
  "name": "package-1",
  "version": "1.0.0",
  "description": "Test 1",
  "main": "index.js",
  "scripts": {
    "test": "test"
  },
  "author": "Test",
  "license": "ISC",
  "dependencies": {}
}
```
**package-2**
```
{
  "name": "package-2",
  "version": "1.0.0",
  "description": "Test 1",
  "main": "index.js",
  "scripts": {
    "test": "test"
  },
  "author": "Test",
  "license": "ISC",
  "dependencies": {
    "package-3": "file:/home/code/package-3"
  }
}
```
**package-3**
```
{
  "name": "package-3",
  "version": "1.0.0",
  "description": "Test 1",
  "main": "index.js",
  "scripts": {
    "test": "test"
  },
  "author": "Test",
  "license": "ISC",
  "dependencies": {}
}
```
Running `yarn add file:/home/code/package-2` from `package-1` will fail with the message 
```
yarn add v0.27.0
[1/4] Resolving packages...
error "/home/code/package-2/home/code/package-3" doesn't exist.
```
...because the path is being modified inside `normalizeDependencyPaths`. With this patch applied that issue is resolved.