### PR TITLE
Fix: show better error messages when Git is not found

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -9,9 +9,18 @@ export class MessageError extends Error {
   code: ?string;
 }
 
+export class ProcessSpawnError extends MessageError {
+  constructor(msg: string, code?: string, process?: string) {
+    super(msg, code);
+    this.process = process;
+  }
+
+  process: ?string;
+}
+
 export class SecurityError extends MessageError {}
 
-export class SpawnError extends MessageError {
+export class ProcessTermError extends MessageError {
   EXIT_CODE: ?number;
   EXIT_SIGNAL: ?string;
 }

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -3,7 +3,7 @@
 
 import * as constants from '../constants.js';
 import BlockingQueue from './blocking-queue.js';
-import {MessageError, SpawnError} from '../errors.js';
+import {ProcessSpawnError, ProcessTermError} from '../errors.js';
 import {promisify} from './promise.js';
 
 const child = require('child_process');
@@ -80,7 +80,7 @@ export function spawn(
 
         proc.on('error', err => {
           if (err.code === 'ENOENT') {
-            reject(new MessageError(`Couldn't find the binary ${program}`));
+            reject(new ProcessSpawnError(`Couldn't find the binary ${program}`, err.code, program));
           } else {
             reject(err);
           }
@@ -124,7 +124,7 @@ export function spawn(
 
         proc.on('close', (code: number, signal: string) => {
           if (signal || code >= 1) {
-            err = new SpawnError(
+            err = new ProcessTermError(
               [
                 'Command failed.',
                 signal ? `Exit signal: ${signal}` : `Exit code: ${code}`,

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -2,7 +2,7 @@
 
 import type {ReporterSpinner} from '../reporters/types.js';
 import type Config from '../config.js';
-import {MessageError, SpawnError} from '../errors.js';
+import {MessageError, ProcessTermError} from '../errors.js';
 import * as constants from '../constants.js';
 import * as child from './child.js';
 import {exists} from './fs.js';
@@ -260,7 +260,7 @@ export async function execCommand(stage: string, config: Config, cmd: string, cw
     await executeLifecycleScript(stage, config, cwd, cmd);
     return Promise.resolve();
   } catch (err) {
-    if (err instanceof SpawnError) {
+    if (err instanceof ProcessTermError) {
       throw new MessageError(
         err.EXIT_SIGNAL
           ? reporter.lang('commandFailedWithSignal', err.EXIT_SIGNAL)


### PR DESCRIPTION
**Summary**

Fixes #4287. Throws a specific error when `child.spawn` cannot find
the executable and handles this error properly in all `git` invocations.

**Test plan**

Existing tests.