### PR TITLE
feat(config): Allow JSON "//" comments in package.json resolutions

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -640,6 +640,30 @@ test.concurrent('install with comments in manifest', (): Promise<void> => {
   });
 });
 
+test.concurrent('install with comments in manifest resolutions does not result in warning', (): Promise<void> => {
+  const fixturesLoc = path.join(__dirname, '..', '..', 'fixtures', 'install');
+
+  return buildRun(
+    reporters.BufferReporter,
+    fixturesLoc,
+    async (args, flags, config, reporter): Promise<void> => {
+      await install(config, reporter, flags, args);
+
+      const output = reporter.getBuffer();
+      const warnings = output.filter(entry => entry.type === 'warning');
+
+      expect(
+        warnings.some(warning => {
+          return warning.data.toString().indexOf(reporter.lang('invalidResolutionName', '//')) > -1;
+        }),
+      ).toEqual(false);
+    },
+    [],
+    {lockfile: false},
+    'install-with-comments',
+  );
+});
+
 test.concurrent('install with null versions in manifest', (): Promise<void> => {
   return runInstall({}, 'install-with-null-version', async config => {
     expect(await fs.exists(path.join(config.cwd, 'node_modules', 'left-pad'))).toEqual(true);

--- a/__tests__/fixtures/install/install-with-comments/package.json
+++ b/__tests__/fixtures/install/install-with-comments/package.json
@@ -6,5 +6,8 @@
       "comment"
     ],
     "foo": "file:bar"
+  },
+  "resolutions": {
+    "//": "This is a comment."
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,8 @@ type Env = {
 };
 
 export const DEPENDENCY_TYPES = ['devDependencies', 'dependencies', 'optionalDependencies', 'peerDependencies'];
+export const RESOLUTIONS = 'resolutions';
+export const MANIFEST_FIELDS = [RESOLUTIONS, ...DEPENDENCY_TYPES];
 
 export const SUPPORTED_NODE_VERSIONS = '^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0';
 

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {DEPENDENCY_TYPES} from '../../constants';
+import {MANIFEST_FIELDS} from '../../constants';
 import type {Reporter} from '../../reporters/index.js';
 import {isValidLicense} from './util.js';
 import {normalizePerson, extractDescription} from './util.js';
@@ -308,7 +308,7 @@ export default (async function(
     }
   }
 
-  for (const dependencyType of ['resolutions', ...DEPENDENCY_TYPES]) {
+  for (const dependencyType of MANIFEST_FIELDS) {
     const dependencyList = info[dependencyType];
     if (dependencyList && typeof dependencyList === 'object') {
       delete dependencyList['//'];

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -308,7 +308,7 @@ export default (async function(
     }
   }
 
-  for (const dependencyType of DEPENDENCY_TYPES) {
+  for (const dependencyType of ['resolutions', ...DEPENDENCY_TYPES]) {
     const dependencyList = info[dependencyType];
     if (dependencyList && typeof dependencyList === 'object') {
       delete dependencyList['//'];


### PR DESCRIPTION
Fixes #4774

**Summary**

Previously package.json comments were being ignored for "dependencies",
"devDependencies", "optionalDependencies".

This change adds "resolutions" to the sections that will ignore
comments.

**Test Plan**

Added unit test to make sure warning is not printed for a comment in a
resolution.