### PR TITLE
[windows] When upgrading Yarn, install into the previously-used directory

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -13,6 +13,11 @@
 		</Property>
 		<Condition Message="Yarn requires Node.js 4.0 or higher to be installed">NODEVERSION</Condition>-->
 
+		<!-- If Yarn is already installed, default to the current installation directory -->
+		<Property Id="INSTALLDIR">
+			<RegistrySearch Id="YarnExistingInstallPath" Root="HKLM" Type="raw" Key="SOFTWARE\Yarn" Name="InstallDir" />
+		</Property>
+
 		<Feature Id="MainFeature" Title="Yarn" Level="1">
 			<ComponentGroupRef Id="YarnFiles" />
 			<ComponentRef Id="YarnRegistryAndPath" />


### PR DESCRIPTION
**Summary**
We're writing the Yarn installation directory to the registry (`HKEY_LOCAL_MACHINE\Software\Yarn\InstallDir`) but aren't reading that on upgrades. derp.

This was pretty much just copypasta from https://www.firegiant.com/wix/tutorial/getting-started/where-to-install/ 😛 

**Test plan**

Now when upgrading, we correctly prefill the path:
![](http://ss.dan.cx/2017/07/18-21.53.42.gif)

On a fresh install, we still default to the Program Files directory:
![](http://ss.dan.cx/2017/07/Yarn_Setup_18-22.03.14.png)

(as an aside, I'd love to install to `C:\Program Files\` rather than `c:\Program Files (x86)\` given all our code is "AnyCPU" / processor-agnostic, but that actually requires building a 64-bit `.msi` file that doesn't even run on 32-bit machines. It's probably not worth it.)

Closes #3944