### PR TITLE
fix(git-spawn): Set `GIT_SSH_VARIANT` to get `plink` working with custom port

### DIFF
--- a/__tests__/util/git/git-spawn.js
+++ b/__tests__/util/git/git-spawn.js
@@ -34,6 +34,7 @@ describe('spawn', () => {
       GIT_ASKPASS: '',
       GIT_TERMINAL_PROMPT: 0,
       GIT_SSH_COMMAND: '"ssh" -oBatchMode=yes',
+      GIT_SSH_VARIANT: 'ssh',
       ...process.env,
     });
   });
@@ -53,6 +54,7 @@ describe('spawn', () => {
       GIT_ASKPASS: '',
       GIT_TERMINAL_PROMPT: 0,
       GIT_SSH_COMMAND: `"${plinkPath}" -batch`,
+      GIT_SSH_VARIANT: 'plink',
       ...process.env,
     });
   });

--- a/src/util/git/git-spawn.js
+++ b/src/util/git/git-spawn.js
@@ -18,6 +18,10 @@ const sshExecutable = path.basename(sshCommand.toLowerCase(), '.exe');
 const sshBatchArgs = BATCH_MODE_ARGS.get(sshExecutable);
 
 if (!env.GIT_SSH_COMMAND && sshBatchArgs) {
+  // We have to manually specify `GIT_SSH_VARIANT`,
+  // because it's not automatically set when using `GIT_SSH_COMMAND` instead of `GIT_SSH`
+  // See: https://github.com/yarnpkg/yarn/issues/4729
+  env.GIT_SSH_VARIANT = sshExecutable;
   env.GIT_SSH_COMMAND = `"${sshCommand}" ${sshBatchArgs}`;
 }
 


### PR DESCRIPTION
**Summary**

Fixes #4729.
Previous version in #4805.

Manually specify `GIT_SSH_VARIANT` in order to get package download via `git+ssh` with non-standard port when using `plink.exe` working.

Without `GIT_SSH_VARIANT` set properly, Git won't convert `-p` into `-P` and `plink.exe` will throw an error about unknown `-p` parameter.

**Test plan**

##### Before:
![virtualbox_msedge_-_win10_30_10_2017_16_35_24](https://user-images.githubusercontent.com/5042328/32179804-9a87c676-bd90-11e7-86d0-09380d61eadf.png)

##### After:
![virtualbox_msedge_-_win10_30_10_2017_19_07_15](https://user-images.githubusercontent.com/5042328/32187512-9bcb980e-bda5-11e7-96ea-27a513837d6e.png)

Also got `git-spawn.js` test suite updated for testing `GIT_SSH_VARIANT`.