### PR TITLE
Chore: enable no-process-exit lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "flowtype/space-after-type-colon": ["error", "always"],
     "flowtype/require-return-type": ["error", "always", {"excludeArrowFunctions": true}],
     "require-await": "error",
+    "no-process-exit": "error",
     "no-return-await": "error",
     "sort-keys": "off",
     "prettier/prettier": ["error", {

--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -17,6 +17,8 @@ if (semver.satisfies(ver, '>=5.0.0')) {
   dirPath = '../lib-legacy';
 } else {
   console.log(require('chalk').red('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.'));
+  // We need to skip the rest and terminate here since the Node version is not supported.
+  // `console.log` calls are sync so we don't have a risk of exiting early before stdout flushes
   process.exit(1); // eslint-disable-line no-process-exit
 }
 

--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -17,7 +17,7 @@ if (semver.satisfies(ver, '>=5.0.0')) {
   dirPath = '../lib-legacy';
 } else {
   console.log(require('chalk').red('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.'));
-  process.exit(1);
+  process.exit(1); // eslint-disable-line no-process-exit
 }
 
 // load v8-compile-cache

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -367,6 +367,6 @@ export default function main({
         reporter.info(commands[commandName].getDocsInfo);
       }
 
-      process.exit(1);
+      process.exit(1); // eslint-disable-line no-process-exit
     });
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -367,6 +367,7 @@ export default function main({
         reporter.info(commands[commandName].getDocsInfo);
       }
 
-      process.exit(1); // eslint-disable-line no-process-exit
+      reporter.close();
+      process.exitCode = 1;
     });
 }

--- a/src/config.js
+++ b/src/config.js
@@ -493,10 +493,10 @@ export default class Config {
   }
 
   /**
- * try get the manifest file by looking
- * 1. manifest file in cache
- * 2. manifest file in registry
- */
+   * try get the manifest file by looking
+   * 1. manifest file in cache
+   * 2. manifest file in registry
+   */
   async maybeReadManifest(dir: string, priorityRegistry?: RegistryNames, isRoot?: boolean = false): Promise<?Manifest> {
     const metadataLoc = path.join(dir, constants.METADATA_FILENAME);
 

--- a/src/util/signal-handler.js
+++ b/src/util/signal-handler.js
@@ -3,7 +3,7 @@ import {forwardSignalToSpawnedProcesses} from './child.js';
 
 function forwardSignalAndExit(signal: string) {
   forwardSignalToSpawnedProcesses(signal);
-  process.exit(1);
+  process.exit(1); // eslint-disable-line no-process-exit
 }
 
 export default function handleSignals() {

--- a/src/util/signal-handler.js
+++ b/src/util/signal-handler.js
@@ -3,6 +3,8 @@ import {forwardSignalToSpawnedProcesses} from './child.js';
 
 function forwardSignalAndExit(signal: string) {
   forwardSignalToSpawnedProcesses(signal);
+  // We want to exit immediately here since `SIGTERM` means that
+  // If we lose stdout messages due to abrupt exit, shoot the messenger?
   process.exit(1); // eslint-disable-line no-process-exit
 }
 


### PR DESCRIPTION
**Summary**

A follow up to #3955 to disable further usage of `process.exit()`.

**Test plan**

`yarn lint` should not produce any errors.