### PR TITLE
Prioritize bin links at the root level

### DIFF
--- a/__tests__/fixtures/install/install-bin-links-eslint/package.json
+++ b/__tests__/fixtures/install/install-bin-links-eslint/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^6.9.0",
-    "react-scripts": "0.9.5"
+    "react-scripts": "0.9.5",
+    "uglify-js": "3.0.14"
   }
 }

--- a/__tests__/fixtures/install/install-bin-links-eslint/yarn.lock
+++ b/__tests__/fixtures/install/install-bin-links-eslint/yarn.lock
@@ -4994,7 +4994,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uglify-js@3.0.x:
+uglify-js@3.0.14, uglify-js@3.0.x:
   version "3.0.14"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.14.tgz#2697af126fd215aac556facb1edfb17875204760"
   dependencies:

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -106,7 +106,7 @@ test('Produces valid destination paths for scoped modules', () => {
     _reference: (({}: any): PackageReference),
   }: any): Manifest);
 
-  const info = new HoistManifest(key, parts, pkg, '', true, false);
+  const info = new HoistManifest(key, parts, pkg, '', true, true, false);
 
   const tree = new Map([['@scoped/dep', info]]);
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -368,7 +368,7 @@ export default class PackageLinker {
       // non-transient dependencies will overwrite these during this.save() to ensure they take priority.
       await promise.queue(
         topLevelDependencies,
-        async ([dest, {pkg}]) => {
+        async ([dest, pkg]) => {
           if (pkg.bin && Object.keys(pkg.bin).length) {
             const binLoc = path.join(this.config.cwd, this.config.getFolder(pkg));
             await this.linkSelfDependencies(pkg, dest, binLoc);
@@ -380,15 +380,15 @@ export default class PackageLinker {
     }
   }
 
-  determineTopLevelBinLinks(flatTree: HoistManifestTuples): HoistManifestTuples {
+  determineTopLevelBinLinks(flatTree: HoistManifestTuples): Array<[string, Manifest]> {
     const linksToCreate = new Map();
+    for (const [dest, {pkg, isDirectRequire}] of flatTree) {
+      const {name} = pkg;
 
-    flatTree.forEach(([dest, hoistManifest]) => {
-      if (!linksToCreate.has(hoistManifest.pkg.name)) {
-        linksToCreate.set(hoistManifest.pkg.name, [dest, hoistManifest]);
+      if (!linksToCreate.has(name) || isDirectRequire) {
+        linksToCreate.set(name, [dest, pkg]);
       }
-    });
-
+    }
     return Array.from(linksToCreate.values());
   }
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -365,7 +365,6 @@ export default class PackageLinker {
       );
 
       // create links at top level for all dependencies.
-      // non-transient dependencies will overwrite these during this.save() to ensure they take priority.
       await promise.queue(
         topLevelDependencies,
         async ([dest, pkg]) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is a fix for https://github.com/yarnpkg/yarn/issues/3801
It seems like there's some history behind this issue, namely

**https://github.com/yarnpkg/yarn/pull/3310**, which 1) looked through all transient dependencies, 2) linked them to node_modules/.bin, then 3) overrode them with any top level dependencies

**https://github.com/yarnpkg/yarn/pull/3545**, removed the last part from above, which I assume was due to it incorrectly detecting what is actually at top level.

So now, the flat tree from `PackageHoister` gives us a list of all the bin paths that are hoisted to top level, but will include same names if their version ranges don't match, since hoisted has a different meaning from being added as an actual top level dependency. The latest implementation before this PR relied on the whatever order it came from and satisfied the bin link with the first one it found. 
So solution was to still allow for the override to happen when the package has `isDirectRequired` equal to true.

@bestander @rally25rs feel free to jump in with any additional knowledge :)

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added tests to actually read versions of the bin links. It passes all the previous test cases with eslint, and passes the new test with uglifyjs bin that fails on master. (Got lucky that we already had uglifyjs tarball in the test fixtures!)

**BEFORE**
<img width="381" alt="screen shot 2017-07-09 at 5 16 40 pm" src="https://user-images.githubusercontent.com/18429494/27998867-921b14e4-64ca-11e7-9102-abf997684eba.png">

**AFTER**
<img width="380" alt="screen shot 2017-07-09 at 5 17 43 pm" src="https://user-images.githubusercontent.com/18429494/27998870-986c1096-64ca-11e7-8686-7fb7a9822dbc.png">

Eslint behavior is the same as before




<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
<img width="420" alt="screen shot 2017-07-09 at 5 26 30 pm" src="https://user-images.githubusercontent.com/18429494/27998968-c876129a-64cb-11e7-90e6-3f245abafb49.png">
