### PR TITLE
Add test for isFakeRoot

### DIFF
--- a/__tests__/util/root-user.js
+++ b/__tests__/util/root-user.js
@@ -1,9 +1,20 @@
 /* @flow */
 
-import {isRootUser} from '../../src/util/root-user.js';
+import {isRootUser, isFakeRoot} from '../../src/util/root-user.js';
 
 test('isRootUser', () => {
   expect(isRootUser(null)).toBe(false);
   expect(isRootUser(1001)).toBe(false);
   expect(isRootUser(0)).toBe(true);
+});
+
+test('isFakeRoot', () => {
+  delete process.env.FAKEROOTKEY;
+
+  expect(isFakeRoot()).toBe(false);
+
+  process.env.FAKEROOTKEY = '15574641';
+  expect(isFakeRoot()).toBe(true);
+
+  delete process.env.FAKEROOTKEY;
 });

--- a/__tests__/util/root-user.js
+++ b/__tests__/util/root-user.js
@@ -9,6 +9,8 @@ test('isRootUser', () => {
 });
 
 test('isFakeRoot', () => {
+  const hasFakerootPreviously = 'FAKEROOTKEY' in process.env;
+  const oldValue = process.env.FAKEROOTKEY;
   delete process.env.FAKEROOTKEY;
 
   expect(isFakeRoot()).toBe(false);
@@ -16,5 +18,7 @@ test('isFakeRoot', () => {
   process.env.FAKEROOTKEY = '15574641';
   expect(isFakeRoot()).toBe(true);
 
-  delete process.env.FAKEROOTKEY;
+  if (hasFakerootPreviously) {
+    process.env.FAKEROOTKEY = oldValue;
+  }
 });


### PR DESCRIPTION
This adds a test for `isFakeRoot()` as proposed by @BYK in #4431.