### PR TITLE
Fix: always output reporter.inspect values and `config get` result

### DIFF
--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -26,7 +26,7 @@ export const {run, setFlags, examples} = buildSubCommands('config', {
       return false;
     }
 
-    reporter.log(String(config.getOption(args[0])));
+    reporter.log(String(config.getOption(args[0])), {force: true});
     return true;
   },
 

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -126,7 +126,7 @@ export default class ConsoleReporter extends BaseReporter {
       });
     }
 
-    this.log('' + value);
+    this.log('' + value, {force: true});
   }
 
   list(key: string, items: Array<string>, hints?: Object) {

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -126,7 +126,7 @@ export default class ConsoleReporter extends BaseReporter {
       });
     }
 
-    this.log('' + value, {force: true});
+    this.log(String(value), {force: true});
   }
 
   list(key: string, items: Array<string>, hints?: Object) {


### PR DESCRIPTION
**Summary**

Fixes #3922. Certain commands in yarn should always produce an
output, regardless of the silent status. This makes
`reporter.inspect` for console reporter to always produce an
output. It also forces the output of `yarn config get` to override
silent mode.

**Test plan**

Should add integration tests.