### PR TITLE
arguement -v is version not verbose

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -51,9 +51,9 @@ export function main({
   handleSignals();
 
   // set global options
-  commander.version(version, '--version');
+  commander.version(version, '-v, --version');
   commander.usage('[command] [flags]');
-  commander.option('-v, --verbose', 'output verbose messages on internal operations');
+  commander.option('--verbose', 'output verbose messages on internal operations');
   commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
   commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
   commander.option('--strict-semver');


### PR DESCRIPTION
**Summary**

Currently running `yarn -v` displays the yarn version number but `yarn -h` says otherwise:

```
$ yarn -h

  Usage: yarn [command] [flags]

  Options:

    -h, --help                          output usage information
    --version                           output the version number
    -v, --verbose                       output verbose messages on internal operations

$ yarn -v
1.0.1

```

this PR fixes `yarn -h` to use `-v` as version number. Output of `yarn -h` with this PR:

```
$ ./bin/yarn -h

  Usage: yarn [command] [flags]

  Options:

    -h, --help                          output usage information
    -v, --version                       output the version number
    --verbose                           output verbose messages on internal operations

```



