### PR TITLE
Fix: exit with non-zero only when wanted pkgs are really outdated

### DIFF
--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -28,11 +28,15 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   const getNameFromHint = hint => (hint ? `${hint}Dependencies` : 'dependencies');
+  const isOutdatedPackage = ({current, wanted, name}) =>
+    current === wanted ? 0 : 1;
   const getColorFromVersion = ({current, wanted, name}) =>
     current === wanted ? reporter.format.yellow(name) : reporter.format.red(name);
 
+  let outdatedPackageCount = 0
   if (deps.length) {
     const body = deps.map((info): Array<string> => {
+      outdatedPackageCount += isOutdatedPackage(info)
       return [
         getColorFromVersion(info),
         info.current,
@@ -44,7 +48,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     });
 
     reporter.table(['Package', 'Current', 'Wanted', 'Latest', 'Package Type', 'URL'], body);
-    return 1;
+    if (outdatedPackageCount >= 1) {
+      return 1;
+    }
   }
   return 0;
 }

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -28,15 +28,14 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   const getNameFromHint = hint => (hint ? `${hint}Dependencies` : 'dependencies');
-  const isOutdatedPackage = ({current, wanted, name}) =>
-    current === wanted ? 0 : 1;
+  const isOutdatedPackage = ({current, wanted, name}) => (current === wanted ? 0 : 1);
   const getColorFromVersion = ({current, wanted, name}) =>
     current === wanted ? reporter.format.yellow(name) : reporter.format.red(name);
 
-  let outdatedPackageCount = 0
+  let outdatedPackageCount = 0;
   if (deps.length) {
     const body = deps.map((info): Array<string> => {
-      outdatedPackageCount += isOutdatedPackage(info)
+      outdatedPackageCount += isOutdatedPackage(info);
       return [
         getColorFromVersion(info),
         info.current,


### PR DESCRIPTION
**Summary**

Today, yarn `outdated` shows a yellow and red formatted list of outdated packages but regardless of each type of outdated packages it exists with an error.

It makes sense to return a non-zero exit code only in cases where the _current_ package installed is not aligned with the _wanted_ package. If they are on the same version and a more up to date version exists, it doesn't necessarily convey a problem.

The strongest motivation behind the error code is that users can run `yarn outdated` on their CI builds and if a version is out of date than what they expect then it will fail the build. This Pull Request will amend the outdated command for this expected behavior.

**Test plan**

Demonstrating the fix:

![image](https://user-images.githubusercontent.com/316371/27974981-02c60d92-6369-11e7-8487-38d6a9e461a7.png)
