### PR TITLE
Tweaks to lockfile package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test/fixtures/**/.fbkpm
 /__tests__/fixtures/request-cache/GET/localhost/.bin
 .idea
 .yarn-meta
+/packages/lockfile/index.js

--- a/packages/lockfile/README.md
+++ b/packages/lockfile/README.md
@@ -4,15 +4,15 @@ parse and/or write `yarn.lock` files
 ## Usage Example
 
 ```js
-const fs = require('fs')
-const lockfile = require('yarn-lockfile')
+const fs = require('fs');
+const lockfile = require('@yarnpkg/lockfile');
 
-let file = fs.readFileSync('yarn.lock', 'utf8')
-let json = lockfile.parse(file)
+let file = fs.readFileSync('yarn.lock', 'utf8');
+let json = lockfile.parse(file);
 
-console.log(json)
+console.log(json);
 
-let fileAgain = lockfile.stringify(json)
+let fileAgain = lockfile.stringify(json);
 
-console.log(fileAgain)
+console.log(fileAgain);
 ```

--- a/packages/lockfile/package.json
+++ b/packages/lockfile/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "yarn-lockfile",
+  "name": "@yarnpkg/lockfile",
   "version": "1.0.0",
-  "description": "The parser/stringifier for yarn lockfiles.",
+  "description": "The parser/stringifier for Yarn lockfiles.",
   "main": "index.js",
   "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
**Summary**
Some tweaks to @wmhilton's work around creating a separate lockfile parser package:
 - Rename package to `@yarnpkg/lockfile` as we've discussed
 - Add Webpack'd JS file to `.gitignore`
 - Capitalize "Yarn" in package description
 - Use semicolons in example code

**Test plan**
Eyeballed. No functional changes. Tested locally using `yarn link` to ensure the scoped package name works as expected.