### PR TITLE
fix(info): Use version from `latest` dist-tag instead of the highest one

### DIFF
--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -7,8 +7,6 @@ import Config from '../../src/config.js';
 import path from 'path';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
-// the mocked requests have stripped metadata, don't use it in the following tests
-jest.unmock('request');
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'info');
 
@@ -47,6 +45,11 @@ const expectedKeys = [
 
 // yarn now ships as built, single JS files so it has no dependencies and no scripts
 const unexpectedKeys = ['dependencies', 'devDependencies', 'scripts'];
+
+beforeEach(() => {
+  // the mocked requests have stripped metadata, don't use it in the following tests
+  jest.unmock('request');
+});
 
 test.concurrent('without arguments and in directory containing a valid package file', (): Promise<void> => {
   return runInfo([], {}, 'local', (config, output): ?Promise<void> => {
@@ -89,6 +92,8 @@ test.concurrent('with two arguments and second argument "readme" shows readme st
 });
 
 test.concurrent('with two arguments and second argument "version" shows `latest` version', (): Promise<void> => {
+  jest.mock('../__mocks__/request.js');
+
   return runInfo(['ui-select', 'version'], {}, '', (config, output): ?Promise<void> => {
     expect(output).toEqual('0.19.8');
   });

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -92,6 +92,12 @@ test.concurrent('with two arguments and second argument "readme" shows readme st
 });
 
 test.concurrent('with two arguments and second argument "version" shows `latest` version', (): Promise<void> => {
+  // Scenario:
+  // If a registry contains versions [1.0.0, 1.0.1, 1.0.2] and latest:1.0.1
+  // If `yarn info` is run, it should choose `1.0.1` because it is "latest", not `1.0.2` even though it is newer.
+  // In other words, when no range is explicitely given, Yarn should choose "latest".
+  //
+  // In this test, `ui-select` has a max version of `0.20.0` but a `latest:0.19.8`
   jest.mock('../__mocks__/request.js');
 
   return runInfo(['ui-select', 'version'], {}, '', (config, output): ?Promise<void> => {

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -88,6 +88,12 @@ test.concurrent('with two arguments and second argument "readme" shows readme st
   });
 });
 
+test.concurrent('with two arguments and second argument "version" shows version with `latest` tag', (): Promise<void> => {
+  return runInfo(['ui-select', 'version'], {}, '', (config, output): ?Promise<void> => {
+    expect(output).toEqual('0.19.8');
+  });
+});
+
 test.concurrent('with two arguments and second argument as a simple field', (): Promise<void> => {
   return runInfo(['yarn', 'repository'], {}, '', (config, output): ?Promise<void> => {
     expect(output).toEqual({

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -88,7 +88,7 @@ test.concurrent('with two arguments and second argument "readme" shows readme st
   });
 });
 
-test.concurrent('with two arguments and second argument "version" shows version with `latest` tag', (): Promise<void> => {
+test.concurrent('with two arguments and second argument "version" shows `latest` version', (): Promise<void> => {
   return runInfo(['ui-select', 'version'], {}, '', (config, output): ?Promise<void> => {
     expect(output).toEqual('0.19.8');
   });

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -72,7 +72,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const versions = result.versions;
   // $FlowFixMe
   result.versions = Object.keys(versions).sort(semver.compareLoose);
-  result.version = version || result.versions[result.versions.length - 1];
+  result.version = version || result['dist-tags'].latest;
   result = Object.assign(result, versions[result.version]);
 
   const fieldPath = args.shift();


### PR DESCRIPTION
**Summary**

Fixes #3947. By default, package `version` was set by sorting all the versions and getting the highest one. Now it's provided via package `latest` dist-tag.

**Test plan**
##### Before:
```bash
yarn info ui-select | grep version: 
  version: '0.20.0',
```
##### After:
```bash
$ yarn info ui-select | grep version:
   version: '0.19.8',
```

I've also added a test case for it in `__tests__/commands/info.js`.
Although, I'm not sure if using a specific package like `ui-select` (from #3947) is a proper way to do it, because it'll break with the new release.

Could we add it to the `__tests__/fixtures/request-cache/`, so the package manifest won't change? Or do you have some other idea how can I write this test better?
