### PR TITLE
Fix various commands asking for a password

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -192,7 +192,7 @@ export default class NpmRegistry extends Registry {
       const availableRegistries = this.getAvailableRegistries();
       const registry = availableRegistries.find(registry => packageName.startsWith(registry));
       if (registry) {
-        return addSuffix(registry, '/');
+        return String(registry);
       }
     }
 
@@ -200,7 +200,7 @@ export default class NpmRegistry extends Registry {
       const registry =
         this.getScopedOption(scope, 'registry') || this.registries.yarn.getScopedOption(scope, 'registry');
       if (registry) {
-        return addSuffix(String(registry), '/');
+        return String(registry);
       }
     }
 


### PR DESCRIPTION
**Summary**

Commands like ```publish``` were asking for a password instead of using the token in ```.npmrc```.

The core code path that was causing the issue is https://github.com/yarnpkg/yarn/blob/master/src/registries/npm-registry.js#L218-L221

``` javascript
// If sending a request to the Yarn registry, we must also send it the auth token for the npm registry
if (baseRegistry === YARN_REGISTRY) {
  registries.push(DEFAULT_REGISTRY);
}
```

The problem was ```baseRegistry = "https://registry.yarnpkg.com"``` while ```YARN_REGISTRY = "https://registry.yarnpkg.com/"```. Notice the trailing slash.

I've reverted the code added in https://github.com/yarnpkg/yarn/commit/33820719e2c049ff93e86d29251b96d496f2b6e8#diff-b053bee294c216269844e5874039b6caR172
which solves the problem. Unclear to me why it was added though.

**Test plan**

yarn publish no longer asks for a password.
