### PR TITLE
Chore: Enable untyped-type-import warnings for Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,7 +12,7 @@
 [libs]
 
 [lints]
-all=warn
+untyped-type-import=warn
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/.flowconfig
+++ b/.flowconfig
@@ -11,9 +11,13 @@
 
 [libs]
 
+[lints]
+all=warn
+
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 unsafe.enable_getters_and_setters=true
+include_warnings=true
 
 [version]
 ^0.52.0

--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -38,13 +38,7 @@ function execCommand(cwd: string, binPath: Array<string>, args: Array<string>): 
         if (error) {
           reject({error, stdout});
         } else {
-          const stdoutLines = stdout
-            .toString()
-            .split('\n')
-            .map((line: ?string) => line && line.trim())
-            .filter((line: ?string) => line);
-
-          resolve(stdoutLines);
+          resolve(stdout.toString().split('\n').map(line => line.trim()).filter(line => line));
         }
       },
     );

--- a/src/lockfile/stringify.js
+++ b/src/lockfile/stringify.js
@@ -24,7 +24,7 @@ function maybeWrap(str: string | boolean | number): string {
   }
 }
 
-const priorities: {[key: string]: ?number} = {
+const priorities: {[key: string]: number} = {
   name: 1,
   version: 2,
   uid: 3,

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -8,7 +8,6 @@ import * as network from './network.js';
 import map from '../util/map.js';
 
 import typeof * as RequestModuleT from 'request';
-import type RequestT from 'request';
 
 const RequestCaptureHar = require('request-capture-har');
 const invariant = require('invariant');
@@ -50,7 +49,7 @@ type RequestParams<T> = {
   headers?: {
     [name: string]: string,
   },
-  process?: (req: RequestT, resolve: (body: T) => void, reject: (err: Error) => void) => void,
+  process?: (req: Object, resolve: (body: T) => void, reject: (err: Error) => void) => void,
   callback?: (err: ?Error, res: any, body: any) => void,
   retryAttempts?: number,
   maxRetryAttempts?: number,


### PR DESCRIPTION
**Summary**

Enables one of the new lint warnings in Flow. Others are left out because they are too noisy to be useful at the time, without and easy override.

**Test plan**

Lint should pass.