### PR TITLE
Fix: always use origin/master instead of master for homebrew

### DIFF
--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -23,11 +23,10 @@ PATH=$PATH:$HOME/.linuxbrew/bin/
 pushd ~/.linuxbrew/Library/Taps/homebrew/homebrew-core
 #git remote set-url origin https://github.com/Daniel15/homebrew-core # for testing
 git remote set-url origin https://github.com/homebrew/homebrew-core
-git reset --hard HEAD
-git clean -fd
 git fetch --prune origin
+git reset --hard origin/master
+git clean -fd
 # Remove any existing branch (eg. if the previous attempt failed)
-git checkout master
 git branch -D yarn-$version || true
 popd
 

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -21,13 +21,18 @@ fi
 PATH=$PATH:$HOME/.linuxbrew/bin/
 # Ensure homebrew-core is pointing to Homebrew rather than Linuxbrew
 pushd ~/.linuxbrew/Library/Taps/homebrew/homebrew-core
-#git remote set-url origin https://github.com/Daniel15/homebrew-core # for testing
-git remote set-url origin https://github.com/homebrew/homebrew-core
-git fetch --prune origin
-git reset --hard origin/master
+git checkout master
 git clean -fd
 # Remove any existing branch (eg. if the previous attempt failed)
 git branch -D yarn-$version || true
+
+#git remote set-url origin https://github.com/Daniel15/homebrew-core # for testing
+git remote set-url origin https://github.com/homebrew/homebrew-core
+git fetch --prune origin
+# Use `git reset` instead of pull since we don't want a merge etc., we just want
+# local master to exactly reflect origin/master
+git reset --hard origin/master
+git clean -fd
 popd
 
 # Grab latest Yarn release so we can hash it


### PR DESCRIPTION
**Summary**

Fixes #3415. The old homebrew update script updated the repo
from remote but did not update the local `master` branch, thus
had the potential for conflicts and mismatches. This patch
forces it to use `origin/master` instead and uses the latest
up-to-date version from the source.

**Test plan**

N/A