### PR TITLE
chore: enable flow languge integration in VScode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+// These settings enable flow language feature integration in the vscode IDE, using the version of flow
+// loaded based on package.json
+{
+  "flow.useNPMPackagedFlow": true,
+  "javascript.validate.enable": false
+}


### PR DESCRIPTION
**Summary**

These two settings are needed to use the flow language add-in for Visual Studio Code IDE.   Without this, VScode displays flow features in JavaScript code with red squiggles.  Configuring this in the project directory, rather than a per-user setting, allows the right version of flow to be selected on a per-package.json basis.

https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode has add-in info, including docs on settings.

**Test plan**

This should only impact visual studio code users.   Test can be accomplished by opening a few flow-enabled source files and verifying no red squiggles appear.
