### PR TITLE
Chore: remove `sudo: required` from TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 ---
-# Without sudo, Travis CI uses AUFS which causes issues with our
-# tests when we write stuff and try to read it back right after to
-# verfify our expectations.
-# See https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
-sudo: required
+sudo: false
 
 git:
   depth: 10


### PR DESCRIPTION
**Summary**

Travis CI actively invests in the containerized builds and they seem to have a lot fewer issues than the "sudo-enabled" builds. We shouldn't be needing any sudo permissions anyways so this PR tries to remove it and see what happens.

**Test plan**

Hopefully, Travis CI builds pass and quickly.
