### PR TITLE
Fix: Always close the reporter before exiting

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -206,6 +206,19 @@ test.concurrent('should run --version command', async () => {
   expect(stdout[0]).toEqual(pkg.version);
 });
 
+test.concurrent('should exit cleanly when running invalid commands', async () => {
+  try {
+    await execCommand('import', ['foobar'], 'run-version');
+  } catch (err) {
+    // not important - we really only want to check that the command terminates
+  }
+  try {
+    await execCommand('remove', ['foobar'], 'run-version');
+  } catch (err) {
+    // not important - we really only want to check that the command terminates
+  }
+});
+
 test.concurrent('should install if no args', async () => {
   const stdout = await execCommand('', [], 'run-add', true);
   expect(stdout[0]).toEqual(`yarn install v${pkg.version}`);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -176,7 +176,7 @@ export function main({
   if (command.noArguments && commander.args.length) {
     reporter.error(reporter.lang('noArguments'));
     reporter.info(command.getDocsInfo);
-    process.exitCode = 1;
+    exit(1);
     return;
   }
 
@@ -193,7 +193,7 @@ export function main({
   //
   if (command.requireLockfile && !fs.existsSync(path.join(config.cwd, constants.LOCKFILE_FILENAME))) {
     reporter.error(reporter.lang('noRequiredLockfile'));
-    process.exitCode = 1;
+    exit(1);
     return;
   }
 
@@ -411,10 +411,10 @@ export function main({
     return errorReportLoc;
   }
 
-  const exit = exitCode => {
+  function exit(exitCode) {
     process.exitCode = exitCode || 0;
-    return reporter.close();
-  };
+    reporter.close();
+  }
 
   const cwd = findProjectRoot(commander.cwd);
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -164,6 +164,11 @@ export function main({
     isSilent: process.env.YARN_SILENT === '1' || commander.silent,
   });
 
+  const exit = exitCode => {
+    process.exitCode = exitCode || 0;
+    reporter.close();
+  };
+
   reporter.initPeakMemoryCounter();
 
   const config = new Config(reporter);
@@ -409,11 +414,6 @@ export function main({
     }
 
     return errorReportLoc;
-  }
-
-  function exit(exitCode) {
-    process.exitCode = exitCode || 0;
-    reporter.close();
   }
 
   const cwd = findProjectRoot(commander.cwd);

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -152,6 +152,7 @@ export default class BaseReporter {
     this.peakMemoryInterval = setInterval(() => {
       this.checkPeakMemory();
     }, 1000);
+    this.peakMemoryInterval.unref();
   }
 
   checkPeakMemory() {

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -152,6 +152,7 @@ export default class BaseReporter {
     this.peakMemoryInterval = setInterval(() => {
       this.checkPeakMemory();
     }, 1000);
+    // $FlowFixMe: Node's setInterval returns a Timeout, not a Number
     this.peakMemoryInterval.unref();
   }
 


### PR DESCRIPTION
**Summary**

Fix #4276

In some particular cases, the reporters are not correctly closed before Yarn exits. It makes the process hang, because the reporters are expected to periodically check for the RAM usage. This patch does two things:

- First the setInterval loop itself is `unref`, so that it will never prevent the process from exiting.
- More importantly, the reporter is now correctly closed when exiting in the two cases I've noticed.

**Test plan**

I don't think tests are required for this fix, since the reproduction steps are fairly narrow (the bug only occurred when using Yarn in an invalid way) and won't allow us to catch any other bug than this one.
