### PR TITLE
Fix devDependencies being installed when passing --production

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -281,7 +281,11 @@ export class Install {
       };
 
       pushDeps('dependencies', projectManifestJson, {hint: null, optional: false}, true);
-      pushDeps('devDependencies', projectManifestJson, {hint: 'dev', optional: false}, !this.config.production);
+
+      if (!this.config.production) {
+        pushDeps('devDependencies', projectManifestJson, {hint: 'dev', optional: false}, !this.config.production);
+      }
+
       pushDeps('optionalDependencies', projectManifestJson, {hint: 'optional', optional: true}, true);
 
       if (this.config.workspacesEnabled) {


### PR DESCRIPTION
Quick fix for #3630 

**Sypnosis:**
Passing `--production` flag to yarn installs currently still installs `devDependencies`

**Notes:**
This is a quick fix. I think there could be a good refactor to move dependency retrieval out of `fetchRequestFromCwd` for testability, and reduce the number of states that `pushDeps` tries to handle at the moment.

Let me know if merging this now is good, or if I should break this apart / add tests.

**Cause:**
`devDependencies` is always called, and the var, `isUsed`, should handle this -- but the early return never happens due to `ignoreUnusedPatterns` evaluating to false.

```javascript
pushDeps('dependencies', projectManifestJson, {hint: null, optional: false}, true);
pushDeps('devDependencies', projectManifestJson, {hint: 'dev', optional: false}, !this.config.production);
pushDeps('optionalDependencies', projectManifestJson, {hint: 'optional', optional: true}, true);
```

```javascript
const pushDeps = (depType, manifest: Object, {hint, optional}, isUsed) => {
  if (ignoreUnusedPatterns && !isUsed) {
    return;
  }
  ...
```