### PR TITLE
Global Config at ${PREFIX}/etc/{nmp,yarn}rc

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -127,15 +127,18 @@ export default class NpmRegistry extends Registry {
   }
 
   async getPossibleConfigLocations(filename: string, reporter: Reporter): Promise<Array<[boolean, string, string]>> {
+    // npmrc --> ./.npmrc, ~/.npmrc, ${prefix}/etc/npmrc
+    const localfile = '.' + filename;
     const possibles = [
-      [false, path.join(this.cwd, filename)],
-      [true, this.config.userconfig || path.join(userHome, filename)],
-      [false, path.join(getGlobalPrefix(), 'etc', filename.slice(1))],
+      [false, path.join(this.cwd, localfile)],
+      [true, this.config.userconfig || path.join(userHome, localfile)],
+      [false, path.join(getGlobalPrefix(), 'etc', filename)],
     ];
 
+    // npmrc --> ../.npmrc, ../../.npmrc, etc.
     const foldersFromRootToCwd = getPosixPath(this.cwd).split('/');
     while (foldersFromRootToCwd.length > 1) {
-      possibles.push([false, path.join(foldersFromRootToCwd.join(path.sep), filename)]);
+      possibles.push([false, path.join(foldersFromRootToCwd.join(path.sep), localfile)]);
       foldersFromRootToCwd.pop();
     }
 
@@ -167,7 +170,7 @@ export default class NpmRegistry extends Registry {
     // docs: https://docs.npmjs.com/misc/config
     this.mergeEnv('npm_config_');
 
-    for (const [, loc, file] of await this.getPossibleConfigLocations('.npmrc', this.reporter)) {
+    for (const [, loc, file] of await this.getPossibleConfigLocations('npmrc', this.reporter)) {
       const config = NpmRegistry.normalizeConfig(ini.parse(file));
 
       // normalize offline mirror path relative to the current npmrc

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -130,7 +130,7 @@ export default class NpmRegistry extends Registry {
     const possibles = [
       [false, path.join(this.cwd, filename)],
       [true, this.config.userconfig || path.join(userHome, filename)],
-      [false, path.join(getGlobalPrefix(), filename)],
+      [false, path.join(getGlobalPrefix(), 'etc', filename.slice(1))],
     ];
 
     const foldersFromRootToCwd = getPosixPath(this.cwd).split('/');

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -71,7 +71,7 @@ export default class YarnRegistry extends NpmRegistry {
   }
 
   async loadConfig(): Promise<void> {
-    for (const [isHome, loc, file] of await this.getPossibleConfigLocations('.yarnrc', this.reporter)) {
+    for (const [isHome, loc, file] of await this.getPossibleConfigLocations('yarnrc', this.reporter)) {
       const {object: config} = parse(file, loc);
 
       if (isHome) {


### PR DESCRIPTION
This searches for the global RC files at `${PREFIX}/etc/{npm,yarn}rc`, whereas previously it looked in `${PREFIX}/.{npm,yarn}rc`.  By code inspection it looks like the NPM code does the same thing on both windows and posix, but the documentation for windows suggests it might not use the `/etc` path component.  I haven't verified behaviour on windows.

Resolves #1931.