### PR TITLE
Fix stripColor to be available again in console reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "request-capture-har": "^1.2.2",
     "rimraf": "^2.5.0",
     "semver": "^5.1.0",
+    "strip-ansi": "^4.0.0",
     "strip-bom": "^3.0.0",
     "tar-fs": "^1.15.1",
     "tar-stream": "^1.5.2",

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -22,6 +22,7 @@ import inquirer from 'inquirer';
 const {inspect} = require('util');
 const readline = require('readline');
 const chalk = require('chalk');
+const stripAnsi = require('strip-ansi');
 const read = require('read');
 const tty = require('tty');
 
@@ -40,6 +41,7 @@ export default class ConsoleReporter extends BaseReporter {
     this._lastCategorySize = 0;
     this._spinners = new Set();
     this.format = (chalk: any);
+    this.format.stripColor = stripAnsi;
     this.isSilent = !!opts.isSilent;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,10 @@ ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -4436,6 +4440,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Summary**
This is a bugfix for the following error which happens on master

```
❯ yarn outdated
yarn outdated v1.0.2
error An unexpected error occurred: "this.format.stripColor is not a function".
info If you think this is a bug, please open a bug report with the information provided in "/Users/danieltschinder/Documents/ResearchGate/PHP/community/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/outdated for documentation about this command.
```


chalk 2.0 removed stripColor see https://github.com/chalk/chalk/releases/tag/v2.0.0 and this wasn't respected in #4482
