### PR TITLE
Fix: make lockfile parser tolerant to CRLF

### DIFF
--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -23,7 +23,20 @@ test('parse', () => {
   expect(parse(`foo:\n  bar "bar"`).object).toEqual(nullify({foo: {bar: 'bar'}}));
   expect(parse(`foo:\n  bar:\n  foo "bar"`).object).toEqual(nullify({foo: {bar: {}, foo: 'bar'}}));
   expect(parse(`foo:\n  bar:\n    foo "bar"`).object).toEqual(nullify({foo: {bar: {foo: 'bar'}}}));
+  expect(parse(`foo:\r\n  bar:\r\n    foo "bar"`).object).toEqual(nullify({foo: {bar: {foo: 'bar'}}}));
   expect(parse('foo:\n  bar:\n    yes no\nbar:\n  yes no').object).toEqual(
+    nullify({
+      foo: {
+        bar: {
+          yes: 'no',
+        },
+      },
+      bar: {
+        yes: 'no',
+      },
+    }),
+  );
+  expect(parse('foo:\r\n  bar:\r\n    yes no\r\nbar:\r\n  yes no').object).toEqual(
     nullify({
       foo: {
         bar: {

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -242,7 +242,9 @@ d:
 
 test('parse single merge conflict with CRLF', () => {
   const file =
-    'a:\r\n  no "yes"\r\n\r\n<<<<<<< HEAD\r\nb:\r\n  foo "bar"\r\n=======\r\nc:\r\n  bar "foo"\r\n>>>>>>> branch-a\r\n\r\nd:\r\n  yes "no"\r\n';
+    'a:\r\n  no "yes"\r\n\r\n<<<<<<< HEAD\r\nb:\r\n  foo "bar"' +
+    '\r\n=======\r\nc:\r\n  bar "foo"\r\n>>>>>>> branch-a' +
+    '\r\n\r\nd:\r\n  yes "no"\r\n';
 
   const {type, object} = parse(file);
   expect(type).toEqual('merge');

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -240,6 +240,20 @@ d:
   });
 });
 
+test('parse single merge conflict with CRLF', () => {
+  const file =
+    'a:\r\n  no "yes"\r\n\r\n<<<<<<< HEAD\r\nb:\r\n  foo "bar"\r\n=======\r\nc:\r\n  bar "foo"\r\n>>>>>>> branch-a\r\n\r\nd:\r\n  yes "no"\r\n';
+
+  const {type, object} = parse(file);
+  expect(type).toEqual('merge');
+  expect(object).toEqual({
+    a: {no: 'yes'},
+    b: {foo: 'bar'},
+    c: {bar: 'foo'},
+    d: {yes: 'no'},
+  });
+});
+
 test('parse multiple merge conflicts', () => {
   const file = `
 a:

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -165,7 +165,7 @@ export function main({
   }
 
   args = [...preCommandArgs, ...args];
-
+  console.log(getRcArgs(commandName, args));
   command.setFlags(commander);
   commander.parse([
     ...startArgs,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -165,7 +165,7 @@ export function main({
   }
 
   args = [...preCommandArgs, ...args];
-  console.log(getRcArgs(commandName, args));
+
   command.setFlags(commander);
   commander.parse([
     ...startArgs,

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -1,12 +1,13 @@
 /* @flow */
 /* eslint quotes: 0 */
 
+import util from 'util';
+import invariant from 'invariant';
+import stripBOM from 'strip-bom';
+
 import {LOCKFILE_VERSION} from '../constants.js';
 import {MessageError} from '../errors.js';
 import map from '../util/map.js';
-
-const invariant = require('invariant');
-const stripBOM = require('strip-bom');
 
 type Token = {
   line: number,
@@ -317,7 +318,7 @@ class Parser {
           this.unexpected('Invalid value type');
         }
       } else {
-        this.unexpected(`Unknown token: ${require('inspect').inspect(propToken)}`);
+        this.unexpected(`Unknown token: ${util.inspect(propToken)}`);
       }
     }
 

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -159,7 +159,7 @@ function* tokenise(input: string): Iterator<Token> {
     }
 
     col += chop;
-    lastNewline = input[0] === '\n' || input[1] === '\n';
+    lastNewline = input[0] === '\n' || (input[0] === '\r' && input[1] === '\n');
     input = input.slice(chop);
   }
 
@@ -335,7 +335,7 @@ const MERGE_CONFLICT_START = '<<<<<<<';
  */
 function extractConflictVariants(str: string): [string, string] {
   const variants = [[], []];
-  const lines = str.split(/\n/g);
+  const lines = str.split(/\r?\n/g);
   let skip = false;
 
   while (lines.length) {

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -56,8 +56,12 @@ function* tokenise(input: string): Iterator<Token> {
   while (input.length) {
     let chop = 0;
 
-    if (input[0] === '\n') {
+    if (input[0] === '\n' || input[0] === '\r') {
       chop++;
+      // If this is a \r\n line, ignore both chars but only add one new line
+      if (input[1] === '\n') {
+        chop++;
+      }
       line++;
       col = 0;
       yield buildToken(TOKEN_TYPES.newline);
@@ -136,7 +140,7 @@ function* tokenise(input: string): Iterator<Token> {
       let name = '';
       for (let i = 0; i < input.length; i++) {
         const char = input[i];
-        if (char === ':' || char === ' ' || char === '\n' || char === ',') {
+        if (char === ':' || char === ' ' || char === '\n' || char === '\r' || char === ',') {
           break;
         } else {
           name += char;
@@ -155,7 +159,7 @@ function* tokenise(input: string): Iterator<Token> {
     }
 
     col += chop;
-    lastNewline = input[0] === '\n';
+    lastNewline = input[0] === '\n' || input[1] === '\n';
     input = input.slice(chop);
   }
 
@@ -313,7 +317,7 @@ class Parser {
           this.unexpected('Invalid value type');
         }
       } else {
-        this.unexpected('Unknown token');
+        this.unexpected(`Unknown token: ${require('inspect').inspect(propToken)}`);
       }
     }
 

--- a/src/rc.js
+++ b/src/rc.js
@@ -80,7 +80,7 @@ export function getRcArgs(commandName: string, args: Array<string>, previousCwds
   const argMap = buildRcArgs(origCwd);
 
   // concat wildcard arguments and arguments meant for this specific command
-  const newArgs = [].concat(argMap.get('*') || [], argMap.get(commandName) || []);
+  const newArgs = [...(argMap.get('*') || []), ...(argMap.get(commandName) || [])];
 
   // check if the .yarnrc args specified a cwd
   const newCwd = extractCwdArg(newArgs);


### PR DESCRIPTION
**Summary**

Lockfile parser fails when the lockfile had Windows-style line
endings with an "Invalid token" error. This is default on Windows
and, say when editing the file using vim, it is not obvious or
trivial that the file endings are in Windows-style. This patch
makes the parser tolareate potential "\r" chars before "\n" while
keeping the existing parsing logic the same.

**Test plan**

Added three new unit tests.
