### PR TITLE
Fix: fix argument parsing and .yarrc argument passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      RAMDISK_SIZE=320;
+      RAMDISK_SIZE=330;
       RAMDISK_SECTORS=$(( $RAMDISK_SIZE * 1024 * 1024 / 512 ));
       RAMDISK=$(hdiutil attach -nomount ram://$RAMDISK_SECTORS);
       newfs_hfs -v yarn_ramfs $RAMDISK;

--- a/__tests__/__snapshots__/integration.js.snap
+++ b/__tests__/__snapshots__/integration.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yarnrc-args 1`] = `
+"{\\"type\\":\\"info\\",\\"data\\":\\"No lockfile found.\\"}
+{\\"type\\":\\"step\\",\\"data\\":{\\"message\\":\\"Resolving packages\\",\\"current\\":1,\\"total\\":4}}
+{\\"type\\":\\"step\\",\\"data\\":{\\"message\\":\\"Fetching packages\\",\\"current\\":2,\\"total\\":4}}
+{\\"type\\":\\"step\\",\\"data\\":{\\"message\\":\\"Linking dependencies\\",\\"current\\":3,\\"total\\":4}}
+{\\"type\\":\\"step\\",\\"data\\":{\\"message\\":\\"Building fresh packages\\",\\"current\\":4,\\"total\\":4}}
+{\\"type\\":\\"success\\",\\"data\\":\\"Saved lockfile.\\"}
+{\\"type\\":\\"success\\",\\"data\\":\\"Saved 1 new dependency.\\"}
+{\\"type\\":\\"tree\\",\\"data\\":{\\"type\\":\\"newDependencies\\",\\"trees\\":[{\\"name\\":\\"left-pad@1.1.3\\",\\"children\\":[],\\"hint\\":null,\\"color\\":null,\\"depth\\":0}]}}"
+`;

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -121,6 +121,23 @@ test('--cwd option', async () => {
   expect(packageJson.dependencies['left-pad']).toBeDefined();
 });
 
+test('yarnrc arguments', async () => {
+  const cwd = await makeTemp();
+
+  await fs.writeFile(
+    `${cwd}/.yarnrc`,
+    ['--emoji false', '--json true', '--add.exact true', '--no-progress true', '--cache-folder "./yarn-cache"'].join(
+      '\n',
+    ),
+  );
+  await fs.writeFile(`${cwd}/package.json`, JSON.stringify({name: 'test', license: 'ISC', version: '1.0.0'}));
+
+  const [stdoutOutput] = await runYarn(['add', 'left-pad'], {cwd});
+  expect(stdoutOutput).toMatchSnapshot('yarnrc-args');
+  expect(JSON.parse(await fs.readFile(`${cwd}/package.json`)).dependencies['left-pad']).toMatch(/^\d+\./);
+  expect((await fs.stat(`${cwd}/yarn-cache`)).isDirectory()).toBe(true);
+});
+
 test('yarnrc binary path (js)', async () => {
   const cwd = await makeTemp();
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -38,6 +38,8 @@ function findProjectRoot(base: string): string {
   return base;
 }
 
+const boolify = val => val.toString().toLowerCase() !== 'false' && val !== '0';
+
 export function main({
   startArgs,
   args,
@@ -68,7 +70,7 @@ export function main({
   commander.option('--check-files', 'install will verify file tree of packages for consistency');
   commander.option('--no-bin-links', "don't generate bin links when setting up packages");
   commander.option('--flat', 'only allow one version of a package');
-  commander.option('--prod, --production [prod]', '');
+  commander.option('--prod, --production [prod]', '', boolify);
   commander.option('--no-lockfile', "don't read or generate a lockfile");
   commander.option('--pure-lockfile', "don't generate a lockfile");
   commander.option('--frozen-lockfile', "don't generate a lockfile and fail if an update is needed");
@@ -82,7 +84,7 @@ export function main({
   commander.option('--preferred-cache-folder <path>', 'specify a custom folder to store the yarn cache if possible');
   commander.option('--cache-folder <path>', 'specify a custom folder that must be used to store the yarn cache');
   commander.option('--mutex <type>[:specifier]', 'use a mutex to ensure only one yarn instance is executing');
-  commander.option('--emoji [bool]', 'enable emoji in output', process.platform === 'darwin');
+  commander.option('--emoji [bool]', 'enable emoji in output', boolify, process.platform === 'darwin');
   commander.option('-s, --silent', 'skip Yarn console logs, other types of logs (script output) will be printed');
   commander.option('--cwd <cwd>', 'working directory to use', process.cwd());
   commander.option('--proxy <host>', '');
@@ -91,7 +93,11 @@ export function main({
   commander.option('--network-concurrency <number>', 'maximum number of concurrent network requests', parseInt);
   commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
   commander.option('--non-interactive', 'do not show interactive prompts');
-  commander.option('--scripts-prepend-node-path [bool]', 'prepend the node executable dir to the PATH in scripts');
+  commander.option(
+    '--scripts-prepend-node-path [bool]',
+    'prepend the node executable dir to the PATH in scripts',
+    boolify,
+  );
 
   // if -v is the first command, then always exit after returning the version
   if (args[0] === '-v') {
@@ -105,7 +111,7 @@ export function main({
     const isOption = arg.startsWith('-');
     const prev = idx > 0 && arr[idx - 1];
     const prevOption = prev && prev.startsWith('-') && commander.optionFor(prev);
-    const boundToPrevOption = prevOption && prevOption.required;
+    const boundToPrevOption = prevOption && (prevOption.optional || prevOption.required);
 
     return !isOption && !boundToPrevOption;
   });

--- a/src/rc.js
+++ b/src/rc.js
@@ -1,6 +1,9 @@
 /* @flow */
 
 import {dirname, resolve} from 'path';
+
+import commander from 'commander';
+
 import {parse} from './lockfile';
 import * as rcUtil from './util/rc.js';
 
@@ -46,12 +49,14 @@ function buildRcArgs(cwd: string): Map<string, Array<string>> {
     argsForCommands.set(commandName, args);
 
     // turn config value into appropriate cli flag
-    if (typeof value === 'string') {
+    const option = commander.optionFor(`--${arg}`);
+
+    // If commander doesn't recognize the option or it takes a value after it
+    if (!option || option.optional || option.required) {
       args.push(`--${arg}`, value);
     } else if (value === true) {
+      // we can't force remove an arg from cli
       args.push(`--${arg}`);
-    } else if (value === false) {
-      args.push(`--no-${arg}`);
     }
   }
 


### PR DESCRIPTION
**Summary**
Fixes #4457, partially handles #4470. `.yarnrc` argument passing logic was not aligned with
how `commander` works. Even more, `commander`'s boolean logic was
also not used correctly. This patch fixes both, allowing use of
boolean type CLI options both ways (enable/disable) both from the
command line and `.yarnrc` file.

**Test plan**

Added new integration test for getting args from `.yarnrc`.