### PR TITLE
Fix: use `git add` with relative path to git root in version command

### DIFF
--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 jest.mock('../../src/util/execute-lifecycle-script');
-jest.mock('../../src/util/child');
+jest.mock('../../src/util/git/git-spawn');
 
 import {run as buildRun} from './_helpers.js';
 import {BufferReporter} from '../../src/reporters/index.js';
@@ -12,6 +12,9 @@ import * as reporters from '../../src/reporters/index.js';
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
 const execCommand: $FlowFixMe = require('../../src/util/execute-lifecycle-script').execCommand;
+const spawn: $FlowFixMe = require('../../src/util/git/git-spawn').spawn;
+
+spawn.mockReturnValue(Promise.resolve(''));
 
 const path = require('path');
 

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import {registryNames} from '../../registries/index.js';
 import {execCommand} from '../../util/execute-lifecycle-script.js';
 import {MessageError} from '../../errors.js';
-import {spawn} from '../../util/child.js';
+import {spawn as spawnGit} from '../../util/git/git-spawn.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
@@ -118,9 +118,7 @@ export async function setVersion(
   // check if committing the new version to git is overriden
   if (!flags.gitTagVersion || !config.getOption('version-git-tag')) {
     // Don't tag the version in Git
-    return function(): Promise<void> {
-      return Promise.resolve();
-    };
+    return Promise.resolve.bind(Promise);
   }
 
   return async function(): Promise<void> {
@@ -146,14 +144,16 @@ export async function setVersion(
       const flag = sign ? '-sm' : '-am';
       const prefix: string = String(config.getOption('version-tag-prefix'));
 
+      const gitRoot = (await spawnGit(['rev-parse', '--show-toplevel'])).trim();
+
       // add manifest
-      await spawn('git', ['add', pkgLoc]);
+      await spawnGit(['add', path.relative(gitRoot, pkgLoc)]);
 
       // create git commit
-      await spawn('git', ['commit', '-m', message]);
+      await spawnGit(['commit', '-m', message]);
 
       // create git tag
-      await spawn('git', ['tag', `${prefix}${newVersion}`, flag, message]);
+      await spawnGit(['tag', `${prefix}${newVersion}`, flag, message]);
     }
 
     await runLifecycle('postversion');

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -118,7 +118,7 @@ export async function setVersion(
   // check if committing the new version to git is overriden
   if (!flags.gitTagVersion || !config.getOption('version-git-tag')) {
     // Don't tag the version in Git
-    return Promise.resolve.bind(Promise);
+    return () => Promise.resolve();
   }
 
   return async function(): Promise<void> {

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -144,16 +144,16 @@ export async function setVersion(
       const flag = sign ? '-sm' : '-am';
       const prefix: string = String(config.getOption('version-tag-prefix'));
 
-      const gitRoot = (await spawnGit(['rev-parse', '--show-toplevel'])).trim();
+      const gitRoot = (await spawnGit(['rev-parse', '--show-toplevel'], {cwd: config.cwd})).trim();
 
       // add manifest
-      await spawnGit(['add', path.relative(gitRoot, pkgLoc)]);
+      await spawnGit(['add', path.relative(gitRoot, pkgLoc)], {cwd: gitRoot});
 
       // create git commit
-      await spawnGit(['commit', '-m', message]);
+      await spawnGit(['commit', '-m', message], {cwd: gitRoot});
 
       // create git tag
-      await spawnGit(['tag', `${prefix}${newVersion}`, flag, message]);
+      await spawnGit(['tag', `${prefix}${newVersion}`, flag, message], {cwd: gitRoot});
     }
 
     await runLifecycle('postversion');


### PR DESCRIPTION
**Summary**

Refs #3610.

Some versions of `git` doesn't support passing absolute paths to
`git add` causing it to fail. This patch runs
`git rev-parse --show-toplevel` to git root and uses the relative
path of `package.json` to that directory when calling `git add`.

**Test plan**

Manual tests for now.