### PR TITLE
Simplify import modules in tests

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -1,15 +1,15 @@
 /* @flow */
 
-import Lockfile from '../../src/lockfile';
-import {ConsoleReporter} from '../../src/reporters/index.js';
-import {Reporter} from '../../src/reporters/index.js';
-import {parse} from '../../src/lockfile';
-import * as constants from '../../src/constants.js';
-import {run as check} from '../../src/cli/commands/check.js';
-import * as fs from '../../src/util/fs.js';
-import {Install} from '../../src/cli/commands/install.js';
-import Config from '../../src/config.js';
-import parsePackagePath from '../../src/util/parse-package-path.js';
+import Lockfile from 'lockfile';
+import {ConsoleReporter} from 'reporters/index.js';
+import {Reporter} from 'reporters/index.js';
+import {parse} from 'lockfile';
+import * as constants from 'constants.js';
+import {run as check} from 'cli/commands/check.js';
+import * as fs from 'util/fs.js';
+import {Install} from 'cli/commands/install.js';
+import Config from 'config.js';
+import parsePackagePath from 'util/parse-package-path.js';
 
 const stream = require('stream');
 const path = require('path');

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import {ConsoleReporter} from '../../src/reporters/index.js';
-import * as reporters from '../../src/reporters/index.js';
+import {ConsoleReporter} from 'reporters/index.js';
+import * as reporters from 'reporters/index.js';
 import {
   getPackageVersion,
   createLockfile,
@@ -10,15 +10,15 @@ import {
   runInstall,
   makeConfigFromDirectory,
 } from './_helpers.js';
-import {Add, run as add} from '../../src/cli/commands/add.js';
-import * as constants from '../../src/constants.js';
-import {parse} from '../../src/lockfile';
-import {Install} from '../../src/cli/commands/install.js';
-import Lockfile from '../../src/lockfile';
-import {run as check} from '../../src/cli/commands/check.js';
-import * as fs from '../../src/util/fs.js';
+import {Add, run as add} from 'cli/commands/add.js';
+import * as constants from 'constants.js';
+import {parse} from 'lockfile';
+import {Install} from 'cli/commands/install.js';
+import Lockfile from 'lockfile';
+import {run as check} from 'cli/commands/check.js';
+import * as fs from 'util/fs.js';
 import semver from 'semver';
-import {promisify} from '../../src/util/promise';
+import {promisify} from 'util/promise';
 import fsNode from 'fs';
 import inquirer from 'inquirer';
 

--- a/__tests__/commands/autoclean.js
+++ b/__tests__/commands/autoclean.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import * as fs from '../../src/util/fs.js';
+import * as fs from 'util/fs.js';
 import {run} from './_helpers.js';
-import {run as autoclean} from '../../src/cli/commands/autoclean.js';
-import {ConsoleReporter} from '../../src/reporters/index.js';
-import {CLEAN_FILENAME} from '../../src/constants.js';
-import Config from '../../src/config.js';
+import {run as autoclean} from 'cli/commands/autoclean.js';
+import {ConsoleReporter} from 'reporters/index.js';
+import {CLEAN_FILENAME} from 'constants.js';
+import Config from 'config.js';
 import path from 'path';
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'autoclean');

--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import * as reporters from '../../src/reporters/index.js';
-import * as fs from '../../src/util/fs.js';
-import {run} from '../../src/cli/commands/cache.js';
+import * as reporters from 'reporters/index.js';
+import * as fs from 'util/fs.js';
+import {run} from 'cli/commands/cache.js';
 import {run as buildRun, runInstall} from './_helpers.js';
 
 const path = require('path');

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -1,12 +1,12 @@
 /* @flow */
 
 import {run as buildRun, runInstall} from './_helpers.js';
-import * as checkCmd from '../../src/cli/commands/check.js';
-import {Install} from '../../src/cli/commands/install.js';
-import Lockfile from '../../src/lockfile';
-import * as reporters from '../../src/reporters/index.js';
-import type {CLIFunctionReturn} from '../../src/types.js';
-import * as fs from '../../src/util/fs.js';
+import * as checkCmd from 'cli/commands/check.js';
+import {Install} from 'cli/commands/install.js';
+import Lockfile from 'lockfile';
+import * as reporters from 'reporters/index.js';
+import type {CLIFunctionReturn} from 'types.js';
+import * as fs from 'util/fs.js';
 
 const path = require('path');
 

--- a/__tests__/commands/config.js
+++ b/__tests__/commands/config.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import type {CLIFunctionReturn} from '../../src/types.js';
-import * as reporters from '../../src/reporters/index.js';
-import * as configCmd from '../../src/cli/commands/config.js';
+import type {CLIFunctionReturn} from 'types.js';
+import * as reporters from 'reporters/index.js';
+import * as configCmd from 'cli/commands/config.js';
 import {run as buildRun} from './_helpers.js';
-import * as fs from '../../src/util/fs.js';
+import * as fs from 'util/fs.js';
 
 const path = require('path');
 

--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import type {CLIFunctionReturn} from '../../src/types.js';
-import {ConsoleReporter} from '../../src/reporters/index.js';
+import type {CLIFunctionReturn} from 'types.js';
+import {ConsoleReporter} from 'reporters/index.js';
 import {run as buildRun} from './_helpers.js';
-import {run as global} from '../../src/cli/commands/global.js';
-import * as fs from '../../src/util/fs.js';
+import {run as global} from 'cli/commands/global.js';
+import * as fs from 'util/fs.js';
 import mkdir from '../_temp.js';
 const isCI = require('is-ci');
 

--- a/__tests__/commands/import.js
+++ b/__tests__/commands/import.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import type {CLIFunctionReturn} from '../../src/types.js';
-import * as reporters from '../../src/reporters/index.js';
-import * as importCmd from '../../src/cli/commands/import.js';
-import Lockfile from '../../src/lockfile';
-import * as fs from '../../src/util/fs.js';
+import type {CLIFunctionReturn} from 'types.js';
+import * as reporters from 'reporters/index.js';
+import * as importCmd from 'cli/commands/import.js';
+import Lockfile from 'lockfile';
+import * as fs from 'util/fs.js';
 import {run as buildRun} from './_helpers.js';
 
 const YARN_VERSION_REGEX = /yarn v\S+/;

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import * as reporters from '../../src/reporters/index.js';
-import {run as info} from '../../src/cli/commands/info.js';
-import {BufferReporter} from '../../src/reporters/index.js';
-import Config from '../../src/config.js';
+import * as reporters from 'reporters/index.js';
+import {run as info} from 'cli/commands/info.js';
+import {BufferReporter} from 'reporters/index.js';
+import Config from 'config.js';
 import path from 'path';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;

--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import type {QuestionOptions} from '../../src/reporters/types.js';
-import {ConsoleReporter} from '../../src/reporters/index.js';
+import type {QuestionOptions} from 'reporters/types.js';
+import {ConsoleReporter} from 'reporters/index.js';
 import {run as buildRun} from './_helpers.js';
-import {getGitConfigInfo, run as runInit} from '../../src/cli/commands/init.js';
-import * as fs from '../../src/util/fs.js';
+import {getGitConfigInfo, run as runInit} from 'cli/commands/init.js';
+import * as fs from 'util/fs.js';
 
 const path = require('path');
 

--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as fs from '../../../src/util/fs.js';
+import * as fs from 'util/fs.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
 

--- a/__tests__/commands/install/integration-deduping.js
+++ b/__tests__/commands/install/integration-deduping.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import {getPackageVersion, getPackageManifestPath, runInstall} from '../_helpers.js';
-import * as fs from '../../../src/util/fs.js';
+import * as fs from 'util/fs.js';
 
 const path = require('path');
 

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -1,16 +1,16 @@
 /* @flow */
 
-import Config from '../../../src/config';
-import PackageResolver from '../../../src/package-resolver.js';
-import {run as add} from '../../../src/cli/commands/add.js';
-import {run as cache} from '../../../src/cli/commands/cache.js';
-import {run as check} from '../../../src/cli/commands/check.js';
-import * as constants from '../../../src/constants.js';
-import * as reporters from '../../../src/reporters/index.js';
-import {parse} from '../../../src/lockfile';
-import {Install, run as install} from '../../../src/cli/commands/install.js';
-import Lockfile from '../../../src/lockfile';
-import * as fs from '../../../src/util/fs.js';
+import Config from 'config';
+import PackageResolver from 'package-resolver.js';
+import {run as add} from 'cli/commands/add.js';
+import {run as cache} from 'cli/commands/cache.js';
+import {run as check} from 'cli/commands/check.js';
+import * as constants from 'constants.js';
+import * as reporters from 'reporters/index.js';
+import {parse} from 'lockfile';
+import {Install, run as install} from 'cli/commands/install.js';
+import Lockfile from 'lockfile';
+import * as fs from 'util/fs.js';
 import {getPackageVersion, explodeLockfile, runInstall, createLockfile, run as buildRun} from '../_helpers.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
@@ -35,15 +35,15 @@ async function mockConstants(base: Config, mocks: Object, cb: (config: Config) =
   opts.production = base.production;
   opts.cacheFolder = base._cacheRootFolder;
 
-  const automock = jest.genMockFromModule('../../../src/constants');
-  jest.setMock('../../../src/constants', Object.assign(automock, mocks));
+  const automock = jest.genMockFromModule('constants');
+  jest.setMock('constants', Object.assign(automock, mocks));
 
   jest.resetModules();
   request = require('request');
 
-  jest.mock('../../../src/constants');
-  await cb(await require('../../../src/config.js').default.create(opts, base.reporter));
-  jest.unmock('../../../src/constants');
+  jest.mock('constants');
+  await cb(await require('config.js').default.create(opts, base.reporter));
+  jest.unmock('constants');
 }
 
 beforeEach(request.__resetAuthedRequests);

--- a/__tests__/commands/install/lockfiles.js
+++ b/__tests__/commands/install/lockfiles.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import {run as check} from '../../../src/cli/commands/check.js';
-import * as constants from '../../../src/constants.js';
-import * as reporters from '../../../src/reporters/index.js';
-import {Install} from '../../../src/cli/commands/install.js';
-import Lockfile from '../../../src/lockfile';
-import * as fs from '../../../src/util/fs.js';
+import {run as check} from 'cli/commands/check.js';
+import * as constants from 'constants.js';
+import * as reporters from 'reporters/index.js';
+import {Install} from 'cli/commands/install.js';
+import Lockfile from 'lockfile';
+import * as fs from 'util/fs.js';
 import {getPackageVersion, isPackagePresent, runInstall} from '../_helpers.js';
-import {promisify} from '../../../src/util/promise';
+import {promisify} from 'util/promise';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
 

--- a/__tests__/commands/install/unit.js
+++ b/__tests__/commands/install/unit.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import {NoopReporter} from '../../../src/reporters/index.js';
-import {Install} from '../../../src/cli/commands/install.js';
-import Lockfile from '../../../src/lockfile';
-import Config from '../../../src/config.js';
+import {NoopReporter} from 'reporters/index.js';
+import {Install} from 'cli/commands/install.js';
+import Lockfile from 'lockfile';
+import Config from 'config.js';
 
 const path = require('path');
 

--- a/__tests__/commands/install/workspaces-install.js
+++ b/__tests__/commands/install/workspaces-install.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import {run as check} from '../../../src/cli/commands/check.js';
-import {Install} from '../../../src/cli/commands/install.js';
-import * as reporters from '../../../src/reporters/index.js';
-import * as fs from '../../../src/util/fs.js';
+import {run as check} from 'cli/commands/check.js';
+import {Install} from 'cli/commands/install.js';
+import * as reporters from 'reporters/index.js';
+import * as fs from 'util/fs.js';
 import {runInstall, run as buildRun} from '../_helpers.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;

--- a/__tests__/commands/licenses.js
+++ b/__tests__/commands/licenses.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import {JSONReporter} from '../../src/reporters/index.js';
+import {JSONReporter} from 'reporters/index.js';
 import {run as buildRun} from './_helpers.js';
-import {run as licenses} from '../../src/cli/commands/licenses.js';
+import {run as licenses} from 'cli/commands/licenses.js';
 
 const path = require('path');
 

--- a/__tests__/commands/link.js
+++ b/__tests__/commands/link.js
@@ -1,11 +1,11 @@
 /* @flow */
 
 import {run as buildRun} from './_helpers.js';
-import {run as link} from '../../src/cli/commands/link.js';
-import {ConsoleReporter} from '../../src/reporters/index.js';
-import type {CLIFunctionReturn} from '../../src/types.js';
+import {run as link} from 'cli/commands/link.js';
+import {ConsoleReporter} from 'reporters/index.js';
+import type {CLIFunctionReturn} from 'types.js';
 import mkdir from './../_temp.js';
-import * as fs from '../../src/util/fs.js';
+import * as fs from 'util/fs.js';
 
 const path = require('path');
 

--- a/__tests__/commands/list.js
+++ b/__tests__/commands/list.js
@@ -1,12 +1,12 @@
 /* @flow */
-jest.mock('../../src/constants');
+jest.mock('constants');
 
 import path from 'path';
-import type {Tree} from '../../src/reporters/types.js';
-import {BufferReporter} from '../../src/reporters/index.js';
+import type {Tree} from 'reporters/types.js';
+import {BufferReporter} from 'reporters/index.js';
 import {run as buildRun} from './_helpers.js';
-import {getParent, getReqDepth, run as list} from '../../src/cli/commands/list.js';
-import * as reporters from '../../src/reporters/index.js';
+import {getParent, getReqDepth, run as list} from 'cli/commands/list.js';
+import * as reporters from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
@@ -137,7 +137,7 @@ describe('list', () => {
   });
 
   test('does not list devDependencies when production', (): Promise<void> => {
-    const isProduction: $FlowFixMe = require('../../src/constants').isProduction;
+    const isProduction: $FlowFixMe = require('constants').isProduction;
     isProduction.mockReturnValue(true);
 
     return runList([], {}, 'dev-deps-prod', (config, reporter): ?Promise<void> => {

--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import {run as buildRun} from './_helpers.js';
-import {run as outdated} from '../../src/cli/commands/outdated.js';
-import {ConsoleReporter, JSONReporter} from '../../src/reporters/index.js';
+import {run as outdated} from 'cli/commands/outdated.js';
+import {ConsoleReporter, JSONReporter} from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -1,7 +1,7 @@
 /* @flow */
-import * as fs from '../../src/util/fs.js';
-import {run as pack} from '../../src/cli/commands/pack.js';
-import {ConsoleReporter} from '../../src/reporters/index.js';
+import * as fs from 'util/fs.js';
+import {run as pack} from 'cli/commands/pack.js';
+import {ConsoleReporter} from 'reporters/index.js';
 import {run as buildRun} from './_helpers.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;

--- a/__tests__/commands/remove.js
+++ b/__tests__/commands/remove.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import {ConsoleReporter} from '../../src/reporters/index.js';
+import {ConsoleReporter} from 'reporters/index.js';
 import {run as buildRun, explodeLockfile} from './_helpers.js';
-import {run as check} from '../../src/cli/commands/check.js';
-import {run as remove} from '../../src/cli/commands/remove.js';
-import * as fs from '../../src/util/fs.js';
-import * as reporters from '../../src/reporters/index.js';
+import {run as check} from 'cli/commands/check.js';
+import {run as remove} from 'cli/commands/remove.js';
+import * as fs from 'util/fs.js';
+import * as reporters from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-jest.mock('../../src/util/execute-lifecycle-script', () => {
+jest.mock('util/execute-lifecycle-script', () => {
   return {
     // $FlowFixMe
-    ...require.requireActual('../../src/util/execute-lifecycle-script'),
+    ...require.requireActual('util/execute-lifecycle-script'),
     execCommand: jest.fn(),
   };
 });
@@ -11,14 +11,14 @@ jest.mock('../../src/util/execute-lifecycle-script', () => {
 import path from 'path';
 
 import {run as buildRun} from './_helpers.js';
-import {BufferReporter} from '../../src/reporters/index.js';
-import {run} from '../../src/cli/commands/run.js';
-import * as fs from '../../src/util/fs.js';
-import * as reporters from '../../src/reporters/index.js';
+import {BufferReporter} from 'reporters/index.js';
+import {run} from 'cli/commands/run.js';
+import * as fs from 'util/fs.js';
+import * as reporters from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
-const {execCommand}: $FlowFixMe = require('../../src/util/execute-lifecycle-script');
+const {execCommand}: $FlowFixMe = require('util/execute-lifecycle-script');
 
 beforeEach(() => execCommand.mockClear());
 

--- a/__tests__/commands/unlink.js
+++ b/__tests__/commands/unlink.js
@@ -1,12 +1,12 @@
 /* @flow */
 
 import {run as buildRun} from './_helpers.js';
-import {run as link} from '../../src/cli/commands/link.js';
-import {run as unlink} from '../../src/cli/commands/unlink.js';
-import {ConsoleReporter} from '../../src/reporters/index.js';
-import type {CLIFunctionReturn} from '../../src/types.js';
+import {run as link} from 'cli/commands/link.js';
+import {run as unlink} from 'cli/commands/unlink.js';
+import {ConsoleReporter} from 'reporters/index.js';
+import type {CLIFunctionReturn} from 'types.js';
 import mkdir from './../_temp.js';
-import * as fs from '../../src/util/fs.js';
+import * as fs from 'util/fs.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
 

--- a/__tests__/commands/upgrade-interactive.js
+++ b/__tests__/commands/upgrade-interactive.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import {ConsoleReporter} from '../../src/reporters/index.js';
+import {ConsoleReporter} from 'reporters/index.js';
 import {run as buildRun} from './_helpers.js';
-import {run as upgradeInteractive} from '../../src/cli/commands/upgrade-interactive.js';
-import * as reporters from '../../src/reporters/index.js';
+import {run as upgradeInteractive} from 'cli/commands/upgrade-interactive.js';
+import * as reporters from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 

--- a/__tests__/commands/upgrade.js
+++ b/__tests__/commands/upgrade.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import {ConsoleReporter} from '../../src/reporters/index.js';
+import {ConsoleReporter} from 'reporters/index.js';
 import {explodeLockfile, run as buildRun} from './_helpers.js';
-import {run as upgrade} from '../../src/cli/commands/upgrade.js';
-import * as fs from '../../src/util/fs.js';
-import * as reporters from '../../src/reporters/index.js';
+import {run as upgrade} from 'cli/commands/upgrade.js';
+import * as fs from 'util/fs.js';
+import * as reporters from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 

--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -1,18 +1,18 @@
 /* @flow */
 
-jest.mock('../../src/util/execute-lifecycle-script');
-jest.mock('../../src/util/git/git-spawn');
+jest.mock('util/execute-lifecycle-script');
+jest.mock('util/git/git-spawn');
 
 import {run as buildRun} from './_helpers.js';
-import {BufferReporter} from '../../src/reporters/index.js';
-import {run} from '../../src/cli/commands/version.js';
-import * as fs from '../../src/util/fs.js';
-import * as reporters from '../../src/reporters/index.js';
+import {BufferReporter} from 'reporters/index.js';
+import {run} from 'cli/commands/version.js';
+import * as fs from 'util/fs.js';
+import * as reporters from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
-const execCommand: $FlowFixMe = require('../../src/util/execute-lifecycle-script').execCommand;
-const spawn: $FlowFixMe = require('../../src/util/git/git-spawn').spawn;
+const execCommand: $FlowFixMe = require('util/execute-lifecycle-script').execCommand;
+const spawn: $FlowFixMe = require('util/git/git-spawn').spawn;
 
 spawn.mockReturnValue(Promise.resolve(''));
 

--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import {BufferReporter} from '../../src/reporters/index.js';
-import {run as why} from '../../src/cli/commands/why.js';
-import * as reporters from '../../src/reporters/index.js';
-import Config from '../../src/config.js';
+import {BufferReporter} from 'reporters/index.js';
+import {run as why} from 'cli/commands/why.js';
+import * as reporters from 'reporters/index.js';
+import Config from 'config.js';
 import path from 'path';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;

--- a/__tests__/commands/workspace.js
+++ b/__tests__/commands/workspace.js
@@ -1,18 +1,18 @@
 /* @flow */
 
-jest.mock('../../src/util/child');
+jest.mock('util/child');
 
-import {BufferReporter} from '../../src/reporters/index.js';
-import {run as workspace} from '../../src/cli/commands/workspace.js';
-import * as reporters from '../../src/reporters/index.js';
-import Config from '../../src/config.js';
+import {BufferReporter} from 'reporters/index.js';
+import {run as workspace} from 'cli/commands/workspace.js';
+import * as reporters from 'reporters/index.js';
+import Config from 'config.js';
 import path from 'path';
-import {NODE_BIN_PATH, YARN_BIN_PATH} from '../../src/constants';
+import {NODE_BIN_PATH, YARN_BIN_PATH} from 'constants';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'workspace');
-const spawn: $FlowFixMe = require('../../src/util/child').spawn;
+const spawn: $FlowFixMe = require('util/child').spawn;
 
 beforeEach(() => spawn.mockClear());
 

--- a/__tests__/constants.js
+++ b/__tests__/constants.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {getPathKey, isProduction} from '../src/constants.js';
+import {getPathKey, isProduction} from 'constants.js';
 
 test('getPathKey', () => {
   expect(getPathKey('win32', {PATH: 'foobar'})).toBe('PATH');

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -1,14 +1,14 @@
 /* @flow */
 /* eslint max-len: 0 */
 
-import {Reporter} from '../src/reporters/index.js';
-import TarballFetcher, {LocalTarballFetcher} from '../src/fetchers/tarball-fetcher.js';
-import BaseFetcher from '../src/fetchers/base-fetcher.js';
-import CopyFetcher from '../src/fetchers/copy-fetcher.js';
-import GitFetcher from '../src/fetchers/git-fetcher.js';
-import Config from '../src/config.js';
+import {Reporter} from 'reporters/index.js';
+import TarballFetcher, {LocalTarballFetcher} from 'fetchers/tarball-fetcher.js';
+import BaseFetcher from 'fetchers/base-fetcher.js';
+import CopyFetcher from 'fetchers/copy-fetcher.js';
+import GitFetcher from 'fetchers/git-fetcher.js';
+import Config from 'config.js';
 import mkdir from './_temp.js';
-import * as fs from '../src/util/fs.js';
+import * as fs from 'util/fs.js';
 import {readdirSync} from 'fs';
 
 const path = require('path');

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import NoopReporter from '../src/reporters/base-reporter.js';
+import NoopReporter from 'reporters/base-reporter.js';
 import makeTemp from './_temp';
-import * as fs from '../src/util/fs.js';
+import * as fs from 'util/fs.js';
 const pkg = require('../package.json');
 
 const path = require('path');

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -3,9 +3,9 @@
 
 import execa from 'execa';
 import makeTemp from './_temp.js';
-import * as fs from '../src/util/fs.js';
-import * as misc from '../src/util/misc.js';
-import * as constants from '../src/constants.js';
+import * as fs from 'util/fs.js';
+import * as misc from 'util/misc.js';
+import * as constants from 'constants.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import NoopReporter from '../src/reporters/base-reporter.js';
+import NoopReporter from 'reporters/base-reporter.js';
 import makeTemp from './_temp';
-import * as fs from '../src/util/fs.js';
+import * as fs from 'util/fs.js';
 
 const path = require('path');
 const exec = require('child_process').exec;

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -1,10 +1,10 @@
 /* @flow */
 /* eslint quotes: 0 */
 
-import Lockfile from '../src/lockfile';
-import stringify from '../src/lockfile/stringify.js';
-import parse from '../src/lockfile/parse.js';
-import nullify from '../src/util/map.js';
+import Lockfile from 'lockfile';
+import stringify from 'lockfile/stringify.js';
+import parse from 'lockfile/parse.js';
+import nullify from 'util/map.js';
 
 const objs = [{foo: 'bar'}, {foo: {}}, {foo: 'foo', bar: 'bar'}, {foo: 5}];
 

--- a/__tests__/normalize-manifest.js
+++ b/__tests__/normalize-manifest.js
@@ -1,12 +1,12 @@
 /* @flow */
 /* eslint max-len: 0 */
 
-import normalizeManifest from '../src/util/normalize-manifest/index.js';
-import NoopReporter from '../src/reporters/base-reporter.js';
-import Config from '../src/config.js';
-import map from '../src/util/map.js';
-import * as util from '../src/util/normalize-manifest/util.js';
-import * as fs from '../src/util/fs.js';
+import normalizeManifest from 'util/normalize-manifest/index.js';
+import NoopReporter from 'reporters/base-reporter.js';
+import Config from 'config.js';
+import map from 'util/map.js';
+import * as util from 'util/normalize-manifest/util.js';
+import * as fs from 'util/fs.js';
 
 const nativeFs = require('fs');
 const path = require('path');

--- a/__tests__/package-compatibility.js
+++ b/__tests__/package-compatibility.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {testEngine} from '../src/package-compatibility.js';
+import {testEngine} from 'package-compatibility.js';
 
 test('node semver semantics', () => {
   expect(testEngine('node', '^5.0.0', {node: '5.1.0'}, true)).toEqual(true);

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import PackageHoister, {HoistManifest} from '../src/package-hoister.js';
-import PackageResolver from '../src/package-resolver.js';
-import Lockfile from '../src/lockfile';
-import type PackageReference from '../src/package-reference.js';
-import type Config from '../src/config.js';
-import type {Manifest} from '../src/types.js';
+import PackageHoister, {HoistManifest} from 'package-hoister.js';
+import PackageResolver from 'package-resolver.js';
+import Lockfile from 'lockfile';
+import type PackageReference from 'package-reference.js';
+import type Config from 'config.js';
+import type {Manifest} from 'types.js';
 
 const path = require('path');
 

--- a/__tests__/package-request.js
+++ b/__tests__/package-request.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import PackageRequest from '../src/package-request.js';
-import * as reporters from '../src/reporters/index.js';
-import PackageResolver from '../src/package-resolver.js';
-import Lockfile from '../src/lockfile';
-import Config from '../src/config.js';
+import PackageRequest from 'package-request.js';
+import * as reporters from 'reporters/index.js';
+import PackageResolver from 'package-resolver.js';
+import Lockfile from 'lockfile';
+import Config from 'config.js';
 
 async function prepareRequest(pattern, version, resolved): Object {
   const privateDepCache = {[pattern]: {version, resolved}};

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -1,13 +1,13 @@
 /* @flow */
 /* eslint max-len: 0 */
 
-import * as reporters from '../src/reporters/index.js';
-import PackageResolver from '../src/package-resolver.js';
-import Lockfile from '../src/lockfile';
-import Config from '../src/config.js';
+import * as reporters from 'reporters/index.js';
+import PackageResolver from 'package-resolver.js';
+import Lockfile from 'lockfile';
+import Config from 'config.js';
 import makeTemp from './_temp.js';
-import * as fs from '../src/util/fs.js';
-import * as constants from '../src/constants.js';
+import * as fs from 'util/fs.js';
+import * as constants from 'constants.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 

--- a/__tests__/rc.js
+++ b/__tests__/rc.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {getRcArgs} from '../src/rc.js';
+import {getRcArgs} from 'rc.js';
 import * as path from 'path';
 
 const fixturesLoc = path.join(__dirname, 'fixtures', 'rc');

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -2,9 +2,9 @@
 
 import {resolve, join as pathJoin} from 'path';
 
-import NpmRegistry from '../../src/registries/npm-registry.js';
-import {BufferReporter} from '../../src/reporters/index.js';
-import homeDir from '../../src/util/user-home-dir.js';
+import NpmRegistry from 'registries/npm-registry.js';
+import {BufferReporter} from 'reporters/index.js';
+import homeDir from 'util/user-home-dir.js';
 
 describe('normalizeConfig', () => {
   beforeAll(() => {

--- a/__tests__/reporters/_mock.js
+++ b/__tests__/reporters/_mock.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type Reporter from '../../src/reporters/base-reporter.js';
+import type Reporter from 'reporters/base-reporter.js';
 const Stdin = require('mock-stdin').stdin.Class;
 const {Writable} = require('stream');
 

--- a/__tests__/reporters/base-reporter.js
+++ b/__tests__/reporters/base-reporter.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint yarn-internal/warn-language: 0 */
 
-import BaseReporter from '../../src/reporters/base-reporter.js';
+import BaseReporter from 'reporters/base-reporter.js';
 
 test('BaseReporter.getTotalTime', () => {
   const reporter = new BaseReporter();

--- a/__tests__/reporters/buffer-reporter.js
+++ b/__tests__/reporters/buffer-reporter.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import BufferReporter from '../../src/reporters/buffer-reporter.js';
+import BufferReporter from 'reporters/buffer-reporter.js';
 import build from './_mock.js';
 
 const getBuff = build(BufferReporter, (data, reporter: any): Array<Object> => reporter.getBuffer());

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import type {MockData} from './_mock.js';
-import ProgressBar from '../../src/reporters/console/progress-bar.js';
-import Spinner from '../../src/reporters/console/spinner-progress.js';
-import ConsoleReporter from '../../src/reporters/console/console-reporter.js';
+import ProgressBar from 'reporters/console/progress-bar.js';
+import Spinner from 'reporters/console/spinner-progress.js';
+import ConsoleReporter from 'reporters/console/console-reporter.js';
 import build from './_mock.js';
 
 const getConsoleBuff = build(ConsoleReporter, (data): MockData => data);

--- a/__tests__/reporters/event-reporter.js
+++ b/__tests__/reporters/event-reporter.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import EventReporter from '../../src/reporters/event-reporter.js';
+import EventReporter from 'reporters/event-reporter.js';
 import build from './_mock.js';
 
 type Events = Array<Object>;

--- a/__tests__/reporters/json-reporter.js
+++ b/__tests__/reporters/json-reporter.js
@@ -2,7 +2,7 @@
 /* eslint quotes: 0 */
 
 import type {MockData} from './_mock.js';
-import JSONReporter from '../../src/reporters/json-reporter.js';
+import JSONReporter from 'reporters/json-reporter.js';
 import build from './_mock.js';
 
 const getJSONBuff = build(JSONReporter, (data): MockData => data);

--- a/__tests__/resolvers/exotics/bitbucket-resolver.js
+++ b/__tests__/resolvers/exotics/bitbucket-resolver.js
@@ -1,9 +1,9 @@
 /* @flow */
-import {explodeHostedGitFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
-import BitBucketResolver from '../../../src/resolvers/exotics/bitbucket-resolver.js';
-import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
-import Git from '../../../src/util/git.js';
-import * as reporters from '../../../src/reporters/index.js';
+import {explodeHostedGitFragment} from 'resolvers/exotics/hosted-git-resolver.js';
+import BitBucketResolver from 'resolvers/exotics/bitbucket-resolver.js';
+import type {ExplodedFragment} from 'resolvers/exotics/hosted-git-resolver.js';
+import Git from 'util/git.js';
+import * as reporters from 'reporters/index.js';
 
 const url = require('url');
 const _bitBucketBase = 'https://bitbucket.org/';

--- a/__tests__/resolvers/exotics/github-resolver.js
+++ b/__tests__/resolvers/exotics/github-resolver.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import GitHubResolver from '../../../src/resolvers/exotics/github-resolver.js';
-import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
-import Git from '../../../src/util/git.js';
+import GitHubResolver from 'resolvers/exotics/github-resolver.js';
+import type {ExplodedFragment} from 'resolvers/exotics/hosted-git-resolver.js';
+import Git from 'util/git.js';
 
 const url = require('url');
 

--- a/__tests__/resolvers/exotics/gitlab-resolver.js
+++ b/__tests__/resolvers/exotics/gitlab-resolver.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import GitLabResolver from '../../../src/resolvers/exotics/gitlab-resolver.js';
-import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
-import Git from '../../../src/util/git.js';
+import GitLabResolver from 'resolvers/exotics/gitlab-resolver.js';
+import type {ExplodedFragment} from 'resolvers/exotics/hosted-git-resolver.js';
+import Git from 'util/git.js';
 
 const url = require('url');
 

--- a/__tests__/resolvers/exotics/hosted-git-resolver.js
+++ b/__tests__/resolvers/exotics/hosted-git-resolver.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import {explodeHostedGitFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
-import type {ExplodedFragment} from '../../../src/resolvers/exotics/hosted-git-resolver.js';
-import * as reporters from '../../../src/reporters/index.js';
+import {explodeHostedGitFragment} from 'resolvers/exotics/hosted-git-resolver.js';
+import type {ExplodedFragment} from 'resolvers/exotics/hosted-git-resolver.js';
+import * as reporters from 'reporters/index.js';
 const reporter = new reporters.NoopReporter({});
 
 test('explodeHostedGitFragment should allow for hashes as part of the branch name', () => {

--- a/__tests__/resolvers/index.js
+++ b/__tests__/resolvers/index.js
@@ -1,14 +1,14 @@
 /* @flow */
 
-import {getExoticResolver} from '../../src/resolvers/index.js';
+import {getExoticResolver} from 'resolvers/index.js';
 // exotic resolvers
-import GitResolver from '../../src/resolvers/exotics/git-resolver.js';
-import GistResolver from '../../src/resolvers/exotics/gist-resolver.js';
-import RegistryResolver from '../../src/resolvers/exotics/registry-resolver.js';
-import TarballResolver from '../../src/resolvers/exotics/tarball-resolver.js';
+import GitResolver from 'resolvers/exotics/git-resolver.js';
+import GistResolver from 'resolvers/exotics/gist-resolver.js';
+import RegistryResolver from 'resolvers/exotics/registry-resolver.js';
+import TarballResolver from 'resolvers/exotics/tarball-resolver.js';
 // registry resolvers
-import NpmRegistryResolver from '../../src/resolvers/registries/npm-resolver.js';
-import YarnRegistryResolver from '../../src/resolvers/registries/yarn-resolver.js';
+import NpmRegistryResolver from 'resolvers/registries/npm-resolver.js';
+import YarnRegistryResolver from 'resolvers/registries/yarn-resolver.js';
 
 test('getExoticResolver does not return a Resolver for 0.0.0 pattern', () => {
   const pattern = '0.0.0';

--- a/__tests__/util/blocking-queue.js
+++ b/__tests__/util/blocking-queue.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import BlockingQueue from '../../src/util/blocking-queue.js';
+import BlockingQueue from 'util/blocking-queue.js';
 
 test('max concurrency', async function(): Promise<void> {
   jest.useFakeTimers();

--- a/__tests__/util/child.js
+++ b/__tests__/util/child.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {spawn, forwardSignalToSpawnedProcesses} from '../../src/util/child.js';
+import {spawn, forwardSignalToSpawnedProcesses} from 'util/child.js';
 
 let mockSpawnedChildren = [];
 

--- a/__tests__/util/colorize-diff.js
+++ b/__tests__/util/colorize-diff.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import colorizeDiff from '../../src/util/colorize-diff';
-import {Reporter} from '../../src/reporters';
+import colorizeDiff from 'util/colorize-diff';
+import {Reporter} from 'reporters';
 
 let from;
 let to;

--- a/__tests__/util/env-replace.js
+++ b/__tests__/util/env-replace.js
@@ -1,5 +1,5 @@
 /* @flow */
-import envReplace from '../../src/util/env-replace';
+import envReplace from 'util/env-replace';
 
 describe('environment variable replacement', () => {
   it('will replace a token that exists in the environment', () => {

--- a/__tests__/util/filter.js
+++ b/__tests__/util/filter.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {ignoreLinesToRegex, filterOverridenGitignores} from '../../src/util/filter.js';
+import {ignoreLinesToRegex, filterOverridenGitignores} from 'util/filter.js';
 
 test('ignoreLinesToRegex', () => {
   expect(

--- a/__tests__/util/fix-cmd-win-slashes.js
+++ b/__tests__/util/fix-cmd-win-slashes.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {fixCmdWinSlashes} from '../../src/util/fix-cmd-win-slashes.js';
+import {fixCmdWinSlashes} from 'util/fix-cmd-win-slashes.js';
 
 const cmdCases = [
   ['fixes just slashed command', 'some/command', 'some\\command'],

--- a/__tests__/util/fs.js
+++ b/__tests__/util/fs.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {fileDatesEqual} from '../../src/util/fs.js';
+import {fileDatesEqual} from 'util/fs.js';
 
 describe('fileDatesEqual', () => {
   const realPlatform = process.platform;

--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-jest.mock('../../src/util/git/git-spawn.js', () => ({
+jest.mock('util/git/git-spawn.js', () => ({
   spawn: jest.fn(([command]) => {
     switch (command) {
       case 'ls-remote':
@@ -13,10 +13,10 @@ jest.mock('../../src/util/git/git-spawn.js', () => ({
   }),
 }));
 
-import Config from '../../src/config.js';
-import Git from '../../src/util/git.js';
-import {spawn as spawnGit} from '../../src/util/git/git-spawn.js';
-import {NoopReporter} from '../../src/reporters/index.js';
+import Config from 'config.js';
+import Git from 'util/git.js';
+import {spawn as spawnGit} from 'util/git/git-spawn.js';
+import {NoopReporter} from 'reporters/index.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 

--- a/__tests__/util/git/git-ref-resolver.js
+++ b/__tests__/util/git/git-ref-resolver.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import Config from '../../../src/config.js';
-import type {ResolvedSha, GitRefResolvingInterface, GitRefs} from '../../../src/util/git/git-ref-resolver.js';
-import {resolveVersion, isCommitSha, parseRefs} from '../../../src/util/git/git-ref-resolver.js';
+import Config from 'config.js';
+import type {ResolvedSha, GitRefResolvingInterface, GitRefs} from 'util/git/git-ref-resolver.js';
+import {resolveVersion, isCommitSha, parseRefs} from 'util/git/git-ref-resolver.js';
 
 class GitMock implements GitRefResolvingInterface {
   resolveDefaultBranch(): Promise<ResolvedSha> {

--- a/__tests__/util/git/git-spawn.js
+++ b/__tests__/util/git/git-spawn.js
@@ -2,8 +2,8 @@
 
 import path from 'path';
 
-jest.mock('../../../src/util/child.js', () => {
-  const realChild = (require: any).requireActual('../../../src/util/child.js');
+jest.mock('util/child.js', () => {
+  const realChild = (require: any).requireActual('util/child.js');
 
   realChild.spawn = jest.fn(() => Promise.resolve(''));
 
@@ -11,8 +11,8 @@ jest.mock('../../../src/util/child.js', () => {
 });
 
 function runGit(args, opts): any {
-  const {spawn} = require('../../../src/util/child.js');
-  const {spawn: spawnGit} = require('../../../src/util/git/git-spawn.js');
+  const {spawn} = require('util/child.js');
+  const {spawn: spawnGit} = require('util/git/git-spawn.js');
   const spawnMock = (spawn: any).mock;
 
   spawnGit(args, opts);

--- a/__tests__/util/guess-name.js
+++ b/__tests__/util/guess-name.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import guessName from '../../src/util/guess-name';
+import guessName from 'util/guess-name';
 
 const examples = [
   'http://github.com/foo-bar/awesome-name',

--- a/__tests__/util/misc.js
+++ b/__tests__/util/misc.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as misc from '../../src/util/misc.js';
+import * as misc from 'util/misc.js';
 
 test('sortAlpha', () => {
   expect(

--- a/__tests__/util/parse-package-name.js
+++ b/__tests__/util/parse-package-name.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import parsePackageName from '../../src/util/parse-package-name.js';
+import parsePackageName from 'util/parse-package-name.js';
 
 test('parsePackageName', () => {
   expect(parsePackageName('foo@1.2.3')).toEqual({

--- a/__tests__/util/parse-package-path.js
+++ b/__tests__/util/parse-package-path.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import parsePackagePath, {isValidPackagePath} from '../../src/util/parse-package-path.js';
+import parsePackagePath, {isValidPackagePath} from 'util/parse-package-path.js';
 
 test('parsePackagePath', () => {
   expect(parsePackagePath('foo/bar/baz')).toEqual(['foo', 'bar', 'baz']);

--- a/__tests__/util/path.js
+++ b/__tests__/util/path.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-jest.mock('../../src/util/user-home-dir.js', () => ({
+jest.mock('util/user-home-dir.js', () => ({
   default: '/home/foo',
 }));
 
@@ -12,7 +12,7 @@ jest.mock('path', () => {
   return path;
 });
 
-import {expandPath, resolveWithHome} from '../../src/util/path.js';
+import {expandPath, resolveWithHome} from 'util/path.js';
 
 describe('expandPath', () => {
   const realPlatform = process.platform;

--- a/__tests__/util/promise.js
+++ b/__tests__/util/promise.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as promise from '../../src/util/promise.js';
+import * as promise from 'util/promise.js';
 
 test('promisify', async function(): Promise<void> {
   expect(

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -1,9 +1,9 @@
 /* @flow */
 /* eslint max-len: 0 */
 
-import {Reporter} from '../../src/reporters/index.js';
-import Config from '../../src/config.js';
-import * as fs from '../../src/util/fs.js';
+import {Reporter} from 'reporters/index.js';
+import Config from 'config.js';
+import * as fs from 'util/fs.js';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 

--- a/__tests__/util/root-user.js
+++ b/__tests__/util/root-user.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {isRootUser, isFakeRoot} from '../../src/util/root-user.js';
+import {isRootUser, isFakeRoot} from 'util/root-user.js';
 
 test('isRootUser', () => {
   expect(isRootUser(null)).toBe(false);

--- a/__tests__/util/semver.js
+++ b/__tests__/util/semver.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {satisfiesWithPreleases} from '../../src/util/semver.js';
+import {satisfiesWithPreleases} from 'util/semver.js';
 
 const semver = require('semver');
 

--- a/__tests__/util/signal-handler.js
+++ b/__tests__/util/signal-handler.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import handleSignals from '../../src/util/signal-handler.js';
+import handleSignals from 'util/signal-handler.js';
 
 (process: any).on = jest.fn();
 (process: any).exit = jest.fn();

--- a/package.json
+++ b/package.json
@@ -118,6 +118,10 @@
     "modulePathIgnorePatterns": [
       "__tests__/fixtures/"
     ],
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
     "testPathIgnorePatterns": [
       "__tests__/(fixtures|__mocks__)/",
       "updates/",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
There are many relative imports in tests files like `../../../src/module-folder/module-name`.
I think import without relative parent folder is more comfortable
```js
import {Install, run as install} from '../../../src/cli/commands/install.js';
// vs
import {Install, run as install} from 'cli/commands/install.js';
```
It's enough to rewrite default Jest's rule for resolve modules.
```json
"moduleDirectories": ["node_modules", "src"]
```
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
