### PR TITLE
Fix #4178: Add original request pattern to fix `yarn list` with resolutions

### DIFF
--- a/__tests__/commands/list.js
+++ b/__tests__/commands/list.js
@@ -1,5 +1,5 @@
 /* @flow */
-
+import path from 'path';
 import type {Tree} from '../../src/reporters/types.js';
 import {BufferReporter} from '../../src/reporters/index.js';
 import {run as buildRun} from './_helpers.js';
@@ -7,8 +7,6 @@ import {getParent, getReqDepth, run as list} from '../../src/cli/commands/list.j
 import * as reporters from '../../src/reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
-
-const path = require('path');
 
 function makeTree(name, {children = [], hint = null, color = null, depth = 0}: Object = {}): Tree {
   return {
@@ -52,6 +50,17 @@ test.concurrent('lists everything with no args', (): Promise<void> => {
 
     rprtr.tree('list', trees);
 
+    expect(tree).toEqual(rprtr.getBuffer());
+  });
+});
+
+test.concurrent('should not throw when list is called with resolutions field', (): Promise<void> => {
+  return runList([], {}, {source: '', cwd: 'resolutions'}, (config, reporter): ?Promise<void> => {
+    const rprtr = new BufferReporter({});
+    const tree = reporter.getBuffer().slice(-1);
+    const children = [{name: 'left-pad@^1.1.3', color: 'dim', shadow: true}];
+    const trees = [makeTree('depA@1.0.0', {children, color: 'bold'}), makeTree('left-pad@1.0.0')];
+    rprtr.tree('list', trees);
     expect(tree).toEqual(rprtr.getBuffer());
   });
 });

--- a/__tests__/fixtures/list/no-args/package.json
+++ b/__tests__/fixtures/list/no-args/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "depA",
+  "version": "1.0.0",
   "dependencies": {
     "left-pad": "^1.1.3"
   },

--- a/__tests__/fixtures/list/resolutions/package.json
+++ b/__tests__/fixtures/list/resolutions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "dependencies": {
+    "depA": "file:../no-args"
+  },
+  "resolutions": {
+    "left-pad": "1.0.0"
+  }
+}

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -568,6 +568,7 @@ export default class PackageResolver {
       invariant(resolutionManifest._reference, 'resolutions should have a resolved reference');
 
       resolutionManifest._reference.patterns.push(pattern);
+      this.addPattern(pattern, resolutionManifest);
       this.lockfile.removePattern(pattern);
 
       return null;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes https://github.com/yarnpkg/yarn/issues/4178
`Yarn list` still expects the original requested pattern to be in the resolver, so use the resolved manifest to add the pattern back
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I've added a test in `list.js`.
<img width="676" alt="screen shot 2017-08-16 at 7 47 55 pm" src="https://user-images.githubusercontent.com/18429494/29393992-56dda80a-82bc-11e7-9445-acac4c574adc.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
