### PR TITLE
fix(git): Refactor Git URL resolution code & remove hash from URL

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -59,12 +59,12 @@ test('npmUrlToGitUrl', () => {
   expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind.git#v1.2.3')).toEqual({
     protocol: 'ssh:',
     hostname: 'github.com',
-    repository: 'ssh://git@github.com/npm-opam/ocamlfind.git#v1.2.3',
+    repository: 'ssh://git@github.com/npm-opam/ocamlfind.git',
   });
   expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind#v1.2.3')).toEqual({
     protocol: 'ssh:',
     hostname: 'github.com',
-    repository: 'ssh://git@github.com/npm-opam/ocamlfind#v1.2.3',
+    repository: 'ssh://git@github.com/npm-opam/ocamlfind',
   });
   expect(Git.npmUrlToGitUrl('github:npm-opam/ocamlfind.git')).toEqual({
     protocol: 'ssh:',

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -105,12 +105,12 @@ export default class Git implements GitRefResolvingInterface {
       parsed.path.startsWith(SCP_PATH_PREFIX) &&
       parsed.port === null
     ) {
+      const auth = parsed.auth ? parsed.auth + '@' : '';
+      const pathname = parsed.path.slice(SCP_PATH_PREFIX.length);
       return {
         hostname: parsed.hostname,
         protocol: parsed.protocol,
-        repository: `${parsed.auth ? parsed.auth + '@' : ''}${parsed.hostname}:${parsed.path.slice(
-          SCP_PATH_PREFIX.length,
-        )}`,
+        repository: `${auth}${parsed.hostname}:${pathname}`,
       };
     }
 

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -401,7 +401,7 @@ export default class Git implements GitRefResolvingInterface {
   }
 
   async setRefRemote(): Promise<string> {
-    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository);
+    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository]);
     const refs = parseRefs(stdout);
     return this.setRef(refs);
   }

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -1,5 +1,12 @@
 /* @flow */
 
+import invariant from 'invariant';
+import {StringDecoder} from 'string_decoder';
+import tarFs from 'tar-fs';
+import tarStream from 'tar-stream';
+import url from 'url';
+import {createWriteStream} from 'fs';
+
 import type Config from '../config.js';
 import type {Reporter} from '../reporters/index.js';
 import type {ResolvedSha, GitRefResolvingInterface, GitRefs} from './git/git-ref-resolver.js';
@@ -10,12 +17,9 @@ import * as crypto from './crypto.js';
 import * as fs from './fs.js';
 import map from './map.js';
 
-const invariant = require('invariant');
-const StringDecoder = require('string_decoder').StringDecoder;
-const tarFs = require('tar-fs');
-const tarStream = require('tar-stream');
-const url = require('url');
-import {createWriteStream} from 'fs';
+const GIT_PROTOCOL_PREFIX = 'git+';
+const SSH_PROTOCOL = 'ssh:';
+const SCP_PATH_PREFIX = '/:';
 
 type GitUrl = {
   protocol: string, // parsed from URL
@@ -32,6 +36,27 @@ const handleSpawnError = err => {
     throw err;
   }
 };
+
+const SHORTHAND_SERVICES: {[key: string]: url.parse} = map({
+  'github:': parsedUrl => ({
+    ...parsedUrl,
+    slashes: true,
+    auth: 'git',
+    protocol: SSH_PROTOCOL,
+    host: 'github.com',
+    hostname: 'github.com',
+    pathname: `/${parsedUrl.hostname}${parsedUrl.pathname}`,
+  }),
+  'bitbucket:': parsedUrl => ({
+    ...parsedUrl,
+    slashes: true,
+    auth: 'git',
+    protocol: SSH_PROTOCOL,
+    host: 'bitbucket.com',
+    hostname: 'bitbucket.com',
+    pathname: `/${parsedUrl.hostname}${parsedUrl.pathname}`,
+  }),
+});
 
 export default class Git implements GitRefResolvingInterface {
   constructor(config: Config, gitUrl: GitUrl, hash: string) {
@@ -60,29 +85,39 @@ export default class Git implements GitRefResolvingInterface {
    */
   static npmUrlToGitUrl(npmUrl: string): GitUrl {
     // Expand shortened format first if needed
-    npmUrl = npmUrl
-      .replace(/^github:/, 'git+ssh://git@github.com/')
-      .replace(/^bitbucket:/, 'git+ssh://git@bitbucket.org/');
+    let parsed = url.parse(npmUrl);
+    const expander = parsed.protocol && SHORTHAND_SERVICES[parsed.protocol];
+    if (expander) {
+      parsed = expander(parsed);
+    }
+
+    if (parsed.protocol && parsed.protocol.startsWith(GIT_PROTOCOL_PREFIX)) {
+      parsed.protocol = parsed.protocol.slice(GIT_PROTOCOL_PREFIX.length);
+    }
 
     // Special case in npm, where ssh:// prefix is stripped to pass scp-like syntax
     // which in git works as remote path only if there are no slashes before ':'.
-    const match = npmUrl.match(/^git\+ssh:\/\/((?:[^@:\/]+@)?([^@:\/]+):([^/]*).*)/);
-    // Additionally, if the host part is digits-only, npm falls back to
-    // interpreting it as an SSH URL with a port number.
-    if (match && /[^0-9]/.test(match[3])) {
+    // See #3146.
+    if (
+      parsed.protocol === SSH_PROTOCOL &&
+      parsed.hostname &&
+      parsed.path &&
+      parsed.path.startsWith(SCP_PATH_PREFIX) &&
+      parsed.port === null
+    ) {
       return {
-        hostname: match[2],
-        protocol: 'ssh:',
-        repository: match[1],
+        hostname: parsed.hostname,
+        protocol: parsed.protocol,
+        repository: `${parsed.auth ? parsed.auth + '@' : ''}${parsed.hostname}:${parsed.path.slice(
+          SCP_PATH_PREFIX.length,
+        )}`,
       };
     }
 
-    const repository = npmUrl.replace(/^git\+/, '');
-    const parsed = url.parse(repository);
     return {
       hostname: parsed.hostname || null,
       protocol: parsed.protocol || 'file:',
-      repository,
+      repository: url.format({...parsed, hash: ''}),
     };
   }
 
@@ -366,7 +401,7 @@ export default class Git implements GitRefResolvingInterface {
   }
 
   async setRefRemote(): Promise<string> {
-    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository.split('#')[0]]);
+    const stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository);
     const refs = parseRefs(stdout);
     return this.setRef(refs);
   }


### PR DESCRIPTION
**Summary**

This PR is triggered by https://git.io/vdzI2. It refactors the
code to allow more hosted Git expansions (like GitLab) in a more
flexible way. It also prefers `url.parse` over regular expressions
and removes any hasehs in `GitUrl.repository` results.

**Test plan**

Existing tests should pass along with the hash removal correction.