### PR TITLE
docs(linker): Use breadcrumbs in peer dependency warnings

### DIFF
--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -468,7 +468,7 @@ export default class PackageLinker {
 
         let peerError = 'unmetPeer';
         let resolvedLevelDistance = Infinity;
-        let resolvedPeerPkgPattern;
+        let resolvedPeerPkg;
         for (const peerPkg of peerPkgs) {
           const peerPkgRef = peerPkg._reference;
           if (!(peerPkgRef && peerPkgRef.patterns)) {
@@ -478,25 +478,31 @@ export default class PackageLinker {
           if (isFinite(levelDistance) && levelDistance < resolvedLevelDistance) {
             if (this._satisfiesPeerDependency(range, peerPkgRef.version)) {
               resolvedLevelDistance = levelDistance;
-              resolvedPeerPkgPattern = peerPkgRef.patterns;
-              this.reporter.verbose(
-                this.reporter.lang(
-                  'selectedPeer',
-                  `${pkg.name}@${pkg.version}`,
-                  `${peerDepName}@${peerPkgRef.version}`,
-                  peerPkgRef.level,
-                ),
-              );
+              resolvedPeerPkg = peerPkgRef;
             } else {
               peerError = 'incorrectPeer';
             }
           }
         }
 
-        if (resolvedPeerPkgPattern) {
-          ref.addDependencies(resolvedPeerPkgPattern);
+        if (resolvedPeerPkg) {
+          ref.addDependencies(resolvedPeerPkg.patterns);
+          this.reporter.verbose(
+            this.reporter.lang(
+              'selectedPeer',
+              `${pkg.name}@${pkg.version}`,
+              `${peerDepName}@${resolvedPeerPkg.version}`,
+              resolvedPeerPkg.level,
+            ),
+          );
         } else {
-          this.reporter.warn(this.reporter.lang(peerError, `${pkg.name}@${pkg.version}`, `${peerDepName}@${range}`));
+          this.reporter.warn(
+            this.reporter.lang(
+              peerError,
+              `${refTree.join(' > ')} > ${pkg.name}@${pkg.version}`,
+              `${peerDepName}@${range}`,
+            ),
+          );
         }
       }
     }


### PR DESCRIPTION
**Summary**

@gaearon called Yarn out for better peer dependency error messages so this is the first step to make
them more useful and informative.

**Test plan**

Use a repo like `https://github.com/edmorley/yarn-unmet-peerdependency-testcase` to have peer dependency
warnings and observe they now show the path for the package missing the peer dependency. This should
allow people to investigate these errors in an easier fashion.

```
warning "neutrino-preset-airbnb-base > eslint-config-airbnb-base@12.0.2" has unmet peer dependency "eslint@^4.8.0".
warning "neutrino-preset-airbnb-base > eslint-plugin-import@2.7.0" has unmet peer dependency "eslint@2.x - 4.x".
```
