### PR TITLE
Fix: Suppress "revealed multiple traversal of the same folder" warnings

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -222,7 +222,7 @@ async function buildActionsForCopy(
     // TODO https://github.com/yarnpkg/yarn/issues/3751
     // related to bundled dependencies handling
     if (files.has(dest.toLowerCase())) {
-      reporter.warn(`The case-insensitive file ${dest} shouldn't be copied twice in one bulk copy`);
+      reporter.verbose(`The case-insensitive file ${dest} shouldn't be copied twice in one bulk copy`);
     } else {
       files.add(dest.toLowerCase());
     }


### PR DESCRIPTION
**Summary**

Refs #3751. Changes `reporter.warn` to `reporter.verbose` for the message "The case-insensitive file ${dest} shouldn't be copied twice in one bulk copy".

**Test plan**

Manual verification.
