### PR TITLE
Handle scripts failing with exit signals (fixes: #3954)

### DIFF
--- a/__tests__/fixtures/lifecycle-scripts/script-fail/app.js
+++ b/__tests__/fixtures/lifecycle-scripts/script-fail/app.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/__tests__/fixtures/lifecycle-scripts/script-fail/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/script-fail/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "test": "node app.js"
+  }
+}

--- a/__tests__/fixtures/lifecycle-scripts/script-segfault/app.js
+++ b/__tests__/fixtures/lifecycle-scripts/script-segfault/app.js
@@ -1,0 +1,1 @@
+process.kill(process.pid, "SIGSEGV");

--- a/__tests__/fixtures/lifecycle-scripts/script-segfault/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/script-segfault/package.json
@@ -1,9 +1,5 @@
 {
   "scripts": {
-    "compile": "gcc segfault.c -g -o segfault",
-    "pretest": "yarn run compile",
-    "test": "./segfault",
-    "pretest-alt": "yarn run compile",
-    "test-alt": "./segfault && true"
+    "test": "node app.js"
   }
 }

--- a/__tests__/fixtures/lifecycle-scripts/script-segfault/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/script-segfault/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "compile": "gcc segfault.c -g -o segfault",
+    "pretest": "yarn run compile",
+    "test": "./segfault",
+    "pretest-alt": "yarn run compile",
+    "test-alt": "./segfault && true"
+  }
+}

--- a/__tests__/fixtures/lifecycle-scripts/script-segfault/segfault.c
+++ b/__tests__/fixtures/lifecycle-scripts/script-segfault/segfault.c
@@ -1,0 +1,5 @@
+int main(void)
+{
+    char *s = "hello world";
+    *s = 'H';
+}

--- a/__tests__/fixtures/lifecycle-scripts/script-segfault/segfault.c
+++ b/__tests__/fixtures/lifecycle-scripts/script-segfault/segfault.c
@@ -1,5 +1,0 @@
-int main(void)
-{
-    char *s = "hello world";
-    *s = 'H';
-}

--- a/__tests__/fixtures/lifecycle-scripts/script-success/app.js
+++ b/__tests__/fixtures/lifecycle-scripts/script-success/app.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/__tests__/fixtures/lifecycle-scripts/script-success/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/script-success/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "test": "node app.js"
+  }
+}

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -142,3 +142,23 @@ test('should inherit existing environment variables when setting via yarnrc', as
   expect(stdout).toMatch(/^RAB$/m);
   expect(stdout).toMatch(/^FOO$/m);
 });
+
+test('should not show any error messages when script ends successfully', async () => {
+  const stdout = await execCommand('test', 'script-success');
+
+  expect(stdout).toMatch(/Done in /);
+});
+
+test('should show correct error message when the script ends with an exit code', async () => {
+  await execCommand('test', 'script-fail').catch(error => {
+    expect(error.message).toMatch(/Command failed with exit code /);
+    expect(error.code).not.toBe(0);
+  });
+});
+
+test('should show correct error message when the script ends an exit signal', async () => {
+  await execCommand('test', 'script-segfault').catch(error => {
+    expect(error.message).toMatch(/Command failed with signal /);
+    expect(error.code).not.toBe(0);
+  });
+});

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -158,7 +158,7 @@ test('should show correct error message when the script ends with an exit code',
 
 test('should show correct error message when the script ends an exit signal', async () => {
   await execCommand('test', 'script-segfault').catch(error => {
-    expect(error.message).toMatch(/Command failed with signal /);
+    expect(error.message).toMatch(/Command failed with signal "SIGSEGV"/);
     expect(error.code).not.toBe(0);
   });
 });

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -144,21 +144,15 @@ test('should inherit existing environment variables when setting via yarnrc', as
 });
 
 test('should not show any error messages when script ends successfully', async () => {
-  const stdout = await execCommand('test', 'script-success');
-
-  expect(stdout).toMatch(/Done in /);
+  await expect(execCommand('test', 'script-success')).resolves.toBeDefined();
 });
 
-test('should show correct error message when the script ends with an exit code', async () => {
-  await execCommand('test', 'script-fail').catch(error => {
-    expect(error.message).toMatch(/Command failed with exit code /);
-    expect(error.code).not.toBe(0);
+test('should throw error when the script ends with an exit code', async () => {
+  await expect(execCommand('test', 'script-fail')).rejects.toBeDefined();
+});
+
+if (process.platform === 'darwin') {
+  test('should throw error when the script ends with an exit signal', async () => {
+    await expect(execCommand('test', 'script-segfault')).rejects.toBeDefined();
   });
-});
-
-test('should show correct error message when the script ends an exit signal', async () => {
-  await execCommand('test', 'script-segfault').catch(error => {
-    expect(error.message).toMatch(/Command failed with signal "SIGSEGV"/);
-    expect(error.code).not.toBe(0);
-  });
-});
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -12,7 +12,8 @@ export class MessageError extends Error {
 export class SecurityError extends MessageError {}
 
 export class SpawnError extends MessageError {
-  EXIT_CODE: number;
+  EXIT_CODE: ?number;
+  EXIT_SIGNAL: ?string;
 }
 
 export class ResponseError extends Error {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -175,7 +175,8 @@ const messages = {
   binCommands: 'Commands available from binary scripts: ',
   possibleCommands: 'Project commands',
   commandQuestion: 'Which command would you like to run?',
-  commandFailed: 'Command failed with exit code $0.',
+  commandFailedWithCode: 'Command failed with exit code $0.',
+  commandFailedWithSignal: 'Command failed with signal $0.',
   packageRequiresNodeGyp:
     'This package requires node-gyp, which is not currently installed. Yarn will attempt to automatically install it. If this fails, you can run "yarn global add node-gyp" to manually install it.',
   nodeGypAutoInstallFailed:

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -94,8 +94,20 @@ export function spawn(
           processingDone = true;
         }
 
-        proc.on('close', (code: number) => {
-          if (code >= 1) {
+        proc.on('close', (code: number, signal: string) => {
+          if (signal) {
+            err = new SpawnError(
+              [
+                'Command failed.',
+                `Exit signal: ${signal}`,
+                `Command: ${program}`,
+                `Arguments: ${args.join(' ')}`,
+                `Directory: ${opts.cwd || process.cwd()}`,
+                `Output:\n${stdout.trim()}`,
+              ].join('\n'),
+            );
+            err.EXIT_SIGNAL = signal;
+          } else if (code >= 1) {
             // TODO make this output nicer
             err = new SpawnError(
               [

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -95,11 +95,11 @@ export function spawn(
         }
 
         proc.on('close', (code: number, signal: string) => {
-          if (signal) {
+          if (signal || code >= 1) {
             err = new SpawnError(
               [
                 'Command failed.',
-                `Exit signal: ${signal}`,
+                signal ? `Exit signal: ${signal}` : `Exit code: ${code}`,
                 `Command: ${program}`,
                 `Arguments: ${args.join(' ')}`,
                 `Directory: ${opts.cwd || process.cwd()}`,
@@ -107,18 +107,6 @@ export function spawn(
               ].join('\n'),
             );
             err.EXIT_SIGNAL = signal;
-          } else if (code >= 1) {
-            // TODO make this output nicer
-            err = new SpawnError(
-              [
-                'Command failed.',
-                `Exit code: ${code}`,
-                `Command: ${program}`,
-                `Arguments: ${args.join(' ')}`,
-                `Directory: ${opts.cwd || process.cwd()}`,
-                `Output:\n${stdout.trim()}`,
-              ].join('\n'),
-            );
             err.EXIT_CODE = code;
           }
 

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -254,7 +254,11 @@ export async function execCommand(stage: string, config: Config, cmd: string, cw
     return Promise.resolve();
   } catch (err) {
     if (err instanceof SpawnError) {
-      throw new MessageError(reporter.lang('commandFailed', err.EXIT_CODE));
+      if (err.EXIT_SIGNAL) {
+        throw new MessageError(reporter.lang('commandFailedWithSignal', err.EXIT_SIGNAL));
+      } else {
+        throw new MessageError(reporter.lang('commandFailedWithCode', err.EXIT_CODE));
+      }
     } else {
       throw err;
     }

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -254,11 +254,11 @@ export async function execCommand(stage: string, config: Config, cmd: string, cw
     return Promise.resolve();
   } catch (err) {
     if (err instanceof SpawnError) {
-      if (err.EXIT_SIGNAL) {
-        throw new MessageError(reporter.lang('commandFailedWithSignal', err.EXIT_SIGNAL));
-      } else {
-        throw new MessageError(reporter.lang('commandFailedWithCode', err.EXIT_CODE));
-      }
+      throw new MessageError(
+        err.EXIT_SIGNAL
+          ? reporter.lang('commandFailedWithSignal', err.EXIT_SIGNAL)
+          : reporter.lang('commandFailedWithCode', err.EXIT_CODE),
+      );
     } else {
       throw err;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes: #3954, Adds error handling for scripts that are failing with a signal such as `SIGBUS`, `SIGSEGV`, etc.

In current behavior, yarn checks the exit code of a script to show errors and fail the process. But certain errors make node child-processes to exit with a signal instead. (e.g. the case in #3954)

This fix adds support for handling exit signals from child processes and shows more informative error messages.

**Note:**  This implementation handles exit signals priorly, assuming exit signals are pointing to more critical low-level issues.

**Test plan**

Added 3 test cases (one for _zero_ exit code, one for _non-zero_ exit code, one for _exit signal_)
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
