### PR TITLE
Support save-exact true

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -223,6 +223,17 @@ test.concurrent('add save-prefix should not expand ~ to home dir', (): Promise<v
   });
 });
 
+test.concurrent('add save-exact should make all package.json strict', (): Promise<void> => {
+  return runAdd(['left-pad'], {}, 'install-strict-all', async config => {
+    const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
+
+    expect(lockfile[0]).toMatch(/^left-pad@\d+\.\d+\.\d+:$/);
+    expect(JSON.parse(await fs.readFile(path.join(config.cwd, 'package.json'))).dependencies['left-pad']).toMatch(
+      /^\d+\.\d+\.\d+$/,
+    );
+  });
+});
+
 test.concurrent('add with new dependency should be deterministic 3', (): Promise<void> => {
   return runAdd([], {}, 'install-should-cleanup-when-package-json-changed-3', async (config, reporter) => {
     // expecting yarn check after installation not to fail

--- a/__tests__/fixtures/add/install-strict-all/.yarnrc
+++ b/__tests__/fixtures/add/install-strict-all/.yarnrc
@@ -1,0 +1,2 @@
+yarn-offline-mirror "./mirror-for-offline"
+save-exact true

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -69,7 +69,9 @@ export class Add extends Install {
    * returns version for a pattern based on Manifest
    */
   getPatternVersion(pattern: string, pkg: Manifest): string {
-    const {exact, tilde} = this.flags;
+    const tilde = this.flags.tilde;
+    const configPrefix = String(this.config.getOption('save-prefix'));
+    const exact = this.flags.exact || Boolean(this.config.getOption('save-exact')) || configPrefix === '';
     const {hasVersion, range} = normalizePattern(pattern);
     let version;
 
@@ -86,7 +88,7 @@ export class Add extends Install {
       } else if (exact) {
         prefix = '';
       } else {
-        prefix = String(this.config.getOption('save-prefix')) || '^';
+        prefix = configPrefix || '^';
       }
 
       version = `${prefix}${pkg.version}`;


### PR DESCRIPTION
**Summary**

Fixes #4343. Currently there is no way to remove the package prefix inside `.yarnrc` file, this PR add support for `save-exact` in `.yarnrc` as discussed in #4343. Full credit goes to @jambonrose

```
save-exact true
```

One small thing, should `yarn` be backwards compatible with the old behavior which is `save-prefix ''`? We can just add an extra check here for do this. What do you think @BYK?


```js
} else if (exact || Boolean(this.config.getOption('save-exact')) || Boolean(this.config.getOption('save-prefix'))) {

```

**Test plan**

New unit test.