### PR TITLE
Fix: Ensure valid target passed to fs.symlink (refs #3276)

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -725,7 +725,9 @@ export async function symlink(src: string, dest: string): Promise<void> {
       } else {
         relative = path.relative(path.dirname(dest), src);
       }
-      await fsSymlink(relative, dest);
+      // When path.relative returns an empty string for the current directory, we should instead use
+      // '.', which is a valid fs.symlink target.
+      await fsSymlink(relative || '.', dest);
     }
   } catch (err) {
     if (err.code === 'EEXIST') {


### PR DESCRIPTION
**Summary**
[`path.relative`](https://nodejs.org/api/path.html#path_path_relative_from_to) returns an empty string for the current directory. This was being passed as the target to `fs.symlink`. Changed it so '.' is passed instead in these cases. Fixes issue #3276.

**Test plan**
The fix is very small and straightforward so haven't added a test. Can do if needed.