### PR TITLE
Fix: always prefer CLI options over env for --prod

### DIFF
--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -5,6 +5,41 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import buildSubCommands from './_build-sub-commands.js';
 
+const CONFIG_KEYS = [
+  // 'reporter',
+  'rootModuleFolders',
+  'registryFolders',
+  'linkedModules',
+  // 'registries',
+  'cache',
+  'cwd',
+  'looseSemver',
+  'commandName',
+  'preferOffline',
+  'modulesFolder',
+  'globalFolder',
+  'linkFolder',
+  'offline',
+  'binLinks',
+  'ignorePlatform',
+  'ignoreScripts',
+  'disablePrepublish',
+  'nonInteractive',
+  'workspaceRootFolder',
+  'lockfileFolder',
+  'networkConcurrency',
+  'childConcurrency',
+  'networkTimeout',
+  'workspacesEnabled',
+  'pruneOfflineMirror',
+  'enableMetaFolder',
+  'enableLockfileVersions',
+  'linkFileDependencies',
+  'cacheFolder',
+  'tempFolder',
+  'production',
+];
+
 export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return args[0] !== 'get';
 }
@@ -52,6 +87,16 @@ export const {run, setFlags, examples} = buildSubCommands('config', {
 
     reporter.info(reporter.lang('configNpm'));
     reporter.inspect(config.registries.npm.config);
+
+    return true;
+  },
+
+  current(config: Config, reporter: Reporter, flags: Object, args: Array<string>): boolean {
+    if (args.length) {
+      return false;
+    }
+
+    reporter.log(JSON.stringify(config, CONFIG_KEYS, 2), {force: true});
 
     return true;
   },

--- a/src/config.js
+++ b/src/config.js
@@ -325,17 +325,14 @@ export default class Config {
     await fs.mkdirp(this.cacheFolder);
     await fs.mkdirp(this.tempFolder);
 
-    if (opts.production === 'false') {
-      this.production = false;
-    } else if (
-      this.getOption('production') ||
-      (process.env.NODE_ENV === 'production' &&
-        process.env.NPM_CONFIG_PRODUCTION !== 'false' &&
-        process.env.YARN_PRODUCTION !== 'false')
-    ) {
-      this.production = true;
+    if (opts.production !== undefined) {
+      this.production = Boolean(opts.production);
     } else {
-      this.production = !!opts.production;
+      this.production =
+        Boolean(this.getOption('production')) ||
+        (process.env.NODE_ENV === 'production' &&
+          process.env.NPM_CONFIG_PRODUCTION !== 'false' &&
+          process.env.YARN_PRODUCTION !== 'false');
     }
 
     if (this.workspaceRootFolder && !this.workspacesEnabled) {


### PR DESCRIPTION
**Summary**

Fixes #4557. Also adds `yarn config current` that lists the current
configuration as JSON for testing purposes.

**Test plan**

Added integration tests.