### PR TITLE
Upgrade flow to ^0.52.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,4 +16,4 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.49.1
+^0.52.0

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-yarn-internal": "file:scripts/eslint-rules",
     "execa": "^0.7.0",
-    "flow-bin": "^0.49.1",
+    "flow-bin": "^0.52.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.0.0",
     "gulp-if": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,9 +1886,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.49.1:
-  version "0.49.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
+flow-bin@^0.52.0:
+  version "0.52.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.52.0.tgz#b6d9abe8bcd1ee5c62df386451a4e2553cadc3a3"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Summary: This upgrades flow, both in the flowconfig and in the flow-bin dependency to ^0.52.0

Test plan: `yarn lint`

*Note*: Should we reconsider using carets for flow versions? While flow is still < 1.0 and shouldn't introduce breaking changes in patch versions, @nmote has told me not to rely on this in the past.