### PR TITLE
Fixes the info tests

### DIFF
--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -41,13 +41,12 @@ const expectedKeys = [
   'repository',
   'bugs',
   'license',
-  'scripts',
   'dist',
   'directories',
 ];
 
-// yarn now ships as built, single JS files so it has no dependencies
-const unexpectedKeys = ['dependencies', 'devDependencies'];
+// yarn now ships as built, single JS files so it has no dependencies and no scripts
+const unexpectedKeys = ['dependencies', 'devDependencies', 'scripts'];
 
 test.concurrent('without arguments and in directory containing a valid package file', (): Promise<void> => {
   return runInfo([], {}, 'local', (config, output): ?Promise<void> => {


### PR DESCRIPTION
**Summary**

This PR fixes #4191. Now that we are using the single-file build with npm, the `scripts` field isn't included into the `package.json` file anymore. It's not clear why the problem only appeared now, but my guess is that this is related to the recent publication of the 0.28.4 release.

**Test plan**

Tests should now pass again.