### PR TITLE
fix(network): Allow `https-proxy false` to not use a proxy for HTTPS

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -271,12 +271,12 @@ export default class Config {
     this.networkTimeout = opts.networkTimeout || Number(this.getOption('network-timeout')) || constants.NETWORK_TIMEOUT;
 
     let httpProxy = opts.httpProxy || this.getOption('proxy');
-    if(httpProxy === 'null') {
+    if (httpProxy === 'null') {
       httpProxy = false;
     }
 
     let httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
-    if(httpsProxy === 'null') {
+    if (httpsProxy === 'null') {
       httpsProxy = false;
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -270,10 +270,12 @@ export default class Config {
 
     this.networkTimeout = opts.networkTimeout || Number(this.getOption('network-timeout')) || constants.NETWORK_TIMEOUT;
 
+    const httpProxy = opts.httpProxy || this.getOption('proxy');
+    const httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
-      httpProxy: String(opts.httpProxy || this.getOption('proxy') || ''),
-      httpsProxy: String(opts.httpsProxy || this.getOption('https-proxy') || ''),
+      httpProxy: httpProxy === false ? false : String(httpProxy || ''),
+      httpsProxy: httpsProxy === false ? false : String(httpsProxy || ''),
       strictSSL: Boolean(this.getOption('strict-ssl')),
       ca: Array.prototype.concat(opts.ca || this.getOption('ca') || []).map(String),
       cafile: String(opts.cafile || this.getOption('cafile', true) || ''),

--- a/src/config.js
+++ b/src/config.js
@@ -270,16 +270,8 @@ export default class Config {
 
     this.networkTimeout = opts.networkTimeout || Number(this.getOption('network-timeout')) || constants.NETWORK_TIMEOUT;
 
-    let httpProxy = opts.httpProxy || this.getOption('proxy');
-    if (httpProxy === 'null') {
-      httpProxy = false;
-    }
-
-    let httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
-    if (httpsProxy === 'null') {
-      httpsProxy = false;
-    }
-
+    const httpProxy = opts.httpProxy || this.getOption('proxy');
+    const httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
       httpProxy: httpProxy === false ? false : String(httpProxy || ''),

--- a/src/config.js
+++ b/src/config.js
@@ -270,8 +270,16 @@ export default class Config {
 
     this.networkTimeout = opts.networkTimeout || Number(this.getOption('network-timeout')) || constants.NETWORK_TIMEOUT;
 
-    const httpProxy = opts.httpProxy || this.getOption('proxy');
-    const httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
+    let httpProxy = opts.httpProxy || this.getOption('proxy');
+    if(httpProxy === 'null') {
+      httpProxy = false;
+    }
+
+    let httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
+    if(httpsProxy === 'null') {
+      httpsProxy = false;
+    }
+
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
       httpProxy: httpProxy === false ? false : String(httpProxy || ''),

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -416,7 +416,6 @@ export default class RequestManager {
       proxy = this.httpsProxy;
     }
     if (proxy && typeof proxy === 'string') {
-      console.log('PROXY', proxy);
       params.proxy = String(proxy);
     }
 

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -78,9 +78,9 @@ export default class RequestManager {
     this._requestModule = null;
     this.offlineQueue = [];
     this.captureHar = false;
-    this.httpsProxy = null;
+    this.httpsProxy = '';
     this.ca = null;
-    this.httpProxy = null;
+    this.httpProxy = '';
     this.strictSSL = true;
     this.userAgent = '';
     this.reporter = reporter;
@@ -96,8 +96,8 @@ export default class RequestManager {
   userAgent: string;
   reporter: Reporter;
   running: number;
-  httpsProxy: ?string | ?boolean;
-  httpProxy: ?string | ?boolean;
+  httpsProxy: string | boolean;
+  httpProxy: string | boolean;
   strictSSL: boolean;
   ca: ?Array<string>;
   cert: ?string;
@@ -142,17 +142,13 @@ export default class RequestManager {
     }
 
     if (opts.httpProxy != null) {
-      this.httpProxy = opts.httpProxy;
+      this.httpProxy = opts.httpProxy || '';
     }
 
-    if (opts.httpsProxy != null) {
-      // fallback to httpProxy if httpsProxy is undefined (not specified).
-      // setting httpsProxy to `false` will not use a proxy for HTTPS. Requested by #4546
-      if (this.httpsProxy === undefined) {
-        this.httpsProxy = opts.httpProxy;
-      } else {
-        this.httpsProxy = opts.httpsProxy;
-      }
+    if (opts.httpsProxy === '') {
+      this.httpsProxy = opts.httpProxy || '';
+    } else {
+      this.httpsProxy = opts.httpsProxy || '';
     }
 
     if (opts.strictSSL !== null && typeof opts.strictSSL !== 'undefined') {
@@ -415,7 +411,7 @@ export default class RequestManager {
     if (params.url.startsWith('https:')) {
       proxy = this.httpsProxy;
     }
-    if (proxy && typeof proxy === 'string') {
+    if (proxy) {
       params.proxy = String(proxy);
     }
 


### PR DESCRIPTION
**Summary**

Fixes #4546. Previous behavior was that if `.npmrc` or `.yarnrc` contained and `http-proxy` but not an `https-proxy`, HTTPS requests would "fall back" to the `http-proxy`.

This is not always the desired behavior; See #4546 sometimes one protocol needs a proxy and the other does not.

This PR adds the ability to set the `https-proxy` to `false` which will cause Yarn to not use an HTTPS proxy (and not fall-back to the HTTP proxy). This allows the code to treat `undefined` as the setting not being specified (which will fall back to http-proxy) and `false` as the setting being specified, but set to false (which will not use a proxy).

**Test plan**

Tested manually on Windows with Fiddler.

I have no idea how to test this since requests go through the mock http requester when running tests. Suggestions welcome!