### PR TITLE
chore(tests): Make integration tests passing on Node 7

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -59,11 +59,7 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/bestander/chrome-app-livereload.git'); // no package.json
 addTest('bestander/chrome-app-livereload'); // no package.json, github, tarball
-// many peer dependencies, there shouldn't be any peerDep warnings
-addTest('react-scripts@1.0.13', {
-  strict: true,
-  args: ['--no-node-version-check'],
-});
+addTest('react-scripts@1.0.13', {strict: true}, ['--no-node-version-check']); // many peer dependencies, there shouldn't be any peerDep warnings
 
 const MIN_PORT_NUM = 56000;
 const MAX_PORT_NUM = 65535;

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -59,7 +59,7 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/bestander/chrome-app-livereload.git'); // no package.json
 addTest('bestander/chrome-app-livereload'); // no package.json, github, tarball
-addTest('react-scripts@1.0.13', {strict: true}, ['--no-node-version-check']); // many peer dependencies, there shouldn't be any peerDep warnings
+addTest('react-scripts@1.0.13', {strict: true}, ['--no-node-version-check', '--ignore-engines']); // many peer dependencies, there shouldn't be any peerDep warnings
 
 const MIN_PORT_NUM = 56000;
 const MAX_PORT_NUM = 65535;

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -60,7 +60,8 @@ addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.
 addTest('https://github.com/bestander/chrome-app-livereload.git'); // no package.json
 addTest('bestander/chrome-app-livereload'); // no package.json, github, tarball
 // Only run `react-scripts` test on Node 6+
-if (parseInt(process.versions.node.split('.')[0], 10) >= 6) {
+const nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
+if (nodeMajorVersion === 6 || nodeMajorVersion >= 8) {
   addTest('react-scripts@1.0.13', {strict: true}); // many peer dependencies, there shouldn't be any peerDep warnings
 }
 

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -11,13 +11,13 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
 const path = require('path');
 
-function addTest(pattern, {strict} = {strict: false}) {
+function addTest(pattern, {strict} = {strict: false}, yarnArgs: Array<string> = []) {
   test.concurrent(`yarn add ${pattern}`, async () => {
     const cwd = await makeTemp();
     const cacheFolder = path.join(cwd, 'cache');
 
     const command = path.resolve(__dirname, '../bin/yarn');
-    const args = ['--cache-folder', cacheFolder];
+    const args = ['--cache-folder', cacheFolder, ...yarnArgs];
 
     const options = {cwd};
 
@@ -59,11 +59,11 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/bestander/chrome-app-livereload.git'); // no package.json
 addTest('bestander/chrome-app-livereload'); // no package.json, github, tarball
-// Only run `react-scripts` test on Node 6+
-const nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
-if (nodeMajorVersion === 6 || nodeMajorVersion >= 8) {
-  addTest('react-scripts@1.0.13', {strict: true}); // many peer dependencies, there shouldn't be any peerDep warnings
-}
+// many peer dependencies, there shouldn't be any peerDep warnings
+addTest('react-scripts@1.0.13', {
+  strict: true,
+  args: ['--no-node-version-check'],
+});
 
 const MIN_PORT_NUM = 56000;
 const MAX_PORT_NUM = 65535;


### PR DESCRIPTION
The change introduced in 96c215c1ce5944a6fe993ab0d9b13e6edfe65675 caused tests to fail on node 7 as react-scripts is not compatible with it, this skips test on node v7 which is used within yarn's Docker.

I excluded this test for node v7, here's the reasoning behind it:
```
Summary of all failing tests
 FAIL  __tests__/integration.js (182.903s)
  ● yarn add react-scripts@1.0.13

    expect(received).not.toMatch(expected)

    Expected value not to match:
      /^warning /gm
    Received:
      "warning You are using Node \"7.10.1\" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: \"^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0\""

      at __tests__/integration.js:82:1793
          at Generator.next (<anonymous>)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:28:13
      at process._tickCallback (internal/process/next_tick.js:109:7)
```
Node 7.x is no longer supported, so this should be completely fine.