### PR TITLE
Chore: fix misues of -p in node infocations

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -15,8 +15,8 @@ case "$(uname -s)" in
     ;;
 esac
 
-version=`node -p -e "require('./package.json').version"`
-node_version=`node -p -e "process.versions.node.split('.')[0]"`
+version=`node -p "require('./package.json').version"`
+node_version=`node -p "process.versions.node.split('.')[0]"`
 
 rm -rf artifacts dist
 mkdir artifacts
@@ -47,7 +47,7 @@ cp node_modules/v8-compile-cache/v8-compile-cache.js dist/lib/v8-compile-cache.j
 # Verify that it works as expected
 [[ "$version" == "$(./dist/bin/yarn --version)" ]] || exit 1;
 
-./scripts/update-dist-manifest.js $(node -p -e "require('fs').realpathSync('dist/package.json')") tar
+./scripts/update-dist-manifest.js $(node -p "require('fs').realpathSync('dist/package.json')") tar
 
 case "$(tar --version)" in
   *GNU*)

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -3,13 +3,13 @@
 set -ex
 
 yarn version --new-version minor
-VERSION=$(node -p -e "require('./package.json').version")
+VERSION=$(node -p "require('./package.json').version")
 BRANCH=$(echo "$VERSION" | (IFS="."; read a b c && echo $a.$b-stable))
 echo "$BRANCH"
 git checkout -b "$BRANCH"
 git push origin "$BRANCH" --follow-tags
 git checkout master
 yarn version --new-version preminor --no-git-tag-version
-NEW_VERSION=$(node -p -e "require('./package.json').version")
+NEW_VERSION=$(node -p "require('./package.json').version")
 git commit -a -m "$NEW_VERSION"
 git push origin master


### PR DESCRIPTION
**Summary**

We've been using `node -p -e` where `-e` is redundant since
it is implied by `-p`: https://nodejs.org/api/cli.html#cli_p_print_script

This patch removes those extra `-e`s.

**Test plan**

All bundles should build on CI without errors.