### PR TITLE
Fix #4346 yarn upgrade interactive exit

### DIFF
--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -453,24 +453,9 @@ export default class ConsoleReporter extends BaseReporter {
       output: this.stdout,
     });
 
-    let rejectRef = () => {};
-    const killListener = () => {
-      rejectRef();
-    };
-
-    const handleKillFromInquirer = new Promise((resolve, reject) => {
-      rejectRef = reject;
-    });
-
-    rl.addListener('SIGINT', killListener);
-
     const {name = 'prompt', type = 'input', validate} = options;
-    const answers: InquirerResponses<string, T> = await Promise.race([
-      prompt([{name, type, message, choices, pageSize, validate}]),
-      handleKillFromInquirer,
-    ]);
+    const answers: InquirerResponses<string, T> = await prompt([{name, type, message, choices, pageSize, validate}]);
 
-    rl.removeListener('SIGINT', killListener);
     rl.close();
 
     return answers[name];


### PR DESCRIPTION
**Summary**

A combination of changes have caused `yarn upgrade-interactive` to exit with a promise rejection. 

In short, I believe it has always been a problem, but #3995 exposed it to the prompt. 

The child rejection inside of [upgrade-interactive](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/upgrade-interactive.js#L152) is fine, as it was handled by the `Promise.race` condition; however, rejecting at the parent level inside of [console-reporter](https://github.com/yarnpkg/yarn/blob/master/src/reporters/console/console-reporter.js#L458) causes[ loud-rejection](https://github.com/sindresorhus/loud-rejection) to handle this.

I believe @arcanis 's PR #4283 is what would allow us not to hook into `SIGINT` inside of the console reporter and allow the reporter to cleanly close itself.

**Test Plan**

Will work on some scenarios! This PR needs some more verification on my end ... @BYK @torifat @arcanis please jump in and provide any feedback you think could be helpful! Opened early for visibility :)