### PR TITLE
Fix: remove the `accept` header from tar fetcher requests

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -142,7 +142,7 @@ export default class TarballFetcher extends BaseFetcher {
           {
             headers: {
               'Accept-Encoding': 'gzip',
-              Accept: 'application/octet-stream',
+              Accept: 'application/octet-stream, application/x-tar',
             },
             buffer: true,
             process: (req, resolve, reject) => {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -142,7 +142,6 @@ export default class TarballFetcher extends BaseFetcher {
           {
             headers: {
               'Accept-Encoding': 'gzip',
-              Accept: 'application/octet-stream, application/x-tar',
             },
             buffer: true,
             process: (req, resolve, reject) => {


### PR DESCRIPTION
**Summary**

Fixes #3833. Removes `accept` header from tar requests as @arcanis suggested since `application/octet` wasn't ensuring any valid tar file and `npm` client does not send this header anyway.

**Test plan**

Run `yarn add http://prerelease.componentone.com/wijmo5/npm-images/C1Wijmo-Enterprise-Eval-System-5.20172.328.tgz`

It fails without the patch, installs correctly with the patch.
