### PR TITLE
Fixes progress display on non-color tty (#4647)

### DIFF
--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import tty from 'tty';
 import type {Stdout} from '../types.js';
 
 const readline = require('readline');
@@ -10,6 +11,9 @@ const CLEAR_RIGHT_OF_CURSOR = 1;
 
 export function clearLine(stdout: Stdout) {
   if (!supportsColor) {
+    if (stdout instanceof tty.WriteStream) {
+      stdout.write(`\r${' '.repeat(stdout.columns - 1)}\r`);
+    }
     return;
   }
 
@@ -19,6 +23,7 @@ export function clearLine(stdout: Stdout) {
 
 export function toStartOfLine(stdout: Stdout) {
   if (!supportsColor) {
+    stdout.write('\r');
     return;
   }
 


### PR DESCRIPTION
If the output does not support color, then each render of the progress bar is added to a single line, which wraps over multiple lines.

As a fallback, a simple carriage return is used to move to the start of the line, and space characters to clear the line.

**Summary**

This is a minor cosmetic output on the formatting of the progress output.

I came across the issue raised when looking for problems to address for Hacktoberfest.

**Test plan**

I verified by running `yarn check` to provide output with the progress bar under the following conditions:
* Interactive use with color output.
* Interactive use with terminal not supporting color output
* Non-interactive use (output was piped)
 
The output from the 3 tests can be seen in the following screenshot.

![image](https://user-images.githubusercontent.com/1571880/31494540-a330735c-af4b-11e7-97ed-134b248fa4bb.png)

This screenshot shows the non-color test with the active progress bar.

![image](https://user-images.githubusercontent.com/1571880/31494624-13a79a48-af4c-11e7-8638-3636f7fd53f6.png)

