### PR TITLE
Fix: symlink error in Windows

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -170,7 +170,11 @@ async function initUpdateBins(config: Config, reporter: Reporter, flags: Object)
         await fs.unlink(dest);
         await linkBin(src, dest);
         if (process.platform === 'win32' && dest.indexOf('.cmd') !== -1) {
-          await fs.rename(dest + '.cmd', dest);
+          // ignore linux or unix script
+          const path = dest + '.cmd';
+          const body = await fs.readFile(path);
+          await fs.writeFile(path, body.replace('%~dp0\\', ''));
+          await fs.rename(path, dest);
         }
       } catch (err) {
         throwPermError(err, dest);


### PR DESCRIPTION
I use ```yarn config set prefix D:\node_modules```，all global packages will have their binaries installed to D:\node_modules\bin。but when I find script is wrong in ```D:\node_modules\bin```,，example ```@"%~dp0\C:\Users\nodece\AppData\Local\Yarn\config\global\node_modules\.bin\create-react-app.cmd"   %*```，The correct thing is ```@"C:\Users\nodece\AppData\Local\Yarn\config\global\node_modules\.bin\create-react-app.cmd"   %*```，Finally found cmd-shim dependent problems。
