### PR TITLE
Yarn 1: Fix regex so single-character @scopes can work again

### DIFF
--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -24,7 +24,7 @@ export default class FileResolver extends ExoticResolver {
   loc: string;
 
   static protocol = 'file';
-  static prefixMatcher = /^.{1,2}\//;
+  static prefixMatcher = /^\.{1,2}\//;
 
   static isVersion(pattern: string): boolean {
     return super.isVersion.call(this, pattern) || this.prefixMatcher.test(pattern) || path.isAbsolute(pattern);


### PR DESCRIPTION
**Summary**

The exotic `file-resolver` checks for `.` and `..`, but the regex is missing the escape on the `.`, so *any* two characters count as a file. This includes single-character scope names, like `@s/packagename`.

This issue was introduced in https://github.com/yarnpkg/yarn/pull/4257.

**Test plan**

I wasn't sure how packages should be named in `__tests__/fixtures/install/resolutions/exotic-version`, so I have not added add a single-character scoped package reference to test.

I don't know of any single-character scopes in the public registry to use as reference, the way `left-pad-1.1.1.tgz` is mirrored in there. Could I just copy `leftpad-1.1.1.tgz` as `@s/leftpad-1.1.1.tgz` and use that?