### PR TITLE
Enhancement: Prevents "yarn add" from being run from the workspace root directory

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -42,6 +42,18 @@ const runAdd = buildRun.bind(
   },
 );
 
+test.concurrent('add without --dev should fail on the workspace root', async () => {
+  await runInstall({}, 'simple-worktree', async (config, reporter): Promise<void> => {
+    await expect(add(config, reporter, {}, ['left-pad'])).rejects.toBeDefined();
+  });
+});
+
+test.concurrent("add with --dev shouldn't fail on the workspace root", async () => {
+  await runInstall({}, 'simple-worktree', async (config, reporter): Promise<void> => {
+    await expect(add(config, reporter, {dev: true}, ['left-pad']));
+  });
+});
+
 test.concurrent('adds any new package to the current workspace, but install from the workspace', async () => {
   await runInstall({}, 'simple-worktree', async (config): Promise<void> => {
     const inOut = new stream.PassThrough();

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -106,6 +106,12 @@ export class Add extends Install {
    */
 
   async init(): Promise<Array<string>> {
+    if (this.config.workspaceRootFolder && this.config.cwd === this.config.workspaceRootFolder) {
+      if (this.flagToOrigin === 'dependencies') {
+        throw new MessageError(this.reporter.lang('workspacesPreferDevDependencies'));
+      }
+    }
+
     this.addedPatterns = [];
     const patterns = await Install.prototype.init.call(this);
     await this.maybeOutputSaveTree(patterns);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -163,6 +163,8 @@ const messages = {
   createMissingPackage:
     'Package not found - this is probably an internal error, and should be reported at https://github.com/yarnpkg/yarn/issues.',
 
+  workspacesPreferDevDependencies:
+    "You're trying to add a regular dependency to a workspace root, which is probably a mistake (do you want to run this command inside a workspace?). If this dependency really should be in your workspace root, use the --dev flag to add it to your devDependencies.",
   workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects',
   workspaceExperimentalDisabled:
     'The workspace feature is currently experimental and needs to be manually enabled - please add "workspaces-experimental true" to your .yarnrc file.',


### PR DESCRIPTION
**Summary**

This PR prevents using `yarn add <pkg>` from within a workspace root folder, in order to prevent common mistakes where a package is added to the workspace root folder instead of being added to the right workspace (which, because of the node resolution algorithm, would be effectively invisible to the user).

If the user really wants to add a dependency to the workspace root folder, then we suggest them to use `yarn add <pkg> --dev` instead. This should be fine since the workspaces will probably only be used in development mode anyway. An alternative would be to introduce a new flag `--force` that would bypass this check, but I think the current heuristic is fine until we receive complaints.

**Test plan**

Added two tests.