### PR TITLE
Scoped packages 403 on yarn install with empty cache

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -176,7 +176,7 @@ describe('request', () => {
     expect(requestParams.headers.authorization).toBe('Bearer testAuthToken');
   });
 
-  test('should add authorization header with token for scope if pathname is to registry and is scoped package', () => {
+  test('should add authorization header with token for custom registries with a scoped package', () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
@@ -258,7 +258,7 @@ describe('getScope functional test', () => {
       const packageNames = [
         ['normal', ''],
         ['normal-package', ''],
-        ['@scopedNoPkg', ''],
+        ['@scopedNoPkg', '@scopedNoPkg'],
         ['@scoped/pkg', '@scoped'],
         ['invalid@scope/pkg', ''],
       ];
@@ -271,7 +271,7 @@ describe('getScope functional test', () => {
     test('in pathname', () => {
       const pathnames = [
         ['http://foo.bar:80/foo/bar/baz', ''],
-        ['http://foo.bar:80/@scopedNoPkg', ''],
+        ['http://foo.bar:80/@scopedNoPkg', '@scopedNoPkg'],
         ['http://foo.bar:80/@scope/bar/baz', '@scope'],
         ['http://foo.bar:80/@scope%2fbar/baz', '@scope'],
         ['http://foo.bar:80/invalid@scope%2fbar/baz', ''],

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -164,7 +164,7 @@ describe('request', () => {
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
 
-    const url = 'https://registry.npmjs.org/@testScope/yarn.tgz';
+    const url = 'https://registry.npmjs.org/@testScope%2fyarn.tgz';
 
     npmRegistry.config = {
       _authToken: 'testAuthToken',
@@ -181,7 +181,7 @@ describe('request', () => {
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
 
-    const url = 'https://some.other.registry/@testScope/yarn.tgz';
+    const url = 'https://some.other.registry/@testScope%2fyarn.tgz';
 
     npmRegistry.config = {
       '//some.other.registry/:_authToken': 'testScopedAuthToken',
@@ -248,38 +248,47 @@ describe('isRequestToRegistry functional test', () => {
   });
 });
 
+const packageIdents = [
+  ['normal', ''],
+  ['@scopedNoPkg', ''],
+  ['@scoped/notescaped', ''],
+  ['not@scope/pkg', ''],
+  ['@scope?query=true', ''],
+  ['@scope%2fpkg', '@scope'],
+  ['@scope%2fpkg%2fext', '@scope'],
+  ['@scope%2fpkg?query=true', '@scope'],
+  ['@scope%2fpkg%2f1.2.3', '@scope'],
+  ['http://foo.bar:80/normal', ''],
+  ['http://foo.bar:80/@scopedNoPkg', ''],
+  ['http://foo.bar:80/@scoped/notescaped', ''],
+  ['http://foo.bar:80/not@scope/pkg', ''],
+  ['http://foo.bar:80/@scope?query=true', ''],
+  ['http://foo.bar:80/@scope%2fpkg', '@scope'],
+  ['http://foo.bar:80/@scope%2fpkg%2fext', '@scope'],
+  ['http://foo.bar:80/@scope%2fpkg?query=true', '@scope'],
+  ['http://foo.bar:80/@scope%2fpkg%2f1.2.3', '@scope'],
+];
+
+describe('isScopedPackage functional test', () => {
+  test('identifies scope correctly', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+
+    packageIdents.forEach(([pathname, scope]) => {
+      expect(npmRegistry.isScopedPackage(pathname)).toEqual(!!scope.length);
+    });
+  });
+});
+
 describe('getScope functional test', () => {
   describe('matches scope correctly', () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
 
-    test('in package names', () => {
-      const packageNames = [
-        ['normal', ''],
-        ['normal-package', ''],
-        ['@scopedNoPkg', '@scopedNoPkg'],
-        ['@scoped/pkg', '@scoped'],
-        ['invalid@scope/pkg', ''],
-      ];
-
-      packageNames.forEach(([packageName, scope]) => {
-        expect(npmRegistry.getScope(packageName)).toEqual(scope);
-      });
-    });
-
-    test('in pathname', () => {
-      const pathnames = [
-        ['http://foo.bar:80/foo/bar/baz', ''],
-        ['http://foo.bar:80/@scopedNoPkg', '@scopedNoPkg'],
-        ['http://foo.bar:80/@scope/bar/baz', '@scope'],
-        ['http://foo.bar:80/@scope%2fbar/baz', '@scope'],
-        ['http://foo.bar:80/invalid@scope%2fbar/baz', ''],
-      ];
-
-      pathnames.forEach(([pathname, scope]) => {
-        expect(npmRegistry.getScope(pathname)).toEqual(scope);
-      });
+    packageIdents.forEach(([pathname, scope]) => {
+      expect(npmRegistry.getScope(pathname)).toEqual(scope);
     });
   });
 });

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -176,7 +176,7 @@ describe('request', () => {
     expect(requestParams.headers.authorization).toBe('Bearer testAuthToken');
   });
 
-  test('should add authorization header with correct token for scoped package', () => {
+  test('should add authorization header with token for a configured scope if pathname is to registry and is scoped package', () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -271,6 +271,7 @@ describe('getScope functional test', () => {
     test('in pathname', () => {
       const pathnames = [
         ['http://foo.bar:80/foo/bar/baz', ''],
+        ['http://foo.bar:80/@scopedNoPkg', ''],
         ['http://foo.bar:80/@scope/bar/baz', '@scope'],
         ['http://foo.bar:80/@scope%2fbar/baz', '@scope'],
         ['http://foo.bar:80/invalid@scope%2fbar/baz', ''],

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -176,7 +176,7 @@ describe('request', () => {
     expect(requestParams.headers.authorization).toBe('Bearer testAuthToken');
   });
 
-  test('should add authorization header with token for a configured scope if pathname is to registry and is scoped package', () => {
+  test('should add authorization header with token for scope if pathname is to registry and is scoped package', () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -50,7 +50,7 @@ function isPathConfigOption(key: string): boolean {
 
 function isScopedPackage(packageIdent: string): boolean {
   // scoped package names will begin with '@', scoped path names will contain '/@'
-  return !!packageIdent.match(/^@|\/@/);
+  return /^@|\/@/.test(packageIdent);
 }
 
 function normalizePath(val: mixed): ?string {
@@ -222,13 +222,9 @@ export default class NpmRegistry extends Registry {
   }
 
   getScope(packageIdent: string): string {
-    // Matches '@scope' in a packageName or pathname, otherwise returns ''
-    if (packageIdent && isScopedPackage(packageIdent)) {
-      const matched = packageIdent.match(/(^@|(?!\/)@).+?((?=%2f)|(?=\/))/);
-      return (matched && matched[0]) || '';
-    }
-
-    return '';
+    // Matches strings beginning with @ or contain /@ up until the next forward slash
+    const match = packageIdent.replace('%2f', '/').match(/(^@|\/@)(.+?)(?=\/)/);
+    return (match && '@' + match[2]) || '';
   }
 
   getRegistry(packageIdent: string): string {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -222,7 +222,7 @@ export default class NpmRegistry extends Registry {
   }
 
   getScope(packageIdent: string): string {
-    // removing escaped / from package names in full paths
+    // removing escaped / from scoped package names added by NpmRegistry.escapeName to assist following regex
     packageIdent = packageIdent.replace('%2f', '/');
 
     // Matches the first path segment that starts with an `@`. The RegEx is constructed as follows:

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -26,9 +26,9 @@ const REGEX_REGISTRY_SUFFIX = /registry\/?$/;
 export const SCOPE_SEPARATOR = '%2f';
 // All scoped package names are of the format `@scope%2fpkg` from the use of NpmRegistry.escapeName
 // `(?:^|\/)` Match either the start of the string or a `/` but don't capture
-// `[^\/?]+` Match any character that is not '/' or '?' and capture, up until the first occurance of:
+// `[^\/?]+?` Match any character that is not '/' or '?' and capture, up until the first occurance of:
 // `%2f` Match SCOPE_SEPARATOR, the escaped '/', and don't capture
-const SCOPED_PKG_REGEXP = /(?:^|\/)(@[^\/?]+)(?=%2f)/;
+const SCOPED_PKG_REGEXP = /(?:^|\/)(@[^\/?]+?)(?=%2f)/;
 
 function getGlobalPrefix(): string {
   if (process.env.PREFIX) {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -222,9 +222,15 @@ export default class NpmRegistry extends Registry {
   }
 
   getScope(packageIdent: string): string {
-    // Matches strings beginning with @ or contain /@ up until the next forward slash
-    const match = packageIdent.replace('%2f', '/').match(/(^@|\/@)(.+?)(?=\/)/);
-    return (match && '@' + match[2]) || '';
+    // removing escaped / from package names in full paths
+    packageIdent = packageIdent.replace('%2f', '/');
+
+    // Matches the first path segment that starts with an `@`. The RegEx is constructed as follows:
+    // `(?:^|\/)` Match either the start of the string or a `/` but don't capture
+    // `(@[^?\/]+)` Match a string starting with an `@` and not having any `/` or `?` in it and capture
+    // `(?:[?\/]|$)/)` Match a path delimiter, a query string delimiter or the end of the string but don't capture
+    const match = packageIdent.replace('%2f', '/').match(/(?:^|\/)(@[^?\/]+)(?:[?\/]|$)/);
+    return (match && match[1]) || '';
   }
 
   getRegistry(packageIdent: string): string {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -23,11 +23,12 @@ const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 const REGEX_REGISTRY_PREFIX = /^https?:/;
 const REGEX_REGISTRY_SUFFIX = /registry\/?$/;
 
+export const SCOPE_SEPARATOR = '%2f';
 // All scoped package names are of the format `@scope%2fpkg` from the use of NpmRegistry.escapeName
 // `(?:^|\/)` Match either the start of the string or a `/` but don't capture
-// `[^\/?]*?` Match any character that is not '/' or '?' and capture, up until the first occurance of:
-// `%2f` Match '%2f' the escaped forward slash and don't capture
-const SCOPED_PKG_REGEXP = /(?:^|\/)(@[^\/?]*?)(?=%2f)/;
+// `[^\/?]+` Match any character that is not '/' or '?' and capture, up until the first occurance of:
+// `%2f` Match SCOPE_SEPARATOR, the escaped '/', and don't capture
+const SCOPED_PKG_REGEXP = /(?:^|\/)(@[^\/?]+)(?=%2f)/;
 
 function getGlobalPrefix(): string {
   if (process.env.PREFIX) {
@@ -76,7 +77,7 @@ export default class NpmRegistry extends Registry {
 
   static escapeName(name: string): string {
     // scoped packages contain slashes and the npm registry expects them to be escaped
-    return name.replace('/', '%2f');
+    return name.replace('/', SCOPE_SEPARATOR);
   }
 
   isScopedPackage(packageIdent: string): boolean {

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import type PackageRequest from '../../package-request.js';
 import {MessageError} from '../../errors.js';
 import RegistryResolver from './registry-resolver.js';
-import NpmRegistry from '../../registries/npm-registry.js';
+import {NpmRegistry, SCOPE_SEPARATOR} from '../../registries/npm-registry.js';
 import map from '../../util/map.js';
 import * as fs from '../../util/fs.js';
 import {YARN_REGISTRY} from '../../constants.js';
@@ -16,6 +16,7 @@ const invariant = require('invariant');
 const path = require('path');
 
 const NPM_REGISTRY = /http[s]:\/\/registry.npmjs.org/g;
+const NPM_REGISTRY_ID = 'npm';
 
 type RegistryResponse = {
   name: string,
@@ -24,7 +25,7 @@ type RegistryResponse = {
 };
 
 export default class NpmResolver extends RegistryResolver {
-  static registry = 'npm';
+  static registry = NPM_REGISTRY_ID;
 
   static async findVersionInRegistryResponse(
     config: Config,
@@ -86,9 +87,11 @@ export default class NpmResolver extends RegistryResolver {
   }
 
   async resolveRequestOffline(): Promise<?Manifest> {
-    const scope = this.config.registries.npm.getScope(NpmRegistry.escapeName(this.name));
+    const escapedName = NpmRegistry.escapeName(this.name);
+    const scope = this.config.registries.npm.getScope(escapedName);
+
     // find modules of this name
-    const prefix = scope ? this.name.split(/\/|%2f/)[1] : `npm-${this.name}-`;
+    const prefix = scope ? escapedName.substr(scope.length + SCOPE_SEPARATOR.length) : `npm-${this.name}-`;
 
     invariant(this.config.cacheFolder, 'expected packages root');
     const cacheFolder = path.join(this.config.cacheFolder, scope ? 'npm-' + scope : '');
@@ -124,7 +127,7 @@ export default class NpmResolver extends RegistryResolver {
       const dir = path.join(cacheFolder, name);
 
       // read manifest and validate correct name
-      const pkg = await this.config.readManifest(dir, 'npm');
+      const pkg = await this.config.readManifest(dir, NPM_REGISTRY_ID);
       if (pkg.name !== this.name) {
         continue;
       }
@@ -169,7 +172,7 @@ export default class NpmResolver extends RegistryResolver {
 
     const info: ?Manifest = await this.resolveRequest();
     if (info == null) {
-      throw new MessageError(this.reporter.lang('packageNotFoundRegistry', this.name, 'npm'));
+      throw new MessageError(this.reporter.lang('packageNotFoundRegistry', this.name, NPM_REGISTRY_ID));
     }
 
     const {deprecated, dist} = info;
@@ -188,7 +191,7 @@ export default class NpmResolver extends RegistryResolver {
         type: 'tarball',
         reference: this.cleanRegistry(dist.tarball),
         hash: dist.shasum,
-        registry: 'npm',
+        registry: NPM_REGISTRY_ID,
         packageName: info.name,
       };
     }

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -91,10 +91,10 @@ export default class NpmResolver extends RegistryResolver {
     const scope = this.config.registries.npm.getScope(escapedName);
 
     // find modules of this name
-    const prefix = scope ? escapedName.substr(scope.length + SCOPE_SEPARATOR.length) : `npm-${this.name}-`;
+    const prefix = scope ? escapedName.split(SCOPE_SEPARATOR)[1] : `${NPM_REGISTRY_ID}-${this.name}-`;
 
     invariant(this.config.cacheFolder, 'expected packages root');
-    const cacheFolder = path.join(this.config.cacheFolder, scope ? 'npm-' + scope : '');
+    const cacheFolder = path.join(this.config.cacheFolder, scope ? `${NPM_REGISTRY_ID}-${scope}` : '');
 
     const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
       const files = await fs.readdir(cacheFolder);

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import type PackageRequest from '../../package-request.js';
 import {MessageError} from '../../errors.js';
 import RegistryResolver from './registry-resolver.js';
-import {NpmRegistry, SCOPE_SEPARATOR} from '../../registries/npm-registry.js';
+import NpmRegistry, {SCOPE_SEPARATOR} from '../../registries/npm-registry.js';
 import map from '../../util/map.js';
 import * as fs from '../../util/fs.js';
 import {YARN_REGISTRY} from '../../constants.js';

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -86,7 +86,7 @@ export default class NpmResolver extends RegistryResolver {
   }
 
   async resolveRequestOffline(): Promise<?Manifest> {
-    const scope = this.config.registries.npm.getScope(this.name);
+    const scope = this.config.registries.npm.getScope(NpmRegistry.escapeName(this.name));
     // find modules of this name
     const prefix = scope ? this.name.split(/\/|%2f/)[1] : `npm-${this.name}-`;
 


### PR DESCRIPTION
**Summary**

Fix scoped packages not adding correct auth headers (#4016)

**Test Plan**

Having set up config for a scoped registry with an auth token. It should be possible to run `yarn cache clean` followed by `yarn install` without having the scoped packages 403
