### PR TITLE
Free tests from FORCE_COLOR environment variable dependency

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -30,14 +30,15 @@ async function execCommand(
   }
 
   return new Promise((resolve, reject) => {
+    const cleanedEnv = {...process.env};
+    cleanedEnv['YARN_SILENT'] = 0;
+    delete cleanedEnv['FORCE_COLOR'];
+
     exec(
       `node "${yarnBin}" ${cmd} ${args.join(' ')}`,
       {
         cwd: workingDir,
-        env: {
-          ...process.env,
-          YARN_SILENT: 0,
-        },
+        env: cleanedEnv,
       },
       (error, stdout) => {
         if (error) {

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -59,6 +59,11 @@ const PORT_RANGE = MAX_PORT_NUM - MIN_PORT_NUM;
 const getRandomPort = () => Math.floor(Math.random() * PORT_RANGE) + MIN_PORT_NUM;
 
 async function runYarn(args: Array<string> = [], options: Object = {}): Promise<Array<Buffer>> {
+  if (!options['env']) {
+    options['env'] = {...process.env};
+    options['extendEnv'] = false;
+  }
+  delete options['env']['FORCE_COLOR'];
   const {stdout, stderr} = await execa(path.resolve(__dirname, '../bin/yarn'), args, options);
 
   return [stdout, stderr];

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -19,14 +19,15 @@ async function execCommand(cmd: string, packageName: string, env = process.env):
   await fs.copy(srcPackageDir, packageDir, new NoopReporter());
 
   return new Promise((resolve, reject) => {
+    const cleanedEnv = {...env};
+    cleanedEnv['YARN_SILENT'] = 0;
+    delete cleanedEnv['FORCE_COLOR'];
+
     exec(
       `node "${yarnBin}" ${cmd}`,
       {
         cwd: packageDir,
-        env: {
-          ...env,
-          YARN_SILENT: 0,
-        },
+        env: cleanedEnv,
       },
       (err, stdout) => {
         if (err) {


### PR DESCRIPTION
FORCE_COLOR environment variable allows to force yarn to use
colors. This makes some of tests fail because of comparing
colorized output with plain strings.

For example, if you run a test in environment where
FORCE_COLOR is set you get this failure:

```
 FAIL  __tests__\index.js
  ● should add package
    expect(received).toEqual(expected)
    Expected value to equal:
      "success Saved lockfile."
    Received:
success Saved lockfile."
```