### PR TITLE
Fix: don't generate a lockfile when --frozen-lockfile is used

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -66,6 +66,7 @@ function expectAddSuccessfullOutput(stdout, pkg) {
 
 function expectAddSuccessfullOutputWithNoLockFile(stdout, pkg) {
   const lastLines = stdout.slice(stdout.length - 4);
+  expect(lastLines[0]).not.toEqual('success Saved lockfile.');
   expect(lastLines[1]).toEqual('success Saved 1 new dependency.');
   expect(lastLines[2]).toContain(pkg);
   expect(lastLines[3]).toContain('Done');
@@ -116,6 +117,12 @@ test.concurrent('should add package with no-lockfile option', async () => {
   const stdout = await execCommand('add', ['repeating', '--no-lockfile'], 'run-add-option', true);
   expectAddSuccessfullOutputWithNoLockFile(stdout, 'repeating');
 });
+
+test.concurrent('should add package with frozzen-lockfile option', async () => {
+  const stdout = await execCommand('add', ['repeating', '--frozen-lockfile'], 'run-add-option', true);
+  expectAddSuccessfullOutputWithNoLockFile(stdout, 'repeating');
+});
+
 
 test.concurrent('should add package with no-lockfile option in front', async () => {
   const stdout = await execCommand('add', ['--no-lockfile', 'split-lines'], 'run-add-option-in-front', true);

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -123,7 +123,6 @@ test.concurrent('should add package with frozzen-lockfile option', async () => {
   expectAddSuccessfullOutputWithNoLockFile(stdout, 'repeating');
 });
 
-
 test.concurrent('should add package with no-lockfile option in front', async () => {
   const stdout = await execCommand('add', ['--no-lockfile', 'split-lines'], 'run-add-option-in-front', true);
   expectAddSuccessfullOutputWithNoLockFile(stdout, 'split-lines');

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -705,8 +705,8 @@ export class Install {
       this.scripts.getArtifacts(),
     );
 
-    // --no-lockfile or --pure-lockfile flag
-    if (this.flags.lockfile === false || this.flags.pureLockfile) {
+    // --no-lockfile or --pure-lockfile or --frozen-lockfile flag
+    if (this.flags.lockfile === false || this.flags.pureLockfile || this.flags.frozenLockfile) {
       return;
     }
 


### PR DESCRIPTION
**Summary**

Fixes #4344.

**Test plan**

Added new test.