### PR TITLE
Add exec to node commands in the binary

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -15,7 +15,7 @@ if command_exists node; then
   if [ "$YARN_FORCE_WINPTY" = 1 ]; then
     winpty node "$basedir/yarn.js" "$@"
   else
-    node "$basedir/yarn.js" "$@"
+    exec node "$basedir/yarn.js" "$@"
   fi
   ret=$?
 # Debian and Ubuntu use "nodejs" as the name of the binary, not "node", so we
@@ -23,7 +23,7 @@ if command_exists node; then
 # https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907
 elif command_exists nodejs; then
-  nodejs "$basedir/yarn.js" "$@"
+  exec nodejs "$basedir/yarn.js" "$@"
   ret=$?
 else
   echo 'Yarn requires Node.js 4.0 or higher to be installed.'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

After merging #1180 `yarn` binary executes node commands it these ways:
```bash
node "$basedir/yarn.js" "$@"
# and
nodejs "$basedir/yarn.js" "$@"
```

This leads to the fact, that yarn uses `/bin/sh` for running:
```bash
# ps aufx
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         8  0.0  0.0   4340   756 ?        S    08:08   0:00 /bin/sh /usr/local/bin/yarn test:unit
root        19  4.0  3.3 1083008 69008 ?       Sl   08:08   0:00  \_ node /opt/yarn/bin/yarn.js test:unit
root        29 28.6  7.4 1284500 152928 ?      Sl   08:08   0:06      \_ node /app/node_modules/.bin/karma start test/unit/karma.conf.js --single-run
```

It causes problems when Yarn is running in Docker container - it doesn't handle `SIGTERM` or any other signals.

To resolve this issue we can rewrite node commands to these:
```bash
exec node "$basedir/yarn.js" "$@"
# and
exec nodejs "$basedir/yarn.js" "$@"
```

With that, Yarn will be started directly without `/bin/sh`:
```bash
$ ps aufx
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  2.3  2.8 1070088 58524 ?       Ssl  08:56   0:00 node /usr/local/bin/yarn test:unit
root        14  0.0  0.0   4340   748 ?        S    08:56   0:00 sh -c karma start test/unit/karma.conf.js --single-run 
root        15 22.9  7.6 1286672 155688 ?      Sl   08:56   0:06  \_ node /app/node_modules/.bin/karma start test/unit/karma.conf.js --single-run
```

And `SIGTERM` became working.

**Test plan**

```bash
$ docker run node yarn test:unit
...
$ ^C
$ make: *** [test.unit] Error 130
```
