### PR TITLE
Fix #4369: Include pull requests in git ref search

### DIFF
--- a/__tests__/util/git/git-ref-resolver.js
+++ b/__tests__/util/git/git-ref-resolver.js
@@ -27,6 +27,7 @@ test('resolveVersion', async () => {
   refs.set('refs/tags/v1.1.0', '37d5ed001dc4402d5446911c4e1cb589449e7d8d');
   refs.set('refs/tags/v2.2.0', 'e88209b9513544a22fc3f8660e3d829281dc2c9f');
   refs.set('refs/tags/both', 'f0dbab0a4345a64f544af37e24fc8187176936a4');
+  refs.set('refs/pull/100/head', '6e97e0159f10c275f227d0f067d99f2a97331cef');
   const emptyRefs: GitRefs = new Map();
   const git = new GitMock();
 
@@ -68,6 +69,10 @@ test('resolveVersion', async () => {
   expect(await resolve('v1.1.0')).toEqual({
     sha: '37d5ed001dc4402d5446911c4e1cb589449e7d8d',
     ref: 'refs/tags/v1.1.0',
+  });
+  expect(await resolve('100/head')).toEqual({
+    sha: '6e97e0159f10c275f227d0f067d99f2a97331cef',
+    ref: 'refs/pull/100/head',
   });
   // not-existing sha
   expect(await resolve('0123456')).toEqual(null);

--- a/src/util/git/git-ref-resolver.js
+++ b/src/util/git/git-ref-resolver.js
@@ -64,7 +64,7 @@ const tryVersionAsTagName = ({version, refs}: ResolveVersionOptions): ?ResolvedS
   tryRef(refs, `${REF_TAG_PREFIX}${version}`);
 
 const tryVersionAsPullRequestNo = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
-    tryRef(refs, `${REF_PR_PREFIX}${version}`);
+  tryRef(refs, `${REF_PR_PREFIX}${version}`);
 
 const tryVersionAsBranchName = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
   tryRef(refs, `${REF_BRANCH_PREFIX}${version}`);

--- a/src/util/git/git-ref-resolver.js
+++ b/src/util/git/git-ref-resolver.js
@@ -21,11 +21,12 @@ type Names = {tags: Array<string>, heads: Array<string>};
 
 const REF_TAG_PREFIX = 'refs/tags/';
 const REF_BRANCH_PREFIX = 'refs/heads/';
+const REF_PR_PREFIX = 'refs/pull/';
 
 // This regex is designed to match output from git of the style:
 //   ebeb6eafceb61dd08441ffe086c77eb472842494  refs/tags/v0.21.0
 // and extract the hash and ref name as capture groups
-const GIT_REF_LINE_REGEXP = /^([a-fA-F0-9]+)\s+(refs\/(?:tags|heads)\/.*)$/;
+const GIT_REF_LINE_REGEXP = /^([a-fA-F0-9]+)\s+(refs\/(?:tags|heads|pull)\/.*)$/;
 
 const COMMIT_SHA_REGEXP = /^[a-f0-9]{5,40}$/;
 const REF_NAME_REGEXP = /^refs\/(tags|heads)\/(.+)$/;
@@ -61,6 +62,9 @@ const tryVersionAsFullRef = ({version, refs}: ResolveVersionOptions): ?ResolvedS
 
 const tryVersionAsTagName = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
   tryRef(refs, `${REF_TAG_PREFIX}${version}`);
+
+const tryVersionAsPullRequestNo = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
+    tryRef(refs, `${REF_PR_PREFIX}${version}`);
 
 const tryVersionAsBranchName = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
   tryRef(refs, `${REF_BRANCH_PREFIX}${version}`);
@@ -112,6 +116,7 @@ const VERSION_RESOLUTION_STEPS: Array<(ResolveVersionOptions) => ?ResolvedSha | 
   tryVersionAsGitCommit,
   tryVersionAsFullRef,
   tryVersionAsTagName,
+  tryVersionAsPullRequestNo,
   tryVersionAsBranchName,
   tryVersionAsSemverRange,
   tryWildcardVersionAsDefaultBranch,


### PR DESCRIPTION
**Summary**

Fixes https://github.com/yarnpkg/yarn/issues/4369, a regression from previous refactor.
Include `pull` requests in ref search and test for it later when it's called by github resolver.

*BEFORE*
![before](https://user-images.githubusercontent.com/18429494/30309691-7aeabe2e-9741-11e7-8e34-c75413b83d99.png)


*AFTER*
![after](https://user-images.githubusercontent.com/18429494/30309693-7dcc3528-9741-11e7-8a74-bc7585fd6177.png)

**Test plan**

Added a unit test in `git/git-ref-resolver.js`