### PR TITLE
Fix #4357 - Allow resolver to delay resolutions for nested dependencies

### DIFF
--- a/__tests__/commands/install/resolutions.js
+++ b/__tests__/commands/install/resolutions.js
@@ -73,7 +73,7 @@ test.concurrent('install with nested resolutions', (): Promise<void> => {
   });
 });
 
-test.concurrent('install with resolutions using flat mode', (): Promise<void> => {
+test.concurrent('install with nested resolutions using flat mode', (): Promise<void> => {
   return runInstall({flat: true}, 'install-nested-resolutions', async config => {
     expect(await getPackageVersion(config, 'strip-ansi')).toEqual('2.0.1');
     expect(await getPackageVersion(config, 'ansi-regex')).toEqual('1.1.1');

--- a/__tests__/commands/install/resolutions.js
+++ b/__tests__/commands/install/resolutions.js
@@ -65,3 +65,17 @@ test.concurrent('install with resolutions should correctly install toplevel scop
     expect(await getPackageVersion(config, '@scoped/b')).toEqual('2.0.0');
   });
 });
+
+test.concurrent('install with nested resolutions', (): Promise<void> => {
+  return runInstall({}, 'install-nested-resolutions', async config => {
+    expect(await getPackageVersion(config, 'strip-ansi')).toEqual('2.0.1');
+    expect(await getPackageVersion(config, 'ansi-regex')).toEqual('1.1.1');
+  });
+});
+
+test.concurrent('install with resolutions using flat mode', (): Promise<void> => {
+  return runInstall({flat: true}, 'install-nested-resolutions', async config => {
+    expect(await getPackageVersion(config, 'strip-ansi')).toEqual('2.0.1');
+    expect(await getPackageVersion(config, 'ansi-regex')).toEqual('1.1.1');
+  });
+});

--- a/__tests__/fixtures/install/install-nested-resolutions/bar/package.json
+++ b/__tests__/fixtures/install/install-nested-resolutions/bar/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bar",
+  "version": "0.0.0",
+  "dependencies": {
+    "strip-ansi": "^2.0.0"
+  }
+}

--- a/__tests__/fixtures/install/install-nested-resolutions/package.json
+++ b/__tests__/fixtures/install/install-nested-resolutions/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "foo": "file:bar"
+  },
+  "resolutions": {
+    "strip-ansi": "2.0.1",
+    "ansi-regex": "1.1.1"
+  }
+}

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -562,7 +562,7 @@ export default class PackageResolver {
   resolveToResolution(req: DependencyRequestPattern): ?DependencyRequestPattern {
     const {parentNames, pattern} = req;
 
-    if (!parentNames) {
+    if (!parentNames || this.flat) {
       return req;
     }
 

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -565,14 +565,16 @@ export default class PackageResolver {
     const resolution = this.resolutionMap.find(pattern, parentNames);
 
     if (resolution) {
-      const resolutionManifest = this.getStrictResolvedPattern(resolution);
-      invariant(resolutionManifest._reference, 'resolutions should have a resolved reference');
+      const resolutionManifest = this.getResolvedPattern(resolution);
 
-      resolutionManifest._reference.patterns.push(pattern);
-      this.addPattern(pattern, resolutionManifest);
-      this.lockfile.removePattern(pattern);
+      if (resolutionManifest) {
+        invariant(resolutionManifest._reference, 'resolutions should have a resolved reference');
+        resolutionManifest._reference.patterns.push(pattern);
+        this.addPattern(pattern, resolutionManifest);
+        this.lockfile.removePattern(pattern);
 
-      return null;
+        return null;
+      }
     }
 
     return req;

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -530,6 +530,10 @@ export default class PackageResolver {
     // resolved to existing versions can be resolved to their best available version
     this.resolvePackagesWithExistingVersions();
 
+    for (const req of this.resolutionMap.delayQueue) {
+      this.resolveToResolution(req);
+    }
+
     activity.end();
     this.activity = null;
   }
@@ -572,9 +576,11 @@ export default class PackageResolver {
         resolutionManifest._reference.patterns.push(pattern);
         this.addPattern(pattern, resolutionManifest);
         this.lockfile.removePattern(pattern);
-
-        return null;
+      } else {
+        this.resolutionMap.addToDelayQueue(req);
       }
+
+      return null;
     }
 
     return req;

--- a/src/resolution-map.js
+++ b/src/resolution-map.js
@@ -4,6 +4,7 @@ import minimatch from 'minimatch';
 import map from './util/map';
 import type Config from './config';
 import type {Reporter} from './reporters';
+import type {DependencyRequestPattern} from './types';
 import {normalizePattern} from './util/normalize-pattern.js';
 import parsePackagePath, {isValidPackagePath} from './util/parse-package-path';
 import {getExoticResolver} from './resolvers';
@@ -37,7 +38,7 @@ export default class ResolutionMap {
   resolutionsByPackage: ResolutionInternalMap;
   config: Config;
   reporter: Reporter;
-  delayQueue: Set;
+  delayQueue: Set<DependencyRequestPattern>;
 
   init(resolutions: ?ResolutionEntry = {}) {
     for (const globPattern in resolutions) {
@@ -50,7 +51,7 @@ export default class ResolutionMap {
     }
   }
 
-  addToDelayQueue(req) {
+  addToDelayQueue(req: DependencyRequestPattern) {
     this.delayQueue.add(req);
   }
 

--- a/src/resolution-map.js
+++ b/src/resolution-map.js
@@ -31,11 +31,13 @@ export default class ResolutionMap {
     this.resolutionsByPackage = map();
     this.config = config;
     this.reporter = config.reporter;
+    this.delayQueue = new Set();
   }
 
   resolutionsByPackage: ResolutionInternalMap;
   config: Config;
   reporter: Reporter;
+  delayQueue: Set;
 
   init(resolutions: ?ResolutionEntry = {}) {
     for (const globPattern in resolutions) {
@@ -46,6 +48,10 @@ export default class ResolutionMap {
         this.resolutionsByPackage[info.name] = [...resolution, info];
       }
     }
+  }
+
+  addToDelayQueue(req) {
+    this.delayQueue.add(req);
   }
 
   parsePatternInfo(globPattern: string, range: string): ?Object {


### PR DESCRIPTION
**Summary**
Fix for https://github.com/yarnpkg/yarn/issues/4357.

The issue is that when a dependency (dep A) defined in resolutions (includes dep A, dep B) depends on another resolution (dep B), then it expects to match its own nested dep B to the top level resolution dep B. So the first part of this fix is "don't run resolutions map check when it's in flat mode", which is what threw the invariant warning. Second part of the fix is that we still want that nested dependency (dep B) of a resolution (dep A) to be resolved correctly. `--flat` mode solves this by [collapsing all versions](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/install.js#L558) after the resolver is done. For resolutions, I'm adding a delay queue for requests with resolutions but no manifests found yet so that they will be resolved later.

**Test plan**
Added tests in resolutions
