### PR TITLE
fix(reporters): Handle process.stdout.columns being zero

### DIFF
--- a/src/reporters/console/util.js
+++ b/src/reporters/console/util.js
@@ -12,7 +12,10 @@ const CLEAR_RIGHT_OF_CURSOR = 1;
 export function clearLine(stdout: Stdout) {
   if (!supportsColor) {
     if (stdout instanceof tty.WriteStream) {
-      stdout.write(`\r${' '.repeat(stdout.columns - 1)}\r`);
+      if (stdout.columns > 0) {
+        stdout.write(`\r${' '.repeat(stdout.columns - 1)}`);
+      }
+      stdout.write(`\r`);
     }
     return;
   }


### PR DESCRIPTION
**Summary**

My recent pull request was to improve the appearance of the progress bar for non-color terminals (PR #4697).

However, @skevy reported a RangeError when running with macOS 10.12, with Node 8.6.  This would have been caused by process.stdout.columns returning a negative number.

In this case, this just assumes a default width of 100 characters (as in spinner-progress.js).

**Test plan**

I have not been able to reproduce the condition where `process.tty.columns` returns a negative number, so have verified the logic by considering key cases, e.g., `undefined > 0`, `-1 > 0`.
