### PR TITLE
Fix: stop all active spinners on reporter.close()

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ConsoleReporter.activity 1`] = `
 Object {
-  "stderr": "[1G⠁ [0K[2K[1G[2K[1G",
+  "stderr": "[1G⠁ [0K[2K[1G",
   "stdout": "",
 }
 `;
@@ -148,21 +148,7 @@ exports[`Spinner 4`] = `"[1G⠁ [0K[1G⠂ foo[0K[1G⠄ bar[0K[2K[1G"`;
 
 exports[`close 1`] = `
 Object {
-  "stderr": "[2K[1G[1G░░ 0/2[1G█░ 1/2[2K[1G",
-  "stdout": "",
-}
-`;
-
-exports[`close 2`] = `
-Object {
-  "stderr": "[1G⠁ [0K[2K[1G",
-  "stdout": "",
-}
-`;
-
-exports[`close 3`] = `
-Object {
-  "stderr": "",
+  "stderr": "[2K[1G[1G░░ 0/2[1G█░ 1/2[1G⠁ [0K[2K[1G[2K[1G",
   "stdout": "",
 }
 `;

--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ConsoleReporter.activity 1`] = `
 Object {
-  "stderr": "[1G⠁ [0K[2K[1G",
+  "stderr": "[1G⠁ [0K[2K[1G[2K[1G",
   "stdout": "",
 }
 `;
@@ -145,3 +145,24 @@ exports[`Spinner 2`] = `"[1G⠁ [0K[1G⠂ foo[0K"`;
 exports[`Spinner 3`] = `"[1G⠁ [0K[1G⠂ foo[0K[1G⠄ bar[0K"`;
 
 exports[`Spinner 4`] = `"[1G⠁ [0K[1G⠂ foo[0K[1G⠄ bar[0K[2K[1G"`;
+
+exports[`close 1`] = `
+Object {
+  "stderr": "[2K[1G[1G░░ 0/2[1G█░ 1/2[2K[1G",
+  "stdout": "",
+}
+`;
+
+exports[`close 2`] = `
+Object {
+  "stderr": "[1G⠁ [0K[2K[1G",
+  "stdout": "",
+}
+`;
+
+exports[`close 3`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
+}
+`;

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -244,3 +244,31 @@ test('Spinner', () => {
   spinner.stop();
   expect(data).toMatchSnapshot();
 });
+
+test('close', async () => {
+  jest.useFakeTimers();
+  expect(
+    await getConsoleBuff(r => {
+      r.noProgress = false; // we need this to override is-ci when running tests on ci
+      const tick = r.progress(2);
+      tick();
+      jest.runAllTimers();
+      tick();
+    }),
+  ).toMatchSnapshot();
+
+  expect(
+    await getConsoleBuff(r => {
+      const activity = r.activity();
+      activity.tick('foo');
+    }),
+  ).toMatchSnapshot();
+
+  expect(
+    await getConsoleBuff(r => {
+      r.close();
+      // .close() should stop all timers and activities
+      jest.runAllTimers();
+    }),
+  ).toMatchSnapshot();
+});

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -254,18 +254,10 @@ test('close', async () => {
       tick();
       jest.runAllTimers();
       tick();
-    }),
-  ).toMatchSnapshot();
 
-  expect(
-    await getConsoleBuff(r => {
       const activity = r.activity();
       activity.tick('foo');
-    }),
-  ).toMatchSnapshot();
 
-  expect(
-    await getConsoleBuff(r => {
       r.close();
       // .close() should stop all timers and activities
       jest.runAllTimers();


### PR DESCRIPTION
**Summary**

We were not stopping any activities in the reporter and were
relying on `process.exit()` to kill them earlier. This patch
fixes that and ensures all activities are stopped when the
reporter is closed.

**Test plan**

Adds a new snapshots test that fails without the fix.

Manual: just try to install a non-existent package and see `yarn`
getting stuck due to an ongoing reporter activity. After the fix,
it shuts down properly.