### PR TITLE
Fallbacks to /tmp if the preferred cache folder isn't writable

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -70,3 +70,20 @@ test('--mutex network', async () => {
     execa(command, ['add', 'foo'].concat(args), options),
   ]);
 });
+
+test('cache folder fallback', async () => {
+  const cwd = await makeTemp();
+  const cacheFolder = path.join(cwd, '.cache');
+
+  await fs.mkdirp(cacheFolder);
+  await fs.chmod(cacheFolder, 0o000);
+
+  const command = path.resolve(__dirname, '../bin/yarn');
+  const args = ['--preferred-cache-folder', cacheFolder];
+
+  const options = {cwd};
+
+  await Promise.all([
+    execa(command, ['cache', 'dir'].concat(args), options),
+  ]);
+});

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -77,38 +77,30 @@ test('cache folder fallback', async () => {
   const cwd = await makeTemp();
   const cacheFolder = path.join(cwd, '.cache');
 
-  await fs.mkdirp(cacheFolder);
-
   const command = path.resolve(__dirname, '../bin/yarn');
   const args = ['--preferred-cache-folder', cacheFolder];
 
   const options = {cwd};
 
-  {
+  function runCacheDir(): Promise<Array<Buffer>> {
     const {stderr, stdout} = execa(command, ['cache', 'dir'].concat(args), options);
 
     const stdoutPromise = misc.consumeStream(stdout);
     const stderrPromise = misc.consumeStream(stderr);
 
-    const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
-
-    expect(stdoutOutput.toString().trim()).toEqual(path.join(cacheFolder, `v${constants.CACHE_VERSION}`));
-    expect(stderrOutput.toString()).not.toMatch(/Skipping preferred cache folder/);
+    return Promise.all([stdoutPromise, stderrPromise]);
   }
 
-  await fs.chmod(cacheFolder, 0o000);
+  const [stdoutOutput, stderrOutput] = await runCacheDir();
 
-  {
-    const {stderr, stdout} = execa(command, ['cache', 'dir'].concat(args), options);
+  expect(stdoutOutput.toString().trim()).toEqual(path.join(cacheFolder, `v${constants.CACHE_VERSION}`));
+  expect(stderrOutput.toString()).not.toMatch(/Skipping preferred cache folder/);
 
-    const stdoutPromise = misc.consumeStream(stdout);
-    const stderrPromise = misc.consumeStream(stderr);
+  await fs.unlink(cacheFolder);
+  await fs.writeFile(cacheFolder, `not a directory`);
 
-    const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
+  const [stdoutOutput2, stderrOutput2] = await runCacheDir();
 
-    expect(stdoutOutput.toString().trim()).toEqual(
-      path.join(constants.PREFERRED_MODULE_CACHE_DIRECTORIES[0], `v${constants.CACHE_VERSION}`),
-    );
-    expect(stderrOutput.toString()).toMatch(/Skipping preferred cache folder/);
-  }
+  expect(stdoutOutput2.toString().trim()).toEqual(path.join(constants.PREFERRED_MODULE_CACHE_DIRECTORIES[0], `v${constants.CACHE_VERSION}`));
+  expect(stderrOutput2.toString()).toMatch(/Skipping preferred cache folder/);
 });

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -83,7 +83,5 @@ test('cache folder fallback', async () => {
 
   const options = {cwd};
 
-  await Promise.all([
-    execa(command, ['cache', 'dir'].concat(args), options),
-  ]);
+  await Promise.all([execa(command, ['cache', 'dir'].concat(args), options)]);
 });

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -101,6 +101,8 @@ test('cache folder fallback', async () => {
 
   const [stdoutOutput2, stderrOutput2] = await runCacheDir();
 
-  expect(stdoutOutput2.toString().trim()).toEqual(path.join(constants.PREFERRED_MODULE_CACHE_DIRECTORIES[0], `v${constants.CACHE_VERSION}`));
+  expect(stdoutOutput2.toString().trim()).toEqual(
+    path.join(constants.PREFERRED_MODULE_CACHE_DIRECTORIES[0], `v${constants.CACHE_VERSION}`),
+  );
   expect(stderrOutput2.toString()).toMatch(/Skipping preferred cache folder/);
 });

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -55,7 +55,7 @@ export const {run, setFlags, examples} = buildSubCommands('cache', {
   },
 
   dir(config: Config, reporter: Reporter) {
-    reporter.log(config.cacheFolder);
+    reporter.log(config.cacheFolder, {force: true});
   },
 
   async clean(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -61,7 +61,7 @@ export function main({
     'rather than installing modules into the node_modules folder relative to the cwd, output them here',
   );
   commander.option('--preferred-cache-folder <path>', 'specify a custom folder to store the yarn cache if possible');
-  commander.option('--cache-folder <path>', 'specify a custom folder to store the yarn cache');
+  commander.option('--cache-folder <path>', 'specify a custom folder that must be used to store the yarn cache');
   commander.option('--mutex <type>[:specifier]', 'use a mutex to ensure only one yarn instance is executing');
   commander.option('--emoji [bool]', 'enable emoji in output', process.platform === 'darwin');
   commander.option('-s, --silent', 'skip Yarn console logs, other types of logs (script output) will be printed');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -60,6 +60,7 @@ export function main({
     '--modules-folder <path>',
     'rather than installing modules into the node_modules folder relative to the cwd, output them here',
   );
+  commander.option('--preferred-cache-folder <path>', 'specify a custom folder to store the yarn cache if possible');
   commander.option('--cache-folder <path>', 'specify a custom folder to store the yarn cache');
   commander.option('--mutex <type>[:specifier]', 'use a mutex to ensure only one yarn instance is executing');
   commander.option('--emoji [bool]', 'enable emoji in output', process.platform === 'darwin');
@@ -324,6 +325,7 @@ export function main({
       binLinks: commander.binLinks,
       modulesFolder: commander.modulesFolder,
       globalFolder: commander.globalFolder,
+      preferredCacheFolder: commander.preferredCacheFolder,
       cacheFolder: commander.cacheFolder,
       preferOffline: commander.preferOffline,
       captureHar: commander.har,

--- a/src/config.js
+++ b/src/config.js
@@ -288,7 +288,7 @@ export default class Config {
       }
 
       for (let t = 0; t < preferredCacheFolders.length && !cacheRootFolder; ++t) {
-        const tentativeCacheFolder = preferredCacheFolders[t];
+        const tentativeCacheFolder = String(preferredCacheFolders[t]);
 
         try {
           await fs.mkdirp(tentativeCacheFolder);

--- a/src/config.js
+++ b/src/config.js
@@ -291,7 +291,6 @@ export default class Config {
         const tentativeCacheFolder = String(preferredCacheFolders[t]);
 
         try {
-
           await fs.mkdirp(tentativeCacheFolder);
 
           const testFile = path.join(tentativeCacheFolder, 'testfile');
@@ -302,7 +301,6 @@ export default class Config {
           await fs.unlink(testFile);
 
           cacheRootFolder = tentativeCacheFolder;
-
         } catch (error) {
           this.reporter.warn(this.reporter.lang('cacheFolderSkipped', tentativeCacheFolder));
         }

--- a/src/config.js
+++ b/src/config.js
@@ -291,10 +291,18 @@ export default class Config {
         const tentativeCacheFolder = String(preferredCacheFolders[t]);
 
         try {
+
           await fs.mkdirp(tentativeCacheFolder);
-          // eslint-disable-next-line
-          await fs.access(tentativeCacheFolder, fs.constants.R_OK | fs.constants.W_OK | fs.constants.X_OK);
+
+          const testFile = path.join(tentativeCacheFolder, 'testfile');
+
+          // fs.access is not enough, because the cache folder could actually be a file.
+          await fs.writeFile(testFile, 'content');
+          await fs.readFile(testFile);
+          await fs.unlink(testFile);
+
           cacheRootFolder = tentativeCacheFolder;
+
         } catch (error) {
           this.reporter.warn(this.reporter.lang('cacheFolderSkipped', tentativeCacheFolder));
         }

--- a/src/constants.js
+++ b/src/constants.js
@@ -46,15 +46,21 @@ function getDirectory(category: string): string {
   return path.join(userHome, `.${category}`, 'yarn');
 }
 
-function getCacheDirectory(): string {
-  if (process.platform === 'darwin') {
-    return path.join(userHome, 'Library', 'Caches', 'Yarn');
+function getPreferredCacheDirectories(): Array<string> {
+  const preferredCacheDirectories = [getDirectory('cache')];
+
+  if (process.platform !== 'win32') {
+    preferredCacheDirectories.unshift('/tmp/.yarn-cache');
   }
 
-  return getDirectory('cache');
+  if (process.platform === 'darwin') {
+    preferredCacheDirectories.unshift(path.join(userHome, 'Library', 'Caches', 'Yarn'));
+  }
+
+  return preferredCacheDirectories;
 }
 
-export const MODULE_CACHE_DIRECTORY = getCacheDirectory();
+export const PREFERRED_MODULE_CACHE_DIRECTORIES = getPreferredCacheDirectories();
 export const CONFIG_DIRECTORY = getDirectory('config');
 export const LINK_REGISTRY_DIRECTORY = path.join(CONFIG_DIRECTORY, 'link');
 export const GLOBAL_MODULE_DIRECTORY = path.join(CONFIG_DIRECTORY, 'global');
@@ -70,6 +76,7 @@ export const LOCKFILE_FILENAME = 'yarn.lock';
 export const METADATA_FILENAME = '.yarn-metadata.json';
 export const TARBALL_FILENAME = '.yarn-tarball.tgz';
 export const CLEAN_FILENAME = '.yarnclean';
+export const WTEST_FILENAME = 'yarn-wtest';
 
 export const DEFAULT_INDENT = '  ';
 export const SINGLE_INSTANCE_PORT = 31997;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+const os = require('os');
 const path = require('path');
 const userHome = require('./util/user-home-dir').default;
 
@@ -47,14 +48,17 @@ function getDirectory(category: string): string {
 }
 
 function getPreferredCacheDirectories(): Array<string> {
-  const preferredCacheDirectories = [getDirectory('cache')];
-
-  if (process.platform !== 'win32') {
-    preferredCacheDirectories.unshift('/tmp/.yarn-cache');
-  }
+  const preferredCacheDirectories = [];
 
   if (process.platform === 'darwin') {
-    preferredCacheDirectories.unshift(path.join(userHome, 'Library', 'Caches', 'Yarn'));
+    preferredCacheDirectories.push(path.join(userHome, 'Library', 'Caches', 'Yarn'));
+  }
+
+  preferredCacheDirectories.push(getDirectory('cache'));
+
+  if (process.platform !== 'win32') {
+    preferredCacheDirectories.push(path.join(os.tmpdir(), '.yarn-cache'));
+    preferredCacheDirectories.push('/tmp/.yarn-cache');
   }
 
   return preferredCacheDirectories;
@@ -76,7 +80,7 @@ export const LOCKFILE_FILENAME = 'yarn.lock';
 export const METADATA_FILENAME = '.yarn-metadata.json';
 export const TARBALL_FILENAME = '.yarn-tarball.tgz';
 export const CLEAN_FILENAME = '.yarnclean';
-export const WTEST_FILENAME = 'yarn-wtest';
+export const ACCESS_FILENAME = '.yarn-access';
 
 export const DEFAULT_INDENT = '  ';
 export const SINGLE_INSTANCE_PORT = 31997;

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,14 +52,11 @@ function getPreferredCacheDirectories(): Array<string> {
 
   if (process.platform === 'darwin') {
     preferredCacheDirectories.push(path.join(userHome, 'Library', 'Caches', 'Yarn'));
+  } else {
+    preferredCacheDirectories.push(getDirectory('cache'));
   }
 
-  preferredCacheDirectories.push(getDirectory('cache'));
-
-  if (process.platform !== 'win32') {
-    preferredCacheDirectories.push(path.join(os.tmpdir(), '.yarn-cache'));
-    preferredCacheDirectories.push('/tmp/.yarn-cache');
-  }
+  preferredCacheDirectories.push(path.join(os.tmpdir(), '.yarn-cache'));
 
   return preferredCacheDirectories;
 }

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -195,7 +195,7 @@ export default class BaseReporter {
   success(message: string) {}
 
   // a simple log message
-  log(message: string) {}
+  log(message: string, {force = false}: {force?: boolean} = {}) {}
 
   // a shell command has been executed
   command(command: string) {}

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -195,6 +195,7 @@ export default class BaseReporter {
   success(message: string) {}
 
   // a simple log message
+  // TODO: rethink the {force} parameter. In the meantime, please don't use it (cf comments in #4143).
   log(message: string, {force = false}: {force?: boolean} = {}) {}
 
   // a shell command has been executed

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -160,13 +160,13 @@ export default class ConsoleReporter extends BaseReporter {
     this.log(this._prependEmoji(msg, '✨'));
   }
 
-  log(msg: string) {
+  log(msg: string, {force = false}: {force?: boolean} = {}) {
     this._lastCategorySize = 0;
-    this._log(msg);
+    this._log(msg, {force});
   }
 
-  _log(msg: string) {
-    if (this.isSilent) {
+  _log(msg: string, {force = false}: {force?: boolean} = {}) {
+    if (this.isSilent && !force) {
       return;
     }
     clearLine(this.stdout);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -181,6 +181,10 @@ const messages = {
   workspaceNameMandatory: 'Missing name in workspace at $0, ignoring.',
   workspaceNameDuplicate: 'There are more than one workspace with name $0',
 
+  cacheFolderSkipped: 'Skipping preferred cache folder $0 because it is not writable.',
+  cacheFolderMissing:
+    "Yarn hasn't been able to find a cache folder. Please use an explicit --cache-folder option to tell it what location to use, or make one of the preferred locations writable.",
+
   execMissingCommand: 'Missing command name.',
 
   commandNotSpecified: 'No command specified.',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -184,6 +184,7 @@ const messages = {
   cacheFolderSkipped: 'Skipping preferred cache folder $0 because it is not writable.',
   cacheFolderMissing:
     "Yarn hasn't been able to find a cache folder. Please use an explicit --cache-folder option to tell it what location to use, or make one of the preferred locations writable.",
+  cacheFolderSelected: 'Selected the next writable cache folder in the list, will be $0.',
 
   execMissingCommand: 'Missing command name.',
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -183,7 +183,7 @@ const messages = {
 
   cacheFolderSkipped: 'Skipping preferred cache folder $0 because it is not writable.',
   cacheFolderMissing:
-    "Yarn hasn't been able to find a cache folder. Please use an explicit --cache-folder option to tell it what location to use, or make one of the preferred locations writable.",
+    "Yarn hasn't been able to find a cache folder it can use. Please use the explicit --cache-folder option to tell it what location to use, or make one of the preferred locations writable.",
   cacheFolderSelected: 'Selected the next writable cache folder in the list, will be $0.',
 
   execMissingCommand: 'Missing command name.',

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -13,7 +13,11 @@ const globModule = require('glob');
 const os = require('os');
 const path = require('path');
 
-export const constants = fs.constants;
+export const constants = typeof fs.constants !== 'undefined' ? fs.constants : {
+    R_OK: fs.R_OK,
+    W_OK: fs.W_OK,
+    X_OK: fs.X_OK,
+};
 
 export const lockQueue = new BlockingQueue('fs lock');
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -13,11 +13,14 @@ const globModule = require('glob');
 const os = require('os');
 const path = require('path');
 
-export const constants = typeof fs.constants !== 'undefined' ? fs.constants : {
-    R_OK: fs.R_OK,
-    W_OK: fs.W_OK,
-    X_OK: fs.X_OK,
-};
+export const constants =
+  typeof fs.constants !== 'undefined'
+    ? fs.constants
+    : {
+        R_OK: fs.R_OK,
+        W_OK: fs.W_OK,
+        X_OK: fs.X_OK,
+      };
 
 export const lockQueue = new BlockingQueue('fs lock');
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -13,6 +13,8 @@ const globModule = require('glob');
 const os = require('os');
 const path = require('path');
 
+export const constants = fs.constants;
+
 export const lockQueue = new BlockingQueue('fs lock');
 
 export const readFileBuffer = promisify(fs.readFile);

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -2,6 +2,24 @@
 
 const _camelCase = require('camelcase');
 
+export function consumeStream(stream: Object): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const buffers = [];
+
+    stream.on(`data`, buffer => {
+      buffers.push(buffer);
+    });
+
+    stream.on(`end`, () => {
+      resolve(Buffer.concat(buffers));
+    });
+
+    stream.on(`error`, error => {
+      reject(error);
+    });
+  });
+}
+
 export function sortAlpha(a: string, b: string): number {
   // sort alphabetically in a deterministic way
   const shortLen = Math.min(a.length, b.length);


### PR DESCRIPTION
**Summary**

Fixes #4141. If `$(yarn cache dir)` isn't writable, Yarn will crash and burn with EACCESS / EPERM. This patch adds a fallback mechanism so that we try different folders until we find one that fits. As a first step, I've added `/tmp/.yarn-cache`.

**Test plan**

Tested with

```
chmod 000 /Users/mael/Library/Caches/Yarn && ~/yarn/bin/yarn
```
