### PR TITLE
Check for npmrc in home directory for linux root users

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -304,9 +304,9 @@ describe('getPossibleConfigLocations', () => {
     const logs = reporter.getBuffer().map(logItem => logItem.data);
     expect(logs).toEqual(
       expect.arrayContaining([
-        expect.stringContaining(pathJoin('project', 'subdirectory', '.npmrc')),
-        expect.stringContaining(pathJoin('project', '.npmrc')),
-        expect.stringContaining(pathJoin(homeDir, '.npmrc')),
+        expect.stringContaining(JSON.stringify(pathJoin('project', 'subdirectory', '.npmrc'))),
+        expect.stringContaining(JSON.stringify(pathJoin('project', '.npmrc'))),
+        expect.stringContaining(JSON.stringify(pathJoin(homeDir, '.npmrc'))),
       ]),
     );
   });

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -299,7 +299,7 @@ describe('getScope functional test', () => {
 });
 
 describe('getPossibleConfigLocations', () => {
-  describe('searches recursively to home directory', async () => {
+  test('searches recursively to home directory', async () => {
     const testCwd = './project/subdirectory';
     const {mockRequestManager, mockRegistries, mockReporter, mockLog} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {resolve} from 'path';
+import {resolve, join as pathJoin} from 'path';
 
 import NpmRegistry from '../../src/registries/npm-registry.js';
 import {BufferReporter} from '../../src/reporters/index.js';
@@ -304,9 +304,9 @@ describe('getPossibleConfigLocations', () => {
     const logs = reporter.getBuffer().map(logItem => logItem.data);
     expect(logs).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('project/subdirectory/.npmrc'),
-        expect.stringContaining('project/.npmrc'),
-        expect.stringContaining(`${homeDir}/.npmrc`),
+        expect.stringContaining(pathJoin('project', 'subdirectory', '.npmrc')),
+        expect.stringContaining(pathJoin('project', '.npmrc')),
+        expect.stringContaining(pathJoin(homeDir, '.npmrc')),
       ]),
     );
   });

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -14,7 +14,7 @@ import {addSuffix} from '../util/misc';
 import {getPosixPath, resolveWithHome} from '../util/path';
 
 const normalizeUrl = require('normalize-url');
-const userHome = require('../util/user-home-dir').default;
+const {default: userHome, rootHome} = require('../util/user-home-dir');
 const path = require('path');
 const url = require('url');
 const ini = require('ini');
@@ -177,6 +177,12 @@ export default class NpmRegistry extends Registry {
       [true, this.config.userconfig || path.join(userHome, localfile)],
       [false, path.join(getGlobalPrefix(), 'etc', filename)],
     ];
+
+    // When home directory for global install is different from where $HOME/npmrc is stored,
+    // E.g. /usr/local/share vs /root on linux machines, check the additional location
+    if (rootHome !== userHome) {
+      possibles.push([true, path.join(rootHome, localfile)]);
+    }
 
     // npmrc --> ../.npmrc, ../../.npmrc, etc.
     const foldersFromRootToCwd = getPosixPath(this.cwd).split('/');

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -12,12 +12,11 @@ import envReplace from '../util/env-replace.js';
 import Registry from './base-registry.js';
 import {addSuffix} from '../util/misc';
 import {getPosixPath, resolveWithHome} from '../util/path';
-
-const normalizeUrl = require('normalize-url');
-const {default: userHome, home} = require('../util/user-home-dir');
-const path = require('path');
-const url = require('url');
-const ini = require('ini');
+import normalizeUrl from 'normalize-url';
+import {default as userHome, home} from '../util/user-home-dir';
+import path from 'path';
+import url from 'url';
+import ini from 'ini';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 const REGEX_REGISTRY_PREFIX = /^https?:/;

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -14,7 +14,7 @@ import {addSuffix} from '../util/misc';
 import {getPosixPath, resolveWithHome} from '../util/path';
 
 const normalizeUrl = require('normalize-url');
-const {default: userHome, rootHome} = require('../util/user-home-dir');
+const {default: userHome, home} = require('../util/user-home-dir');
 const path = require('path');
 const url = require('url');
 const ini = require('ini');
@@ -180,8 +180,8 @@ export default class NpmRegistry extends Registry {
 
     // When home directory for global install is different from where $HOME/npmrc is stored,
     // E.g. /usr/local/share vs /root on linux machines, check the additional location
-    if (rootHome !== userHome) {
-      possibles.push([true, path.join(rootHome, localfile)]);
+    if (home !== userHome) {
+      possibles.push([true, path.join(home, localfile)]);
     }
 
     // npmrc --> ../.npmrc, ../../.npmrc, etc.

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -6,6 +6,6 @@ const path = require('path');
 
 export const home = require('os').homedir();
 
-const userHomeDir = process.platform === 'linux' && ROOT_USER ? path.resolve('/usr/local/share') : home;
+const userHomeDir = ROOT_USER ? path.resolve('/usr/local/share') : home;
 
 export default userHomeDir;

--- a/src/util/user-home-dir.js
+++ b/src/util/user-home-dir.js
@@ -4,7 +4,8 @@ import ROOT_USER from './root-user.js';
 
 const path = require('path');
 
-const userHomeDir =
-  process.platform === 'linux' && ROOT_USER ? path.resolve('/usr/local/share') : require('os').homedir();
+export const home = require('os').homedir();
+
+const userHomeDir = process.platform === 'linux' && ROOT_USER ? path.resolve('/usr/local/share') : home;
 
 export default userHomeDir;


### PR DESCRIPTION
**Summary**
Fix for https://github.com/yarnpkg/yarn/issues/3920.

In this [commit](https://github.com/wtgtybhertgeghgtwtg/yarn/commit/f4fe7431ed992862a1c1d2357e6521c268bad7a7), `userHome` for linux users running as root was changed to `/usr/local/share`, mainly to allow for other users to run globally added bins. However this introduced a bug where npmrc wasn't being looked in the root directory after checking `/user/local/share`. So this change pushes another location to check in case `userHome` is different from native home directory returned by `os.homedir()`

**Test plan**
I've added a test to generally test the `getPossibleConfigLocations` method, but I haven't been able to properly mock out running it as a root user on linux. Suggestions welcome!