### PR TITLE
Add ability to filter yarn list with pattern

### DIFF
--- a/__tests__/commands/list.js
+++ b/__tests__/commands/list.js
@@ -81,6 +81,18 @@ describe('list', () => {
     });
   });
 
+  test.concurrent('accepts a pattern', (): Promise<void> => {
+    return runList([], {pattern: 'is-plain-obj'}, 'one-arg', (config, reporter): ?Promise<void> => {
+      const rprtr = new BufferReporter({});
+      const tree = reporter.getBuffer().slice(-1);
+      const trees = [makeTree('is-plain-obj@1.1.0')];
+
+      rprtr.tree('list', trees);
+
+      expect(tree).toEqual(rprtr.getBuffer());
+    });
+  });
+
   test.concurrent('should not throw when list is called with resolutions field', (): Promise<void> => {
     return runList([], {}, {source: '', cwd: 'resolutions'}, (config, reporter): ?Promise<void> => {
       const rprtr = new BufferReporter({});
@@ -106,11 +118,16 @@ describe('list', () => {
     });
   });
 
-  test.concurrent('matches exactly without glob', (): Promise<void> => {
+  test.concurrent('matches exactly without glob in argument', (): Promise<void> => {
     return runList(['gulp'], {}, 'glob-arg', (config, reporter): ?Promise<void> => {
       const rprtr = new BufferReporter({});
       const tree = reporter.getBuffer().slice(-1);
       const trees = [makeTree('gulp@3.9.1', {color: 'bold'})];
+
+      const messageParts = reporter.lang('deprecatedListArgs').split('undefined');
+      const output = reporter.getBuffer();
+      const hasWarningMessage = output.some(messages => messageParts.indexOf(String(messages.data)) > -1);
+      expect(hasWarningMessage).toBe(true);
 
       rprtr.tree('list', trees);
 
@@ -118,8 +135,20 @@ describe('list', () => {
     });
   });
 
-  test.concurrent('expands a glob', (): Promise<void> => {
+  test.concurrent('expands a glob in argument', (): Promise<void> => {
     return runList(['gulp*'], {}, 'glob-arg', (config, reporter): ?Promise<void> => {
+      const rprtr = new BufferReporter({});
+      const tree = reporter.getBuffer().slice(-1);
+      const trees = [makeTree('gulp@3.9.1', {color: 'bold'}), makeTree('gulp-babel@6.1.2', {color: 'bold'})];
+
+      rprtr.tree('list', trees);
+
+      expect(tree).toEqual(rprtr.getBuffer());
+    });
+  });
+
+  test.concurrent('expands a glob in pattern', (): Promise<void> => {
+    return runList([], {pattern: 'gulp*'}, 'glob-arg', (config, reporter): ?Promise<void> => {
       const rprtr = new BufferReporter({});
       const tree = reporter.getBuffer().slice(-1);
       const trees = [makeTree('gulp@3.9.1', {color: 'bold'}), makeTree('gulp-babel@6.1.2', {color: 'bold'})];

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -359,6 +359,7 @@ const messages = {
   scopeNotValid: 'The specified scope is not valid.',
 
   deprecatedCommand: '$0 is deprecated. Please use $1.',
+  deprecatedListArgs: 'Filtering by arguments is deprecated. Please use the pattern option instead.',
   implicitFileDeprecated:
     'Using the "file:" protocol implicitly is deprecated. Please either the protocol or prepend the path $0 with "./".',
   unsupportedNodeVersion:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In PR #4571, list was highlighted to be a candidate for adding a pattern option to allow filtering.

This PR adds this option.

Usage:
`yarn list --pattern mypattern`

Still allows:
`yarn list exact-package --pattern mypattern`

but this is now deprecated.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Updated current tests to use new flag.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
