### PR TITLE
Allow insecure URLs with warnings

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -324,10 +324,8 @@ const messages = {
 
   unknownFetcherFor: 'Unknown fetcher for $0',
 
-  refusingDownloadGitWithoutCommit: 'Refusing to download the git repo $0 over plain git without a commit hash',
-  refusingDownloadHTTPWithoutCommit: 'Refusing to download the git repo $0 over HTTP without a commit hash',
-  refusingDownloadHTTPSWithoutCommit:
-    'Refusing to download the git repo $0 over HTTPS without a commit hash - possible certificate error?',
+  downloadGitWithoutCommit: 'Downloading the git repo $0 over plain git without a commit hash',
+  downloadHTTPWithoutCommit: 'Downloading the git repo $0 over HTTP without a commit hash',
 
   packageInstalledWithBinaries: 'Installed $0 with binaries:',
   packageHasBinaries: '$0 has binaries:',

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -10,7 +10,7 @@ import {createWriteStream} from 'fs';
 import type Config from '../config.js';
 import type {Reporter} from '../reporters/index.js';
 import type {ResolvedSha, GitRefResolvingInterface, GitRefs} from './git/git-ref-resolver.js';
-import {MessageError, SecurityError, ProcessSpawnError} from '../errors.js';
+import {MessageError, ProcessSpawnError} from '../errors.js';
 import {spawn as spawnGit} from './git/git-spawn.js';
 import {resolveVersion, isCommitSha, parseRefs} from './git/git-ref-resolver.js';
 import * as crypto from './crypto.js';
@@ -181,7 +181,8 @@ export default class Git implements GitRefResolvingInterface {
       if (await Git.repoExists(secureUrl)) {
         return secureUrl;
       } else {
-        throw new SecurityError(reporter.lang('refusingDownloadGitWithoutCommit', ref));
+        reporter.warn(reporter.lang('downloadGitWithoutCommit', ref.repository));
+        return ref;
       }
     }
 
@@ -190,19 +191,8 @@ export default class Git implements GitRefResolvingInterface {
       if (await Git.repoExists(secureRef)) {
         return secureRef;
       } else {
-        if (await Git.repoExists(ref)) {
-          return ref;
-        } else {
-          throw new SecurityError(reporter.lang('refusingDownloadHTTPWithoutCommit', ref));
-        }
-      }
-    }
-
-    if (ref.protocol === 'https:') {
-      if (await Git.repoExists(ref)) {
+        reporter.warn(reporter.lang('downloadHTTPWithoutCommit', ref.repository));
         return ref;
-      } else {
-        throw new SecurityError(reporter.lang('refusingDownloadHTTPSWithoutCommit', ref));
       }
     }
 


### PR DESCRIPTION
This makes the handling of insecure repository URLs more consistent, according to issue #4307. 

Some insecure URLs were allowed (plain HTTP) while others did raise different kinds of `SecurityError`s, With this pull requests all insecure URLs report a warning, but don't raise hard errors. See issue #4307 for details.