### PR TITLE
Bolds the titles in a list

### DIFF
--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -134,7 +134,7 @@ export default class ConsoleReporter extends BaseReporter {
 
     if (hints) {
       for (const item of items) {
-        this._log(`${' '.repeat(gutterWidth)}- ${item}`);
+        this._log(`${' '.repeat(gutterWidth)}- ${this.format.bold(item)}`);
         this._log(`  ${' '.repeat(gutterWidth)} ${hints[item]}`);
       }
     } else {


### PR DESCRIPTION
**Summary**

Not substantial. It makes it easier to differentiate the items in a list vs the hint. Here is the before:

![screen shot 2017-09-11 at 3 18 25 pm](https://user-images.githubusercontent.com/49038/30292973-0431c13c-9706-11e7-95da-f32452154004.png)

and the after:

![screen shot 2017-09-11 at 3 20 57 pm](https://user-images.githubusercontent.com/49038/30292985-1133c164-9706-11e7-813e-c26f422f068d.png)


**Test plan**

I ran the tests, and only ones that failed on master failed for me here 🥇