### PR TITLE
ref(autoclean): remove *.gz from the default .yarnclean file

### DIFF
--- a/src/cli/commands/autoclean.js
+++ b/src/cli/commands/autoclean.js
@@ -53,7 +53,6 @@ Gruntfile.js
 *.yml
 
 # misc
-*.gz
 *.md
 `.trim();
 


### PR DESCRIPTION
Hello!

**Summary**

I removed the *.gz from the default .yarnclean generated by the `yarn autoclean --init` command. 

**Test plan**

I tested by hand and launch `yarn test` and didn't find a test case for the autoclean --init option. If needed I could write a test case to check the default .yarnclean file content against the constant DEFAULT_FILTER.

I hope it resolve half the issue #4450 :)