### PR TITLE
Update: add DNS caching to request manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "death": "^1.0.0",
     "debug": "^2.2.0",
     "detect-indent": "^5.0.0",
+    "dnscache": "^1.0.1",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-relay": "0.0.8",

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -1,5 +1,11 @@
 /* @flow */
 
+import fs from 'fs';
+import url from 'url';
+import dnscache from 'dnscache';
+import invariant from 'invariant';
+import RequestCaptureHar from 'request-capture-har';
+
 import type {Reporter} from '../reporters/index.js';
 import {MessageError} from '../errors.js';
 import BlockingQueue from './blocking-queue.js';
@@ -9,11 +15,14 @@ import map from '../util/map.js';
 
 import typeof * as RequestModuleT from 'request';
 
-const RequestCaptureHar = require('request-capture-har');
-const invariant = require('invariant');
-const url = require('url');
-const fs = require('fs');
-
+// Initialize DNS cache so we don't look up the same
+// domains like registry.yarnpkg.com over and over again
+// for each request.
+dnscache({
+  enable: true,
+  ttl: 300,
+  cachesize: 10,
+});
 const successHosts = map();
 const controlOffline = network.isOffline();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,6 +194,10 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+
 asn1.js@^4.0.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.1.tgz#48ba240b45a9280e94748990ba597d216617fd40"
@@ -1402,6 +1406,13 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dnscache@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dnscache/-/dnscache-1.0.1.tgz#42cb2b9bfb5e8fbdfa395aac74e127fc05074d31"
+  dependencies:
+    asap "~2.0.3"
+    lodash.clone "~4.3.2"
 
 doctrine@^2.0.0:
   version "2.0.0"
@@ -3125,6 +3136,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash._baseclone@~4.5.0:
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz#ce42ade08384ef5d62fa77c30f61a46e686f8434"
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -3164,6 +3179,12 @@ lodash._root@^3.0.0:
 lodash.assignwith@^4.0.7:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb"
+
+lodash.clone@~4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.3.2.tgz#e56b176b6823a7dde38f7f2bf58de7d5971200e9"
+  dependencies:
+    lodash._baseclone "~4.5.0"
 
 lodash.escape@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
**Summary**

Fixes #746. Unfortunately, neither Node, nor many systems come with
built-in DNS caching so the many parallel requests that Yarn makes
sometimes overwhelm the DNS servers, and most of the time, for the
very same domain(s). Even worse, we pay the DNS look up cost for
each request, which is quite sad at best. This patch introduces
the `dnscache` module which intercepts all DNS look ups and answers
them from an in-memory cache when possible. This applies to the
built-in `http` and `https` modules, used by `request`.

**Test plan**

Existing tests should pass, and hopefully be faster. Total number of
DNS look ups should decrease dramatically.