### PR TITLE
#3818 Add -v command to show version when specified without other commands

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -167,11 +167,6 @@ test.concurrent('should run help command with -h', async () => {
   expectHelpOutput(stdout);
 });
 
-test.concurrent('should show version of yarn with -v', async () => {
-  const stdout = await execCommand('-v', [], 'run-help');
-  expect(stdout[0]).toEqual(pkg.version);
-});
-
 test.concurrent('should run add command with help option', async () => {
   const stdout = await execCommand('add', ['--help'], 'run-help');
   expectHelpOutputAsSubcommand(stdout);
@@ -195,6 +190,11 @@ test.concurrent('should run --help command with add option', async () => {
 test.concurrent('should run -h command with add option', async () => {
   const stdout = await execCommand('-h', ['add'], 'run-help');
   expectHelpOutputAsSubcommand(stdout);
+});
+
+test.concurrent('should show version of yarn with -v', async () => {
+  const stdout = await execCommand('-v', [], 'run-version');
+  expect(stdout[0]).toEqual(pkg.version);
 });
 
 test.concurrent('should run version command', async () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -167,6 +167,11 @@ test.concurrent('should run help command with -h', async () => {
   expectHelpOutput(stdout);
 });
 
+test.concurrent('should show version of yarn with -v', async () => {
+  const stdout = await execCommand('-v', [], 'run-help');
+  expect(stdout[0]).toEqual(pkg.version);
+});
+
 test.concurrent('should run add command with help option', async () => {
   const stdout = await execCommand('add', ['--help'], 'run-help');
   expectHelpOutputAsSubcommand(stdout);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -33,7 +33,7 @@ const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex
 // set global options
 commander.version(version, '--version');
 commander.usage('[command] [flags]');
-commander.option('--verbose', 'output verbose messages on internal operations');
+commander.option('-v, --verbose', 'output verbose messages on internal operations');
 commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
 commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
 commander.option('--strict-semver');
@@ -72,6 +72,12 @@ commander.option('--scripts-prepend-node-path [bool]', 'prepend the node executa
 
 // get command name
 let commandName: string = args.shift() || 'install';
+
+// if -v is the first command, then always exit after returning the version
+if (commandName === '-v') {
+  console.log(version.trim());
+  process.exit(0);
+}
 
 if (commandName === '--help' || commandName === '-h') {
   commandName = 'help';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Request from issue https://github.com/yarnpkg/yarn/issues/3818
Shows the version of yarn only when `-v` is the first argument passed to the cli. Also added -v as a shortcut for verbose flag on install and other commands.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
*BEFORE*
<img width="300" alt="screen shot 2017-07-11 at 11 25 51 pm" src="https://user-images.githubusercontent.com/18429494/28104789-99feb864-6691-11e7-8829-32cd440d4c34.png">

*AFTER*
<img width="684" alt="screen shot 2017-07-11 at 11 24 52 pm" src="https://user-images.githubusercontent.com/18429494/28104792-9cf9abd2-6691-11e7-983f-063d02c28d22.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
