### PR TITLE
Update: warn when used with not supported Node versions

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,5 +1,17 @@
 /* @flow */
 
+import http from 'http';
+import net from 'net';
+import path from 'path';
+
+import commander from 'commander';
+import fs from 'fs';
+import invariant from 'invariant';
+import lockfile from 'proper-lockfile';
+import loudRejection from 'loud-rejection';
+import onDeath from 'death';
+import semver from 'semver';
+
 import {ConsoleReporter, JSONReporter} from '../reporters/index.js';
 import {registries, registryNames} from '../registries/index.js';
 import commands from './commands/index.js';
@@ -11,16 +23,6 @@ import {getRcConfigForCwd, getRcArgs} from '../rc.js';
 import {spawnp, forkp} from '../util/child.js';
 import {version} from '../util/yarn-version.js';
 import handleSignals from '../util/signal-handler.js';
-
-const commander = require('commander');
-const fs = require('fs');
-const invariant = require('invariant');
-const lockfile = require('proper-lockfile');
-const loudRejection = require('loud-rejection');
-const http = require('http');
-const net = require('net');
-const onDeath = require('death');
-const path = require('path');
 
 function findProjectRoot(base: string): string {
   let prev = null;
@@ -92,6 +94,7 @@ export function main({
   commander.option('--network-timeout <milliseconds>', 'TCP timeout for network requests', parseInt);
   commander.option('--non-interactive', 'do not show interactive prompts');
   commander.option('--scripts-prepend-node-path [bool]', 'prepend the node executable dir to the PATH in scripts');
+  commander.option('--no-node-version-check', 'do not warn when using a potentially unsupported Node version');
 
   // if -v is the first command, then always exit after returning the version
   if (args[0] === '-v') {
@@ -201,6 +204,10 @@ export function main({
 
   if (outputWrapper) {
     reporter.header(commandName, {name: 'yarn', version});
+  }
+
+  if (commander.nodeVersionCheck && !semver.satisfies(process.versions.node, constants.SUPPORTED_NODE_VERSIONS)) {
+    reporter.warn(reporter.lang('unsupportedNodeVersion', process.versions.node, constants.SUPPORTED_NODE_VERSIONS));
   }
 
   if (command.noArguments && commander.args.length) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,8 @@ type Env = {
 
 export const DEPENDENCY_TYPES = ['devDependencies', 'dependencies', 'optionalDependencies', 'peerDependencies'];
 
+export const SUPPORTED_NODE_VERSIONS = '^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0';
+
 export const YARN_REGISTRY = 'https://registry.yarnpkg.com';
 
 export const YARN_DOCS = 'https://yarnpkg.com/en/docs/cli/';

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -361,6 +361,8 @@ const messages = {
   deprecatedCommand: '$0 is deprecated. Please use $1.',
   implicitFileDeprecated:
     'Using the "file:" protocol implicitly is deprecated. Please either the protocol or prepend the path $0 with "./".',
+  unsupportedNodeVersion:
+    'You are using Node $0 which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: $1',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
**Summary**

Fixes #4501, refs #4490, refs #4284. Yarn now warns when it
detects it is running in a Node version that is not fully
supported and warns the user about this. This is different than
the hard Node 4+ check in the entry file since in that case,
Yarn wouldn't run at all due to syntax incompatibilities. This
warning is to signal that users may encounter unexpected errors
but are allowed to use Yarn if they wish. It also adds a new
flag to suppress this warning: `--no-node-version-check`.

**Test plan**

Since we cannot add unsupported Node versions to our CI and
spoof the Node version internally, this has to be tested
manually, which I did.