### PR TITLE
Chore: add instructions about using local builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,30 +10,36 @@ please read the [code of conduct](CODE_OF_CONDUCT.md).
 1. Run the following commands:
 
 ```sh
-$ git clone YOUR_YARN_REPO_URL
-$ cd yarn
-$ yarn
-$ yarn run build
+git clone YOUR_YARN_REPO_URL
+cd yarn
+yarn
+yarn run build
 ```
 
 ## Building
 
 ```sh
-$ yarn run build
+yarn run build
 ```
 
 ```sh
-$ yarn run watch
+yarn run watch
+```
+
+## Using the local builds
+
+```sh
+alias yarn="node /path/to/yarn/lib/cli/index.js"
 ```
 
 ## Testing
 
 ```sh
-$ yarn run test
+yarn run test
 ```
 
 ```sh
-$ yarn run lint
+yarn run lint
 ```
 
 ## Pull Requests


### PR DESCRIPTION
**Summary**

I got questions about how to run the latest master locally and realized this is not document. This patch documents how to run local yarn builds for potential contributors. 

**Test plan**

Test the suggested change locally and verify it actually works.