### PR TITLE
Fix: More resillient global and cache folder determination

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -103,7 +103,7 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
 
   if (!prefix) {
     throw new MessageError(
-      config.reporter.lang('noGlobalFolder', prefixFolderQueryResult.skipped.map(item => item.folder)),
+      config.reporter.lang('noGlobalFolder', prefixFolderQueryResult.skipped.map(item => item.folder).join(', ')),
     );
   }
 

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -102,9 +102,14 @@ async function getGlobalPrefix(config: Config, flags: Object, mode): Promise<str
   const prefix = prefixFolderQueryResult.folder && path.dirname(prefixFolderQueryResult.folder);
 
   if (!prefix) {
-    throw new MessageError(
-      config.reporter.lang('noGlobalFolder', prefixFolderQueryResult.skipped.map(item => item.folder).join(', ')),
+    config.reporter.warn(
+      config.reporter.lang(
+        'noGlobalFolder',
+        prefixFolderQueryResult.skipped.map(item => path.dirname(item.folder)).join(', '),
+      ),
     );
+
+    return FALLBACK_GLOBAL_PREFIX;
   }
 
   return prefix;

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -87,29 +87,26 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
     return process.env.PREFIX;
   }
 
-  let prefix = FALLBACK_GLOBAL_PREFIX;
+  const potentialPrefixFolders = [FALLBACK_GLOBAL_PREFIX];
   if (process.platform === 'win32') {
     // %LOCALAPPDATA%\Yarn --> C:\Users\Alice\AppData\Local\Yarn
     if (process.env.LOCALAPPDATA) {
-      prefix = path.join(process.env.LOCALAPPDATA, 'Yarn');
+      potentialPrefixFolders.unshift(path.join(process.env.LOCALAPPDATA, 'Yarn'));
     }
   } else {
-    prefix = POSIX_GLOBAL_PREFIX;
+    potentialPrefixFolders.unshift(POSIX_GLOBAL_PREFIX);
   }
 
-  const binFolder = path.join(prefix, 'bin');
-  try {
-    // eslint-disable-next-line no-bitwise
-    await fs.access(binFolder, fs.constants.W_OK | fs.constants.X_OK);
-  } catch (err) {
-    if (err.code === 'EACCES') {
-      prefix = FALLBACK_GLOBAL_PREFIX;
-    } else if (err.code === 'ENOENT') {
-      // ignore - that just means we don't have the folder, yet
-    } else {
-      throw err;
-    }
+  const binFolders = potentialPrefixFolders.map(prefix => path.join(prefix, 'bin'));
+  const prefixFolderQueryResult = await fs.getFirstWriteableFolder(binFolders);
+  const prefix = prefixFolderQueryResult.folder && path.dirname(prefixFolderQueryResult.folder);
+
+  if (!prefix) {
+    throw new MessageError(
+      config.reporter.lang('noPermission', prefixFolderQueryResult.skipped.map(item => item.folder)),
+    );
   }
+
   return prefix;
 }
 

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -87,11 +87,7 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
     return process.env.PREFIX;
   }
 
-  const potentialPrefixFolders = [
-    FALLBACK_GLOBAL_PREFIX,
-    // This is the last resort
-    path.dirname(process.execPath),
-  ];
+  const potentialPrefixFolders = [FALLBACK_GLOBAL_PREFIX];
   if (process.platform === 'win32') {
     // %LOCALAPPDATA%\Yarn --> C:\Users\Alice\AppData\Local\Yarn
     if (process.env.LOCALAPPDATA) {

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -87,7 +87,11 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
     return process.env.PREFIX;
   }
 
-  const potentialPrefixFolders = [FALLBACK_GLOBAL_PREFIX];
+  const potentialPrefixFolders = [
+    FALLBACK_GLOBAL_PREFIX,
+    // This is the last resort
+    path.dirname(process.execPath),
+  ];
   if (process.platform === 'win32') {
     // %LOCALAPPDATA%\Yarn --> C:\Users\Alice\AppData\Local\Yarn
     if (process.env.LOCALAPPDATA) {

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -78,7 +78,7 @@ async function getBins(config: Config): Promise<Set<string>> {
   return paths;
 }
 
-async function getGlobalPrefix(config: Config, flags: Object, mode): Promise<string> {
+async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
   if (flags.prefix) {
     return flags.prefix;
   } else if (config.getOption('prefix', true)) {
@@ -98,7 +98,7 @@ async function getGlobalPrefix(config: Config, flags: Object, mode): Promise<str
   }
 
   const binFolders = potentialPrefixFolders.map(prefix => path.join(prefix, 'bin'));
-  const prefixFolderQueryResult = await fs.getFirstSuitableFolder(binFolders, mode);
+  const prefixFolderQueryResult = await fs.getFirstSuitableFolder(binFolders);
   const prefix = prefixFolderQueryResult.folder && path.dirname(prefixFolderQueryResult.folder);
 
   if (!prefix) {

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -103,7 +103,7 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
 
   if (!prefix) {
     throw new MessageError(
-      config.reporter.lang('noPermission', prefixFolderQueryResult.skipped.map(item => item.folder)),
+      config.reporter.lang('noGlobalFolder', prefixFolderQueryResult.skipped.map(item => item.folder)),
     );
   }
 

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -78,7 +78,7 @@ async function getBins(config: Config): Promise<Set<string>> {
   return paths;
 }
 
-async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
+async function getGlobalPrefix(config: Config, flags: Object, mode): Promise<string> {
   if (flags.prefix) {
     return flags.prefix;
   } else if (config.getOption('prefix', true)) {
@@ -98,7 +98,7 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
   }
 
   const binFolders = potentialPrefixFolders.map(prefix => path.join(prefix, 'bin'));
-  const prefixFolderQueryResult = await fs.getFirstWriteableFolder(binFolders);
+  const prefixFolderQueryResult = await fs.getFirstSuitableFolder(binFolders, mode);
   const prefix = prefixFolderQueryResult.folder && path.dirname(prefixFolderQueryResult.folder);
 
   if (!prefix) {

--- a/src/config.js
+++ b/src/config.js
@@ -293,7 +293,10 @@ export default class Config {
         preferredCacheFolders = [String(preferredCacheFolder)].concat(preferredCacheFolders);
       }
 
-      const cacheFolderQuery = await fs.getFirstWriteableFolder(preferredCacheFolders);
+      const cacheFolderQuery = await fs.getFirstSuitableFolder(
+        preferredCacheFolders,
+        fs.constants.W_OK | fs.constants.X_OK | fs.constants.R_OK, // eslint-disable-line no-bitwise
+      );
       for (const skippedEntry of cacheFolderQuery.skipped) {
         this.reporter.warn(this.reporter.lang('cacheFolderSkipped', skippedEntry.folder));
       }

--- a/src/config.js
+++ b/src/config.js
@@ -290,29 +290,17 @@ export default class Config {
       const preferredCacheFolder = opts.preferredCacheFolder || this.getOption('preferred-cache-folder', true);
 
       if (preferredCacheFolder) {
-        preferredCacheFolders = [preferredCacheFolder].concat(preferredCacheFolders);
+        preferredCacheFolders = [String(preferredCacheFolder)].concat(preferredCacheFolders);
       }
 
-      for (let t = 0; t < preferredCacheFolders.length && !cacheRootFolder; ++t) {
-        const tentativeCacheFolder = String(preferredCacheFolders[t]);
+      const cacheFolderQuery = await fs.getFirstWriteableFolder(preferredCacheFolders);
+      for (const failedFolder of cacheFolderQuery.skipped) {
+        this.reporter.warn(this.reporter.lang('cacheFolderSkipped', failedFolder));
+      }
 
-        try {
-          await fs.mkdirp(tentativeCacheFolder);
-
-          const testFile = path.join(tentativeCacheFolder, 'testfile');
-
-          // fs.access is not enough, because the cache folder could actually be a file.
-          await fs.writeFile(testFile, 'content');
-          await fs.readFile(testFile);
-
-          cacheRootFolder = tentativeCacheFolder;
-        } catch (error) {
-          this.reporter.warn(this.reporter.lang('cacheFolderSkipped', tentativeCacheFolder));
-        }
-
-        if (cacheRootFolder && t > 0) {
-          this.reporter.warn(this.reporter.lang('cacheFolderSelected', cacheRootFolder));
-        }
+      cacheRootFolder = cacheFolderQuery.folder;
+      if (cacheRootFolder && cacheFolderQuery.skipped.length > 0) {
+        this.reporter.warn(this.reporter.lang('cacheFolderSelected', cacheRootFolder));
       }
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -294,8 +294,8 @@ export default class Config {
       }
 
       const cacheFolderQuery = await fs.getFirstWriteableFolder(preferredCacheFolders);
-      for (const failedFolder of cacheFolderQuery.skipped) {
-        this.reporter.warn(this.reporter.lang('cacheFolderSkipped', failedFolder));
+      for (const skippedEntry of cacheFolderQuery.skipped) {
+        this.reporter.warn(this.reporter.lang('cacheFolderSkipped', skippedEntry.folder));
       }
 
       cacheRootFolder = cacheFolderQuery.folder;

--- a/src/constants.js
+++ b/src/constants.js
@@ -82,7 +82,7 @@ function getYarnBinPath(): string {
 export const NODE_MODULES_FOLDER = 'node_modules';
 export const NODE_PACKAGE_JSON = 'package.json';
 
-export const POSIX_GLOBAL_PREFIX = `${process.env.DESTIR || ''}/usr/local`;
+export const POSIX_GLOBAL_PREFIX = `${process.env.DESTDIR || ''}/usr/local`;
 export const FALLBACK_GLOBAL_PREFIX = path.join(userHome, '.yarn');
 
 export const META_FOLDER = '.yarn-meta';

--- a/src/constants.js
+++ b/src/constants.js
@@ -82,7 +82,7 @@ function getYarnBinPath(): string {
 export const NODE_MODULES_FOLDER = 'node_modules';
 export const NODE_PACKAGE_JSON = 'package.json';
 
-export const POSIX_GLOBAL_PREFIX = '/usr/local';
+export const POSIX_GLOBAL_PREFIX = `${process.env.DESTIR || ''}/usr/local`;
 export const FALLBACK_GLOBAL_PREFIX = path.join(userHome, '.yarn');
 
 export const META_FOLDER = '.yarn-meta';

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -29,6 +29,7 @@ export const SCOPE_SEPARATOR = '%2f';
 // `%2f` Match SCOPE_SEPARATOR, the escaped '/', and don't capture
 const SCOPED_PKG_REGEXP = /(?:^|\/)(@[^\/?]+?)(?=%2f)/;
 
+// TODO: Use the method from src/cli/commands/global.js for this instead
 function getGlobalPrefix(): string {
   if (process.env.PREFIX) {
     return process.env.PREFIX;

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -110,6 +110,7 @@ const messages = {
   unexpectedError: 'An unexpected error occurred: $0.',
   jsonError: 'Error parsing JSON at $0, $1.',
   noPermission: 'Cannot create $0 due to insufficient permissions.',
+  noGlobalFolder: 'Cannot find a suitable global folder. Tried these: $0',
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
   legendColorsForUpgradeInteractive:
     'Color legend : \n $0    : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2  : Patch Update backward-compatible bug fixes',

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -33,6 +33,7 @@ export const rename: (oldPath: string, newPath: string) => Promise<void> = promi
 export const access: (path: string, mode?: number) => Promise<void> = promisify(fs.access);
 export const stat: (path: string) => Promise<fs.Stats> = promisify(fs.stat);
 export const unlink: (path: string) => Promise<void> = promisify(require('rimraf'));
+export const unlinkFile: (path: string) => Promise<void> = promisify(fs.unlink);
 export const mkdirp: (path: string) => Promise<void> = promisify(require('mkdirp'));
 export const exists: (path: string) => Promise<boolean> = promisify(fs.exists, true);
 export const lstat: (path: string) => Promise<fs.Stats> = promisify(fs.lstat);
@@ -903,7 +904,7 @@ export async function getFirstWriteableFolder(paths: Iterable<string>): Promise<
       const testFile = path.join(folder, `.yarn-write-test-${process.pid}`);
       await writeFile(testFile, '');
       await readFile(testFile);
-      await unlink(testFile);
+      await unlinkFile(testFile);
 
       result.folder = folder;
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -892,7 +892,10 @@ export async function readFirstAvailableStream(
   return {stream, triedPaths};
 }
 
-export async function getFirstWriteableFolder(paths: Iterable<string>): Promise<FolderQueryResult> {
+export async function getFirstSuitableFolder(
+  paths: Iterable<string>,
+  mode = constants.R_OK | constants.X_OK, // eslint-disable-line no-bitwise
+): Promise<FolderQueryResult> {
   const result: FolderQueryResult = {
     skipped: [],
     folder: null,
@@ -901,10 +904,7 @@ export async function getFirstWriteableFolder(paths: Iterable<string>): Promise<
   for (const folder of paths) {
     try {
       await mkdirp(folder);
-      const testFile = path.join(folder, `.yarn-write-test-${process.pid}`);
-      await writeFile(testFile, '');
-      await readFile(testFile);
-      await unlinkFile(testFile);
+      await access(folder, mode);
 
       result.folder = folder;
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -33,7 +33,6 @@ export const rename: (oldPath: string, newPath: string) => Promise<void> = promi
 export const access: (path: string, mode?: number) => Promise<void> = promisify(fs.access);
 export const stat: (path: string) => Promise<fs.Stats> = promisify(fs.stat);
 export const unlink: (path: string) => Promise<void> = promisify(require('rimraf'));
-export const unlinkFile: (path: string) => Promise<void> = promisify(fs.unlink);
 export const mkdirp: (path: string) => Promise<void> = promisify(require('mkdirp'));
 export const exists: (path: string) => Promise<boolean> = promisify(fs.exists, true);
 export const lstat: (path: string) => Promise<fs.Stats> = promisify(fs.lstat);

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -894,7 +894,7 @@ export async function readFirstAvailableStream(
 
 export async function getFirstSuitableFolder(
   paths: Iterable<string>,
-  mode = constants.R_OK | constants.X_OK, // eslint-disable-line no-bitwise
+  mode: number = constants.R_OK | constants.X_OK, // eslint-disable-line no-bitwise
 ): Promise<FolderQueryResult> {
   const result: FolderQueryResult = {
     skipped: [],

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -894,7 +894,7 @@ export async function readFirstAvailableStream(
 
 export async function getFirstSuitableFolder(
   paths: Iterable<string>,
-  mode: number = constants.R_OK | constants.X_OK, // eslint-disable-line no-bitwise
+  mode: number = constants.W_OK | constants.X_OK, // eslint-disable-line no-bitwise
 ): Promise<FolderQueryResult> {
   const result: FolderQueryResult = {
     skipped: [],

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -1,17 +1,17 @@
 /* @flow */
 
 import type {ReadStream} from 'fs';
-
 import type Reporter from '../reporters/base-reporter.js';
+
+import fs from 'fs';
+import globModule from 'glob';
+import os from 'os';
+import path from 'path';
+
 import BlockingQueue from './blocking-queue.js';
 import * as promise from './promise.js';
 import {promisify} from './promise.js';
 import map from './map.js';
-
-const fs = require('fs');
-const globModule = require('glob');
-const os = require('os');
-const path = require('path');
 
 export const constants =
   typeof fs.constants !== 'undefined'
@@ -90,6 +90,16 @@ type CopyOptions = {
   possibleExtraneous: Set<string>,
   ignoreBasenames: Array<string>,
   artifactFiles: Array<string>,
+};
+
+type FailedFolderQuery = {
+  error: Error,
+  folder: string,
+};
+
+type FolderQueryResult = {
+  skipped: Array<FailedFolderQuery>,
+  folder: ?string,
 };
 
 export const fileDatesEqual = (a: Date, b: Date) => {
@@ -879,4 +889,31 @@ export async function readFirstAvailableStream(
   }
 
   return {stream, triedPaths};
+}
+
+export async function getFirstWriteableFolder(paths: Iterable<string>): Promise<FolderQueryResult> {
+  const result: FolderQueryResult = {
+    skipped: [],
+    folder: null,
+  };
+
+  for (const folder of paths) {
+    try {
+      await mkdirp(folder);
+      const testFile = path.join(folder, `.yarn-write-test-${process.pid}`);
+      await writeFile(testFile, '');
+      await readFile(testFile);
+      await unlink(testFile);
+
+      result.folder = folder;
+
+      return result;
+    } catch (error) {
+      result.skipped.push({
+        error,
+        folder,
+      });
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
**Summary**

Fixes #4320 and fixes #4323. We were using `fs.access` when selecting
the global prefix folder automatically and expecting only an `EACCES` error.
This caused issues on Heroku where one of our first tries had threw an
`EROFS` error.

This patch also adds `$DESTIR` support back, which was removed in #3721,
probably inadvertently.

**Test plan**

Existing cache folder fallback tests should be enough for now. We should
move the core of those tests for the newly added `fs.getFirstWriteableFolder`
method.