### PR TITLE
Only show `--ignore-scripts` for `install` command

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -181,6 +181,16 @@ test.concurrent('should run add command with help option', async () => {
   expectHelpOutputAsSubcommand(stdout);
 });
 
+test.concurrent('should not show --ignore-scripts for `run` command', async () => {
+  const stdout = await execCommand('--help', ['run'], 'run-help');
+  expect(stdout.join('\n')).not.toContain('--ignore-scripts');
+});
+
+test.concurrent('should show --ignore-scripts for `install` command', async () => {
+  const stdout = await execCommand('--help', ['install'], 'run-help');
+  expect(stdout.join('\n')).toContain('--ignore-scripts');
+});
+
 test.concurrent('should run add command with h option', async () => {
   const stdout = await execCommand('add', ['-h'], 'run-help');
   expectHelpOutputAsSubcommand(stdout);

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -917,6 +917,7 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 
 export function setFlags(commander: Object) {
   commander.usage('install [flags]');
+  commander.option('--ignore-scripts', "don't run lifecycle scripts");
   commander.option('-g, --global', 'DEPRECATED');
   commander.option('-S, --save', 'DEPRECATED - save package to your `dependencies`');
   commander.option('-D, --save-dev', 'DEPRECATED - save package to your `devDependencies`');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -62,7 +62,6 @@ export function main({
   commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
   commander.option('--strict-semver');
   commander.option('--json', '');
-  commander.option('--ignore-scripts', "don't run lifecycle scripts");
   commander.option('--har', 'save HAR output of network traffic');
   commander.option('--ignore-platform', 'ignore platform checks');
   commander.option('--ignore-engines', 'ignore engines check');


### PR DESCRIPTION
Fixes #2735

**Summary**

Moves the help line for `--ignore-scripts` from generic to just `install` command.

**Test plan**

Check output for `bin/yarn --help run` and `bin/yarn --help install` and confirm that the switch only shows up for `install`.
