### PR TITLE
Add ability to filter yarn cache (fixes #3200)

### DIFF
--- a/__tests__/commands/cache.js
+++ b/__tests__/commands/cache.js
@@ -42,6 +42,72 @@ test('ls with scoped package', async (): Promise<void> => {
   });
 });
 
+test('ls with filter that matches cache', async (): Promise<void> => {
+  await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+    await run(config, reporter, {pattern: 'dummy'}, ['list']);
+    const stdout = String(out.read());
+    expect(stdout).toContain('dummy');
+    expect(stdout).toContain('0.0.0');
+  });
+});
+
+test('ls with filter that matches cache with wildcard', async (): Promise<void> => {
+  await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+    await run(config, reporter, {pattern: 'dum*'}, ['list']);
+    const stdout = String(out.read());
+    expect(stdout).toContain('dummy');
+    expect(stdout).toContain('0.0.0');
+  });
+});
+
+test('ls with multiple patterns, one matching', async (): Promise<void> => {
+  await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+    await run(config, reporter, {pattern: 'dum|dummy'}, ['list']);
+    const stdout = String(out.read());
+    expect(stdout).toContain('dummy');
+    expect(stdout).toContain('0.0.0');
+  });
+});
+
+test('ls with pattern that only partially matches', async (): Promise<void> => {
+  await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+    await run(config, reporter, {pattern: 'dum'}, ['list']);
+    const stdout = String(out.read());
+    expect(stdout).toContain('dummy');
+    expect(stdout).toContain('0.0.0');
+  });
+});
+
+test('ls with filter that does not match', async (): Promise<void> => {
+  await runInstall({}, 'artifacts-finds-and-saves', async (config): Promise<void> => {
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+    await run(config, reporter, {pattern: 'noMatch'}, ['list']);
+    const stdout = String(out.read());
+    expect(stdout).not.toContain('dummy');
+    expect(stdout).not.toContain('0.0.0');
+  });
+});
+
+test('ls filter by pattern with scoped package', async (): Promise<void> => {
+  await runInstall({}, 'install-from-authed-private-registry', async (config): Promise<void> => {
+    const out = new stream.PassThrough();
+    const reporter = new reporters.JSONReporter({stdout: out});
+    await run(config, reporter, {pattern: '@types/*'}, ['list']);
+    const stdout = String(out.read());
+    expect(stdout).toContain('@types/lodash');
+    expect(stdout).toContain('4.14.37');
+  });
+});
+
 test('dir', async (): Promise<void> => {
   await runCache(['dir'], {}, '', (config, reporter, stdout) => {
     expect(stdout).toContain(JSON.stringify(config.cacheFolder));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This was proposed in #3200. It adds the ability filter the cache list with multiple filters.

If it matches any of the filters it will add the module to the list. If it doesn't it just skips.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added tests for this new feature.

Matching with single filter:
<img width="826" alt="screen shot 2017-09-28 at 14 14 34" src="https://user-images.githubusercontent.com/17152391/30968732-282726e0-a458-11e7-955e-ef2026283dff.png">

Matching with different filters:
<img width="906" alt="screen shot 2017-09-28 at 14 18 22" src="https://user-images.githubusercontent.com/17152391/30968729-23ef08e0-a458-11e7-8d50-63a7d11ab249.png">

No match in the cache:
<img width="358" alt="screen shot 2017-09-28 at 14 21 52" src="https://user-images.githubusercontent.com/17152391/30968809-68d8412e-a458-11e7-8efe-9b4edde51476.png">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
