### PR TITLE
fix(git-spawn): Add custom Batch wrapper when using plink.exe (#4729)

### DIFF
--- a/__tests__/util/git/git-spawn.js
+++ b/__tests__/util/git/git-spawn.js
@@ -42,6 +42,7 @@ describe('spawn', () => {
     process.env.GIT_SSH_COMMAND = '';
     // Test for case-sensitivity too (should be insensitive)
     const plinkPath = path.join('C:', 'pLink.EXE');
+    const plinkWrapperPath = path.join(__dirname, '..', '..', '..', 'bin', 'yarn-plink.cmd');
     process.env.GIT_SSH = plinkPath;
 
     const gitCall = runGit(['status']);
@@ -52,7 +53,7 @@ describe('spawn', () => {
     expect(gitCall[2].env).toMatchObject({
       GIT_ASKPASS: '',
       GIT_TERMINAL_PROMPT: 0,
-      GIT_SSH_COMMAND: `"${plinkPath}" -batch`,
+      GIT_SSH_COMMAND: `"${plinkWrapperPath}" "${plinkPath}" -batch`,
       ...process.env,
     });
   });

--- a/bin/yarn-plink.cmd
+++ b/bin/yarn-plink.cmd
@@ -1,0 +1,33 @@
+@echo off
+
+set PLINK_PATH="%~1"
+set PARAMS=""
+
+REM Shift params once at the beginning to exclude the first one
+shift
+
+REM Start of the loop
+:params_loop
+  if "%~1"=="" (
+    REM If we went through all the params, go to the end of the loop
+    goto after_params_loop
+  )
+
+  if "%~1"=="-p" (
+    REM If the param is `-p`, append it to `PARAMS` as a `-P` required by `plink.exe`
+    set PARAMS=%PARAMS% "-P"
+  ) else (
+    REM Else, just append the parameter to `PARAMS`
+    set PARAMS=%PARAMS% %1
+  )
+
+  REM Shift the params again
+  shift
+
+  REM Start the loop again
+  goto params_loop
+REM End of the loop
+:after_params_loop
+
+REM Run given plink.exe with proper params
+%PLINK_PATH% %PARAMS%

--- a/src/util/git/git-spawn.js
+++ b/src/util/git/git-spawn.js
@@ -5,6 +5,7 @@ import path from 'path';
 import * as child from '../child.js';
 
 const BATCH_MODE_ARGS = new Map([['ssh', '-oBatchMode=yes'], ['plink', '-batch']]);
+const WRAPPER_PATHS = new Map([['plink', path.resolve(__dirname, '..', '..', '..', 'bin', 'yarn-plink.cmd')]]);
 
 // Suppress any password prompts since we run these in the background
 const env = {
@@ -14,11 +15,13 @@ const env = {
 };
 
 const sshCommand = env.GIT_SSH || 'ssh';
-const sshExecutable = path.basename(sshCommand.toLowerCase(), '.exe');
-const sshBatchArgs = BATCH_MODE_ARGS.get(sshExecutable);
+const sshBasename = path.basename(sshCommand.toLowerCase(), '.exe');
+const sshWrapper = WRAPPER_PATHS.get(sshBasename);
+const sshExecutable = sshWrapper ? `"${sshWrapper}" "${sshCommand}"` : `"${sshCommand}"`;
+const sshBatchArgs = BATCH_MODE_ARGS.get(sshBasename);
 
 if (!env.GIT_SSH_COMMAND && sshBatchArgs) {
-  env.GIT_SSH_COMMAND = `"${sshCommand}" ${sshBatchArgs}`;
+  env.GIT_SSH_COMMAND = `${sshExecutable} ${sshBatchArgs}`;
 }
 
 export const spawn = (args: Array<string>, opts?: child_process$spawnOpts = {}): Promise<string> => {


### PR DESCRIPTION
**Summary**

Fixes #4729.

The main issue is that we use `GIT_SSH_COMMAND` instead of `GIT_SSH`, as we have to pass `-batch` argument in order to use `ssh`/`plink` in the non-interactive mode. Unfortunately, Git converts `-p` to `-P` for `plink.exe` **only** when using `GIT_SSH`.

The only way I could find to get out of this tricky issue is to create a wrapper script responsible for the `-p`/`-P` conversion and use it when `plink.exe` is provided via `GIT_SSH`.

Similar issue was also described here: https://jira.atlassian.com/browse/SRCTREEWIN-5600?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

I'm not quite sure if the `bin/` directory is the best place for the wrapper script `yarn-plink.cmd`, would `scripts/` be a better choice?

**Test plan**

##### Before:
![virtualbox_msedge_-_win10_30_10_2017_16_35_24](https://user-images.githubusercontent.com/5042328/32179804-9a87c676-bd90-11e7-86d0-09380d61eadf.png)

##### After:
![virtualbox_msedge_-_win10_30_10_2017_16_31_42](https://user-images.githubusercontent.com/5042328/32179739-743ad49a-bd90-11e7-9f0a-655285035a33.png)

I've also updated the test suite for `git-spawn.js` accordingly, but couldn't figure out how to test the `yarn-plink.cmd` wrapper script.