### PR TITLE
quickwin for failed fetch of missing fsevents

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -106,7 +106,8 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
     const ref = info._reference;
     invariant(ref, 'expected package reference');
 
-    if (ref.optional) {
+    // no location -> no previous fetch, possibly optional
+    if (ref.optional || !info.location) {
       ref.ignore = true;
       ref.incompatible = true;
 


### PR DESCRIPTION
fsevents is an optional dependency. Although platforms such as linux ignore the failed fetch, I'm having a situation that Yarn still wants to resolve the version due to conflicting consumer plugins and eventually adds it as a resolution to package.json (and to the lock file).
If you want to re-run yarn install, Yarn insists on checking the fsevents entry at "resolutions" without having the information that it's just optional.
My approach is a bit more generic that just "is it fsevents" and simply checks whether the config holds a location for the current item. If falsy, pretend that it's optional.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
