### PR TITLE
Fix: fix incorrect argument parsing

### DIFF
--- a/__tests__/fixtures/index/run-custom-script-with-arguments/echo.js
+++ b/__tests__/fixtures/index/run-custom-script-with-arguments/echo.js
@@ -1,1 +1,1 @@
-console.log(`A message from custom script with args ${process.argv[process.argv.length - 1]}`);
+console.log(JSON.stringify(process.argv));

--- a/__tests__/fixtures/index/run-custom-script-with-arguments/echo.js
+++ b/__tests__/fixtures/index/run-custom-script-with-arguments/echo.js
@@ -1,0 +1,1 @@
+console.log(`A message from custom script with args ${process.argv[process.argv.length - 1]}`);

--- a/__tests__/fixtures/index/run-custom-script-with-arguments/package.json
+++ b/__tests__/fixtures/index/run-custom-script-with-arguments/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "scripts": {
-    "custom-script": "node -p -e \"`A message from custom script with args ${process.argv[process.argv.length - 1]}`\" -- "
+    "custom-script": "node -p -e \"'A message from custom script with args ' + process.argv[process.argv.length - 1]\" -- "
   }
 }

--- a/__tests__/fixtures/index/run-custom-script-with-arguments/package.json
+++ b/__tests__/fixtures/index/run-custom-script-with-arguments/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "scripts": {
-    "custom-script": "print() { echo \"A message from custom script with args \"$@\"\"; }; print "
+    "custom-script": "node -p -e \"`A message from custom script with args ${process.argv[process.argv.length - 1]}`\" -- "
   }
 }

--- a/__tests__/fixtures/index/run-custom-script-with-arguments/package.json
+++ b/__tests__/fixtures/index/run-custom-script-with-arguments/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "scripts": {
-    "custom-script": "node -p -e \"'A message from custom script with args ' + process.argv[process.argv.length - 1]\" -- "
+    "custom-script": "node echo.js"
   }
 }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -256,7 +256,7 @@ test.concurrent('should run help of run command if --help is before script', asy
 
 test.concurrent('should run help of custom-script if --help is after script', async () => {
   const stdout = await execCommand('run', ['--silent', 'custom-script', '--help'], 'run-custom-script-with-arguments');
-  expect(JSON.parse(stdout)).toContain('--help');
+  expect(JSON.parse(stdout.join('\n'))).toContain('--help');
 });
 
 test.concurrent('should run bin command', async () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -248,12 +248,10 @@ test.concurrent('should run help of run command if --help is before script', asy
   );
 });
 
-if (process.platform !== 'win32') {
-  test.concurrent('should run help of custom-script if --help is after script', async () => {
-    const stdout = await execCommand('run', ['custom-script', '--help'], 'run-custom-script-with-arguments');
-    expect(stdout[stdout.length - 2]).toEqual('A message from custom script with args --help');
-  });
-}
+test.concurrent('should run help of custom-script if --help is after script', async () => {
+  const stdout = await execCommand('run', ['custom-script', '--help'], 'run-custom-script-with-arguments');
+  expect(stdout[stdout.length - 2]).toEqual('A message from custom script with args --help');
+});
 
 test.concurrent('should run bin command', async () => {
   const stdout = await execCommand('bin', [], '', true);

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -255,8 +255,8 @@ test.concurrent('should run help of run command if --help is before script', asy
 });
 
 test.concurrent('should run help of custom-script if --help is after script', async () => {
-  const stdout = await execCommand('run', ['custom-script', '--help'], 'run-custom-script-with-arguments');
-  expect(stdout[stdout.length - 2]).toEqual('A message from custom script with args --help');
+  const stdout = await execCommand('run', ['--silent', 'custom-script', '--help'], 'run-custom-script-with-arguments');
+  expect(JSON.parse(stdout)).toContain('--help');
 });
 
 test.concurrent('should run bin command', async () => {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -101,7 +101,14 @@ export function main({
   }
 
   // get command name
-  const firstNonFlagIndex = args.findIndex(arg => !arg.startsWith('-'));
+  const firstNonFlagIndex = args.findIndex((arg, idx, arr) => {
+    const isOption = arg.startsWith('-');
+    const prev = idx > 0 && arr[idx - 1];
+    const prevOption = prev && prev.startsWith('-') && commander.optionFor(prev);
+    const boundToPrevOption = prevOption && prevOption.required;
+
+    return !isOption && !boundToPrevOption;
+  });
   let preCommandArgs;
   let commandName = '';
   if (firstNonFlagIndex > -1) {
@@ -114,7 +121,6 @@ export function main({
   }
 
   let isKnownCommand = Object.prototype.hasOwnProperty.call(commands, commandName);
-
   const isHelp = arg => arg === '--help' || arg === '-h';
   const helpInPre = preCommandArgs.findIndex(isHelp);
   const helpInArgs = args.findIndex(isHelp);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -113,8 +113,9 @@ export function main({
     args = [];
   }
 
-  const isHelp = arg => arg === '--help' || arg === '-h';
   let isKnownCommand = Object.prototype.hasOwnProperty.call(commands, commandName);
+
+  const isHelp = arg => arg === '--help' || arg === '-h';
   const helpInPre = preCommandArgs.findIndex(isHelp);
   const helpInArgs = args.findIndex(isHelp);
   const setHelpMode = () => {
@@ -128,7 +129,7 @@ export function main({
   if (helpInPre > -1) {
     preCommandArgs.splice(helpInPre);
     setHelpMode();
-  } else if (isKnownCommand && helpInArgs > -1) {
+  } else if (isKnownCommand && helpInArgs === 0) {
     args.splice(helpInArgs);
     setHelpMode();
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -93,38 +93,56 @@ export function main({
   commander.option('--non-interactive', 'do not show interactive prompts');
   commander.option('--scripts-prepend-node-path [bool]', 'prepend the node executable dir to the PATH in scripts');
 
-  // get command name
-  let commandName: string = args.shift() || 'install';
-
   // if -v is the first command, then always exit after returning the version
-  if (commandName === '-v') {
+  if (args[0] === '-v') {
     console.log(version.trim());
     process.exitCode = 0;
     return;
   }
 
-  if (commandName === '--help' || commandName === '-h') {
-    commandName = 'help';
+  // get command name
+  const firstNonFlagIndex = args.findIndex(arg => !arg.startsWith('-'));
+  let preCommandArgs;
+  let commandName = '';
+  if (firstNonFlagIndex > -1) {
+    preCommandArgs = args.slice(0, firstNonFlagIndex);
+    commandName = args[firstNonFlagIndex];
+    args = args.slice(firstNonFlagIndex + 1);
+  } else {
+    preCommandArgs = args;
+    args = [];
   }
 
-  if (Object.prototype.hasOwnProperty.call(commands, commandName) && (args[0] === '--help' || args[0] === '-h')) {
-    args.unshift(commandName);
+  const isHelp = arg => arg === '--help' || arg === '-h';
+  let isKnownCommand = Object.prototype.hasOwnProperty.call(commands, commandName);
+  const helpInPre = preCommandArgs.findIndex(isHelp);
+  const helpInArgs = args.findIndex(isHelp);
+  const setHelpMode = () => {
+    if (isKnownCommand) {
+      args.unshift(commandName);
+    }
     commandName = 'help';
-  }
+    isKnownCommand = true;
+  };
 
-  // if no args or command name looks like a flag then set default to `install`
-  if (commandName[0] === '-') {
-    args.unshift(commandName);
-    commandName = 'install';
+  if (helpInPre > -1) {
+    preCommandArgs.splice(helpInPre);
+    setHelpMode();
+  } else if (isKnownCommand && helpInArgs > -1) {
+    args.splice(helpInArgs);
+    setHelpMode();
   }
 
   let command;
-  if (Object.prototype.hasOwnProperty.call(commands, commandName)) {
-    command = commands[commandName];
+  if (!commandName) {
+    commandName = 'install';
+    isKnownCommand = true;
   }
 
-  // if command is not recognized, then set default to `run`
-  if (!command) {
+  if (isKnownCommand) {
+    command = commands[commandName];
+  } else {
+    // if command is not recognized, then set default to `run`
     args.unshift(commandName);
     command = commands.run;
   }
@@ -138,6 +156,8 @@ export function main({
       warnAboutRunDashDash = true;
     }
   }
+
+  args = [...preCommandArgs, ...args];
 
   command.setFlags(commander);
   commander.parse([
@@ -489,8 +509,8 @@ export function main({
         onUnexpectedError(err);
       }
 
-      if (commands[commandName]) {
-        reporter.info(commands[commandName].getDocsInfo);
+      if (command.getDocsInfo) {
+        reporter.info(command.getDocsInfo);
       }
 
       return exit(1);


### PR DESCRIPTION
**Summary**

Fixes #4383. This patch makes argument parsing a bit tidier, and
starts supporting `yarn --silent custom-script` style commands as
initiall intended by #4152.

**Test plan**

Existing unit tests. Should ideally add a few more.