### PR TITLE
Added missing pre/post hooks for `pack` (#4177)

### DIFF
--- a/__tests__/fixtures/lifecycle-scripts/lifecycle-scripts/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/lifecycle-scripts/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "prepublish": "echo running the prepublish hook",
     "prepublishOnly": "echo running the prepublishOnly hook",
-    "prepare": "echo running the prepare hook"
+    "prepare": "echo running the prepare hook",
+    "prepack": "echo running the prepack hook",
+    "postpack": "echo running the postpack hook"
   }
 }

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -137,6 +137,13 @@ test.concurrent('should run both prepublish and prepare when installing, but not
   expect(stdout).not.toMatch(/^running the prepublishOnly hook$/m);
 });
 
+test.concurrent('should run both prepack and postpack', async () => {
+  const stdout = await execCommand('pack', 'lifecycle-scripts');
+
+  expect(stdout).toMatch(/^running the prepack hook$/m);
+  expect(stdout).toMatch(/^running the postpack hook$/m);
+});
+
 test.concurrent('should allow setting environment variables via yarnrc', async () => {
   const stdout = await execCommand('install', 'yarnrc-env');
   expect(stdout).toMatch(/^BAR$/m);

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -160,6 +160,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const normaliseScope = name => (name[0] === '@' ? name.substr(1).replace('/', '-') : name);
   const filename = flags.filename || path.join(config.cwd, `${normaliseScope(pkg.name)}-v${pkg.version}.tgz`);
 
+  await config.executeLifecycleScript('prepack');
+
   const stream = await pack(config, config.cwd);
 
   await new Promise((resolve, reject) => {
@@ -167,6 +169,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     stream.on('error', reject);
     stream.on('close', resolve);
   });
+
+  await config.executeLifecycleScript('postpack');
 
   reporter.success(reporter.lang('packWroteTarball', filename));
 }


### PR DESCRIPTION
**Summary**
Yarn wouldn't run the `prepack` and `postpack` scripts, as it is expected when `pack` is ran (#4177).
This PR adds those missing calls and updates tests accordingly.

**Test plan**
Added tests.
