### PR TITLE
fix(request): pass a proxy to request even if falsy

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -412,9 +412,7 @@ export default class RequestManager {
     if (params.url.startsWith('https:')) {
       proxy = this.httpsProxy;
     }
-    if (proxy) {
-      params.proxy = String(proxy);
-    }
+    params.proxy = String(proxy);
 
     if (this.ca != null) {
       params.ca = this.ca;


### PR DESCRIPTION
**Summary**

Fixes #4546.

Pass a `proxy` value to `request` to prevent it from falling back to
checking envirnment variables.
Yarn already gets the env var values through it's configuration and may
have overriden them to it's own liking.
See use case in mentioned issue.

If a `proxy` value is not set, then [this logic](https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/request.js#L277) causes it to check the env vars instead, which will fallback to `http_proxy`. This was preventing the `https_proxy false` config setting from working if environment variables were set, because the request library would fallback to using that instead.

**Test plan**

Manually test with and without https_proxy set in config and in
environment variable.