### PR TITLE
Remove babel-plugin-transform-es2015-typeof-symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babel-jest": "^19.0.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-array-includes": "^2.0.3",
-    "babel-plugin-transform-es2015-typeof-symbol": "^6.8.0",
     "babel-plugin-transform-inline-imports-commonjs": "^1.0.0",
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-es2015-node4": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,12 +588,6 @@ babel-plugin-transform-es2015-sticky-regex@^6.5.0:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.8.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-es2015-unicode-regex@^6.5.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
@@ -795,10 +789,6 @@ babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24.1:
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
-
-babylon@7.0.0-beta.8:
-  version "7.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
 
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0, babylon@^6.5.0:
   version "6.17.1"


### PR DESCRIPTION
**Summary**
Remove `babel-plugin-transform-es2015-typeof-symbol` from package.json because it is not used.

**Test plan**
Everything is working like before

cc @Daniel15 @BYK 