### PR TITLE
Fix: Ensure bin folder exists before trying to use it

### DIFF
--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -335,7 +335,6 @@ test.concurrent('--integrity should not die on missing fields in integrity file'
   try {
     await runCheck([], {integrity: true}, 'missing-fields');
   } catch (err) {
-    console.log(err);
     integrityError = true;
   }
   expect(integrityError).toEqual(false);

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -202,12 +202,12 @@ test('yarn create', async () => {
   const command = path.resolve(__dirname, '../bin/yarn');
   const options = {cwd, env: {YARN_SILENT: 1}};
 
-  const {stderr: stderr, stdout: stdout} = execa(command, ['create', 'index', '.'], options);
+  const {stderr: stderr, stdout: stdout} = execa(command, ['create', 'html'], options);
 
   const stdoutPromise = misc.consumeStream(stdout);
   const stderrPromise = misc.consumeStream(stderr);
 
   const [stdoutOutput, _] = await Promise.all([stdoutPromise, stderrPromise]);
 
-  expect(stdoutOutput.toString()).toMatch(/\[created index\]/);
+  expect(stdoutOutput.toString()).toMatch(/<!doctype html>/);
 });

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -196,3 +196,18 @@ test('cache folder fallback', async () => {
   );
   expect(stderrOutput2.toString()).toMatch(/Skipping preferred cache folder/);
 });
+
+test('yarn create', async () => {
+  const cwd = await makeTemp();
+  const command = path.resolve(__dirname, '../bin/yarn');
+  const options = {cwd, env: {YARN_SILENT: 1}};
+
+  const {stderr: stderr, stdout: stdout} = execa(command, ['create', 'index', '.'], options);
+
+  const stdoutPromise = misc.consumeStream(stdout);
+  const stderrPromise = misc.consumeStream(stderr);
+
+  const [stdoutOutput, _] = await Promise.all([stdoutPromise, stderrPromise]);
+
+  expect(stdoutOutput.toString()).toMatch(/\[created index\]/);
+});

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -167,19 +167,12 @@ test('cache folder fallback', async () => {
   const cwd = await makeTemp();
   const cacheFolder = path.join(cwd, '.cache');
 
-  const command = path.resolve(__dirname, '../bin/yarn');
   const args = ['--preferred-cache-folder', cacheFolder];
-
   const options = {cwd};
 
-  function runCacheDir(): Promise<Array<Buffer>> {
-    const {stderr, stdout} = execa(command, ['cache', 'dir'].concat(args), options);
-
-    const stdoutPromise = misc.consumeStream(stdout);
-    const stderrPromise = misc.consumeStream(stderr);
-
-    return Promise.all([stdoutPromise, stderrPromise]);
-  }
+  const runCacheDir = () => {
+    return runYarn(['cache', 'dir'].concat(args), options);
+  };
 
   const [stdoutOutput, stderrOutput] = await runCacheDir();
 
@@ -199,15 +192,9 @@ test('cache folder fallback', async () => {
 
 test('yarn create', async () => {
   const cwd = await makeTemp();
-  const command = path.resolve(__dirname, '../bin/yarn');
   const options = {cwd, env: {YARN_SILENT: 1}};
 
-  const {stderr: stderr, stdout: stdout} = execa(command, ['create', 'html'], options);
-
-  const stdoutPromise = misc.consumeStream(stdout);
-  const stderrPromise = misc.consumeStream(stderr);
-
-  const [stdoutOutput, _] = await Promise.all([stdoutPromise, stderrPromise]);
+  const [stdoutOutput, _] = await runYarn(['create', 'html'], options);
 
   expect(stdoutOutput.toString()).toMatch(/<!doctype html>/);
 });

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -98,7 +98,7 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
     if (err.code === 'EACCES') {
       prefix = FALLBACK_GLOBAL_PREFIX;
     } else if (err.code === 'ENOENT') {
-      await fs.mkdirp(binFolder);
+      // ignore - that just means we don't have the folder, yet
     } else {
       throw err;
     }

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -17,8 +17,6 @@ import {linkBin} from '../../package-linker.js';
 import {POSIX_GLOBAL_PREFIX, FALLBACK_GLOBAL_PREFIX} from '../../constants.js';
 import * as fs from '../../util/fs.js';
 
-const nativeFs = require('fs');
-
 class GlobalAdd extends Add {
   maybeOutputSaveTree(): Promise<void> {
     for (const pattern of this.addedPatterns) {
@@ -93,7 +91,8 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
 
   const binFolder = path.join(prefix, 'bin');
   try {
-    await fs.access(binFolder, (nativeFs.constants || nativeFs).W_OK);
+    // eslint-disable-next-line no-bitwise
+    await fs.access(binFolder, fs.constants.W_OK | fs.constants.X_OK);
   } catch (err) {
     if (err.code === 'EACCES') {
       prefix = FALLBACK_GLOBAL_PREFIX;

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -90,11 +90,15 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
   } else {
     prefix = POSIX_GLOBAL_PREFIX;
   }
+
+  const binFolder = path.join(prefix, 'bin');
   try {
-    await fs.access(path.join(prefix, 'bin'), (nativeFs.constants || nativeFs).W_OK);
+    await fs.access(binFolder, (nativeFs.constants || nativeFs).W_OK);
   } catch (err) {
     if (err.code === 'EACCES') {
       prefix = FALLBACK_GLOBAL_PREFIX;
+    } else if (err.code === 'ENOENT') {
+      await fs.mkdirp(binFolder);
     } else {
       throw err;
     }
@@ -113,13 +117,19 @@ async function initUpdateBins(config: Config, reporter: Reporter, flags: Object)
 
   function throwPermError(err: Error & {[code: string]: string}, dest: string) {
     if (err.code === 'EACCES') {
-      throw new MessageError(reporter.lang('noFilePermission', dest));
+      throw new MessageError(reporter.lang('noPermission', dest));
     } else {
       throw err;
     }
   }
 
   return async function(): Promise<void> {
+    try {
+      await fs.mkdirp(binFolder);
+    } catch (err) {
+      throwPermError(err, binFolder);
+    }
+
     const afterBins = await getBins(config);
 
     // remove old bins

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -108,7 +108,7 @@ const messages = {
   bugReport: 'If you think this is a bug, please open a bug report with the information provided in $0.',
   unexpectedError: 'An unexpected error occurred: $0.',
   jsonError: 'Error parsing JSON at $0, $1.',
-  noFilePermission: "We don't have permissions to touch the file $0.",
+  noPermission: 'Cannot create $0 due to insufficient permissions.',
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
   legendColorsForUpgradeInteractive:
     'Color legend : \n $0    : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2  : Patch Update backward-compatible bug fixes',


### PR DESCRIPTION
**Summary**

Fixes #4164. Ensures we have the bin folder before trying to link
binaries into it and throws a user-friendly error if it encounters
any permission issues.

**Test plan**
```
rm -rf $(yarn global bin);
yarn create react-app hello-world
```

Make sure it doesn't throw.