### PR TITLE
Fixes yarn why when using workspaces

### DIFF
--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -59,6 +59,10 @@ test.concurrent('throws error with too many arguments', (): Promise<void> => {
   });
 });
 
+test.concurrent("doesn't throw when using it inside a workspace", (): Promise<void> => {
+  return runWhy({}, ['mime-types'], 'workspace');
+});
+
 test.concurrent('throws error if module does not exist', (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
 

--- a/__tests__/fixtures/why/workspace/package.json
+++ b/__tests__/fixtures/why/workspace/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "workspaces": [],
+  "dependencies": {
+    "mime-types": "2.1.12",
+    "glob": "7.1.1",
+    "uglifyify": "3.0.0"
+  },
+  "devDependencies": {
+    "left-pad": "1.1.3"
+  }
+}

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -130,8 +130,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   reporter.step(2, 4, reporter.lang('whyInitGraph'), emoji.get('truck'));
   const lockfile = await Lockfile.fromDirectory(config.lockfileFolder, reporter);
   const install = new Install(flags, config, reporter, lockfile);
-  const {requests: depRequests, patterns} = await install.fetchRequestFromCwd();
-  await install.resolver.init(depRequests, {isFlat: install.flags.flat, isFrozen: install.flags.frozenLockfile});
+  const {requests: depRequests, patterns, workspaceLayout} = await install.fetchRequestFromCwd();
+  await install.resolver.init(depRequests, {
+    isFlat: install.flags.flat,
+    isFrozen: install.flags.frozenLockfile,
+    workspaceLayout,
+  });
   const hoisted = await install.linker.getFlatHoistedTree(patterns);
 
   // finding


### PR DESCRIPTION
**Summary**

We were not passing the `workspaceLayout` to the resolver, which was breaking the resolution process for workspaces (the resolver was trying to resolve the workspaces on NPM). This PR fix this.

A followup will be to remove (or rather reformat) the aggregator from the display. Given the current time constraints I haven't took time to completely remove it:

<img width="1027" alt="screen shot 2017-09-04 at 6 15 05 pm" src="https://user-images.githubusercontent.com/1037931/30034972-0a293502-919d-11e7-9310-45b0377e45d8.png">

**Test plan**

Existing tests should pass + added a new one + manually tested `yarn why` inside a workspace