### PR TITLE
Fix: invalid versions for workspace package

### DIFF
--- a/src/fetchers/workspace-fetcher.js
+++ b/src/fetchers/workspace-fetcher.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {PackageRemote, FetchedMetadata, Manifest} from '../types.js';
+import type {PackageRemote, FetchedMetadata} from '../types.js';
 import type Config from '../config.js';
 import type {RegistryNames} from '../registries/index.js';
 
@@ -9,7 +9,7 @@ export default class WorkspaceFetcher {
     this.config = config;
     this.dest = dest;
     this.registry = remote.registry;
-    this.workspaceDir = remote.reference;
+    this.workspaceDir = remote.reference || '.';
   }
 
   config: Config;
@@ -21,26 +21,18 @@ export default class WorkspaceFetcher {
     return Promise.resolve();
   }
 
-  async fetch(defaultManifest: ?Manifest): Promise<FetchedMetadata> {
-    let pkg = defaultManifest;
-    // load the manifest from the workspace directory or return the default
-    try {
-      pkg = await this.config.readManifest(this.workspaceDir, this.registry);
-    } catch (e) {
-      if (e.code !== 'ENOENT' || !defaultManifest) {
-        throw e;
-      }
-    }
+  async fetch(): Promise<FetchedMetadata> {
+    const pkg = await this.config.readManifest(this.workspaceDir, this.registry);
 
-    return Promise.resolve({
+    return {
       resolved: null,
       hash: '',
       cached: false,
       dest: this.dest,
       package: {
         ...pkg,
-        _uid: (pkg && pkg.version) || '',
+        _uid: pkg.version,
       },
-    });
+    };
   }
 }

--- a/src/fetchers/workspace-fetcher.js
+++ b/src/fetchers/workspace-fetcher.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {PackageRemote, FetchedMetadata} from '../types.js';
+import type {PackageRemote, FetchedMetadata, Manifest} from '../types.js';
 import type Config from '../config.js';
 import type {RegistryNames} from '../registries/index.js';
 
@@ -21,7 +21,7 @@ export default class WorkspaceFetcher {
     return Promise.resolve();
   }
 
-  async fetch(defaultManifest: ?Object): Promise<FetchedMetadata> {
+  async fetch(defaultManifest: ?Manifest): Promise<FetchedMetadata> {
     let pkg = defaultManifest;
     // load the manifest from the workspace directory or return the default
     try {
@@ -39,8 +39,7 @@ export default class WorkspaceFetcher {
       dest: this.dest,
       package: {
         ...pkg,
-        _uid: '',
-        version: '0.0.0',
+        _uid: (pkg && pkg.version) || '',
       },
     });
   }


### PR DESCRIPTION
**Summary**

When resolving workspace packages, we were always using the version `0.0.0` instead of the version defined in that package. This patch fixes it to use the correct version available from the package.json file inside.

**Test plan**

Existing tests.