### PR TITLE
Fixes how the exit code was forwarded when using the yarnrc path

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -554,9 +554,9 @@ async function start(): Promise<void> {
       } catch (error) {
         throw firstError;
       }
-
-      process.exitCode = exitCode;
     }
+
+    process.exitCode = exitCode;
   } else {
     // ignore all arguments after a --
     const doubleDashIndex = process.argv.findIndex(element => element === '--');


### PR DESCRIPTION
**Summary**

Yarn doesn't correctly forward the exit code if the process is executed via `spawnp`.

**Test plan**

Will write tests in a separate PR, but I'd prefer to merge this one asap.
