### PR TITLE
fixes global add error message

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -914,7 +914,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     let command = 'add';
     if (flags.global) {
       error = 'globalFlagRemoved';
-      command = 'global';
+      command = 'global add';
     }
     throw new MessageError(reporter.lang(error, `yarn ${command} ${exampleArgs.join(' ')}`));
   }


### PR DESCRIPTION
**Summary**
Fixed incorrect documentation for global add deprecated message

**Test plan**

Run `yarn add -g left-pad` and follow the suggested command on the console. It should work.