### PR TITLE
Fix: Add the missing link-folder flag

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -56,6 +56,7 @@ export function main({
   commander.option('--pure-lockfile', "don't generate a lockfile");
   commander.option('--frozen-lockfile', "don't generate a lockfile and fail if an update is needed");
   commander.option('--link-duplicates', 'create hardlinks to the repeated modules in node_modules');
+  commander.option('--link-folder <path>', 'specify a custom folder to store global links');
   commander.option('--global-folder <path>', 'specify a custom folder to store global packages');
   commander.option(
     '--modules-folder <path>',
@@ -341,6 +342,7 @@ export function main({
     .init({
       binLinks: commander.binLinks,
       modulesFolder: commander.modulesFolder,
+      linkFolder: commander.linkFolder,
       globalFolder: commander.globalFolder,
       preferredCacheFolder: commander.preferredCacheFolder,
       cacheFolder: commander.cacheFolder,


### PR DESCRIPTION
**Summary**

The command line flags are missing the `--link-folder` option. Because we always try to create the global and cache folders if they don't exist, if the path is readonly, then Yarn will crash. The new option makes it possible to workaround this issue by manually selecting a different, writable, path.

Followup will be to:

  - Make it easier to change all folders at once by selecting a "yarn internal folder" and derivating the others (cache, global, link) from this one.

  - Prevent Yarn from automatically creating the global and link folders, unless it really needs to write into them.
