### PR TITLE
Remove babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "babel-core": "^6.24.1",
-    "babel-eslint": "^7.2.3",
     "babel-loader": "^6.2.5",
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-transform-inline-imports-commonjs": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,7 +267,7 @@ babel-core@^6.0.0, babel-core@^6.0.2, babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-eslint@^7.1.1, babel-eslint@^7.2.3:
+babel-eslint@^7.1.1:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
   dependencies:


### PR DESCRIPTION
**Summary**
Remove `babel-eslint` because we don't use it.

**Test plan**
The same tests
