### PR TITLE
Restore version if publish is aborted before publishing

### DIFF
--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -130,7 +130,6 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   // save current version so we can restore it in case of an abort
   const oldVersion = await getVersion(config);
 
-  // sorry if this try/catch breaks your stack trace :'(
   try {
     return await _run(config, reporter, flags, args, pkg, dir);
   } catch(e) {
@@ -144,7 +143,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       // this was a last ditch effort to restore the version. ignore errors here
     }
 
-    throw new Error(e);
+    throw e;
   }
 }
 async function _run(config: Config, reporter: Reporter, flags: Object, args: Array<string>, pkg:any, dir:string): Promise<void> {

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -28,6 +28,14 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 
+export async function getVersion(
+  config: Config,
+): Promise<string> {
+  const pkg = await config.readRootManifest();
+
+  return pkg.version || '0.0.0';
+}
+
 export async function setVersion(
   config: Config,
   reporter: Reporter,

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -13,6 +13,7 @@ const messages = {
   buildingFreshPackages: 'Building fresh packages',
   cleaningModules: 'Cleaning modules',
   bumpingVersion: 'Bumping version',
+  restoringVersion: 'Restoring version',
   savingHar: 'Saving HAR file: $0',
   answer: 'Answer?',
   usage: 'Usage',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Bug fix: the version in `package.jscon` would be updated even if the `publish` command failed prior to actually publishing.

Fixes #662

**Test plan**

This is a wip, need input on how to write a test for this. There currently appear to be no tests for `publish` to take as an example AND it needs to throw an error somewhere after writing the version.
