### PR TITLE
Removes the unlink test when selecting the cache folder

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -298,7 +298,6 @@ export default class Config {
           // fs.access is not enough, because the cache folder could actually be a file.
           await fs.writeFile(testFile, 'content');
           await fs.readFile(testFile);
-          await fs.unlink(testFile);
 
           cacheRootFolder = tentativeCacheFolder;
         } catch (error) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Since the merging of #, the AppVeyor tests seem to broke randomly on Windows. I suspect this is because Windows is temporarily locking the files after they are created (for inspection?), and that the unlink call is failing because of this. This PR removes the unlink call, which is not required strictly speaking.

This should also make the code more resilient to concurrency issues (there was a slight possibility that two Yarn processes run an `unlink` at the same time, which would cause the second one to fail).

**Test plan**

I'll run the tests multiple times on AppVeyor before merging this PR, to make sure it works as expected.