### PR TITLE
Chore: fix flaky `add` tests by using separate cache

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -33,7 +33,7 @@ async function execCommand(
 
   return new Promise((resolve, reject) => {
     exec(
-      `node "${yarnBin}" ${cmd} --cache-folder="${cacheDir}" ${args.join(' ')}`,
+      `node "${yarnBin}" --cache-folder="${cacheDir}" ${cmd} ${args.join(' ')}`,
       {
         cwd: workingDir,
         env: {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -29,9 +29,11 @@ async function execCommand(
     await fs.copy(srcDir, workingDir, new NoopReporter());
   }
 
+  const cacheDir = path.join(workingDir, '.yarn-cache');
+
   return new Promise((resolve, reject) => {
     exec(
-      `node "${yarnBin}" ${cmd} ${args.join(' ')}`,
+      `node "${yarnBin}" ${cmd} --cache-folder="${cacheDir}" ${args.join(' ')}`,
       {
         cwd: workingDir,
         env: {


### PR DESCRIPTION
**Summary**

This PR fixes some test flakiness, especially in the
"should add package with frozzen-lockfile option" tests
where we get `ENOENT` errors from cache. This is most
likely because multiple `add` tests are run concurrently
causing cache corruption. This PR makes all `execCommand`
invocations use a separate cache.

**Test plan**

Tests should not be flaky anymore.