### PR TITLE
Prioritize git environment variables from parent process

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -144,9 +144,9 @@ test('spawn', () => {
   Git.spawn(['status']);
 
   expect(spawnMock.calls[0][2].env).toMatchObject({
-    ...process.env,
     GIT_ASKPASS: '',
     GIT_TERMINAL_PROMPT: 0,
     GIT_SSH_COMMAND: 'ssh -oBatchMode=yes',
+    ...process.env,
   });
 });

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -33,10 +33,10 @@ const supportsArchiveCache: {[key: string]: boolean} = map({
 
 // Suppress any password prompts since we run these in the background
 const env = {
-  ...process.env,
   GIT_ASKPASS: '',
   GIT_TERMINAL_PROMPT: 0,
   GIT_SSH_COMMAND: 'ssh -oBatchMode=yes',
+  ...process.env,
 };
 
 // This regex is designed to match output from git of the style:


### PR DESCRIPTION
**Summary**

If there are any ENV variables specified for the parent process - use them.
The main reason for this is that our CI uses `GIT_SSH_COMMAND` env to specify ssh keys to use for cloning and not via ssh-agent.
For example for github the user is always `git@` and it is obviously possible to make fake users in ssh config, etc...
But there should be an option to customize `GIT_SSH_COMMAND` directly.

**Test plan**

Before:
```
$ GIT_SSH_COMMAND="ssh -i ~/git.pem -F /dev/null" yarn install
yarn install v0.27.5
[1/4] Resolving packages...
[2/4] Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: clone git@github.com:monder/test.git /home/monder/.cache/yarn/v1/.tmp/f13ca8a124faac37abd837f21d8375bf
Directory: /tmp/test
Output:
Cloning into '/home/monder/.cache/yarn/v1/.tmp/f13ca8a124faac37abd837f21d8375bf'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

After:
```
$ GIT_SSH_COMMAND="ssh -i ~/git.pem -F /dev/null" yarn install
yarn install v0.27.5
[1/4] Resolving packages...
[2/4] Fetching packages...
warning fsevents@1.1.2: The platform "freebsd" is incompatible with this module.
info "fsevents@1.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 108.73s.
```
