### PR TITLE
Fix: Uses an actual error object in __tests__/index.js

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -41,7 +41,7 @@ async function execCommand(
       },
       (error, stdout) => {
         if (error) {
-          reject(new Error(error.message + `\n\n` + stdout));
+          reject(Object.assign(new Error(error.message), {stdout}));
         } else {
           const stdoutLines = stdout
             .toString()
@@ -96,7 +96,7 @@ function expectAnErrorMessage(command: Promise<Array<?string>>, error: string): 
     .then(function() {
       throw new Error('the command did not fail');
     })
-    .catch(reason => expect(reason.error.message).toContain(error));
+    .catch(error => expect(error.message).toContain(error));
 }
 
 function expectAnInfoMessageAfterError(command: Promise<Array<?string>>, info: string): Promise<void> {
@@ -104,7 +104,7 @@ function expectAnInfoMessageAfterError(command: Promise<Array<?string>>, info: s
     .then(function() {
       throw new Error('the command did not fail');
     })
-    .catch(reason => expect(reason.stdout).toContain(info));
+    .catch(error => expect(error.stdout).toContain(info));
 }
 
 test.concurrent('should add package', async () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -41,7 +41,7 @@ async function execCommand(
       },
       (error, stdout) => {
         if (error) {
-          reject({error, stdout});
+          reject(new Error(error.message + `\n\n` + stdout));
         } else {
           const stdoutLines = stdout
             .toString()

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -91,20 +91,20 @@ function expectHelpOutputAsSubcommand(stdout) {
   );
 }
 
-function expectAnErrorMessage(command: Promise<Array<?string>>, error: string): Promise<void> {
+function expectAnErrorMessage(command: Promise<Array<?string>>, expectedMessage: string): Promise<void> {
   return command
     .then(function() {
       throw new Error('the command did not fail');
     })
-    .catch(error => expect(error.message).toContain(error));
+    .catch(error => expect(error.message).toContain(expectedMessage));
 }
 
-function expectAnInfoMessageAfterError(command: Promise<Array<?string>>, info: string): Promise<void> {
+function expectAnInfoMessageAfterError(command: Promise<Array<?string>>, expectedInfo: string): Promise<void> {
   return command
     .then(function() {
       throw new Error('the command did not fail');
     })
-    .catch(error => expect(error.stdout).toContain(info));
+    .catch(error => expect(error.stdout).toContain(expectedInfo));
 }
 
 test.concurrent('should add package', async () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -41,7 +41,7 @@ async function execCommand(
       },
       (error, stdout) => {
         if (error) {
-          reject(Object.assign(new Error(error.message), {stdout}));
+          reject(Object.assign((new Error(error.message): any), {stdout}));
         } else {
           const stdoutLines = stdout
             .toString()


### PR DESCRIPTION
**Summary**

AppVeyor sometimes fail with buggy errors. This PR tries to change that to reject actual errors that Jest will be able to correctly print.

<img width="924" alt="screen shot 2017-08-17 at 6 11 59 pm" src="https://user-images.githubusercontent.com/1037931/29425652-f37f9b40-837b-11e7-8d31-48855dde25b1.png">

**Test plan**

Nothing particular, since this is only affecting the tests that don't pass.