### PR TITLE
Fix for #4735 Ignore `returnAllPackages` param in upgrade

### DIFF
--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -199,7 +199,6 @@ export async function getOutdated(
 ): Promise<Array<Dependency>> {
   const install = new Install(flags, config, reporter, lockfile);
   const outdatedFieldName = flags.latest ? 'latest' : 'wanted';
-  const updateAll = patterns.length === 0;
 
   // ensure scope is of the form `@scope/`
   const normalizeScope = function() {
@@ -234,7 +233,6 @@ export async function getOutdated(
     reporter,
     patterns,
     flags,
-    updateAll,
   ))
     .filter(versionFilter)
     .filter(scopeFilter.bind(this, flags));

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -226,14 +226,7 @@ export async function getOutdated(
 
   normalizeScope();
 
-  const deps = (await PackageRequest.getOutdatedPackages(
-    lockfile,
-    install,
-    config,
-    reporter,
-    patterns,
-    flags,
-  ))
+  const deps = (await PackageRequest.getOutdatedPackages(lockfile, install, config, reporter, patterns, flags))
     .filter(versionFilter)
     .filter(scopeFilter.bind(this, flags));
   deps.forEach(dep => {

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -342,7 +342,6 @@ export default class PackageRequest {
     reporter: Reporter,
     filterByPatterns: ?Array<string>,
     flags: ?Object,
-    returnAllPackages: ?boolean,
   ): Promise<Array<Dependency>> {
     const {requests: reqPatterns, workspaceLayout} = await install.fetchRequestFromCwd();
 
@@ -402,9 +401,9 @@ export default class PackageRequest {
 
     // Make sure to always output `exotic` versions to be compatible with npm
     const isDepOld = ({current, latest, wanted}) =>
-      latest === 'exotic' || (latest !== 'exotic' && (semver.lt(current, wanted) || semver.lt(current, latest)));
+      latest === 'exotic' || (semver.lt(current, wanted) || semver.lt(current, latest));
     const orderByName = (depA, depB) => depA.name.localeCompare(depB.name);
 
-    return returnAllPackages ? deps.sort(orderByName) : deps.filter(isDepOld).sort(orderByName);
+    return deps.filter(isDepOld).sort(orderByName);
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes https://github.com/yarnpkg/yarn/issues/4735

Upgrade-interactive uses upgrade's `getOutdated` method, which previously called package-request's `getOutdatedPackages` method with `returnAllPackages` when package name wasn't being specified. This was unnecessary since `getOutdatedPackages` [already checks for filter patterns](https://github.com/yarnpkg/yarn/blob/master/src/package-request.js#L356-L363).

It also inadvertently caused a bug where it would list packages that weren't outdated. For example, `react-refetch@1.0.3-0` was being correctly filtered [here](https://github.com/yarnpkg/yarn/blob/master/src/package-request.js#L405), but because all dependencies were being returned, it was added back as an outdated package [here](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/upgrade.js#L218).
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I've verified that the `returnAllPackages` param was only being used in upgrade file. All existing tests related to upgrade should pass. Will try and see if I can add more.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
*BEFORE*

<img width="683" alt="screen shot 2017-10-21 at 12 25 51 pm" src="https://user-images.githubusercontent.com/18429494/31855209-50778080-b65b-11e7-8b31-1ea7235f5c37.png">

*AFTER*

<img width="677" alt="screen shot 2017-10-21 at 12 26 11 pm" src="https://user-images.githubusercontent.com/18429494/31855208-4a7799ae-b65b-11e7-8603-45e54a28d1dd.png">