### PR TITLE
fix: Use wanted package repository URL and homepage from npm

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -349,3 +349,127 @@ describe('getPossibleConfigLocations', () => {
     );
   });
 });
+
+describe('checkOutdated functional test', () => {
+  const mockConfig = {
+    resolveConstraints(): string {
+      return '2.0.0';
+    },
+  };
+
+  test('homepage URL from top level', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+
+    mockRequestManager.request = () => {
+      return {
+        homepage: 'http://package.homepage.com',
+        'dist-tags': {
+          latest: '2.0.0',
+        },
+        versions: {
+          '2.0.0': {
+            version: '2.0.0',
+          },
+        },
+      };
+    };
+
+    const result = await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0');
+
+    expect(result).toMatchObject({
+      latest: '2.0.0',
+      wanted: '2.0.0',
+      url: 'http://package.homepage.com',
+    });
+  });
+
+  test('homepage URL fallback to wanted package manifest', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+
+    mockRequestManager.request = () => {
+      return {
+        'dist-tags': {
+          latest: '2.0.0',
+        },
+        versions: {
+          '2.0.0': {
+            version: '2.0.0',
+            homepage: 'http://package.homepage.com',
+          },
+        },
+      };
+    };
+
+    const result = await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0');
+
+    expect(result).toMatchObject({
+      latest: '2.0.0',
+      wanted: '2.0.0',
+      url: 'http://package.homepage.com',
+    });
+  });
+
+  test('repository URL from top level', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+
+    mockRequestManager.request = () => {
+      return {
+        repository: {
+          url: 'http://package.repo.com',
+        },
+        'dist-tags': {
+          latest: '2.0.0',
+        },
+        versions: {
+          '2.0.0': {
+            version: '2.0.0',
+          },
+        },
+      };
+    };
+
+    const result = await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0');
+
+    expect(result).toMatchObject({
+      latest: '2.0.0',
+      wanted: '2.0.0',
+      url: 'http://package.repo.com',
+    });
+  });
+
+  test('repository URL fallback to wanted package manifest', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+
+    mockRequestManager.request = () => {
+      return {
+        'dist-tags': {
+          latest: '2.0.0',
+        },
+        versions: {
+          '2.0.0': {
+            version: '2.0.0',
+            repository: {
+              url: 'http://package.repo.com',
+            },
+          },
+        },
+      };
+    };
+
+    const result = await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0');
+
+    expect(result).toMatchObject({
+      latest: '2.0.0',
+      wanted: '2.0.0',
+      url: 'http://package.repo.com',
+    });
+  });
+});

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -164,12 +164,13 @@ export default class NpmRegistry extends Registry {
       throw new Error('couldnt find ' + name);
     }
 
-    const {repository, homepage} = req;
+    const wantedPkg = await NpmResolver.findVersionInRegistryResponse(config, range, req);
+    const {repository, homepage} = wantedPkg;
     const url = homepage || (repository && repository.url) || '';
 
     return {
       latest: req['dist-tags'].latest,
-      wanted: (await NpmResolver.findVersionInRegistryResponse(config, range, req)).version,
+      wanted: wantedPkg.version,
       url,
     };
   }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -164,8 +164,17 @@ export default class NpmRegistry extends Registry {
       throw new Error('couldnt find ' + name);
     }
 
+    // By default use top level 'repository' and 'homepage' values
+    let {repository, homepage} = req;
     const wantedPkg = await NpmResolver.findVersionInRegistryResponse(config, range, req);
-    const {repository, homepage} = wantedPkg;
+
+    // But some local repositories like Verdaccio do not return 'repository' nor 'homepage'
+    // in top level data structure, so we fallback to wanted package manifest
+    if (!repository && !homepage) {
+      repository = wantedPkg.repository;
+      homepage = wantedPkg.homepage;
+    }
+
     const url = homepage || (repository && repository.url) || '';
 
     return {


### PR DESCRIPTION
**Summary**

Fixes #4650.

Problem is that Verdaccio (and probably Sinopia2) both are affected as they do not return "repository" nor "homepage" in top level data structure.

**Test plan**

Added new test cases. Also, manually tested with and without https://github.com/verdaccio/verdaccio as registry.
