### PR TITLE
Do not convert empty string to cwd path.

### DIFF
--- a/__tests__/config.js
+++ b/__tests__/config.js
@@ -1,0 +1,44 @@
+/* @flow */
+
+import Config from '../src/config.js';
+import {ConsoleReporter} from '../src/reporters/index.js';
+
+const stream = require('stream');
+
+const initConfig = async cfg => {
+  const stdout = new stream.Writable({
+    decodeStrings: false,
+    write(data, encoding, cb) {
+      cb();
+    },
+  });
+
+  const reporter = new ConsoleReporter({stdout, stderr: stdout});
+  const config = new Config(reporter);
+  await config.init(cfg);
+  return config;
+};
+
+test('getOption changes ~ to cwd when resolve=true', async () => {
+  const config = await initConfig({});
+  config.registries.yarn.config.cafile = '~/';
+  expect(config.getOption('cafile', true)).not.toContain('~');
+});
+
+test('getOption does not change ~ when resolve=false', async () => {
+  const config = await initConfig({});
+  config.registries.yarn.config.cafile = '~/';
+  expect(config.getOption('cafile', false)).toEqual('~/');
+});
+
+test('getOption does not change empty-string when resolve=true', async () => {
+  const config = await initConfig({});
+  config.registries.yarn.config.cafile = '';
+  expect(config.getOption('cafile', true)).toEqual('');
+});
+
+test('getOption does not change empty-string when resolve=false', async () => {
+  const config = await initConfig({});
+  config.registries.yarn.config.cafile = '';
+  expect(config.getOption('cafile', false)).toEqual('');
+});

--- a/src/config.js
+++ b/src/config.js
@@ -195,7 +195,7 @@ export default class Config {
   getOption(key: string, resolve: boolean = false): mixed {
     const value = this.registries.yarn.getOption(key);
 
-    if (resolve && typeof value === 'string') {
+    if (resolve && typeof value === 'string' && value.length) {
       return resolveWithHome(value);
     }
 


### PR DESCRIPTION
**Summary**

fixes #4695 

Do not convert empty string to cwd directory. This avoids a problem where a `cafile=''` setting was trying to load the directory as the cert file.

**Test plan**

Requests are mocked during tests so request-manager doesn't try to load the `cafile`, so the exact fix is hard to test.

I added a new test file for `config.js` and a couple initial tests.
