### PR TITLE
fix(resolver): `parentNames` is missing in package warning breadcrumbs

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -30,7 +30,7 @@ const micromatch = require('micromatch');
 export default class PackageRequest {
   constructor(req: DependencyRequestPattern, resolver: PackageResolver) {
     this.parentRequest = req.parentRequest;
-    this.parentNames = [];
+    this.parentNames = req.parentNames || [];
     this.lockfile = resolver.lockfile;
     this.registry = req.registry;
     this.reporter = resolver.reporter;


### PR DESCRIPTION
**Summary**

Bugfix for #4480. Change suggested by @BYK 

**Test plan**
Running yarn on local.

_**Before Changes**_
```bash
warning node-uuid@1.4.8: Use uuid module instead
```

_**After Changes**_
```bash
warning raven > node-uuid@1.4.8: Use uuid module instead
```