### PR TITLE
Fix local mirror invalid file name (#4076)

### DIFF
--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -76,6 +76,25 @@ test('GitFetcher.fetch', async () => {
   expect(name).toBe('beeper');
 });
 
+test('GitFetcher.getTarballMirrorPath without slashes in the repo path', async () => {
+  const dir = await mkdir('git-fetcher');
+  const config = await Config.create();
+  config.registries.yarn.config['yarn-offline-mirror'] = 'test';
+
+  const fetcher = new GitFetcher(
+    dir,
+    {
+      type: 'git',
+      reference: 'ssh://git@github.com:example-without-slash-repo.git',
+      hash: '8beb0413a8028ca2d52dbb86c75f42069535591b',
+      registry: 'npm',
+    },
+    config,
+  );
+  const cachePath = fetcher.getTarballMirrorPath();
+  expect(cachePath).toBe(path.join('test', 'example-without-slash-repo.git-8beb0413a8028ca2d52dbb86c75f42069535591b'));
+});
+
 test('GitFetcher.fetch with prepare script', async () => {
   const dir = await mkdir('git-fetcher-with-prepare');
   const fetcher = new GitFetcher(

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -46,7 +46,11 @@ export default class GitFetcher extends BaseFetcher {
 
     const hash = this.hash;
 
-    const packageFilename = withCommit && hash ? `${path.basename(pathname)}-${hash}` : `${path.basename(pathname)}`;
+    let packageFilename = withCommit && hash ? `${path.basename(pathname)}-${hash}` : `${path.basename(pathname)}`;
+
+    if (packageFilename.startsWith(':')) {
+      packageFilename = packageFilename.substr(1);
+    }
 
     return this.config.getOfflineMirrorPath(packageFilename);
   }


### PR DESCRIPTION
There is a problem related to how url.parse and path.basename is used to build the repository name. So the simplest and easiest solution to this, is after the parsing remove ":" when is needed. Looks quick and dirty but understanding that the objective of the function is to transform reference to the packageFilename looks like the correct place to manage exceptional behavior.