### PR TITLE
Preserve workspace packages when adding to the root

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -54,6 +54,24 @@ test.concurrent("add with --dev shouldn't fail on the workspace root", async () 
   });
 });
 
+test.concurrent('adding to the workspace root should preserve workspace packages in lockfile', async () => {
+  await runInstall({}, 'workspaces-install-basic', async (config, reporter): Promise<void> => {
+    await add(config, reporter, {dev: true}, ['max-safe-integer@1.0.0']);
+
+    expect(await fs.exists(`${config.cwd}/yarn.lock`)).toEqual(true);
+
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.devDependencies).toEqual({'max-safe-integer': '1.0.0'});
+    expect(pkg.dependencies).toEqual({'left-pad': '1.1.3'});
+
+    const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
+    expect(lockfile).toHaveLength(15);
+    expect(lockfile.indexOf('isarray@2.0.1:')).toEqual(0);
+    expect(lockfile.indexOf('left-pad@1.1.3:')).toEqual(3);
+    expect(lockfile.indexOf('max-safe-integer@1.0.0:')).toEqual(6);
+  });
+});
+
 test.concurrent('adds any new package to the current workspace, but install from the workspace', async () => {
   await runInstall({}, 'simple-worktree', async (config): Promise<void> => {
     const inOut = new stream.PassThrough();

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -34,7 +34,7 @@ export class Add extends Install {
       .shift();
 
     if (this.config.workspaceRootFolder && this.config.cwd === this.config.workspaceRootFolder) {
-      this.setIgnoreWorkspaces(true);
+      this.inWorkspaceRoot = true;
       // flagsToOrgin defaults to being a hard `dependency` when no flags are passed (see above),
       // so it incorrectly throws a warning when upgrading existing devDependencies in workspace root
       // To allow for a successful upgrade, override flagsToOrigin when `existing` flag is passed by `upgrade` command
@@ -46,6 +46,7 @@ export class Add extends Install {
 
   args: Array<string>;
   flagToOrigin: string;
+  inWorkspaceRoot: boolean;
   addedPatterns: Array<string>;
 
   /**
@@ -132,7 +133,7 @@ export class Add extends Install {
    */
 
   async init(): Promise<Array<string>> {
-    if (this.ignoreWorkspaces) {
+    if (this.inWorkspaceRoot) {
       if (this.flagToOrigin === 'dependencies') {
         throw new MessageError(this.reporter.lang('workspacesPreferDevDependencies'));
       }


### PR DESCRIPTION
**Summary**

Fixes #4348

Before this, adding a dev dependency to the workspace root would clear out workspace dependencies from `yarn.lock`. This is because `ignoreWorkspaces` was being set to `true` when executing `add` in the workspace root.

**Test plan**

- Added new test
- Existing tests pass
- Manually tested in [repro project](https://github.com/jgoz/yarn-workspace-issue)