### PR TITLE
Fix: Progress bar continue to update after footer

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -136,7 +136,7 @@ exports[`ProgressBar 1`] = `"[2K[1G[1G░░ 0/2"`;
 
 exports[`ProgressBar 2`] = `"[2K[1G[1G░░ 0/2[1G█░ 1/2"`;
 
-exports[`ProgressBar 3`] = `"[2K[1G[1G░░ 0/2[1G█░ 1/2[2K[1G[1G██ 2/2"`;
+exports[`ProgressBar 3`] = `"[2K[1G[1G░░ 0/2[1G█░ 1/2[1G██ 2/2[2K[1G"`;
 
 exports[`Spinner 1`] = `"[1G⠁ [0K"`;
 

--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -136,7 +136,7 @@ exports[`ProgressBar 1`] = `"[2K[1G[1G░░ 0/2"`;
 
 exports[`ProgressBar 2`] = `"[2K[1G[1G░░ 0/2[1G█░ 1/2"`;
 
-exports[`ProgressBar 3`] = `"[2K[1G[1G░░ 0/2[1G█░ 1/2[1G██ 2/2[2K[1G"`;
+exports[`ProgressBar 3`] = `"[2K[1G[1G░░ 0/2[1G█░ 1/2[1G██ 2/2"`;
 
 exports[`Spinner 1`] = `"[1G⠁ [0K"`;
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -170,7 +170,6 @@ export function main({
   const run = (): Promise<void> => {
     invariant(command, 'missing command');
     return command.run(config, reporter, commander, commander.args).then(exitCode => {
-      reporter.close();
       if (outputWrapper) {
         reporter.footer(false);
       }

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -395,8 +395,13 @@ export default class ConsoleReporter extends BaseReporter {
       };
     }
 
-    const bar = (this._progressBar = new Progress(count, this.stderr, () => {
-      this._progressBar = null;
+    // Clear any potentiall old progress bars
+    this.stopProgress();
+
+    const bar = (this._progressBar = new Progress(count, this.stderr, (progress: Progress) => {
+      if (progress === this._progressBar) {
+        this._progressBar = null;
+      }
     }));
 
     bar.render();

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -42,6 +42,7 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   _lastCategorySize: number;
+  _progressBar: ?Progress;
 
   _prependEmoji(msg: string, emoji: ?string): string {
     if (this.emoji && emoji && this.isTTY) {
@@ -61,6 +62,11 @@ export default class ConsoleReporter extends BaseReporter {
 
   _verboseInspect(obj: any) {
     this.inspect(obj);
+  }
+
+  close() {
+    this.stopProgress();
+    super.close();
   }
 
   table(head: Array<string>, body: Array<Row>) {
@@ -136,6 +142,8 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   footer(showPeakMemory?: boolean) {
+    this.stopProgress();
+
     const totalTime = (this.getTotalTime() / 1000).toFixed(2);
     let msg = `Done in ${totalTime}s.`;
     if (showPeakMemory) {
@@ -387,13 +395,21 @@ export default class ConsoleReporter extends BaseReporter {
       };
     }
 
-    const bar = new Progress(count, this.stderr);
+    const bar = (this._progressBar = new Progress(count, this.stderr, () => {
+      this._progressBar = null;
+    }));
 
     bar.render();
 
     return function() {
       bar.tick();
     };
+  }
+
+  stopProgress() {
+    if (this._progressBar) {
+      this._progressBar.stop();
+    }
   }
 
   async prompt<T>(message: string, choices: Array<*>, options?: PromptOptions = {}): Promise<Array<T>> {

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -21,7 +21,7 @@ export default class ProgressBar {
   chars: [string, string];
   delay: number;
   id: ?number;
-  _callback: ?Function;
+  _callback: ?(progressBar: ProgressBar) => void;
 
   static bars = [['█', '░']];
 

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -77,7 +77,5 @@ export default class ProgressBar {
 
     toStartOfLine(this.stdout);
     this.stdout.write(bar);
-
-    // progress complete
   }
 }

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -4,7 +4,7 @@ import type {Stdout} from '../types.js';
 import {clearLine, toStartOfLine} from './util.js';
 
 export default class ProgressBar {
-  constructor(total: number, stdout: Stdout = process.stderr, callback: ?Function) {
+  constructor(total: number, stdout: Stdout = process.stderr, callback: ?(progressBar: ProgressBar) => void) {
     this.stdout = stdout;
     this.total = total;
     this.chars = ProgressBar.bars[0];

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -52,7 +52,7 @@ export default class ProgressBar {
     this.cancelTick();
     clearLine(this.stdout);
     if (this._callback) {
-      this._callback();
+      this._callback(this);
     }
   }
 

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -39,7 +39,7 @@ export default class ProgressBar {
   }
 
   cancelTick() {
-    if (!this.id) {
+    if (this.id) {
       clearTimeout(this.id);
       this.id = null;
     }
@@ -79,8 +79,5 @@ export default class ProgressBar {
     this.stdout.write(bar);
 
     // progress complete
-    if (this.curr >= this.total) {
-      this.stop();
-    }
   }
 }

--- a/src/reporters/console/progress-bar.js
+++ b/src/reporters/console/progress-bar.js
@@ -4,12 +4,13 @@ import type {Stdout} from '../types.js';
 import {clearLine, toStartOfLine} from './util.js';
 
 export default class ProgressBar {
-  constructor(total: number, stdout: Stdout = process.stderr) {
+  constructor(total: number, stdout: Stdout = process.stderr, callback: ?Function) {
     this.stdout = stdout;
     this.total = total;
     this.chars = ProgressBar.bars[0];
     this.delay = 60;
     this.curr = 0;
+    this._callback = callback;
     clearLine(stdout);
   }
 
@@ -20,28 +21,44 @@ export default class ProgressBar {
   chars: [string, string];
   delay: number;
   id: ?number;
+  _callback: ?Function;
 
   static bars = [['█', '░']];
 
   tick() {
+    if (this.curr >= this.total) {
+      return;
+    }
+
     this.curr++;
 
     // schedule render
     if (!this.id) {
       this.id = setTimeout((): void => this.render(), this.delay);
     }
+  }
 
-    // progress complete
-    if (this.curr >= this.total) {
+  cancelTick() {
+    if (!this.id) {
       clearTimeout(this.id);
-      clearLine(this.stdout);
+      this.id = null;
+    }
+  }
+
+  stop() {
+    // "stop" by setting current to end so `tick` becomes noop
+    this.curr = this.total;
+
+    this.cancelTick();
+    clearLine(this.stdout);
+    if (this._callback) {
+      this._callback();
     }
   }
 
   render() {
     // clear throttle
-    clearTimeout(this.id);
-    this.id = null;
+    this.cancelTick();
 
     let ratio = this.curr / this.total;
     ratio = Math.min(Math.max(ratio, 0), 1);
@@ -60,5 +77,10 @@ export default class ProgressBar {
 
     toStartOfLine(this.stdout);
     this.stdout.write(bar);
+
+    // progress complete
+    if (this.curr >= this.total) {
+      this.stop();
+    }
   }
 }


### PR DESCRIPTION
**Summary**

Fixes #4023. There was nothing preventing the console reporter from
having more than one progress bars, or keep updating and rendering
its progress bar after it was finished or the reporter was "done".

This patch stores the active progress bar, and stops it before
`footer` is printed out. Also makes sure the progress bar itself
ignores any updates once it stops.

**Test plan**

One, weak, existing test with updated snapshot. Manual steps:

- Run `yarn install express`
- Observe that your console is properly cleared after `yarn`
  finishes and the last thing you see is the "Done in X.YZs."
  message and not a corrupted progress bar.