### PR TITLE
Fix fakeroot detection

### DIFF
--- a/src/util/root-user.js
+++ b/src/util/root-user.js
@@ -7,9 +7,9 @@ function getUid(): ?number {
   return null;
 }
 
-export default isRootUser(getUid()) && isNotFakeRoot();
+export default isRootUser(getUid()) && !isFakeRoot();
 
-export function isNotFakeRoot(): boolean {
+export function isFakeRoot(): boolean {
   return Boolean(process.env.FAKEROOTKEY);
 }
 


### PR DESCRIPTION
I think that fixes #4430

`fakeroot` detection was added in #3924 (7a053e2ca07d19b2e2eebeeb0c27edaacfd67904); it actually tests the exact opposite though. 

For testing this I added the line
```JavaScript
console.log("isFakeRoot", isFakeRoot());
```

I then tried the lines
```
./yarn global add
sudo ./yarn global add
fakeroot ./yarn global add
```

I also tried if `ROOT_USER` is now correct in [user-home-dir.js](https://github.com/yarnpkg/yarn/blob/0ef3bf1f03d128e4793eca3fe3b5f93542451f15/src/util/user-home-dir.js) for these 3 commands. 
```JavaScript
console.log("ROOT_USER", ROOT_USER);
```