### PR TITLE
Fix: 'yarn --flat' unbound transitive deps shouldn't conflict with top level deps

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -1049,8 +1049,7 @@ test.concurrent('transitive file: dependencies should work', (): Promise<void> =
   });
 });
 
-// Unskip once https://github.com/yarnpkg/yarn/issues/3778 is resolved
-test.skip('unbound transitive dependencies should not conflict with top level dependency', async () => {
+test('unbound transitive dependencies should not conflict with top level dependency', async () => {
   await runInstall({flat: true}, 'install-conflicts', async config => {
     expect((await fs.readJson(path.join(config.cwd, 'node_modules', 'left-pad', 'package.json'))).version).toEqual(
       '1.0.0',


### PR DESCRIPTION
**Summary**

Fixes #3780, and makes the failing test from #3779 passing.

As a final step of package resolution, for each dependency we check whether any version satisfies all resolved version ranges. 

**Test plan**

Fixes an existing (failing) test: "unbound transitive dependencies should not conflict with top level dependency"