### PR TITLE
fix(config): Don't override registry with `undefined` by default

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -197,6 +197,25 @@ describe('--registry option', () => {
       expect(stdoutOutput.toString()).toMatch(/getaddrinfo ENOTFOUND example-registry-doesnt-exist\.com/g);
     }
   });
+
+  test('registry option from yarnrc', async () => {
+    const cwd = await makeTemp();
+
+    const registry = 'https://registry.npmjs.org';
+    await fs.writeFile(`${cwd}/.yarnrc`, 'registry "' + registry + '"\n');
+
+    const packageJsonPath = path.join(cwd, 'package.json');
+    await fs.writeFile(packageJsonPath, JSON.stringify({}));
+
+    await runYarn(['add', 'left-pad'], {cwd});
+
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath));
+    const lockfile = explodeLockfile(await fs.readFile(path.join(cwd, 'yarn.lock')));
+
+    expect(packageJson.dependencies['left-pad']).toBeDefined();
+    expect(lockfile).toHaveLength(3);
+    expect(lockfile[2]).toContain(registry);
+  });
 });
 
 test('--cwd option', async () => {

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -102,7 +102,14 @@ export default class BaseRegistry {
   async init(overrides: Object = {}): Promise<void> {
     this.mergeEnv('yarn_');
     await this.loadConfig();
-    Object.assign(this.config, overrides);
+
+    for (const override of Object.keys(overrides)) {
+      const val = overrides[override];
+
+      if (val !== undefined) {
+        this.config[override] = val;
+      }
+    }
     this.loc = path.join(this.cwd, this.folder);
   }
 


### PR DESCRIPTION
**Summary**

Follow up to #4238. We were always passing the `registry` key in
registry overrides but its value was `undefined` when an override
was not in place. `Object.assign` doesn't care about that though
so we were overriding the registry all the time, mostly with
`undefined`.

**Test plan**

Added new test case.