### PR TITLE
fix(request-manager): Flaky network messsage should be info, not warning

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -308,7 +308,7 @@ export default class RequestManager {
 
   queueForOffline(opts: RequestOptions) {
     if (!this.offlineQueue.length) {
-      this.reporter.warn(this.reporter.lang('offlineRetrying'));
+      this.reporter.info(this.reporter.lang('offlineRetrying'));
       this.initOfflineRetry();
     }
 


### PR DESCRIPTION
**Summary**

Sometimes Yarn saturates the network and sometimes the network itself
has issues, especially on CI and Yarn reports this as a warning. This
should be a simple info message unless it actually completely fails.

This also fixes a flaky integration test with react-scripts.

**Test plan**

`react-scripts` integration test should not be flaky anymore.