### PR TITLE
Fix: handle potential race conditions when using cache

### DIFF
--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -37,29 +37,6 @@ export default class GitFetcher extends BaseFetcher {
     }
   }
 
-  async getLocalAvailabilityStatus(): Promise<boolean> {
-    // Some mirrors might still have files named "./reponame" instead of "./reponame-commit"
-    const tarballLegacyMirrorPath = this.getTarballMirrorPath({
-      withCommit: false,
-    });
-    const tarballModernMirrorPath = this.getTarballMirrorPath();
-    const tarballCachePath = this.getTarballCachePath();
-
-    if (tarballLegacyMirrorPath != null && (await fsUtil.exists(tarballLegacyMirrorPath))) {
-      return true;
-    }
-
-    if (tarballModernMirrorPath != null && (await fsUtil.exists(tarballModernMirrorPath))) {
-      return true;
-    }
-
-    if (await fsUtil.exists(tarballCachePath)) {
-      return true;
-    }
-
-    return false;
-  }
-
   getTarballMirrorPath({withCommit = true}: {withCommit: boolean} = {}): ?string {
     const {pathname} = url.parse(this.reference);
 
@@ -78,30 +55,47 @@ export default class GitFetcher extends BaseFetcher {
     return path.join(this.dest, constants.TARBALL_FILENAME);
   }
 
-  async fetchFromLocal(override: ?string): Promise<FetchedOverride> {
-    const tarballLegacyMirrorPath = this.getTarballMirrorPath({
+  *getLocalPaths(override: ?string): Generator<?string, void, void> {
+    if (override) {
+      yield path.resolve(this.config.cwd, override);
+    }
+    yield this.getTarballMirrorPath();
+    yield this.getTarballMirrorPath({
       withCommit: false,
     });
-    const tarballModernMirrorPath = this.getTarballMirrorPath();
-    const tarballCachePath = this.getTarballCachePath();
+    yield this.getTarballCachePath();
+  }
 
-    const tarballMirrorPath =
-      tarballModernMirrorPath && (await fsUtil.exists(tarballModernMirrorPath))
-        ? tarballModernMirrorPath
-        : tarballLegacyMirrorPath && (await fsUtil.exists(tarballLegacyMirrorPath)) ? tarballLegacyMirrorPath : null;
-
-    const tarballPath = override || tarballMirrorPath || tarballCachePath;
-
-    if (!tarballPath || !await fsUtil.exists(tarballPath)) {
-      throw new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarballPath));
+  async fetchFromLocal(override: ?string): Promise<FetchedOverride> {
+    let cachedStream;
+    const triedPaths = [];
+    for (const tarballPath of this.getLocalPaths(override)) {
+      if (tarballPath) {
+        try {
+          cachedStream = await new Promise((resolve, reject) => {
+            const stream = fs.createReadStream(tarballPath);
+            stream.on('error', reject).on('readable', resolve.bind(this, stream));
+          });
+          break;
+        } catch (err) {
+          // Try the next one
+          triedPaths.push(tarballPath);
+        }
+      }
     }
 
     return new Promise((resolve, reject) => {
+      if (!cachedStream) {
+        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, triedPaths)));
+        return;
+      }
+      invariant(cachedStream, 'cachedStream should be available at this point');
+      // $FlowFixMe - This is available https://nodejs.org/api/fs.html#fs_readstream_path
+      const tarballPath = cachedStream.path;
+
       const untarStream = this._createUntarStream(this.dest);
 
       const hashStream = new crypto.HashStream();
-
-      const cachedStream = fs.createReadStream(tarballPath);
       cachedStream
         .pipe(hashStream)
         .pipe(untarStream)
@@ -266,11 +260,7 @@ export default class GitFetcher extends BaseFetcher {
     }
   }
 
-  async _fetch(): Promise<FetchedOverride> {
-    if (await this.getLocalAvailabilityStatus()) {
-      return this.fetchFromLocal();
-    } else {
-      return this.fetchFromExternal();
-    }
+  _fetch(): Promise<FetchedOverride> {
+    return this.fetchFromLocal().catch(err => this.fetchFromExternal());
   }
 }

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -7,7 +7,7 @@ import * as constants from '../constants.js';
 import * as crypto from '../util/crypto.js';
 import BaseFetcher from './base-fetcher.js';
 import * as fsUtil from '../util/fs.js';
-import {sleep} from '../util/misc.js';
+import {removePrefix, sleep} from '../util/misc.js';
 
 const path = require('path');
 const tarFs = require('tar-fs');
@@ -15,7 +15,7 @@ const url = require('url');
 const fs = require('fs');
 const stream = require('stream');
 const gunzip = require('gunzip-maybe');
-import {removePrefix} from '../util/misc.js';
+const invariant = require('invariant');
 
 export default class TarballFetcher extends BaseFetcher {
   async setupMirrorFromCache(): Promise<?string> {
@@ -31,21 +31,6 @@ export default class TarballFetcher extends BaseFetcher {
       await fsUtil.mkdirp(path.dirname(tarballMirrorPath));
       await fsUtil.copy(tarballCachePath, tarballMirrorPath, this.reporter);
     }
-  }
-
-  async getLocalAvailabilityStatus(): Promise<boolean> {
-    const tarballMirrorPath = this.getTarballMirrorPath();
-    const tarballCachePath = this.getTarballCachePath();
-
-    if (tarballMirrorPath != null && (await fsUtil.exists(tarballMirrorPath))) {
-      return true;
-    }
-
-    if (await fsUtil.exists(tarballCachePath)) {
-      return true;
-    }
-
-    return false;
   }
 
   getTarballCachePath(): string {
@@ -112,19 +97,42 @@ export default class TarballFetcher extends BaseFetcher {
     return {validateStream, extractorStream};
   }
 
+  *getLocalPaths(override: ?string): Generator<?string, void, void> {
+    if (override) {
+      yield path.resolve(this.config.cwd, override);
+    }
+    yield this.getTarballMirrorPath();
+    yield this.getTarballCachePath();
+  }
+
   async fetchFromLocal(override: ?string): Promise<FetchedOverride> {
-    const tarballMirrorPath = this.getTarballMirrorPath();
-    const tarballCachePath = this.getTarballCachePath();
-
-    const tarballPath = path.resolve(this.config.cwd, override || tarballMirrorPath || tarballCachePath);
-
-    if (!tarballPath || !await fsUtil.exists(tarballPath)) {
-      throw new MessageError(this.config.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarballPath));
+    let cachedStream;
+    const triedPaths = [];
+    for (const tarballPath of this.getLocalPaths(override)) {
+      if (tarballPath) {
+        try {
+          cachedStream = await new Promise((resolve, reject) => {
+            const stream = fs.createReadStream(tarballPath);
+            stream.on('error', reject).on('readable', resolve.bind(this, stream));
+          });
+          break;
+        } catch (err) {
+          // Try the next one
+          cachedStream = null;
+          triedPaths.push(tarballPath);
+        }
+      }
     }
 
     return new Promise((resolve, reject) => {
+      if (!cachedStream) {
+        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, triedPaths)));
+        return;
+      }
+      invariant(cachedStream, 'cachedStream should be available at this point');
+      // $FlowFixMe - This is available https://nodejs.org/api/fs.html#fs_readstream_path
+      const tarballPath = cachedStream.path;
       const {validateStream, extractorStream} = this.createExtractor(resolve, reject, tarballPath);
-      const cachedStream = fs.createReadStream(tarballPath);
 
       cachedStream.pipe(validateStream).pipe(extractorStream).on('error', err => {
         reject(new MessageError(this.config.reporter.lang('fetchErrorCorrupt', err.message, tarballPath)));
@@ -194,7 +202,7 @@ export default class TarballFetcher extends BaseFetcher {
     throw new Error('Ran out of retries!');
   }
 
-  async _fetch(): Promise<FetchedOverride> {
+  _fetch(): Promise<FetchedOverride> {
     const isFilePath = this.reference.startsWith('file:');
     this.reference = removePrefix(this.reference, 'file:');
     const urlParse = url.parse(this.reference);
@@ -208,11 +216,7 @@ export default class TarballFetcher extends BaseFetcher {
       return this.fetchFromLocal(this.reference);
     }
 
-    if (await this.getLocalAvailabilityStatus()) {
-      return this.fetchFromLocal();
-    } else {
-      return this.fetchFromExternal();
-    }
+    return this.fetchFromLocal().catch(err => this.fetchFromExternal());
   }
 }
 

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -106,35 +106,19 @@ export default class TarballFetcher extends BaseFetcher {
   }
 
   async fetchFromLocal(override: ?string): Promise<FetchedOverride> {
-    let cachedStream;
-    const triedPaths = [];
-    for (const tarballPath of this.getLocalPaths(override)) {
-      if (tarballPath) {
-        try {
-          cachedStream = await new Promise((resolve, reject) => {
-            const stream = fs.createReadStream(tarballPath);
-            stream.on('error', reject).on('readable', resolve.bind(this, stream));
-          });
-          break;
-        } catch (err) {
-          // Try the next one
-          cachedStream = null;
-          triedPaths.push(tarballPath);
-        }
-      }
-    }
+    const {stream, triedPaths} = await fsUtil.readFirstAvailableStream(this.getLocalPaths(override));
 
     return new Promise((resolve, reject) => {
-      if (!cachedStream) {
+      if (!stream) {
         reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, triedPaths)));
         return;
       }
-      invariant(cachedStream, 'cachedStream should be available at this point');
+      invariant(stream, 'stream should be available at this point');
       // $FlowFixMe - This is available https://nodejs.org/api/fs.html#fs_readstream_path
-      const tarballPath = cachedStream.path;
+      const tarballPath = stream.path;
       const {validateStream, extractorStream} = this.createExtractor(resolve, reject, tarballPath);
 
-      cachedStream.pipe(validateStream).pipe(extractorStream).on('error', err => {
+      stream.pipe(validateStream).pipe(extractorStream).on('error', err => {
         reject(new MessageError(this.config.reporter.lang('fetchErrorCorrupt', err.message, tarballPath)));
       });
     });


### PR DESCRIPTION
**Summary**

There's a delay between when we make sure a file in cache exists and when we actually start reading it. Our code wasn't doing any error handling when trying to open the file so if another process removes the file we assume existing we were throwing an unexpected `ENOENT ... open` error.

This patch removes all delayed existence checks and catches the error directly on the `ReadStream` instance directly. Moreover, it automatically falls back for local caches: direct, cache, offline mirror.

This revealed a bug in tarball path resolution which I fixed.

**Test plan**

Existing tests.