### PR TITLE
fix(autoclean): Include only common CI configs in default .yarnclean

### DIFF
--- a/src/cli/commands/autoclean.js
+++ b/src/cli/commands/autoclean.js
@@ -40,6 +40,11 @@ Gulpfile.js
 Gruntfile.js
 
 # configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
 .tern-project
 .gitattributes
 .editorconfig
@@ -49,8 +54,7 @@ Gruntfile.js
 .flowconfig
 .documentup.json
 .yarn-metadata.json
-.*.yml
-*.yml
+.travis.yml
 
 # misc
 *.md


### PR DESCRIPTION
**Summary**

Remove entries to clean `*.yml` and `.*.yml` from the default filter list in `.yarnclean`. Instead, include configuration files from common CI and build tools.

- Travis CI
- CircleCI
- AppVeyor
- Codeship
- Wercker

Fixes #4281, fixes #2276.

**Test plan**

```shell
$ yarn autoclean --init
yarn autoclean v1.2.1
[1/1] Creating ".yarnclean"...
info Created ".yarnclean". Please review the contents of this file then run "yarn autoclean --force" to perform a clean.
✨  Done in 0.15s.
$ grep yml .yarnclean 
appveyor.yml
circle.yml
codeship-services.yml
codeship-steps.yml
wercker.yml
.travis.yml
```