### PR TITLE
Chore: ignore flow warnings from graphql

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 <PROJECT_ROOT>/lib-legacy/.*
 <PROJECT_ROOT>/lib/.*
 <PROJECT_ROOT>/node_modules/babel.*
+<PROJECT_ROOT>/node_modules/graphql.*
 <PROJECT_ROOT>/node_modules/y18n/test/.*
 <PROJECT_ROOT>/updates/.*
 


### PR DESCRIPTION
**Summary**

Right now `yarn lint` produces 27 warnings from flow, all coming from `grpahql` which is not even used (required by `eslint-plugin-relay`). This creates unnecessary noise and makes it hard to see actual flow warnings in Yarn code. This patch adds a directive to `.flowconfig` to ignore erros from graphql.

**Test plan**

Run `yarn lint`. You should see 0 errors and 0 warnings.