### PR TITLE
Fix: bring back the aggressive concurrency protection

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -603,10 +603,10 @@ export async function copyBulk(
 
   await promise.queue(
     fileActions,
-    (data: CopyFileAction): Promise<void> => {
-      const writePromise = currentlyWriting.get(data.dest);
-      if (writePromise) {
-        return writePromise;
+    async (data: CopyFileAction): Promise<void> => {
+      let writePromise;
+      while ((writePromise = currentlyWriting.get(data.dest))) {
+        await writePromise;
       }
 
       reporter.verbose(reporter.lang('verboseFileCopy', data.src, data.dest));


### PR DESCRIPTION
**Summary**

Follow up to #4486 which reverted the while loop that waits on
potential multiple copies of the same file. This seems to have
some random breakages and needs more investigation for optimizing.

**Test plan**

N/A