### PR TITLE
Added workaround for Node.js <= 6.2.1 bugs

### DIFF
--- a/src/util/child.js
+++ b/src/util/child.js
@@ -87,7 +87,8 @@ export function spawn(
         });
 
         // Workaround for stream handling bug in Node.js <= 6.2.1 on Linux. See #4282
-        proc.stdout.on('readable', () => {});
+        if (proc.stdout) proc.stdout.on('readable', () => {});
+        if (proc.stderr) proc.stderr.on('readable', () => {});
 
         function updateStdout(chunk: string) {
           stdout += chunk;

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -87,8 +87,19 @@ export function spawn(
         });
 
         // Workaround for stream handling bug in Node.js <= 6.2.1 on Linux. See #4282
-        if (proc.stdout) proc.stdout.on('readable', () => {});
-        if (proc.stderr) proc.stderr.on('readable', () => {});
+        let dummyListener = () => {};
+        if (proc.stdout) { 
+          proc.stdout.on('readable', dummyListener);
+          proc.stdout.once('close', () => {
+            proc.stdout.removeListener('readable', dummyListener);
+          } );
+        }
+        if (proc.stderr) {
+          proc.stderr.on('readable', dummyListener);
+          proc.stderr.once('close', () => {
+            proc.stderr.removeListener('readable', dummyListener);
+          } );
+        }
 
         function updateStdout(chunk: string) {
           stdout += chunk;

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -87,18 +87,22 @@ export function spawn(
         });
 
         // Workaround for stream handling bug in Node.js <= 6.2.1 on Linux. See #4282
-        let dummyListener = () => {};
-        if (proc.stdout) { 
+        const dummyListener = () => {};
+        if (proc.stdout) {
           proc.stdout.on('readable', dummyListener);
           proc.stdout.once('close', () => {
-            proc.stdout.removeListener('readable', dummyListener);
-          } );
+            if (!processClosed) {
+              proc.stdout.removeListener('readable', dummyListener);
+            }
+          });
         }
         if (proc.stderr) {
           proc.stderr.on('readable', dummyListener);
           proc.stderr.once('close', () => {
-            proc.stderr.removeListener('readable', dummyListener);
-          } );
+            if (!processClosed) {
+              proc.stderr.removeListener('readable', dummyListener);
+            }
+          });
         }
 
         function updateStdout(chunk: string) {
@@ -155,9 +159,9 @@ export function spawn(
 
           if (processingDone || err) {
             finish();
-          } else {
-            processClosed = true;
           }
+
+          processClosed = true;
         });
       }),
   );

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -86,6 +86,9 @@ export function spawn(
           }
         });
 
+        // Workaround for stream handling bug in Node.js <= 6.2.1 on Linux. See #4282
+        proc.stdout.on('readable', () => {});
+
         function updateStdout(chunk: string) {
           stdout += chunk;
           if (onData) {


### PR DESCRIPTION
**Summary**

Fixes #4282. It seems that Node.js <= 6.2.1 on Linux can improperly handle stdout stream of the spawned child process. This PR works around the issue, hiding the bug.

**Test plan**

Git-related stuff should not fail or hang on Node <= 6.2.1 on Linux.