### PR TITLE
Fix list, outdated commands when workspaces enabled

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -381,7 +381,12 @@ export default class PackageRequest {
     config: Config,
     reporter: Reporter,
   ): Promise<Array<Dependency>> {
-    const {requests: depReqPatterns} = await install.fetchRequestFromCwd();
+    const {requests: reqPatterns, workspaceLayout} = await install.fetchRequestFromCwd();
+
+    // Filter out workspace patterns if necessary
+    const depReqPatterns = workspaceLayout
+      ? reqPatterns.filter(p => !workspaceLayout.getManifestByPattern(p.pattern))
+      : reqPatterns;
 
     const deps = await Promise.all(
       depReqPatterns.map(async ({pattern, hint}): Promise<Dependency> => {


### PR DESCRIPTION
**Summary**

Fixes #3859 and #3841.

These both seemed to be related to the virtual manifest that's included when workspaces are enabled, so I took a stab at fixing both places.

**Test plan**

Existing tests should ensure this doesn't break things for people not trying out the experimental workspaces feature.
