### PR TITLE
fix(install): Rebuild native modules when node version changes

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -424,6 +424,12 @@ export class Install {
       return false;
     }
 
+    if (match.nodeVersionDoesntMatch) {
+      // node version doesn't match, force script installations
+      this.scripts.setForce(true);
+      return false;
+    }
+
     if (!patterns.length && !match.integrityFileMissing) {
       this.reporter.success(this.reporter.lang('nothingToInstall'));
       await this.createEmptyManifestFolders();

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -424,8 +424,8 @@ export class Install {
       return false;
     }
 
-    if (match.nodeVersionDoesntMatch) {
-      // node version doesn't match, force script installations
+    if (match.hardRefreshRequired) {
+      // e.g. node version doesn't match, force script installations
       this.scripts.setForce(true);
       return false;
     }

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -38,7 +38,7 @@ type IntegrityHashLocation = {
 };
 
 type IntegrityFile = {
-  node_version: string,
+  nodeVersion: string,
   flags: Array<string>,
   modulesFolders: Array<string>,
   linkedModules: Array<string>,
@@ -56,7 +56,7 @@ type IntegrityFlags = {
 };
 
 const INTEGRITY_FILE_DEFAULTS = () => ({
-  node_version: process.version,
+  nodeVersion: process.version,
   modulesFolders: [],
   flags: [],
   linkedModules: [],
@@ -298,7 +298,7 @@ export default class InstallationIntegrityChecker {
       return 'LINKED_MODULES_DONT_MATCH';
     }
 
-    if (actual.node_version !== expected.node_version) {
+    if (actual.nodeVersion !== expected.nodeVersion) {
       return 'NODE_VERSION_DOESNT_MATCH';
     }
 
@@ -393,7 +393,7 @@ export default class InstallationIntegrityChecker {
       integrityMatches: integrityMatches === 'OK',
       integrityError: integrityMatches === 'OK' ? undefined : integrityMatches,
       missingPatterns,
-      nodeVersionDoesntMatch: integrityMatches === 'NODE_VERSION_DOESNT_MATCH',
+      hardRefreshRequired: integrityMatches === 'NODE_VERSION_DOESNT_MATCH',
     };
   }
 

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -19,6 +19,7 @@ export const integrityErrors = {
   LINKED_MODULES_DONT_MATCH: 'integrityCheckLinkedModulesDontMatch',
   PATTERNS_DONT_MATCH: 'integrityPatternsDontMatch',
   MODULES_FOLDERS_MISSING: 'integrityModulesFoldersMissing',
+  NODE_VERSION_DOESNT_MATCH: 'integrityNodeDoesntMatch',
 };
 
 type IntegrityError = $Keys<typeof integrityErrors>;
@@ -37,6 +38,7 @@ type IntegrityHashLocation = {
 };
 
 type IntegrityFile = {
+  node_version: string,
   flags: Array<string>,
   modulesFolders: Array<string>,
   linkedModules: Array<string>,
@@ -54,6 +56,7 @@ type IntegrityFlags = {
 };
 
 const INTEGRITY_FILE_DEFAULTS = () => ({
+  node_version: process.version,
   modulesFolders: [],
   flags: [],
   linkedModules: [],
@@ -295,6 +298,10 @@ export default class InstallationIntegrityChecker {
       return 'LINKED_MODULES_DONT_MATCH';
     }
 
+    if (actual.node_version !== expected.node_version) {
+      return 'NODE_VERSION_DOESNT_MATCH';
+    }
+
     let relevantExpectedFlags = expected.flags.slice();
 
     // If we run "yarn" after "yarn --check-files", we shouldn't fail the less strict validation
@@ -386,6 +393,7 @@ export default class InstallationIntegrityChecker {
       integrityMatches: integrityMatches === 'OK',
       integrityError: integrityMatches === 'OK' ? undefined : integrityMatches,
       missingPatterns,
+      nodeVersionDoesntMatch: integrityMatches === 'NODE_VERSION_DOESNT_MATCH',
     };
   }
 


### PR DESCRIPTION
**Summary**

Fixes #756. We have multiple versions of our app and each one uses a different version of node. 
Therefore we need to rebuild our `node-sass` module every time we move from one to another. 

This PR addresses that by saving the NODE version those artifacts were built with within the `.yarn-integrity` file and triggers forced scripts install (only if the node version is different ofc).

**Test plan**

```
1. Install Node.js 7.x
2. Add the node-sass dependency to the project via Yarn
3. Update Node.js to 8.x (new NODE_VERSION)
4. Run "yarn install" (you should see yarn downloading fresh scripts/binaries)
```