### PR TITLE
Fix: yarn bin should produce output even when silent

### DIFF
--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -14,6 +14,6 @@ export function setFlags(commander: Object) {}
 
 export function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const binFolder = path.join(config.cwd, config.registries[RegistryYarn.registry].folder, '.bin');
-  reporter.log(binFolder);
+  reporter.log(binFolder, {force: true});
   return Promise.resolve();
 }


### PR DESCRIPTION
**Summary**

Fixes #4371.

**Test plan**

Manual verification: `yarn --silent bin` or `YARN_SILENT=1 yarn bin` should produce output.