### PR TITLE
Publish npm release of Yarn directly from CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,10 +46,10 @@ deployment:
     tag: /v[0-9]+(\.[0-9]+)*/
     owner: yarnpkg
     commands:
-      # Deployment is handled by a webhook. However, CircleCI requires this
-      # dummy "deployment" section in order to build the tag.
-      # https://circleci.com/docs/1.0/configuration/#tags
+      # Only NPM is handled here - All other release files are handled in a webhook.
       - echo "Releasing $CIRCLE_TAG..."
+      - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - ./scripts/update-npm.sh
 
 notify:
   webhooks:

--- a/jenkins_jobs.groovy
+++ b/jenkins_jobs.groovy
@@ -38,7 +38,6 @@ job('yarn-version') {
       trigger([
         'yarn-chocolatey',
         'yarn-homebrew',
-        'yarn-npm',
       ]) {
         parameters {
           currentBuild()
@@ -110,26 +109,6 @@ job('yarn-homebrew') {
   }
   steps {
     shell './scripts/update-homebrew.sh'
-  }
-  publishers {
-    gitHubIssueNotifier {
-    }
-  }
-}
-
-job('yarn-npm') {
-  description 'Ensures the npm package for Yarn is up-to-date'
-  label 'linux'
-  scm {
-    github 'yarnpkg/yarn', 'master'
-  }
-  parameters {
-    // Passed from yarn-version job
-    stringParam 'YARN_VERSION'
-    booleanParam 'YARN_RC'
-  }
-  steps {
-    shell './scripts/update-npm.sh'
   }
   publishers {
     gitHubIssueNotifier {

--- a/scripts/update-npm.sh
+++ b/scripts/update-npm.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-# Pushes the latest Yarn version to npm
+# Pushes the locally built Yarn version to npm
 
 set -ex
 
-# See if YARN_VERSION was passed in the environment, otherwise get version
-# number from Yarn site
-if [ -z "$YARN_VERSION" ]; then
-  echo 'Getting Yarn version from https://yarnpkg.com/latest-version'
-  version=`curl --fail https://yarnpkg.com/latest-version`
-else
-  version="$YARN_VERSION"
-fi
+version=`./dist/bin/yarn --version`
+tarball="./artifacts/yarn-v$version.tar.gz"
+
+# Ensure Yarn tarball was built
+if [ ! -f "$tarball" ]; then
+  echo 'Could not find Yarn tarball; please re-run "yarn build-dist".'
+  exit 1
+fi;
 
 # Check if this version is already published to npm.
 # Note: npm doesn't return a non-zero error code when "npm view" can't find a
@@ -20,14 +20,11 @@ if [ "`npm view yarn@$version name`" = 'yarn' ]; then
   exit 0
 fi;
 
-# Grab the tarball so we can publish it as-is
-url=https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz
-tempfile=`mktemp -t 'yarn-release-XXXXXXXX.tar.gz'`
-curl --fail -L -o $tempfile $url
-
+# Determine if this is an RC or a stable release
+release_type=`curl --fail https://release.yarnpkg.com/release_type/$version`
 npm_flags=''
-if [ "$YARN_RC" = "true" ]; then
+if [ "$release_type" = "rc" ]; then
   npm_flags='--tag rc'
 fi;
 
-eval "npm publish '$tempfile' --access public $npm_flags"
+eval "npm publish '$tarball' --access public $npm_flags"


### PR DESCRIPTION
**Summary**
This is a followup to #3866. I originally moved the Yarn npm publish to our external build infra. After thinking about this for a while, I'm going to move this particular step back to publishing directly from CircleCI. The reasons that the other releases are pushed from infra under our own control (eg. signing them with GPG/Authenticode) don't really apply to the npm package as it just doesn't support this functionality. 

We'll have to revisit it if npm add extra security in the future, but it's fine for now.

**Test plan**

This is difficult to test without publishing a new Yarn version. I tested the script locally by commenting out the check for if the specific version already exists on npm, and it worked up until the point of publishing (which obviously threw an error "You cannot publish over the previously published version 0.28.1.")