### PR TITLE
Fix: Prevents linking binaries from workspaces

### DIFF
--- a/__tests__/fixtures/install/workspaces-install-link-bin/package.json
+++ b/__tests__/fixtures/install/workspaces-install-link-bin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "my-project",
   "private": true,
+  "bin": {"file": "file.js"},
   "dependencies": {},
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
**Summary**

When running `yarn install` on some kind of workspaces (I still have to find out the exact criteria that trigger this bug), Yarn crashes with the following error message:

```
ENOENT: No such file or directory, lstat '/some/path/.../node_modules/workspace-aggregator-...'
```

This fix is an hotfix to prevent this error from happening. I still need to investigate to understand what exactly happens, and under what circumstances. This is probably related to #3896.

**Test plan**

Tests will be wrote. Do not merge.
