### PR TITLE
Fix: only switch to help mode for valid commands

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -240,8 +240,8 @@ test.concurrent('should not output JSON activity/progress if given --no-progress
   });
 });
 
-test.concurrent('should run help of run command if --help is before --', async () => {
-  const stdout = await execCommand('run', ['custom-script', '--help', '--'], 'run-custom-script-with-arguments');
+test.concurrent('should run help of run command if --help is before script', async () => {
+  const stdout = await execCommand('run', ['--help', 'custom-script'], 'run-custom-script-with-arguments');
   expect(stdout[0]).toEqual('Usage: yarn [command] [flags]');
   expect(stdout[stdout.length - 1]).toEqual(
     'Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.',
@@ -249,8 +249,8 @@ test.concurrent('should run help of run command if --help is before --', async (
 });
 
 if (process.platform !== 'win32') {
-  test.concurrent('should run help of custom-script if --help is after --', async () => {
-    const stdout = await execCommand('run', ['custom-script', '--', '--help'], 'run-custom-script-with-arguments');
+  test.concurrent('should run help of custom-script if --help is after script', async () => {
+    const stdout = await execCommand('run', ['custom-script', '--help'], 'run-custom-script-with-arguments');
     expect(stdout[stdout.length - 2]).toEqual('A message from custom script with args --help');
   });
 }
@@ -286,11 +286,6 @@ test.concurrent('should display documentation link for known command', async () 
 
 test.concurrent('should throws missing command for constructor command', async () => {
   await expectAnErrorMessage(execCommand('constructor', [], 'run-add', true), 'Command "constructor" not found');
-});
-
-test.concurrent('should show help and ignore constructor command', async () => {
-  const stdout = await execCommand('constructor', ['--help'], 'run-help');
-  expectHelpOutput(stdout);
 });
 
 test.concurrent('should run command with hyphens', async () => {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -107,7 +107,7 @@ export function main({
     commandName = 'help';
   }
 
-  if (args.indexOf('--help') >= 0 || args.indexOf('-h') >= 0) {
+  if (Object.prototype.hasOwnProperty.call(commands, commandName) && (args[0] === '--help' || args[0] === '-h')) {
     args.unshift(commandName);
     commandName = 'help';
   }


### PR DESCRIPTION
**Summary**

Fixes #4345. This patch triggers the `help` command with `-h` or
`--help` only when the command name is known to `yarn` and the flag
is set immediately after the command name itself.

**Test plan**

Should add unit tests.