### PR TITLE
Better active directory selection

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -244,7 +244,7 @@ if (process.platform !== 'win32') {
 
 test.concurrent('should run bin command', async () => {
   const stdout = await execCommand('bin', [], '', true);
-  expect(stdout[0].trim()).toMatch(/[\\\/]node_modules[\\\/]\.bin$/);
+  expect(stdout[0]).toMatch(/[\\\/]node_modules[\\\/]\.bin\n?$/);
   expect(stdout.length).toEqual(1);
 });
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -244,7 +244,7 @@ if (process.platform !== 'win32') {
 
 test.concurrent('should run bin command', async () => {
   const stdout = await execCommand('bin', [], '', true);
-  expect(stdout[0]).toEqual(path.join(fixturesLoc, 'node_modules', '.bin'));
+  expect(stdout[0].trim()).toMatch(/[\\\/]node_modules[\\\/]\.bin$/);
   expect(stdout.length).toEqual(1);
 });
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -243,7 +243,7 @@ if (process.platform !== 'win32') {
 }
 
 test.concurrent('should run bin command', async () => {
-  const stdout = await execCommand('bin', [], '', false);
+  const stdout = await execCommand('bin', [], '', true);
   expect(stdout[0]).toEqual(path.join(fixturesLoc, 'node_modules', '.bin'));
   expect(stdout.length).toEqual(1);
 });

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -82,6 +82,22 @@ test('--mutex network', async () => {
   ]);
 });
 
+test('--cwd option', async () => {
+  const cwd = await makeTemp();
+  const cacheFolder = path.join(cwd, '.cache');
+
+  const subdir = path.join(cwd, 'a/b/c/d/e/f/g/h/i');
+  await fs.mkdirp(subdir);
+
+  const packageJsonPath = path.join(cwd, 'package.json');
+  await fs.writeFile(packageJsonPath, JSON.stringify({}));
+
+  await runYarn(['add', 'left-pad'], {cwd: subdir});
+
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath));
+  expect(packageJson.dependencies['left-pad']).toBeDefined();
+});
+
 test('yarnrc binary path (js)', async () => {
   const cwd = await makeTemp();
 

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -86,7 +86,7 @@ test('--cwd option', async () => {
   const cwd = await makeTemp();
   const cacheFolder = path.join(cwd, '.cache');
 
-  const subdir = path.join(cwd, 'a/b/c/d/e/f/g/h/i');
+  const subdir = path.join(cwd, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i');
   await fs.mkdirp(subdir);
 
   const packageJsonPath = path.join(cwd, 'package.json');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -21,9 +21,9 @@ const net = require('net');
 const onDeath = require('death');
 const path = require('path');
 
-function findActiveDirectory(base) {
-  let prev,
-    dir = base;
+function findActiveDirectory(base): string {
+  let prev = null;
+  let dir = base;
 
   do {
     if (fs.existsSync(path.join(dir, constants.NODE_PACKAGE_JSON))) {
@@ -37,7 +37,7 @@ function findActiveDirectory(base) {
   return base;
 }
 
-export async function main({
+export function main({
   startArgs,
   args,
   endArgs,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -21,7 +21,7 @@ const net = require('net');
 const onDeath = require('death');
 const path = require('path');
 
-function findActiveDirectory(base): string {
+function findProjectRoot(base: string): string {
   let prev = null;
   let dir = base;
 
@@ -353,7 +353,7 @@ export function main({
     return reporter.close();
   };
 
-  const cwd = findActiveDirectory(commander.cwd);
+  const cwd = findProjectRoot(commander.cwd);
 
   config
     .init({

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -457,7 +457,7 @@ async function start(): Promise<void> {
     const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
     const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex);
 
-    await main({startArgs, args, endArgs});
+    main({startArgs, args, endArgs});
   }
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -21,7 +21,24 @@ const net = require('net');
 const onDeath = require('death');
 const path = require('path');
 
-export function main({
+function findActiveDirectory(base) {
+    let prev, dir = base;
+
+    do {
+
+      if (fs.existsSync(path.join(dir, constants.NODE_PACKAGE_JSON))) {
+        return dir;
+      }
+
+      prev = dir;
+      dir = path.dirname(dir);
+
+    } while (dir !== prev);
+
+    return base;
+}
+
+export async function main({
   startArgs,
   args,
   endArgs,
@@ -337,8 +354,12 @@ export function main({
     return reporter.close();
   };
 
+  const cwd = findActiveDirectory(commander.cwd);
+
   config
     .init({
+      cwd,
+
       binLinks: commander.binLinks,
       modulesFolder: commander.modulesFolder,
       globalFolder: commander.globalFolder,
@@ -358,7 +379,6 @@ export function main({
       networkTimeout: commander.networkTimeout,
       nonInteractive: commander.nonInteractive,
       scriptsPrependNodePath: commander.scriptsPrependNodePath,
-      cwd: commander.cwd,
 
       commandName: commandName === 'run' ? commander.args[0] : commandName,
     })
@@ -438,7 +458,7 @@ async function start(): Promise<void> {
     const args = process.argv.slice(2, doubleDashIndex === -1 ? process.argv.length : doubleDashIndex);
     const endArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex);
 
-    main({startArgs, args, endArgs});
+    await main({startArgs, args, endArgs});
   }
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -22,20 +22,19 @@ const onDeath = require('death');
 const path = require('path');
 
 function findActiveDirectory(base) {
-    let prev, dir = base;
+  let prev,
+    dir = base;
 
-    do {
+  do {
+    if (fs.existsSync(path.join(dir, constants.NODE_PACKAGE_JSON))) {
+      return dir;
+    }
 
-      if (fs.existsSync(path.join(dir, constants.NODE_PACKAGE_JSON))) {
-        return dir;
-      }
+    prev = dir;
+    dir = path.dirname(dir);
+  } while (dir !== prev);
 
-      prev = dir;
-      dir = path.dirname(dir);
-
-    } while (dir !== prev);
-
-    return base;
+  return base;
 }
 
 export async function main({

--- a/src/constants.js
+++ b/src/constants.js
@@ -67,6 +67,7 @@ export const LINK_REGISTRY_DIRECTORY = path.join(CONFIG_DIRECTORY, 'link');
 export const GLOBAL_MODULE_DIRECTORY = path.join(CONFIG_DIRECTORY, 'global');
 
 export const NODE_MODULES_FOLDER = 'node_modules';
+export const NODE_PACKAGE_JSON = 'package.json';
 
 export const POSIX_GLOBAL_PREFIX = '/usr/local';
 export const FALLBACK_GLOBAL_PREFIX = path.join(userHome, '.yarn');


### PR DESCRIPTION
**Summary**

Fix #2709 - Yarn will now try to move to the closest ancestor directory that contains a `package.json` file if it can. If none is to be found, the current directory will be used as usual. Note that the same behavior if applied to the `--cwd` option, so `--cwd foo/bar` will go to `foo` if `foo/package.json` exists but not `foo/bar/package.json`.

I thought about doing this in the same pass than the rc file selection, but it wouldn't change anything because we're not stat'ing the same files, so we could not factorize the checks.

**Test plan**

Added a test case, and the old one should still pass as expected.
