### PR TITLE
Refactors the network mutex implementation

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -90,7 +90,7 @@ test('--mutex network 2', async () => {
 
   const promises = [];
 
-  for (let t = 0; t < 100; ++t) {
+  for (let t = 0; t < 40; ++t) {
     const subCwd = path.join(cwd, String(t));
 
     await fs.mkdirp(subCwd);

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -59,34 +59,16 @@ const PORT_RANGE = MAX_PORT_NUM - MIN_PORT_NUM;
 const getRandomPort = () => Math.floor(Math.random() * PORT_RANGE) + MIN_PORT_NUM;
 
 async function runYarn(args: Array<string> = [], options: Object = {}): Promise<Array<Buffer>> {
-  const process = execa(path.resolve(__dirname, '../bin/yarn'), args, options);
+  const {stdout, stderr} = await execa(path.resolve(__dirname, '../bin/yarn'), args, options);
 
-  const stdoutPromise = misc.consumeStream(process.stdout);
-  const stderrPromise = misc.consumeStream(process.stderr);
-
-  await process;
-
-  return Promise.all([stdoutPromise, stderrPromise]);
+  return [stdout, stderr];
 }
 
 test('--mutex network', async () => {
   const cwd = await makeTemp();
-  const cacheFolder = path.join(cwd, '.cache');
 
-  const command = path.resolve(__dirname, '../bin/yarn');
-  const args = ['--cache-folder', cacheFolder, '--verbose', '--mutex', `network:${getRandomPort()}`];
-
-  const options = {cwd};
-
-  await Promise.all([
-    execa(command, ['add', 'left-pad'].concat(args), options),
-    execa(command, ['add', 'foo'].concat(args), options),
-  ]);
-});
-
-test('--mutex network 2', async () => {
-  const cwd = await makeTemp();
-  await fs.writeFile(path.join(cwd, '.yarnrc'), '--mutex network\n');
+  const port = 56000 + Math.floor(Math.random() * 100);
+  await fs.writeFile(path.join(cwd, '.yarnrc'), `--mutex "network:${port}"\n`);
 
   const promises = [];
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -307,6 +307,7 @@ export function main({
             console.error('Process stalled');
             if (process._getActiveHandles) {
               console.error('Active handles:');
+              // $FlowFixMe: getActiveHandles is undocumented, but it exists
               for (const handle of process._getActiveHandles()) {
                 console.error(`  - ${handle.constructor.name}`);
               }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -19,6 +19,7 @@ const messages = {
   installCommandRenamed: '`install` has been replaced with `add` to add new dependencies. Run $0 instead.',
   globalFlagRemoved: '`--global` has been deprecated. Please run $0 instead.',
   waitingInstance: 'Waiting for the other yarn instance to finish',
+  waitingNamedInstance: 'Waiting for the other yarn instance to finish ($0)',
   offlineRetrying: 'There appears to be trouble with your network connection. Retrying...',
   clearedCache: 'Cleared cache.',
   couldntClearPackageFromCache: "Couldn't clear package $0 from cache",

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -18,7 +18,7 @@ const messages = {
   usage: 'Usage',
   installCommandRenamed: '`install` has been replaced with `add` to add new dependencies. Run $0 instead.',
   globalFlagRemoved: '`--global` has been deprecated. Please run $0 instead.',
-  waitingInstance: 'Waiting for the other yarn instance to finish',
+  waitingInstance: 'Waiting for the other yarn instance to finish (pid $0, inside $1)',
   waitingNamedInstance: 'Waiting for the other yarn instance to finish ($0)',
   offlineRetrying: 'There appears to be trouble with your network connection. Retrying...',
   clearedCache: 'Cleared cache.',


### PR DESCRIPTION
**Summary**

I'm currently debugging a concurrency issue that I noticed when running some internal tests, and the current mutex implementation makes it difficult to know exactly what's happening, because we only know that the process are waiting, with no indication as to *who* they're waiting.

This PR solves this issue by refactoring the mutex to now be an actual webserver (no extra dependency is required, I simply use the `http` native module). When a process fails to create a server, it sends an http request to the one already existing, and print the response (usually the active process `$PWD`) to its standard output as part of the warning message. Once this is done, it opens a new raw socket to the server, and patiently wait for it to be terminated (like in the current workflow).

<img width="650" alt="screen shot 2017-08-30 at 3 29 35 pm" src="https://user-images.githubusercontent.com/1037931/29877637-176ed69e-8d98-11e7-9ff0-d057214c5c2d.png">

Note that pretty much anything can now be printed: I've chosen the `$CWD` since we're not supposed to run Yarn concurrently in the same directory, but the command line arguments and/or the PID might also be good candidates.

**Test plan**

This feature should be partially covered by the [already existing test](https://github.com/yarnpkg/yarn/blob/master/__tests__/integration.js#L70-L83), but I'm open to write new ones.
