### PR TITLE
Fix: Prevents interpreting run options as yarn options

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -75,59 +75,57 @@ test('--mutex network', async () => {
 
 // Windows doesn't have the "echo" utility
 // Since this feature isn't platform-specific, running them on OSX and Linux only should be fine
-if (process.platform !== 'win32') {
-  test('yarn run <script> --opt', async () => {
-    const cwd = await makeTemp();
+test('yarn run <script> --opt', async () => {
+  const cwd = await makeTemp();
 
-    await fs.writeFile(
-      path.join(cwd, 'package.json'),
-      JSON.stringify({
-        scripts: {echo: 'echo'},
-      }),
-    );
+  await fs.writeFile(
+    path.join(cwd, 'package.json'),
+    JSON.stringify({
+      scripts: {echo: `echo`},
+    }),
+  );
 
-    const command = path.resolve(__dirname, '../bin/yarn');
-    const options = {cwd, env: {YARN_SILENT: 1}};
+  const command = path.resolve(__dirname, '../bin/yarn');
+  const options = {cwd, env: {YARN_SILENT: 1}};
 
-    const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--opt'], options);
+  const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--opt'], options);
 
-    const stdoutPromise = misc.consumeStream(stdout);
-    const stderrPromise = misc.consumeStream(stderr);
+  const stdoutPromise = misc.consumeStream(stdout);
+  const stderrPromise = misc.consumeStream(stderr);
 
-    const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
+  const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
 
-    expect(stdoutOutput.toString().trim()).toEqual('--opt');
-    expect(stderrOutput.toString()).not.toMatch(
-      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
-    );
-  });
+  expect(stdoutOutput.toString().trim()).toEqual('--opt');
+  expect(stderrOutput.toString()).not.toMatch(
+    /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
+  );
+});
 
-  test('yarn run <script> -- --opt', async () => {
-    const cwd = await makeTemp();
+test('yarn run <script> -- --opt', async () => {
+  const cwd = await makeTemp();
 
-    await fs.writeFile(
-      path.join(cwd, 'package.json'),
-      JSON.stringify({
-        scripts: {echo: 'echo'},
-      }),
-    );
+  await fs.writeFile(
+    path.join(cwd, 'package.json'),
+    JSON.stringify({
+      scripts: {echo: `echo`},
+    }),
+  );
 
-    const command = path.resolve(__dirname, '../bin/yarn');
-    const options = {cwd, env: {YARN_SILENT: 1}};
+  const command = path.resolve(__dirname, '../bin/yarn');
+  const options = {cwd, env: {YARN_SILENT: 1}};
 
-    const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--', '--opt'], options);
+  const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--', '--opt'], options);
 
-    const stdoutPromise = misc.consumeStream(stdout);
-    const stderrPromise = misc.consumeStream(stderr);
+  const stdoutPromise = misc.consumeStream(stdout);
+  const stderrPromise = misc.consumeStream(stderr);
 
-    const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
+  const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
 
-    expect(stdoutOutput.toString().trim()).toEqual('--opt');
-    expect(stderrOutput.toString()).toMatch(
-      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
-    );
-  });
-}
+  expect(stdoutOutput.toString().trim()).toEqual('--opt');
+  expect(stderrOutput.toString()).toMatch(
+    /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
+  );
+});
 
 test('cache folder fallback', async () => {
   const cwd = await makeTemp();

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -73,59 +73,60 @@ test('--mutex network', async () => {
   ]);
 });
 
-// Windows doesn't have the "echo" utility
-// Since this feature isn't platform-specific, running them on OSX and Linux only should be fine
-test('yarn run <script> --opt', async () => {
-  const cwd = await makeTemp();
+// Windows could run these tests, but we currently suffer from an escaping issue that breaks them (#4135)
+if (process.platform !== 'win32') {
+  test('yarn run <script> --opt', async () => {
+    const cwd = await makeTemp();
 
-  await fs.writeFile(
-    path.join(cwd, 'package.json'),
-    JSON.stringify({
-      scripts: {echo: `echo`},
-    }),
-  );
+    await fs.writeFile(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({
+        scripts: {echo: `echo`},
+      }),
+    );
 
-  const command = path.resolve(__dirname, '../bin/yarn');
-  const options = {cwd, env: {YARN_SILENT: 1}};
+    const command = path.resolve(__dirname, '../bin/yarn');
+    const options = {cwd, env: {YARN_SILENT: 1}};
 
-  const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--opt'], options);
+    const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--opt'], options);
 
-  const stdoutPromise = misc.consumeStream(stdout);
-  const stderrPromise = misc.consumeStream(stderr);
+    const stdoutPromise = misc.consumeStream(stdout);
+    const stderrPromise = misc.consumeStream(stderr);
 
-  const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
+    const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
 
-  expect(stdoutOutput.toString().trim()).toEqual('--opt');
-  expect(stderrOutput.toString()).not.toMatch(
-    /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
-  );
-});
+    expect(stdoutOutput.toString().trim()).toEqual('--opt');
+    expect(stderrOutput.toString()).not.toMatch(
+      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
+    );
+  });
 
-test('yarn run <script> -- --opt', async () => {
-  const cwd = await makeTemp();
+  test('yarn run <script> -- --opt', async () => {
+    const cwd = await makeTemp();
 
-  await fs.writeFile(
-    path.join(cwd, 'package.json'),
-    JSON.stringify({
-      scripts: {echo: `echo`},
-    }),
-  );
+    await fs.writeFile(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({
+        scripts: {echo: `echo`},
+      }),
+    );
 
-  const command = path.resolve(__dirname, '../bin/yarn');
-  const options = {cwd, env: {YARN_SILENT: 1}};
+    const command = path.resolve(__dirname, '../bin/yarn');
+    const options = {cwd, env: {YARN_SILENT: 1}};
 
-  const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--', '--opt'], options);
+    const {stderr: stderr, stdout: stdout} = execa(command, ['run', 'echo', '--', '--opt'], options);
 
-  const stdoutPromise = misc.consumeStream(stdout);
-  const stderrPromise = misc.consumeStream(stderr);
+    const stdoutPromise = misc.consumeStream(stdout);
+    const stderrPromise = misc.consumeStream(stderr);
 
-  const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
+    const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
 
-  expect(stdoutOutput.toString().trim()).toEqual('--opt');
-  expect(stderrOutput.toString()).toMatch(
-    /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
-  );
-});
+    expect(stdoutOutput.toString().trim()).toEqual('--opt');
+    expect(stderrOutput.toString()).toMatch(
+      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
+    );
+  });
+}
 
 test('cache folder fallback', async () => {
   const cwd = await makeTemp();

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -97,7 +97,9 @@ if (process.platform !== 'win32') {
     const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
 
     expect(stdoutOutput.toString().trim()).toEqual('--opt');
-    expect(stderrOutput.toString()).not.toMatch(/Using -- to pass arguments to your scripts isn't required anymore/);
+    expect(stderrOutput.toString()).not.toMatch(
+      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
+    );
   });
 
   test('yarn run <script> -- --opt', async () => {
@@ -121,7 +123,9 @@ if (process.platform !== 'win32') {
     const [stdoutOutput, stderrOutput] = await Promise.all([stdoutPromise, stderrPromise]);
 
     expect(stdoutOutput.toString().trim()).toEqual('--opt');
-    expect(stderrOutput.toString()).toMatch(/Using -- to pass arguments to your scripts isn't required anymore/);
+    expect(stderrOutput.toString()).toMatch(
+      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
+    );
   });
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -110,9 +110,14 @@ export function main({
     command = commands.run;
   }
 
+  let warnAboutRunDashDash = false;
   // we using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
   if (command === commands.run) {
-    args.unshift('--');
+    if (endArgs.length === 0) {
+      endArgs = ['--', ... args.splice(1, args.length)];
+    } else {
+      warnAboutRunDashDash = true;
+    }
   }
 
   command.setFlags(commander);
@@ -124,7 +129,7 @@ export function main({
     ...getRcArgs(commandName, args),
     ...args,
   ]);
-  commander.args = commander.args.concat(endArgs);
+  commander.args = commander.args.concat(endArgs.slice(1));
 
   // we strip cmd
   console.assert(commander.args.length >= 1);
@@ -176,6 +181,11 @@ export function main({
   //
   const run = (): Promise<void> => {
     invariant(command, 'missing command');
+
+    if (warnAboutRunDashDash) {
+      reporter.warn(reporter.lang('dashDashDeprecation'));
+    }
+
     return command.run(config, reporter, commander, commander.args).then(exitCode => {
       if (outputWrapper) {
         reporter.footer(false);
@@ -408,7 +418,7 @@ export default function start() {
   const doubleDashIndex = process.argv.findIndex(element => element === '--');
   const startArgs = process.argv.slice(0, 2);
   const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
-  const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1, process.argv.length);
+  const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex, process.argv.length);
 
   main({startArgs, args, endArgs});
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -111,7 +111,7 @@ export function main({
   }
 
   let warnAboutRunDashDash = false;
-  // we using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
+  // we are using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
   if (command === commands.run) {
     if (endArgs.length === 0) {
       endArgs = ['--', ...args.splice(1)];

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -110,6 +110,11 @@ export function main({
     command = commands.run;
   }
 
+  // we using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
+  if (command === commands.run) {
+    args.unshift('--');
+  }
+
   command.setFlags(commander);
   commander.parse([
     ...startArgs,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -114,7 +114,7 @@ export function main({
   // we using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
   if (command === commands.run) {
     if (endArgs.length === 0) {
-      endArgs = ['--', ... args.splice(1, args.length)];
+      endArgs = ['--', ...args.splice(1, args.length)];
     } else {
       warnAboutRunDashDash = true;
     }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -114,7 +114,7 @@ export function main({
   // we using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
   if (command === commands.run) {
     if (endArgs.length === 0) {
-      endArgs = ['--', ...args.splice(1, args.length)];
+      endArgs = ['--', ...args.splice(1)];
     } else {
       warnAboutRunDashDash = true;
     }
@@ -418,7 +418,7 @@ export default function start() {
   const doubleDashIndex = process.argv.findIndex(element => element === '--');
   const startArgs = process.argv.slice(0, 2);
   const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
-  const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex, process.argv.length);
+  const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex);
 
   main({startArgs, args, endArgs});
 }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -188,7 +188,8 @@ const messages = {
 
   execMissingCommand: 'Missing command name.',
 
-  dashDashDeprecation: "Using -- to pass arguments to your scripts isn't required anymore. Doing this may cause issues in future versions.",
+  dashDashDeprecation:
+    "Using -- to pass arguments to your scripts isn't required anymore. Doing this may cause issues in future versions.",
   commandNotSpecified: 'No command specified.',
   binCommands: 'Commands available from binary scripts: ',
   possibleCommands: 'Project commands',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -188,6 +188,7 @@ const messages = {
 
   execMissingCommand: 'Missing command name.',
 
+  dashDashDeprecation: "Using -- to pass arguments to your scripts isn't required anymore. Doing this may cause issues in future versions.",
   commandNotSpecified: 'No command specified.',
   binCommands: 'Commands available from binary scripts: ',
   possibleCommands: 'Project commands',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -188,8 +188,7 @@ const messages = {
 
   execMissingCommand: 'Missing command name.',
 
-  dashDashDeprecation:
-    "Using -- to pass arguments to your scripts isn't required anymore. Doing this may cause issues in future versions.",
+  dashDashDeprecation: `From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`,
   commandNotSpecified: 'No command specified.',
   binCommands: 'Commands available from binary scripts: ',
   possibleCommands: 'Project commands',


### PR DESCRIPTION
**Summary**

Running the following command doesn't have the expected effect, because the `--no-coverage` option is interpreter by Yarn instead of being forwarded to the script. This patch fix this.

```
$> yarn test-only --no-coverage     # currently bad
$> yarn test-only -- --no-coverage  # currently good
```

This is a breaking change: it will change some edge-case behaviors.
