### PR TITLE
Fix `yarn run` on window

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -166,23 +166,9 @@ export async function executeLifecycleScript(
   env[constants.ENV_PATH_KEY] = pathParts.join(path.delimiter);
 
   // get shell
-  const conf = {windowsVerbatimArguments: false};
-  let sh = 'sh';
-  let shFlag = '-c';
   if (process.platform === 'win32') {
-    // cmd or command.com
-    sh = process.env.comspec || 'cmd';
-
-    // d - Ignore registry AutoRun commands
-    // s - Strip " quote characters from command.
-    // c - Run Command and then terminate
-    shFlag = '/d /s /c';
-
     // handle windows run scripts starting with a relative path
     cmd = fixCmdWinSlashes(cmd);
-
-    // handle quotes properly in windows environments - https://github.com/nodejs/node/issues/5060
-    conf.windowsVerbatimArguments = true;
   }
 
   let updateProgress;
@@ -204,7 +190,7 @@ export async function executeLifecycleScript(
       }
     };
   }
-  const stdout = await child.spawn(sh, [shFlag, cmd], {cwd, env, stdio, ...conf}, updateProgress);
+  const stdout = await child.spawn(cmd, [], {shell: true, cwd, env, stdio}, updateProgress);
 
   return {cwd, command: cmd, stdout};
 }


### PR DESCRIPTION
**Summary**

Fix for #3773
> Yarn run no longer works on windows with executables not mentioned in package.json/scripts

**Test plan**

I think we don't have automated tests for this case, it's OS specific and the fix relies on the `shell` option of `child_process.spawn`, so we cannot use mock to reliably test this issue.
(Any idea welcomed)

I ran manual tests on Windows 10 and a linux VM.
We should get more manual tests from the community before merging.
