### PR TITLE
Breaking: rename every `yarn <command> rm` to `yarn <command> remove`

### DIFF
--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -192,5 +192,5 @@ export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
       return list(config, reporter, flags, args);
     },
   },
-  ['add <user> [[<@scope>/]<pkg>]', 'rm <user> [[<@scope>/]<pkg>]', 'ls [<@scope>/]<pkg>'],
+  ['add <user> [[<@scope>/]<pkg>]', 'remove <user> [[<@scope>/]<pkg>]', 'ls [<@scope>/]<pkg>'],
 );

--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -118,7 +118,7 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
   }
 }
 
-async function remove(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
+function remove(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
   return mutate(
     args,
     config,

--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -118,6 +118,34 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
   }
 }
 
+async function remove(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
+  return mutate(
+    args,
+    config,
+    reporter,
+    (username: string, name: string): Messages => ({
+      info: reporter.lang('ownerRemoving', username, name),
+      success: reporter.lang('ownerRemoved'),
+      error: reporter.lang('ownerRemoveError'),
+    }),
+    (user: Object, pkg: Object): boolean => {
+      let found = false;
+
+      pkg.maintainers = pkg.maintainers.filter((o): boolean => {
+        const match = o.name === user.name;
+        found = found || match;
+        return !match;
+      });
+
+      if (!found) {
+        reporter.error(reporter.lang('userNotAnOwner', user.name));
+      }
+
+      return found;
+    },
+  );
+}
+
 export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
   'owner',
   {
@@ -147,31 +175,12 @@ export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
     },
 
     rm(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
-      return mutate(
-        args,
-        config,
-        reporter,
-        (username: string, name: string): Messages => ({
-          info: reporter.lang('ownerRemoving', username, name),
-          success: reporter.lang('ownerRemoved'),
-          error: reporter.lang('ownerRemoveError'),
-        }),
-        (user: Object, pkg: Object): boolean => {
-          let found = false;
+      reporter.warn(`\`yarn owner rm\` is deprecated. Please use \`yarn owner remove\`.`);
+      return remove(config, reporter, flags, args);
+    },
 
-          pkg.maintainers = pkg.maintainers.filter((o): boolean => {
-            const match = o.name === user.name;
-            found = found || match;
-            return !match;
-          });
-
-          if (!found) {
-            reporter.error(reporter.lang('userNotAnOwner', user.name));
-          }
-
-          return found;
-        },
-      );
+    remove(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
+      return remove(config, reporter, flags, args);
     },
 
     ls(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -148,5 +148,5 @@ export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
       await list(config, reporter, flags, args);
     },
   },
-  ['add <pkg>@<version> [<tag>]', 'rm <pkg> <tag>', 'ls [<pkg>]'],
+  ['add <pkg>@<version> [<tag>]', 'remove <pkg> <tag>', 'ls [<pkg>]'],
 );

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -52,6 +52,38 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
   }
 }
 
+async function remove(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
+  if (args.length !== 2) {
+    return false;
+  }
+
+  const name = await getName(args, config);
+  const tag = args.shift();
+
+  reporter.step(1, 3, reporter.lang('loggingIn'));
+  const revoke = await getToken(config, reporter, name);
+
+  reporter.step(2, 3, reporter.lang('deletingTags'));
+  const result = await config.registries.npm.request(`-/package/${name}/dist-tags/${encodeURI(tag)}`, {
+    method: 'DELETE',
+  });
+
+  if (result === false) {
+    reporter.error(reporter.lang('deletedTagFail'));
+  } else {
+    reporter.success(reporter.lang('deletedTag'));
+  }
+
+  reporter.step(3, 3, reporter.lang('revokingToken'));
+  await revoke();
+
+  if (result === false) {
+    throw new Error();
+  } else {
+    return true;
+  }
+}
+
 export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
   'tag',
   {
@@ -98,36 +130,13 @@ export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
       }
     },
 
-    async rm(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<boolean> {
-      if (args.length !== 2) {
-        return false;
-      }
+    async rm(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+      reporter.warn(`\`yarn tag rm\` is deprecated. Please use \`yarn tag remove\`.`);
+      await remove(config, reporter, flags, args);
+    },
 
-      const name = await getName(args, config);
-      const tag = args.shift();
-
-      reporter.step(1, 3, reporter.lang('loggingIn'));
-      const revoke = await getToken(config, reporter, name);
-
-      reporter.step(2, 3, reporter.lang('deletingTags'));
-      const result = await config.registries.npm.request(`-/package/${name}/dist-tags/${encodeURI(tag)}`, {
-        method: 'DELETE',
-      });
-
-      if (result === false) {
-        reporter.error(reporter.lang('deletedTagFail'));
-      } else {
-        reporter.success(reporter.lang('deletedTag'));
-      }
-
-      reporter.step(3, 3, reporter.lang('revokingToken'));
-      await revoke();
-
-      if (result === false) {
-        throw new Error();
-      } else {
-        return true;
-      }
+    async remove(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+      await remove(config, reporter, flags, args);
     },
 
     async ls(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {

--- a/src/cli/commands/team.js
+++ b/src/cli/commands/team.js
@@ -44,7 +44,6 @@ function warnDeprecation(reporter: Reporter) {
 
 function wrapRequired(callback: CLIFunctionWithParts, requireTeam: boolean, isDeprecated?: boolean): CLIFunction {
   return async function(config: Config, reporter: Reporter, flags: Object, args: Array<string>): CLIFunctionReturn {
-
     if (isDeprecated) {
       warnDeprecation(reporter);
     }
@@ -89,44 +88,45 @@ function wrapRequiredTeam(callback: CLIFunctionWithParts, requireTeam: boolean =
 }
 
 function wrapRequiredUser(callback: CLIFunctionWithParts, subCommandDeprecated?: boolean): CLIFunction {
-  return wrapRequired(function(
-    parts: TeamParts,
-    config: Config,
-    reporter: Reporter,
-    flags: Object,
-    args: Array<string>,
-  ): CLIFunctionReturn {
-    if (args.length === 2) {
-      return callback(
-        {
-          user: args[1],
-          ...parts,
-        },
-        config,
-        reporter,
-        flags,
-        args,
-      );
-    } else {
-      return false;
-    }
-  }, true, subCommandDeprecated);
+  return wrapRequired(
+    function(
+      parts: TeamParts,
+      config: Config,
+      reporter: Reporter,
+      flags: Object,
+      args: Array<string>,
+    ): CLIFunctionReturn {
+      if (args.length === 2) {
+        return callback(
+          {
+            user: args[1],
+            ...parts,
+          },
+          config,
+          reporter,
+          flags,
+          args,
+        );
+      } else {
+        return false;
+      }
+    },
+    true,
+    subCommandDeprecated,
+  );
 }
 
-async function removeTeamUser(
-  parts: TeamParts,
-  config: Config,
-  reporter: Reporter): CLIFunction {
-    reporter.step(2, 3, reporter.lang('teamRemovingUser'));
-    reporter.inspect(
-      await config.registries.npm.request(`team/${parts.scope}/${parts.team}/user`, {
-        method: 'DELETE',
-        body: {
-          user: parts.user,
-        },
-      }),
-    );
-    return true;
+async function removeTeamUser(parts: TeamParts, config: Config, reporter: Reporter): Promise<boolean> {
+  reporter.step(2, 3, reporter.lang('teamRemovingUser'));
+  reporter.inspect(
+    await config.registries.npm.request(`team/${parts.scope}/${parts.team}/user`, {
+      method: 'DELETE',
+      body: {
+        user: parts.user,
+      },
+    }),
+  );
+  return true;
 }
 
 export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
@@ -186,23 +186,23 @@ export const {run, setFlags, hasWrapper, examples} = buildSubCommands(
       return true;
     }),
 
-    rm: wrapRequiredUser(async function(
+    rm: wrapRequiredUser(function(
       parts: TeamParts,
       config: Config,
       reporter: Reporter,
       flags: Object,
       args: Array<string>,
-    ): Promise<boolean> {
-      removeTeamUser(parts, config, reporter)
+    ) {
+      removeTeamUser(parts, config, reporter);
     }, true),
 
-    remove: wrapRequiredUser(async function(
+    remove: wrapRequiredUser(function(
       parts: TeamParts,
       config: Config,
       reporter: Reporter,
       flags: Object,
       args: Array<string>,
-    ): Promise<boolean> {
+    ) {
       removeTeamUser(parts, config, reporter);
     }),
 


### PR DESCRIPTION
**Summary**

From #3952 - For the sake of consistency and clarity, we need to rename the `rm` command to `remove` and add a deprecation warning for `rm`.

**Test plan**
I have done some rounds of functional manual testing.

Unfortunately, every command with `rm` requires a login. Coincidentally, and if I am not mistaken, none of the commands that implement `rm` has tests ( `owner`,  `tag`, `team`).

I will happily add tests for those but I can't seem to make a mock login to work... I need suggestions/guidance?

Note: I'm working on a windows machine. When I try to run `yarn run test`  I get the following
```
$ yarn lint && yarn test-only
Found 0 errors
C:\code\projects\yarn\node_modules\.bin\jest:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^
SyntaxError: missing ) after argument list
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
error Command failed with exit code 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```