### PR TITLE
fix(git): Fix Bitbucket exotic shortcut resolvers with private repositories

### DIFF
--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -45,17 +45,14 @@ export default class BitbucketResolver extends HostedGitResolver {
   }
 
   async hasHTTPCapability(url: string): Promise<boolean> {
-    try {
-      const result = await this.config.requestManager.request({
+    return (
+      (await this.config.requestManager.request({
         url,
         method: 'HEAD',
         queue: this.resolver.fetchingQueue,
         followRedirect: false,
         rejectStatusCode: 302,
-      });
-      return result !== false;
-    } catch (e) {
-      return false;
-    }
+      })) !== false
+    );
   }
 }

--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -7,6 +7,20 @@ export default class BitbucketResolver extends HostedGitResolver {
   static hostname = 'bitbucket.org';
   static protocol = 'bitbucket';
 
+  static isVersion(pattern: string): boolean {
+    // bitbucket proto
+    if (pattern.startsWith('bitbucket:')) {
+      return true;
+    }
+
+    // bitbucket shorthand
+    if (/^[^:@%/\s.-][^:@%/\s]*[/][^:@\s/%]+(?:#.*)?$/.test(pattern)) {
+      return true;
+    }
+
+    return false;
+  }
+
   static getTarballUrl(parts: ExplodedFragment, hash: string): string {
     return `https://${this.hostname}/${parts.user}/${parts.repo}/get/${hash}.tar.gz`;
   }
@@ -28,5 +42,20 @@ export default class BitbucketResolver extends HostedGitResolver {
 
   static getHTTPFileUrl(parts: ExplodedFragment, filename: string, commit: string): string {
     return `https://${this.hostname}/${parts.user}/${parts.repo}/raw/${commit}/${filename}`;
+  }
+
+  async hasHTTPCapability(url: string): Promise<boolean> {
+    try {
+      const result = await this.config.requestManager.request({
+        url,
+        method: 'HEAD',
+        queue: this.resolver.fetchingQueue,
+        followRedirect: false,
+        rejectStatusCode: 302
+      });
+      return result !== false;
+    } catch (e) {
+      return false;
+    }
   }
 }

--- a/src/resolvers/exotics/bitbucket-resolver.js
+++ b/src/resolvers/exotics/bitbucket-resolver.js
@@ -51,7 +51,7 @@ export default class BitbucketResolver extends HostedGitResolver {
         method: 'HEAD',
         queue: this.resolver.fetchingQueue,
         followRedirect: false,
-        rejectStatusCode: 302
+        rejectStatusCode: 302,
       });
       return result !== false;
     } catch (e) {

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -60,8 +60,9 @@ export default class Git implements GitRefResolvingInterface {
    */
   static npmUrlToGitUrl(npmUrl: string): GitUrl {
     // Expand shortened format first if needed
-    npmUrl = npmUrl.replace(/^github:/, 'git+ssh://git@github.com/');
-    npmUrl = npmUrl.replace(/^bitbucket:/, 'git+ssh://git@bitbucket.org/');
+    npmUrl = npmUrl
+      .replace(/^github:/, 'git+ssh://git@github.com/')
+      .replace(/^bitbucket:/, 'git+ssh://git@bitbucket.org/');
 
     // Special case in npm, where ssh:// prefix is stripped to pass scp-like syntax
     // which in git works as remote path only if there are no slashes before ':'.

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -61,6 +61,7 @@ export default class Git implements GitRefResolvingInterface {
   static npmUrlToGitUrl(npmUrl: string): GitUrl {
     // Expand shortened format first if needed
     npmUrl = npmUrl.replace(/^github:/, 'git+ssh://git@github.com/');
+    npmUrl = npmUrl.replace(/^bitbucket:/, 'git+ssh://git@bitbucket.org/');
 
     // Special case in npm, where ssh:// prefix is stripped to pass scp-like syntax
     // which in git works as remote path only if there are no slashes before ':'.
@@ -364,7 +365,7 @@ export default class Git implements GitRefResolvingInterface {
   }
 
   async setRefRemote(): Promise<string> {
-    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository]);
+    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository.split('#')[ 0 ]]);
     const refs = parseRefs(stdout);
     return this.setRef(refs);
   }

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -365,7 +365,7 @@ export default class Git implements GitRefResolvingInterface {
   }
 
   async setRefRemote(): Promise<string> {
-    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository.split('#')[ 0 ]]);
+    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository.split('#')[0]]);
     const refs = parseRefs(stdout);
     return this.setRef(refs);
   }

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -63,6 +63,7 @@ type RequestParams<T> = {
   retryAttempts?: number,
   maxRetryAttempts?: number,
   followRedirect?: boolean,
+  rejectStatusCode?: number|Array<number>
 };
 
 type RequestOptions = {
@@ -393,7 +394,7 @@ export default class RequestManager {
           const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
           reject(new Error(errMsg));
         } else {
-          if (res.statusCode === 400 || res.statusCode === 404 || res.statusCode === 401) {
+          if ([400, 401, 404].concat(params.rejectStatusCode || []).includes(res.statusCode)) {
             body = false;
           }
           resolve(body);

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -63,7 +63,7 @@ type RequestParams<T> = {
   retryAttempts?: number,
   maxRetryAttempts?: number,
   followRedirect?: boolean,
-  rejectStatusCode?: number|Array<number>
+  rejectStatusCode?: number | Array<number>
 };
 
 type RequestOptions = {

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -396,7 +396,7 @@ export default class RequestManager {
           const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
           reject(new Error(errMsg));
         } else {
-          if ([400, 401, 404].concat(params.rejectStatusCode || []).includes(res.statusCode)) {
+          if (~[400, 401, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode)) {
             body = false;
           }
           resolve(body);

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -63,7 +63,7 @@ type RequestParams<T> = {
   retryAttempts?: number,
   maxRetryAttempts?: number,
   followRedirect?: boolean,
-  rejectStatusCode?: number | Array<number>
+  rejectStatusCode?: number | Array<number>,
 };
 
 type RequestOptions = {

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -396,7 +396,7 @@ export default class RequestManager {
           const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
           reject(new Error(errMsg));
         } else {
-          if (~[400, 401, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode)) {
+          if ([400, 401, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode) !== -1) {
             body = false;
           }
           resolve(body);


### PR DESCRIPTION
**Summary**

* fix hasHTTPCapability issue with bitbucket shortcut resolver and private repo (#4393)
  *bug with a private repo that used like `"module": "bitbucket:team/repo"`*
* fix setRefRemote issue with exotic shortcut resolvers and branch/tag/commit
  *bug with a repo that used like `"module": "bitbucket:team/repo#tag"`*

**Test plan**

If I have a private dependency like `"activities": "bitbucket:openagenda/activities"` in my package.json, and I run `yarn install --verbose` then I have this error:

```
[1/4] Resolving packages...
verbose 0.407 Performing "HEAD" request to "https://bitbucket.org/openagenda/es-node".
verbose 0.867 Request "https://bitbucket.org/openagenda/es-node" finished with status code 302.
verbose 0.873 Performing "GET" request to "https://bitbucket.org/openagenda/es-node.git/info/refs?service=git-upload-pack".
verbose 0.98 Request "https://bitbucket.org/openagenda/es-node.git/info/refs?service=git-upload-pack" finished with status code 401.
verbose 0.981 Error: Error connecting to repository. Please, check the url.
    at /home/bertho/.config/yarn/global/node_modules/yarn/lib/cli.js:33269:15
    at Generator.next (<anonymous>)
    at step (/home/bertho/.config/yarn/global/node_modules/yarn/lib/cli.js:92:30)
    at /home/bertho/.config/yarn/global/node_modules/yarn/lib/cli.js:103:13
    at process._tickCallback (internal/process/next_tick.js:109:7)
error An unexpected error occurred: "Error connecting to repository. Please, check the url.".
info If you think this is a bug, please open a bug report with the information provided in "/home/bertho/OpenAgenda/cibul-node/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```