### PR TITLE
fix(resolver): Only optimize patterns in flat mode

### DIFF
--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -545,9 +545,11 @@ export default class PackageResolver {
       this.resolveToResolution(req);
     }
 
-    for (const dep of deps) {
-      const name = normalizePattern(dep.pattern).name;
-      this.optimizeResolutions(name);
+    if (isFlat) {
+      for (const dep of deps) {
+        const name = normalizePattern(dep.pattern).name;
+        this.optimizeResolutions(name);
+      }
     }
 
     activity.end();


### PR DESCRIPTION
**Summary**

Fixes #4550. The optimization introduced in #4488 should only
apply to flat installations since even if a single pattern can
satisfy all resolved versions, it is not guaranteed that it is
strict enough for resolving correctly for all patterns under all
circumstances.

**Test plan**

Manual verification.