### PR TITLE
Do not use /usr/local/share as home under fakeroot

### DIFF
--- a/src/util/root-user.js
+++ b/src/util/root-user.js
@@ -7,7 +7,11 @@ function getUid(): ?number {
   return null;
 }
 
-export default isRootUser(getUid());
+export default isRootUser(getUid()) && isNotFakeRoot();
+
+export function isNotFakeRoot(): boolean {
+  return Boolean(process.env.FAKEROOTKEY);
+}
 
 export function isRootUser(uid: ?number): boolean {
   return uid === 0;

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -4,7 +4,7 @@ import ROOT_USER from './root-user.js';
 
 const path = require('path');
 
-const isNotFakeRoot = typeof process.env.FAKEROOTKEY === 'undefined';
+const isNotFakeRoot = Boolean(process.env.FAKEROOTKEY);
 
 const userHomeDir =
   process.platform === 'linux' && ROOT_USER && isNotFakeRoot

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -4,11 +4,7 @@ import ROOT_USER from './root-user.js';
 
 const path = require('path');
 
-const isNotFakeRoot = Boolean(process.env.FAKEROOTKEY);
-
 const userHomeDir =
-  process.platform === 'linux' && ROOT_USER && isNotFakeRoot
-    ? path.resolve('/usr/local/share')
-    : require('os').homedir();
+  process.platform === 'linux' && ROOT_USER ? path.resolve('/usr/local/share') : require('os').homedir();
 
 export default userHomeDir;

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -4,7 +4,11 @@ import ROOT_USER from './root-user.js';
 
 const path = require('path');
 
+const isNotFakeRoot = typeof process.env.FAKEROOTKEY === 'undefined';
+
 const userHomeDir =
-  process.platform === 'linux' && ROOT_USER ? path.resolve('/usr/local/share') : require('os').homedir();
+  process.platform === 'linux' && ROOT_USER && isNotFakeRoot
+    ? path.resolve('/usr/local/share')
+    : require('os').homedir();
 
 export default userHomeDir;


### PR DESCRIPTION
Fixes #2536

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When packaging software that uses yarn for dependency management, some distributions use fakeroot as a part of their build system (my case, Solus OS). 

What happens is that the uid is set to 0, and because of that yarn tried to use /usr/local/share as the home directory. When yarn tried to create this directory it fails, because the user is not really root and does not have the permissions. 

This added check makes sure that we use the right home directory when running under fakeroot  

**Test plan**

This is what was executed (in the yarn codebase) to prove the difference:

With current yarn:

```
 ~/tmp/yarn $ fakeroot yarn
/usr/lib64/node_modules/yarn/node_modules/mkdirp/index.js:90
                    throw err0;
                    ^

Error: EACCES: permission denied, mkdir '/usr/local'
    at Object.fs.mkdirSync (fs.js:895:18)
    at sync (/usr/lib64/node_modules/yarn/node_modules/mkdirp/index.js:71:13)
    at sync (/usr/lib64/node_modules/yarn/node_modules/mkdirp/index.js:77:24)
    at sync (/usr/lib64/node_modules/yarn/node_modules/mkdirp/index.js:77:24)
    at Function.sync (/usr/lib64/node_modules/yarn/node_modules/mkdirp/index.js:77:24)
    at Object.<anonymous> (/usr/lib64/node_modules/yarn/bin/yarn.js:31:8)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
```

and with the modified yarn:

```
 ~/tmp/yarn $ fakeroot bin/yarn 
yarn install v0.28.0
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@1.1.1: The platform "linux" is incompatible with this module.
info "fsevents@1.1.1" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
warning "ajv-keywords@1.5.1" has incorrect peer dependency "ajv@>=4.10.0".
warning "eslint-config-fbjs@2.0.0-alpha.1" has incorrect peer dependency "babel-eslint@^7.1.1".
[5/5] Building fresh packages...
Done in 2.48s.
```

