### PR TITLE
Fix: Diffing identical versions should not include extra period at end (#4395)

### DIFF
--- a/__tests__/util/colorize-diff.js
+++ b/__tests__/util/colorize-diff.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+import colorizeDiff from '../../src/util/colorize-diff';
+import {Reporter} from '../../src/reporters';
+
+let from;
+let to;
+let reporter;
+
+describe('colorizeDiff', () => {
+  beforeAll(() => {
+    reporter = new Reporter();
+  });
+
+  describe('when `from` and `to` versions are identical', () => {
+    beforeEach(() => {
+      from = '1.0.0';
+      to = '1.0.0';
+    });
+
+    it('returns from/to value', () => {
+      expect(colorizeDiff(from, to, reporter)).toEqual(from);
+    });
+  });
+});

--- a/src/util/colorize-diff.js
+++ b/src/util/colorize-diff.js
@@ -6,8 +6,10 @@ export default function(from: string, to: string, reporter: Reporter): string {
   const parts = to.split('.');
   const fromParts = from.split('.');
 
-  const index = parts.findIndex((part, i) => part !== fromParts[i]);
-  const splitIndex = index >= 0 ? index : parts.length;
+  const splitIndex = parts.findIndex((part, i) => part !== fromParts[i]);
+  if (splitIndex === -1) {
+    return from;
+  }
 
   const colorized = reporter.format.green(parts.slice(splitIndex).join('.'));
   return parts.slice(0, splitIndex).concat(colorized).join('.');


### PR DESCRIPTION
**Summary**
Fixes #4395 

This PR fixes a bug that causes `colorizedDiff` to append a period at the end of the return value if the `from`/`to` versions are identical. If they do happen to be identical, then it will simply return the `from` value.

**Test plan**
I am currently testing that, given identical `from`/`to` versions, it returns the `from` (or `to`) version. I've not added unit tests to cover when the versions differ in any way, nor am I testing that the returned string is formatted correctly (e.g., if `from = '1.0.0'` and `to = '1.0.1'`, the result should be `1.0.1` with the trailing one being formatted to green)