### PR TITLE
Fix: fix support for registry URLs without trailing slash

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -281,6 +281,27 @@ describe('isScopedPackage functional test', () => {
   });
 });
 
+describe('getRequestUrl functional test', () => {
+  test('returns pathname when it is a full URL', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+    const fullURL = 'HTTP://xn--xample-hva.com:80/foo/bar/baz';
+
+    expect(npmRegistry.getRequestUrl('https://my.registry.co', fullURL)).toEqual(fullURL);
+  });
+
+  test('correctly handles registries lacking a trailing slash', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+    const registry = 'https://my.registry.co/registry';
+    const pathname = 'foo/bar/baz';
+
+    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://my.registry.co/registry/foo/bar/baz');
+  });
+});
+
 describe('getScope functional test', () => {
   describe('matches scope correctly', () => {
     const testCwd = '.';

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -85,12 +85,12 @@ export default class NpmRegistry extends Registry {
   }
 
   getRequestUrl(registry: string, pathname: string): string {
-    const isUrl = /^https?:/.test(pathname);
+    const isUrl = /^https?:/i.test(pathname);
 
     if (isUrl) {
       return pathname;
     } else {
-      return url.resolve(registry, pathname);
+      return url.resolve(addSuffix(registry, '/'), pathname);
     }
   }
 


### PR DESCRIPTION
**Summary**

Fixes #4339. Also fixes handling of upper-case registry names.

**Test plan**

Added unit tests for `NpmRegistry.prototype.getRequestUrl()`.
