### PR TITLE
Fix: pruneOfflineMirror handle undefined resolved

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -634,8 +634,8 @@ export class Install {
     const requiredTarballs = new Set();
     for (const dependency in lockfile) {
       const resolved = lockfile[dependency].resolved;
-      const basename = path.basename(resolved.split('#')[0]);
       if (resolved) {
+        const basename = path.basename(resolved.split('#')[0]);
         if (dependency[0] === '@' && basename[0] !== '@') {
           requiredTarballs.add(`${dependency.split('/')[0]}-${basename}`);
         }

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -6,6 +6,7 @@ import type {ReporterSelectOption} from '../../reporters/types.js';
 import type {Manifest, DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
 import type {RegistryNames} from '../../registries/index.js';
+import type {LockfileObject} from '../../lockfile/wrapper.js';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
 import {MessageError} from '../../errors.js';
 import InstallationIntegrityChecker from '../../integrity-checker.js';
@@ -625,7 +626,7 @@ export class Install {
    * Remove offline tarballs that are no longer required
    */
 
-  async pruneOfflineMirror(lockfile: Object): Promise<void> {
+  async pruneOfflineMirror(lockfile: LockfileObject): Promise<void> {
     const mirror = this.config.getOfflineMirrorPath();
     if (!mirror) {
       return;

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -176,7 +176,7 @@ export default class InstallationIntegrityChecker {
     }
 
     Object.keys(lockfile).forEach(key => {
-      result.lockfileEntries[key] = lockfile[key].resolved;
+      result.lockfileEntries[key] = lockfile[key].resolved || '';
     });
 
     if (flags.checkFiles) {

--- a/src/lockfile/wrapper.js
+++ b/src/lockfile/wrapper.js
@@ -22,7 +22,7 @@ type Dependencies = {
 export type LockManifest = {
   name: string,
   version: string,
-  resolved: string,
+  resolved: ?string,
   registry: RegistryNames,
   uid: string,
   permissions: ?{[key: string]: boolean},
@@ -33,12 +33,16 @@ export type LockManifest = {
 type MinimalLockManifest = {
   name: ?string,
   version: string,
-  resolved: string,
+  resolved: ?string,
   registry: ?RegistryNames,
   uid: ?string,
   permissions: ?{[key: string]: boolean},
   optionalDependencies: ?Dependencies,
   dependencies: ?Dependencies,
+};
+
+export type LockfileObject = {
+  [key: string]: LockManifest,
 };
 
 function getName(pattern: string): string {
@@ -141,7 +145,7 @@ export default class Lockfile {
     delete cache[pattern];
   }
 
-  getLockfile(patterns: {[packagePattern: string]: Manifest}): Object {
+  getLockfile(patterns: {[packagePattern: string]: Manifest}): LockfileObject {
     const lockfile = {};
     const seen: Map<string, Object> = new Map();
 


### PR DESCRIPTION
**Summary**

Bug: pruneOfflineMirror does not guard against `lockfile[dependency].resolved == undefined` (eg. the dependency is a local file)
This results in the following error when running `yarn install`:
`TypeError: Cannot read property 'split' of undefined`

To reproduce:

- set a `yarn-offline-mirror` path and set `yarn-offline-mirror-pruning` to `true`
- have a `file:` local dependency in `package.json`
- run `yarn install`

Simple fix - set basename only if resolved is valid.

**Test plan**

The fix is obvious - call `resolved.split()` only after making sure `resolved` is not undefined. Nothing changes at the functional level.

Please let me know if I should still create a test case for this scenario.
