### PR TITLE
feat(cli): Disable only header/footer in nested commands, not all output

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -75,7 +75,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     if (cmds.length) {
       // Disable wrapper in executed commands
-      process.env.YARN_WRAPOUTPUT = '0';
+      process.env.YARN_WRAPOUTPUT = 'false';
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
         const cmdWithArgs = stage === action ? sh`${unquoted(cmd)} ${args}` : cmd;

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -75,7 +75,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     if (cmds.length) {
       // Disable wrapper in executed commands
-      process.env.YARN_WRAPOUTPUT = 'false';
+      process.env.YARN_WRAP_OUTPUT = 'false';
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
         const cmdWithArgs = stage === action ? sh`${unquoted(cmd)} ${args}` : cmd;

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -74,8 +74,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     }
 
     if (cmds.length) {
-      // propagate YARN_SILENT env variable to executed commands
-      process.env.YARN_SILENT = '1';
+      // Disable wrapper in executed commands
+      process.env.YARN_WRAPPER = '0';
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
         const cmdWithArgs = stage === action ? sh`${unquoted(cmd)} ${args}` : cmd;

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -75,7 +75,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     if (cmds.length) {
       // Disable wrapper in executed commands
-      process.env.YARN_WRAPPER = '0';
+      process.env.YARN_WRAPOUTPUT = '0';
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
         const cmdWithArgs = stage === action ? sh`${unquoted(cmd)} ${args}` : cmd;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -207,7 +207,7 @@ export function main({
   reporter.initPeakMemoryCounter();
 
   const config = new Config(reporter);
-  const outputWrapperEnv = process.env.YARN_WRAPPER === undefined || process.env.YARN_WRAPPER == '1';
+  const outputWrapperEnv = process.env.YARN_WRAPOUTPUT === undefined || process.env.YARN_WRAPOUTPUT == '1';
   const outputWrapper = !commander.json && outputWrapperEnv && command.hasWrapper(commander, commander.args);
 
   if (outputWrapper) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -42,6 +42,14 @@ function findProjectRoot(base: string): string {
 
 const boolify = val => val.toString().toLowerCase() !== 'false' && val !== '0';
 
+function boolifyWithDefault(val: any, defaultResult: boolean): boolean {
+  if (val === undefined || val === null || val === '') {
+    return defaultResult;
+  } else {
+    return boolify(val);
+  }
+}
+
 export function main({
   startArgs,
   args,
@@ -207,10 +215,10 @@ export function main({
   reporter.initPeakMemoryCounter();
 
   const config = new Config(reporter);
-  const outputWrapperEnv = process.env.YARN_WRAPOUTPUT === undefined || process.env.YARN_WRAPOUTPUT == '1';
-  const outputWrapper = !commander.json && outputWrapperEnv && command.hasWrapper(commander, commander.args);
+  const outputWrapperEnabled = boolifyWithDefault(process.env.YARN_WRAPOUTPUT, true);
+  const shouldWrapOutput = outputWrapperEnabled && !commander.json && command.hasWrapper(commander, commander.args);
 
-  if (outputWrapper) {
+  if (shouldWrapOutput) {
     reporter.header(commandName, {name: 'yarn', version});
   }
 
@@ -244,7 +252,7 @@ export function main({
     }
 
     return command.run(config, reporter, commander, commander.args).then(exitCode => {
-      if (outputWrapper) {
+      if (shouldWrapOutput) {
         reporter.footer(false);
       }
       return exitCode;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -207,7 +207,8 @@ export function main({
   reporter.initPeakMemoryCounter();
 
   const config = new Config(reporter);
-  const outputWrapper = !commander.json && command.hasWrapper(commander, commander.args);
+  const outputWrapperEnv = process.env.YARN_WRAPPER === undefined || process.env.YARN_WRAPPER == '1';
+  const outputWrapper = !commander.json && outputWrapperEnv && command.hasWrapper(commander, commander.args);
 
   if (outputWrapper) {
     reporter.header(commandName, {name: 'yarn', version});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -215,7 +215,7 @@ export function main({
   reporter.initPeakMemoryCounter();
 
   const config = new Config(reporter);
-  const outputWrapperEnabled = boolifyWithDefault(process.env.YARN_WRAPOUTPUT, true);
+  const outputWrapperEnabled = boolifyWithDefault(process.env.YARN_WRAP_OUTPUT, true);
   const shouldWrapOutput = outputWrapperEnabled && !commander.json && command.hasWrapper(commander, commander.args);
 
   if (shouldWrapOutput) {


### PR DESCRIPTION
**Summary**

Fixes #4615. Disabling all Yarn output in nested commands with `YARN_SILENT` is a bit much, we usually want to see the output. This pull request introduces a new environment variable `YARN_WRAP_OUTPUT` that can be set to `0` to disable the header and footer Yarn normally displays.

Disabling the header/footer might also be useful in other situations, like other tools calling Yarn, so the `YARN_WRAP_OUTPUT` variable has general use.

**Test plan**

Existing integration tests.