### PR TITLE
Breaking: Deprecate yarn <command> ls in favor of yarn <command> list

### DIFF
--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -20,11 +20,11 @@ const runCache = buildRun.bind(
   },
 );
 
-test('ls', async (): Promise<void> => {
+test('list', async (): Promise<void> => {
   await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
     const out = new stream.PassThrough();
     const reporter = new reporters.JSONReporter({stdout: out});
-    await run(config, reporter, {}, ['ls']);
+    await run(config, reporter, {}, ['list']);
     const stdout = String(out.read());
     expect(stdout).toContain('dummy');
     expect(stdout).toContain('0.0.0');
@@ -35,7 +35,7 @@ test('ls with scoped package', async (): Promise<void> => {
   await runInstall({}, 'install-from-authed-private-registry', async (config): Promise<void> => {
     const out = new stream.PassThrough();
     const reporter = new reporters.JSONReporter({stdout: out});
-    await run(config, reporter, {}, ['ls']);
+    await run(config, reporter, {}, ['list']);
     const stdout = String(out.read());
     expect(stdout).toContain('@types/lodash');
     expect(stdout).toContain('4.14.37');

--- a/__tests__/commands/licenses.js
+++ b/__tests__/commands/licenses.js
@@ -20,7 +20,7 @@ const runLicenses = buildRun.bind(
 );
 
 test('lists all licenses of the dependencies with the --json argument', async (): Promise<void> => {
-  await runLicenses(['ls'], {json: true}, '', (config, reporter, stdout) => {
+  await runLicenses(['list'], {json: true}, '', (config, reporter, stdout) => {
     expect(stdout).toContain(JSON.stringify(expectedTable));
   });
 });

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -12,37 +12,46 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] !== 'dir';
 }
 
-export const {run, setFlags, examples} = buildSubCommands('cache', {
-  async ls(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
-    async function readCacheMetadata(
-      parentDir = config.cacheFolder,
-      metadataFile = METADATA_FILENAME,
-    ): Promise<Array<Array<string>>> {
-      const folders = await fs.readdir(parentDir);
-      const packagesMetadata = [];
+async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  async function readCacheMetadata(
+    parentDir = config.cacheFolder,
+    metadataFile = METADATA_FILENAME,
+  ): Promise<Array<Array<string>>> {
+    const folders = await fs.readdir(parentDir);
+    const packagesMetadata = [];
 
-      for (const folder of folders) {
-        if (folder[0] === '.') {
-          continue;
-        }
-
-        const loc = path.join(config.cacheFolder, parentDir.replace(config.cacheFolder, ''), folder);
-        // Check if this is a scoped package
-        if (!await fs.exists(path.join(loc, metadataFile))) {
-          // If so, recurrently read scoped packages metadata
-          packagesMetadata.push(...(await readCacheMetadata(loc)));
-        } else {
-          const {registry, package: manifest, remote} = await config.readPackageMetadata(loc);
-          packagesMetadata.push([manifest.name, manifest.version, registry, (remote && remote.resolved) || '']);
-        }
+    for (const folder of folders) {
+      if (folder[0] === '.') {
+        continue;
       }
 
-      return packagesMetadata;
+      const loc = path.join(config.cacheFolder, parentDir.replace(config.cacheFolder, ''), folder);
+      // Check if this is a scoped package
+      if (!await fs.exists(path.join(loc, metadataFile))) {
+        // If so, recurrently read scoped packages metadata
+        packagesMetadata.push(...(await readCacheMetadata(loc)));
+      } else {
+        const {registry, package: manifest, remote} = await config.readPackageMetadata(loc);
+        packagesMetadata.push([manifest.name, manifest.version, registry, (remote && remote.resolved) || '']);
+      }
     }
 
-    const body = await readCacheMetadata();
+    return packagesMetadata;
+  }
 
-    reporter.table(['Name', 'Version', 'Registry', 'Resolved'], body);
+  const body = await readCacheMetadata();
+
+  reporter.table(['Name', 'Version', 'Registry', 'Resolved'], body);
+}
+
+export const {run, setFlags, examples} = buildSubCommands('cache', {
+  async ls(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    reporter.warn(`\`yarn cache ls\` is deprecated. Please use \`yarn cache list\`.`);
+    await list(config, reporter, flags, args);
+  },
+
+  async list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    await list(config, reporter, flags, args);
   },
 
   dir(config: Config, reporter: Reporter) {

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -47,50 +47,59 @@ async function getManifests(config: Config, flags: Object): Promise<Array<Manife
   return manifests;
 }
 
+async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  const manifests: Array<Manifest> = await getManifests(config, flags);
+
+  if (flags.json) {
+    const body = [];
+
+    for (const {name, version, license, repository, homepage, author} of manifests) {
+      const url = repository ? repository.url : homepage;
+      const vendorUrl = homepage || (author && author.url);
+      const vendorName = author && author.name;
+      body.push([
+        name,
+        version,
+        license || 'Unknown',
+        url || 'Unknown',
+        vendorUrl || 'Unknown',
+        vendorName || 'Unknown',
+      ]);
+    }
+
+    reporter.table(['Name', 'Version', 'License', 'URL', 'VendorUrl', 'VendorName'], body);
+  } else {
+    const trees = [];
+
+    for (const {name, version, license, repository, homepage} of manifests) {
+      const children = [];
+      children.push({
+        name: `${reporter.format.bold('License:')} ${license || reporter.format.red('UNKNOWN')}`,
+      });
+
+      const url = repository ? repository.url : homepage;
+      if (url) {
+        children.push({name: `${reporter.format.bold('URL:')} ${url}`});
+      }
+
+      trees.push({
+        name: `${name}@${version}`,
+        children,
+      });
+    }
+
+    reporter.tree('licenses', trees);
+  }
+}
+
 export const {run, setFlags, examples} = buildSubCommands('licenses', {
   async ls(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
-    const manifests: Array<Manifest> = await getManifests(config, flags);
+    reporter.warn(`\`yarn licenses ls\` is deprecated. Please use \`yarn licenses list\`.`);
+    await list(config, reporter, flags, args);
+  },
 
-    if (flags.json) {
-      const body = [];
-
-      for (const {name, version, license, repository, homepage, author} of manifests) {
-        const url = repository ? repository.url : homepage;
-        const vendorUrl = homepage || (author && author.url);
-        const vendorName = author && author.name;
-        body.push([
-          name,
-          version,
-          license || 'Unknown',
-          url || 'Unknown',
-          vendorUrl || 'Unknown',
-          vendorName || 'Unknown',
-        ]);
-      }
-
-      reporter.table(['Name', 'Version', 'License', 'URL', 'VendorUrl', 'VendorName'], body);
-    } else {
-      const trees = [];
-
-      for (const {name, version, license, repository, homepage} of manifests) {
-        const children = [];
-        children.push({
-          name: `${reporter.format.bold('License:')} ${license || reporter.format.red('UNKNOWN')}`,
-        });
-
-        const url = repository ? repository.url : homepage;
-        if (url) {
-          children.push({name: `${reporter.format.bold('URL:')} ${url}`});
-        }
-
-        trees.push({
-          name: `${name}@${version}`,
-          children,
-        });
-      }
-
-      reporter.tree('licenses', trees);
-    }
+  async list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    await list(config, reporter, flags, args);
   },
 
   async generateDisclaimer(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {


### PR DESCRIPTION
**Summary**
This pull request deprecates every `yarn <command> ls` in favor of `yarn <command> list`

**Test plan**
I check every command and every test that took these commands

If you like it, do you think we should do the same for `yarn <command> rm`? And delete everything deprecated when we roll out the version 1.0?
