### PR TITLE
Updated node to 8.x in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,7 @@
 # Dockerfile for building Yarn.
 # docker build -t yarnpkg/dev -f Dockerfile.dev .
 
-FROM node:7
-MAINTAINER Daniel Lo Nigro <yarn@dan.cx>
+FROM node:8
 
 # Debian packages
 RUN apt-get -y update && \


### PR DESCRIPTION
The reasoning behind this:
1) As discovered in #4606 not all of the tests are passing on 7.x 
2) Node 7.x is no longer supported anyway

I also removed MAINTAINER field from Dockerfile as it's not required.