### PR TITLE
fix(cli): Don't warn when running on node 9

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,7 @@ export const DEPENDENCY_TYPES = ['devDependencies', 'dependencies', 'optionalDep
 export const RESOLUTIONS = 'resolutions';
 export const MANIFEST_FIELDS = [RESOLUTIONS, ...DEPENDENCY_TYPES];
 
-export const SUPPORTED_NODE_VERSIONS = '^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0';
+export const SUPPORTED_NODE_VERSIONS = '^4.8.0 || ^5.7.0 || ^6.2.2 || >=8.0.0';
 
 export const YARN_REGISTRY = 'https://registry.yarnpkg.com';
 


### PR DESCRIPTION
**Summary**

Update the accepted semver range to not warn on unknown future versions of node.

**Test plan**

N/A since we don't want to add Node 9 into our build matrix just yet.