### PR TITLE
Fix: Handle `null` versions in package.json

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -623,6 +623,12 @@ test.concurrent('install with comments in manifest', (): Promise<void> => {
   });
 });
 
+test.concurrent('install with null versions in manifest', (): Promise<void> => {
+  return runInstall({}, 'install-with-null-version', async config => {
+    expect(await fs.exists(path.join(config.cwd, 'node_modules', 'left-pad'))).toEqual(true);
+  });
+});
+
 test.concurrent('run install scripts in the order when one dependency does not have install script', (): Promise<
   void,
 > => {

--- a/__tests__/fixtures/install/install-with-null-version/package.json
+++ b/__tests__/fixtures/install/install-with-null-version/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "left-pad": null
+  }
+}

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -309,8 +309,12 @@ export default (async function(
   }
 
   for (const dependencyType of DEPENDENCY_TYPES) {
-    if (info[dependencyType] && typeof info[dependencyType] === 'object') {
-      delete info[dependencyType]['//'];
+    const dependencyList = info[dependencyType];
+    if (dependencyList && typeof dependencyList === 'object') {
+      delete dependencyList['//'];
+      for (const name in dependencyList) {
+        dependencyList[name] = dependencyList[name] || '';
+      }
     }
   }
 });


### PR DESCRIPTION
**Summary**

Fixes #4429. Apparently there's an advice on the internet to use
`null` as the package version to install the latest and even worse,
some people are actually doing this. This patch makes sure the 
version is at least a string (albeit an empty one) when fixing the 
manifest.

**Test plan**

Added new integration test.