### PR TITLE
Fix #3697 Improve error handling when tarball fetcher receives bad hash

### DIFF
--- a/__tests__/__snapshots__/fetchers.js.snap
+++ b/__tests__/__snapshots__/fetchers.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TarballFetcher.fetch throws on invalid hash 1`] = `"https://github.com/sindresorhus/beeper/archive/master.tar.gz: Hashes don't match when extracting file \\"https://github.com/sindresorhus/beeper/archive/master.tar.gz\\". Expected \\"foo\\" but got \\"51f12d36860fc3d2ab747377991746e8ea3faabb\\""`;
+exports[`TarballFetcher.fetch throws on invalid hash 1`] = `"https://github.com/sindresorhus/beeper/archive/master.tar.gz: Fetch succeeded for undefined. However, extracting \\"https://github.com/sindresorhus/beeper/archive/master.tar.gz\\" resulted in hash \\"foo\\", which did not match the requested hash \\"51f12d36860fc3d2ab747377991746e8ea3faabb\\"."`;

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -335,7 +335,6 @@ test.concurrent('--integrity should not die on missing fields in integrity file'
   try {
     await runCheck([], {integrity: true}, 'missing-fields');
   } catch (err) {
-    console.log(err);
     integrityError = true;
   }
   expect(integrityError).toEqual(false);

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -9,6 +9,7 @@ import GitFetcher from '../src/fetchers/git-fetcher.js';
 import Config from '../src/config.js';
 import mkdir from './_temp.js';
 import * as fs from '../src/util/fs.js';
+import {readdirSync} from 'fs';
 
 const path = require('path');
 
@@ -143,6 +144,11 @@ test('TarballFetcher.fetch', async () => {
 
 test('TarballFetcher.fetch throws on invalid hash', async () => {
   const dir = await mkdir('tarball-fetcher');
+  const offlineMirrorDir = await mkdir('offline-mirror');
+
+  const config = await Config.create();
+  config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
+
   const url = 'https://github.com/sindresorhus/beeper/archive/master.tar.gz';
   const fetcher = new TarballFetcher(
     dir,
@@ -160,6 +166,7 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
   } catch (e) {
     error = e;
   }
+  console.log(readdirSync(path.join(offlineMirrorDir)))
   expect(error && error.message).toMatchSnapshot();
 });
 

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -146,7 +146,7 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
   const dir = await mkdir('tarball-fetcher');
   const offlineMirrorDir = await mkdir('offline-mirror');
 
-  const config = await Config.create();
+  const config = await Config.create({}, new Reporter());
   config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
 
   const url = 'https://github.com/sindresorhus/beeper/archive/master.tar.gz';
@@ -158,7 +158,7 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
       reference: url,
       registry: 'npm',
     },
-    await Config.create({}, new Reporter()),
+    config,
   );
   let error;
   try {
@@ -166,8 +166,9 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
   } catch (e) {
     error = e;
   }
-  console.log(readdirSync(path.join(offlineMirrorDir)))
+
   expect(error && error.message).toMatchSnapshot();
+  expect(readdirSync(path.join(offlineMirrorDir))).toEqual([]);
 });
 
 test('TarballFetcher.fetch supports local ungzipped tarball', async () => {

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -101,7 +101,17 @@ export default class GitFetcher extends BaseFetcher {
               hash: expectHash,
             });
           } else {
-            reject(new SecurityError(this.reporter.lang('fetchBadHashWithPath', tarballPath, expectHash, actualHash)));
+            reject(
+              new SecurityError(
+                this.config.reporter.lang(
+                  'fetchBadHashWithPath',
+                  this.packageName,
+                  this.remote.reference,
+                  expectHash,
+                  actualHash,
+                ),
+              ),
+            );
           }
         })
         .on('error', function(err) {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -78,7 +78,7 @@ export default class TarballFetcher extends BaseFetcher {
         error.message = `${error.message}${tarballPath ? ` (${tarballPath})` : ''}`;
         reject(error);
       })
-      .on('finish', async () => {
+      .on('finish', () => {
         const expectHash = this.hash;
         const actualHash = validateStream.getHash();
 
@@ -87,17 +87,6 @@ export default class TarballFetcher extends BaseFetcher {
             hash: actualHash,
           });
         } else {
-          const tarballMirrorPath = this.getTarballMirrorPath();
-          const tarballCachePath = this.getTarballCachePath();
-
-          if (await fsUtil.exists(tarballMirrorPath)) {
-            fsUtil.unlink(tarballMirrorPath);
-          }
-
-          if (await fsUtil.exists(tarballCachePath)) {
-            fsUtil.unlink(tarballCachePath);
-          }
-
           reject(
             new SecurityError(
               this.config.reporter.lang(
@@ -196,6 +185,17 @@ export default class TarballFetcher extends BaseFetcher {
           this.reporter.warn(this.reporter.lang('retryOnInternalServerError'));
           await sleep(3000);
         } else {
+          const tarballMirrorPath = this.getTarballMirrorPath();
+          const tarballCachePath = this.getTarballCachePath();
+
+          if (await fsUtil.exists(tarballMirrorPath)) {
+            fsUtil.unlink(tarballMirrorPath);
+          }
+
+          if (await fsUtil.exists(tarballCachePath)) {
+            fsUtil.unlink(tarballCachePath);
+          }
+
           throw err;
         }
       }

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -189,11 +189,11 @@ export default class TarballFetcher extends BaseFetcher {
           const tarballCachePath = this.getTarballCachePath();
 
           if (tarballMirrorPath && (await fsUtil.exists(tarballMirrorPath))) {
-            fsUtil.unlink(tarballMirrorPath);
+            await fsUtil.unlink(tarballMirrorPath);
           }
 
           if (tarballCachePath && (await fsUtil.exists(tarballCachePath))) {
-            fsUtil.unlink(tarballCachePath);
+            await fsUtil.unlink(tarballCachePath);
           }
 
           throw err;

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -188,11 +188,11 @@ export default class TarballFetcher extends BaseFetcher {
           const tarballMirrorPath = this.getTarballMirrorPath();
           const tarballCachePath = this.getTarballCachePath();
 
-          if (await fsUtil.exists(tarballMirrorPath)) {
+          if (tarballMirrorPath && (await fsUtil.exists(tarballMirrorPath))) {
             fsUtil.unlink(tarballMirrorPath);
           }
 
-          if (await fsUtil.exists(tarballCachePath)) {
+          if (tarballCachePath && (await fsUtil.exists(tarballCachePath))) {
             fsUtil.unlink(tarballCachePath);
           }
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -302,7 +302,8 @@ const messages = {
   requestError: 'Request $0 returned a $1',
   requestFailed: 'Request failed $0',
   tarballNotInNetworkOrCache: '$0: Tarball is not in network and can not be located in cache ($1)',
-  fetchBadHashWithPath: "Hashes don't match when extracting file $0. Expected $1 but got $2",
+  fetchBadHashWithPath:
+    'Fetch succeeded for $0. However, extracting $1 resulted in hash $2, which did not match the requested hash $3.',
   fetchErrorCorrupt:
     '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  rm -rf $1\n  yarn install',
   errorDecompressingTarball: '$0. Error decompressing $1, it appears to be corrupt.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fix for https://github.com/yarnpkg/yarn/issues/3697
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->
- Previously, the tarball fetcher always piped the content to offline cache path when the request succeeded (<=400), regardless of whether the received hash matched the requested hash or not. So I moved the write process to the `finish` block of the stream when it checks for the matching hash.
- Improved warning message to include package name and be more user friendly
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


**Test plan**
Added a test case in fetchers

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
*BEFORE*
<img width="681" alt="screen shot 2017-08-23 at 8 50 34 am" src="https://user-images.githubusercontent.com/18429494/29625595-07a5d314-87e1-11e7-8527-2be605bac7d2.png">

*AFTER*

<img width="684" alt="screen shot 2017-08-23 at 8 47 01 am" src="https://user-images.githubusercontent.com/18429494/29625593-0536974e-87e1-11e7-8a78-0149e105be60.png">
*note hashes are the same in the screenshots bc I made the code block fail intentionally