### PR TITLE
Add ability to upgrade based on pattern

### DIFF
--- a/__tests__/commands/upgrade.js
+++ b/__tests__/commands/upgrade.js
@@ -112,6 +112,21 @@ test.concurrent('upgrades from fixed version to latest with workspaces', (): Pro
   });
 });
 
+test.concurrent('works with just a pattern', (): Promise<void> => {
+  return runUpgrade([], {pattern: 'max'}, 'multiple-packages', async (config): ?Promise<void> => {
+    await expectInstalledDependency(config, 'max-safe-integer', '^1.0.0', '1.0.1');
+    await expectInstalledDependency(config, 'is-negative-zero', '^1.0.0', '1.0.0');
+  });
+});
+
+test.concurrent('works with arguments and a pattern', (): Promise<void> => {
+  return runUpgrade(['left-pad'], {pattern: 'max'}, 'multiple-packages', async (config): ?Promise<void> => {
+    await expectInstalledDependency(config, 'left-pad', '^1.0.0', '1.1.3');
+    await expectInstalledDependency(config, 'max-safe-integer', '^1.0.0', '1.0.1');
+    await expectInstalledDependency(config, 'is-negative-zero', '^1.0.0', '1.0.0');
+  });
+});
+
 test.concurrent('upgrades to latest matching package.json semver when no package name passed', (): Promise<void> => {
   return runUpgrade([], {}, 'range-to-latest', async (config): ?Promise<void> => {
     await expectInstalledDependency(config, 'left-pad', '<=1.1.1', '1.1.1');

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -51,6 +51,7 @@ export function setFlags(commander: Object) {
   commander.option('-S, --scope <scope>', 'upgrade packages under the specified scope');
   commander.option('-L, --latest', 'list the latest version of packages, ignoring version ranges in package.json');
   commander.option('-E, --exact', 'install exact version. Only used when --latest is specified.');
+  commander.option('-P, --pattern [pattern]', 'upgrade packages that match pattern');
   commander.option(
     '-T, --tilde',
     'install most recent release with the same minor version. Only used when --latest is specified.',
@@ -168,7 +169,7 @@ export async function getOutdated(
 
   normalizeScope();
 
-  const deps = (await PackageRequest.getOutdatedPackages(lockfile, install, config, reporter, patterns))
+  const deps = (await PackageRequest.getOutdatedPackages(lockfile, install, config, reporter, patterns, flags))
     .filter(versionFilter)
     .filter(scopeFilter);
   deps.forEach(dep => (dep.upgradeTo = buildPatternToUpgradeTo(dep, flags)));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In PR #4571, upgrade was highlighted to be a candidate for adding a pattern option to allow filtering.

This can be used with the current args or by itself.

Usage:
`yarn upgrade --pattern mypattern`
`yarn upgrade diff-package --pattern mypattern`

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Added test that filter with pattern and with the current args together.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
