### PR TITLE
Fix: fix unknown single-instance type error

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -356,8 +356,15 @@ export function main({
       const mutex: mixed = commander.mutex;
       if (mutex && typeof mutex === 'string') {
         const separatorLoc = mutex.indexOf(':');
-        const mutexType = mutex.substring(0, separatorLoc);
-        const mutexSpecifier = mutex.substring(separatorLoc + 1);
+        let mutexType;
+        let mutexSpecifier;
+        if (separatorLoc === -1) {
+          mutexType = mutex;
+          mutexSpecifier = undefined;
+        } else {
+          mutexType = mutex.substring(0, separatorLoc);
+          mutexSpecifier = mutex.substring(separatorLoc + 1);
+        }
 
         if (mutexType === 'file') {
           return runEventuallyWithFile(mutexSpecifier, true).then(exit);


### PR DESCRIPTION
**Summary**

When `:` is not used in the `mutex` argument to provide a specifier,
`mutexType` and `mutexSpecifier` are parsed incorrectly. This patch
fixes that.

**Test plan**

Run `yarn --mutex=network` before the patch, observe the error. Run
the same command after the patch and see it pass.