### PR TITLE
fix(config): Relay exit code when using yarn-path from yarnrc

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -250,30 +250,48 @@ test('yarnrc arguments', async () => {
   expect((await fs.stat(`${cwd}/yarn-cache`)).isDirectory()).toBe(true);
 });
 
-test('yarnrc binary path (js)', async () => {
-  const cwd = await makeTemp();
+describe('yarnrc path', () => {
+  test('js file', async () => {
+    const cwd = await makeTemp();
 
-  await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override.js"\n');
-  await fs.writeFile(`${cwd}/override.js`, 'console.log("override called")\n');
+    await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override.js"\n');
+    await fs.writeFile(`${cwd}/override.js`, 'console.log("override called")\n');
 
-  const [stdoutOutput] = await runYarn([], {cwd});
-  expect(stdoutOutput.toString().trim()).toEqual('override called');
-});
+    const [stdoutOutput] = await runYarn([], {cwd});
+    expect(stdoutOutput.toString().trim()).toEqual('override called');
+  });
 
-test('yarnrc binary path (executable)', async () => {
-  const cwd = await makeTemp();
+  test('executable file', async () => {
+    const cwd = await makeTemp();
 
-  if (process.platform === 'win32') {
-    await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override.cmd"\n');
-    await fs.writeFile(`${cwd}/override.cmd`, '@echo override called\n');
-  } else {
-    await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override"\n');
-    await fs.writeFile(`${cwd}/override`, '#!/usr/bin/env sh\necho override called\n');
-    await fs.chmod(`${cwd}/override`, 0o755);
-  }
+    if (process.platform === 'win32') {
+      await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override.cmd"\n');
+      await fs.writeFile(`${cwd}/override.cmd`, '@echo override called\n');
+    } else {
+      await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override"\n');
+      await fs.writeFile(`${cwd}/override`, '#!/usr/bin/env sh\necho override called\n');
+      await fs.chmod(`${cwd}/override`, 0o755);
+    }
 
-  const [stdoutOutput] = await runYarn([], {cwd});
-  expect(stdoutOutput.toString().trim()).toEqual('override called');
+    const [stdoutOutput] = await runYarn([], {cwd});
+    expect(stdoutOutput.toString().trim()).toEqual('override called');
+  });
+
+  test('js file exit code', async () => {
+    const cwd = await makeTemp();
+
+    await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override.js"\n');
+    await fs.writeFile(`${cwd}/override.js`, 'process.exit(1);');
+
+    let error = false;
+    try {
+      await runYarn([], {cwd});
+    } catch (err) {
+      error = true;
+    }
+
+    expect(error).toEqual(true);
+  });
 });
 
 for (const withDoubleDash of [false, true]) {

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -281,16 +281,16 @@ describe('yarnrc path', () => {
     const cwd = await makeTemp();
 
     await fs.writeFile(`${cwd}/.yarnrc`, 'yarn-path "./override.js"\n');
-    await fs.writeFile(`${cwd}/override.js`, 'process.exit(1);');
+    await fs.writeFile(`${cwd}/override.js`, 'process.exit(123);');
 
     let error = false;
     try {
       await runYarn([], {cwd});
     } catch (err) {
-      error = true;
+      error = err.code;
     }
 
-    expect(error).toEqual(true);
+    expect(error).toEqual(123);
   });
 });
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -544,15 +544,18 @@ async function start(): Promise<void> {
   if (yarnPath && process.env.YARN_IGNORE_PATH !== '1') {
     const argv = process.argv.slice(2);
     const opts = {stdio: 'inherit', env: Object.assign({}, process.env, {YARN_IGNORE_PATH: 1})};
+    let exitCode = 0;
 
     try {
-      await spawnp(yarnPath, argv, opts);
+      exitCode = await spawnp(yarnPath, argv, opts);
     } catch (firstError) {
       try {
-        await forkp(yarnPath, argv, opts);
+        exitCode = await forkp(yarnPath, argv, opts);
       } catch (error) {
         throw firstError;
       }
+
+      process.exitCode = exitCode;
     }
   } else {
     // ignore all arguments after a --


### PR DESCRIPTION
**Summary**

Follow up to #4204. We forgot to relay the exit code of the
newly spawned yarn instance when using `yarn-path` which is
causing false negatives especially when using `yarn run`. This
patch relays the exit code of the spawned process.

**Test plan**

Added a new test that fails without the fix.