### PR TITLE
Add npm_lifecycle_script to env in makeEnv

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -65,9 +65,11 @@ export async function makeEnv(
     original: [config.commandName],
   });
 
-  // add npm_package_*
   const manifest = await config.maybeReadManifest(cwd);
   if (manifest) {
+    env.npm_lifecycle_script = manifest.scripts && manifest.scripts[stage];
+
+    // add npm_package_*
     const queue = [['', manifest]];
     while (queue.length) {
       const [key, val] = queue.pop();

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -67,7 +67,9 @@ export async function makeEnv(
 
   const manifest = await config.maybeReadManifest(cwd);
   if (manifest) {
-    env.npm_lifecycle_script = manifest.scripts && manifest.scripts[stage];
+    if (manifest.scripts && Object.prototype.hasOwnProperty.call(manifest.scripts, stage)) {
+      env.npm_lifecycle_script = manifest.scripts[stage];
+    }
 
     // add npm_package_*
     const queue = [['', manifest]];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #4003. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The motivation behind this PR is to get more parity with npm wrt the `process.env` variables available when running scripts.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Made these exact changes in my globally installed `yarn`'s node_modules. Using the following `package.json`
```json
{
  "name": "foo",
  "version": "1.0.0",
  "scripts": {
    "test": "env | grep npm_"
  }
}
```
I ran `yarn test` to yield:
```
MacBook-Pro:temp adityavohra7$ yarn test
yarn test v0.27.5
warning package.json: No license field
$ env | grep npm_
npm_config_version_git_tag=true
npm_config_init_license=MIT
npm_config_registry=https://registry.yarnpkg.com
npm_execpath=/usr/local/lib/node_modules/yarn/bin/yarn.js
npm_config_argv={"remain":[],"cooked":["test"],"original":["test"]}
npm_lifecycle_event=test
npm_package_name=foo
npm_package_version=1.0.0
npm_package_scripts_test=env | grep npm_
npm_config_strict_ssl=true
npm_config_save_prefix=^
npm_config_version_git_message=v%s
npm_lifecycle_script=env | grep npm_
npm_config_user_agent=yarn/0.27.5 npm/? node/v8.4.0 darwin x64
npm_config_ignore_scripts=
npm_config_version_git_sign=
npm_config_ignore_optional=
npm_config_init_version=1.0.0
npm_config_version_tag_prefix=v
npm_node_execpath=/usr/local/bin/node
Done in 0.15s.
```
`npm_lifecycle_script` now appears in `process.env`.