### PR TITLE
Fix HTTP status check for publish

### DIFF
--- a/__tests__/util/misc.js
+++ b/__tests__/util/misc.js
@@ -7,8 +7,3 @@ test('sortAlpha', () => {
     ['foo@6.x', 'foo@^6.5.0', 'foo@~6.8.x', 'foo@^6.7.0', 'foo@~6.8.0', 'foo@^6.8.0', 'foo@6.8.0'].sort(misc.sortAlpha),
   ).toEqual(['foo@6.8.0', 'foo@6.x', 'foo@^6.5.0', 'foo@^6.7.0', 'foo@^6.8.0', 'foo@~6.8.0', 'foo@~6.8.x']);
 });
-
-test('has2xxResponse', () => {
-  const response = {responseCode: 200};
-  expect(misc.has2xxResponse(response)).toEqual(true);
-});

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -8,7 +8,6 @@ import {setVersion, setFlags as versionSetFlags} from './version.js';
 import * as fs from '../../util/fs.js';
 import {pack} from './pack.js';
 import {getToken} from './login.js';
-import {has2xxResponse} from '../../util/misc.js';
 
 const invariant = require('invariant');
 const crypto = require('crypto');
@@ -101,7 +100,7 @@ async function publish(config: Config, pkg: any, flags: Object, dir: string): Pr
     body: root,
   });
 
-  if (res !== null && has2xxResponse(res)) {
+  if (res) {
     await config.executeLifecycleScript('publish');
     await config.executeLifecycleScript('postpublish');
   } else {

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -2,10 +2,6 @@
 
 const _camelCase = require('camelcase');
 
-export function has2xxResponse(res: Object): boolean {
-  return res.responseCode >= 200 && res.responseCode < 300;
-}
-
 export function sortAlpha(a: string, b: string): number {
   // sort alphabetically in a deterministic way
   const shortLen = Math.min(a.length, b.length);


### PR DESCRIPTION
**Summary**

```publish``` still uses the old ```has2xxResponse``` method of checking the registry request. This was causing publish to fail.

**Test plan**
```
johnf@kermit:~/dev/npm-test$ ~/dev/small_patches/yarn/bin/yarn publish  --new-version 1.0.5 
yarn publish v0.27.0
[1/4] Bumping version...
info Current version: 1.0.5
[2/4] Logging in...
info npm username: johnf
info npm email: johnf@inodes.org
question npm password: 
success Logged in.
[3/4] Publishing...
success Published.
[4/4] Revoking token...
success Revoked login token.
Done in 18.24s.
```

Was previously returning
```
ohnf@kermit:~/dev/npm-test$ ~/dev/small_patches/yarn/bin/yarn publish --new-version 1.0.3
yarn publish v0.27.0
[1/4] Bumping version...
info Current version: 1.0.2
info New version: 1.0.3
[2/4] Logging in...
info npm username: johnf
info npm email: johnf@inodes.org
question npm password: 
success Logged in.
[3/4] Publishing...
error Couldn't publish package.
info Visit https://yarnpkg.com/en/docs/cli/publish for documentation about this command.
```