### PR TITLE
Major optimization on hoisting

### DIFF
--- a/__tests__/commands/install/integration-hoisting.js
+++ b/__tests__/commands/install/integration-hoisting.js
@@ -14,6 +14,35 @@ test.concurrent('install hoister should prioritise popular transitive dependenci
   });
 });
 
+test.concurrent('install hoister should prioritise popular deep dependencies', (): Promise<void> => {
+  // Arrange (fixture):
+  //   /foo
+  //     /baz-1
+  //       /hello
+  //         /foobar-1
+  //       /world
+  //   /bar
+  //     /baz-1
+  //       /hello
+  //         /foobar-1
+  //       /world
+  //   /alice
+  //     /bob
+  //       /foobar-2
+  //     /baz-2
+  //       /hello
+  //         /foobar-1
+  //       /world
+  // Act: install
+  // Assert: package version picked are foobar-2 and baz-1
+  return runInstall({}, 'install-should-prioritise-popular-deep', async config => {
+    expect(await getPackageVersion(config, 'bob/foobar')).toEqual('2.0.0');
+    expect(await getPackageVersion(config, 'foobar')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'baz')).toEqual('1.0.0');
+    expect(await getPackageVersion(config, 'alice/baz')).toEqual('2.0.0');
+  });
+});
+
 test.concurrent(
   'install hoister should not install prioritised popular transitive devDependencies in --prod mode',
   (): Promise<void> => {

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/alice/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/alice/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "alice",
+  "version": "2.0.0",
+  "dependencies": {
+    "bob": "file:../bob",
+    "baz": "file:../baz-2"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/bar/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/bar/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bar",
+  "version": "0.0.0",
+  "dependencies": {
+    "baz": "file:../baz-1"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/baz-1/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/baz-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "baz",
+  "version": "1.0.0",
+  "dependencies": {
+    "hello": "file:../hello",
+    "world": "file:../world"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/baz-2/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/baz-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "baz",
+  "version": "2.0.0",
+  "dependencies": {
+    "hello": "file:../hello",
+    "world": "file:../world"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/bob/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/bob/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bob",
+  "version": "2.0.0",
+  "dependencies": {
+    "foobar": "file:../foobar-2"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/foo/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/foo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "foo",
+  "version": "0.0.0",
+  "dependencies": {
+    "baz": "file:../baz-1"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/foobar-1/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/foobar-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foobar",
+  "version": "1.0.0"
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/foobar-2/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/foobar-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foobar",
+  "version": "2.0.0"
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/hello/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/hello/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hello",
+  "version": "2.0.0",
+  "dependencies": {
+    "foobar": "file:../foobar-1"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "foo": "file:foo",
+    "bar": "file:bar",
+    "alice": "file:alice"
+  }
+}

--- a/__tests__/fixtures/install/install-should-prioritise-popular-deep/world/package.json
+++ b/__tests__/fixtures/install/install-should-prioritise-popular-deep/world/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "world",
+  "version": "0.0.0"
+}

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -532,7 +532,7 @@ export default class PackageHoister {
           visitAdd(visitPkg.pkg, visitPkg.ancestry, visitPkg.pattern);
         });
 
-        visitAdd(pkg, ancestry, pattern, patterns);
+        visitAdd(pkg, ancestry, pattern);
 
         return;
       }
@@ -542,7 +542,7 @@ export default class PackageHoister {
 
       visited[pattern] = visited[pattern] || [];
 
-      visitAdd(pkg, ancestry, pattern, patterns);
+      visitAdd(pkg, ancestry, pattern);
 
       for (const depPattern of ref.dependencies) {
         const depAncestry = ancestry.concat(pkg);

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -492,7 +492,7 @@ export default class PackageHoister {
         pkg: Manifest,
         ancestry: Array<Manifest>,
         pattern: string,
-      }[]
+      }[],
     } = {};
 
     const occurences: {
@@ -511,7 +511,7 @@ export default class PackageHoister {
         occurences: new Set(),
         pattern,
       });
-      
+
       if (ancestry.length) {
         version.occurences.add(ancestry[ancestry.length - 1]);
       }
@@ -522,7 +522,7 @@ export default class PackageHoister {
       const pkg = this.resolver.getStrictResolvedPattern(pattern);
       if (ancestry.indexOf(pkg) >= 0) {
         // prevent recursive dependencies
-        return;
+        return pkg;
       }
 
       if (visited[pattern]) {
@@ -531,9 +531,9 @@ export default class PackageHoister {
         visited[pattern].forEach(visitPkg => {
           visitAdd(pkg, ancestry, pattern);
         });
-        return;
+        return pkg;
       }
-      
+
       const ref = pkg._reference;
       invariant(ref, 'expected reference');
 
@@ -544,10 +544,10 @@ export default class PackageHoister {
       for (const depPattern of ref.dependencies) {
         const depAncestry = ancestry.concat(pkg);
         const depPkg = add(depPattern, depAncestry);
-        visited[pattern].push({ pkg: depPkg, ancestry: depAncestry, pattern: depPattern });
+        visited[pattern].push({pkg: depPkg, ancestry: depAncestry, pattern: depPattern});
       }
 
-      visited[pattern].push({ pkg: pkg, ancestry: ancestry, pattern: pattern });
+      visited[pattern].push({pkg, ancestry, pattern});
 
       return pkg;
     };


### PR DESCRIPTION
Keep track of side-effects of each visit of package, and replay side-effects rather than re-crawling through the subtree given the same exact pattern

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is a bug fix for #4008. Since Package Hoisting prepass was introduced, the algorithm crawls through the dependency tree regardless of whether the package has been seen before or not. This is okay for small repositories. To scale this to a large repository that has packages numbered in the 50+k, this prepass eats up CPU and hangs for upwards of 15-30minutes. 

The fix is to cache the side-effects of adding occurrences of the packages. This PR preserves the ability for the occurrence to be accounted for as well - it remembers what changed last time the same pattern was encountered and simply reruns the same side-effects (visits) as last time.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I re-ran the unit tests available - the most important one being the integration-hoisting.js tests. These demonstrate that the hoisting functionality is preserved.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
