### PR TITLE
Update: add `yarn global dir` command

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -40,7 +40,7 @@ class GlobalAdd extends Add {
 const path = require('path');
 
 export function hasWrapper(flags: Object, args: Array<string>): boolean {
-  return args[0] !== 'bin';
+  return args[0] !== 'bin' && args[0] !== 'dir';
 }
 
 async function updateCwd(config: Config): Promise<void> {
@@ -228,7 +228,12 @@ const {run, setFlags: _setFlags} = buildSubCommands('global', {
   },
 
   async bin(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
-    reporter.log(await getBinFolder(config, flags));
+    reporter.log(await getBinFolder(config, flags), {force: true});
+  },
+
+  dir(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    reporter.log(config.globalFolder, {force: true});
+    return Promise.resolve();
   },
 
   async ls(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {


### PR DESCRIPTION
**Summary**

Fixes #2652. Adds a `yarn global dir` command that prints the output
of the global installation folder that houses the global `node_modules`.

**Test plan**

Manual verification.