### PR TITLE
Fix: Clean-up cwd after integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      RAMDISK_SIZE=300;
+      RAMDISK_SIZE=320;
       RAMDISK_SECTORS=$(( $RAMDISK_SIZE * 1024 * 1024 / 512 ));
       RAMDISK=$(hdiutil attach -nomount ram://$RAMDISK_SECTORS);
       newfs_hfs -v yarn_ramfs $RAMDISK;

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -5,7 +5,7 @@ import execa from 'execa';
 import makeTemp from './_temp.js';
 import * as fs from '../src/util/fs.js';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
 const path = require('path');
 

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -23,6 +23,8 @@ function addTest(pattern) {
     await fs.writeFile(path.join(cwd, 'package.json'), JSON.stringify({name: 'test'}));
 
     await execa(command, ['add', pattern].concat(args), options);
+
+    await fs.unlink(cwd);
   });
 }
 


### PR DESCRIPTION
**Summary**

We normally clean up the test `cwd` after running them but we
don't for integration tests. With the addition of a new test case,
this started causing macOS builds to fail on TravisCI due to exhaustion
of space on ramdisk which we use to run tests on for speed.

**Test plan**

macOS tests should pass on TravisCI.