### PR TITLE
#3821 Remove manifest check for global commands

### DIFF
--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -27,8 +27,12 @@ export default (async function(info: Object, moduleLoc: string, config: Config, 
     }
     config.reporter.warn(msg);
   }
-
   await fix(info, moduleLoc, config.reporter, warn, config.looseSemver);
+
+  if (config.cwd === config.globalFolder) {
+    return info;
+  }
+
   try {
     validate(info, isRoot, config.reporter, warn);
   } catch (err) {

--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -27,6 +27,7 @@ export default (async function(info: Object, moduleLoc: string, config: Config, 
     }
     config.reporter.warn(msg);
   }
+
   await fix(info, moduleLoc, config.reporter, warn, config.looseSemver);
 
   if (config.cwd === config.globalFolder) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
From #3821
When `global` command is used, skip the validation check for manifest, such as missing license or name field listed here https://github.com/yarnpkg/yarn/blob/master/src/util/normalize-manifest/validate.js#L44-L98
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added a test in `/__tests__/normalize-manifest.js`, refactored out the test function used for non-global commands

*BEFORE*
<img width="573" alt="screen shot 2017-07-12 at 8 29 20 pm" src="https://user-images.githubusercontent.com/18429494/28150671-ad586022-674a-11e7-8463-11898eea11ac.png">


*AFTER*


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
<img width="581" alt="screen shot 2017-07-12 at 8 27 58 pm" src="https://user-images.githubusercontent.com/18429494/28150686-cd6b44ce-674a-11e7-8887-de0dceb2332a.png">
