### PR TITLE
Chore: fix info tests

### DIFF
--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -43,10 +43,11 @@ const expectedKeys = [
   'license',
   'dist',
   'directories',
+  'scripts',
 ];
 
 // yarn now ships as built, single JS files so it has no dependencies and no scripts
-const unexpectedKeys = ['dependencies', 'devDependencies', 'scripts'];
+const unexpectedKeys = ['dependencies', 'devDependencies'];
 
 test.concurrent('without arguments and in directory containing a valid package file', (): Promise<void> => {
   return runInfo([], {}, 'local', (config, output): ?Promise<void> => {


### PR DESCRIPTION
**Summary**

Looks like bumping the version on npm invalidated a cache that
revealed the new API response from npm for yarn. Now the
`scripts` field always exists even if it is empty.

**Test plan**

CI should pass.
