### PR TITLE
Fix offline npm cache resolve for scoped packages

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -764,6 +764,19 @@ test.concurrent('install with latest tag and --offline flag', (): Promise<void> 
   });
 });
 
+test.concurrent('install with latest tag and --offline flag scoped', (): Promise<void> => {
+  return runAdd(['@types/node@8.0.0'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {
+    config.offline = true;
+    const add = new Add(['@types/node@latest'], {}, config, reporter, previousAdd.lockfile);
+    await add.init();
+
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    const version = await getPackageVersion(config, '@types/node');
+
+    expect(pkg.dependencies).toEqual({'@types/node': `^${version}`});
+  });
+});
+
 test.concurrent('install with latest tag and --prefer-offline flag', (): Promise<void> => {
   return runAdd(['left-pad@1.1.0'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {
     config.preferOffline = true;
@@ -774,6 +787,20 @@ test.concurrent('install with latest tag and --prefer-offline flag', (): Promise
     const version = await getPackageVersion(config, 'left-pad');
 
     expect(pkg.dependencies).toEqual({'left-pad': `^${version}`});
+    expect(version).not.toEqual('1.1.0');
+  });
+});
+
+test.concurrent('install with latest tag and --prefer-offline flag scoped', (): Promise<void> => {
+  return runAdd(['@types/node@8.0.0'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {
+    config.preferOffline = true;
+    const add = new Add(['@types/node@latest'], {}, config, reporter, previousAdd.lockfile);
+    await add.init();
+
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    const version = await getPackageVersion(config, '@types/node');
+
+    expect(pkg.dependencies).toEqual({'@types/node': `^${version}`});
     expect(version).not.toEqual('1.1.0');
   });
 });

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -106,9 +106,17 @@ export default class NpmResolver extends RegistryResolver {
     const cacheFolder = path.join(this.config.cacheFolder, scope ? `${NPM_REGISTRY_ID}-${scope}` : '');
 
     const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
-      // make sure the folder exists and then read it
-      await fs.mkdirp(cacheFolder);
-      const files = await fs.readdir(cacheFolder);
+      // Try to read the folder.
+      let files = [];
+      try {
+        files = await fs.readdir(cacheFolder);
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          return [];
+        }
+        throw err;
+      }
+
       const validFiles = [];
 
       for (const name of files) {

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -106,6 +106,8 @@ export default class NpmResolver extends RegistryResolver {
     const cacheFolder = path.join(this.config.cacheFolder, scope ? `${NPM_REGISTRY_ID}-${scope}` : '');
 
     const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
+      // make sure the folder exists and then read it
+      await fs.mkdirp(cacheFolder);
       const files = await fs.readdir(cacheFolder);
       const validFiles = [];
 


### PR DESCRIPTION
Fixes #4818.

Demonstration on Windows 10:

```
builder: ~/workspace/test
$ ls
package.json

builder: ~/workspace/test
$ yarn cache clean
yarn cache v1.2.1
success Cleared cache.
Done in 5.72s.

builder: ~/workspace/test
$ yarn install --prefer-offline
yarn install v1.2.1
info No lockfile found.
[1/4] Resolving packages...
error An unexpected error occurred: "ENOENT: no such file or directory, scandir 'C:\\Users\\builder\\AppData\\Local\\Yarn\\cache\\v1\\npm-@types'".
info If you think this is a bug, please open a bug report with the information provided in "C:\\Users\\builder\\workspace\\test\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

builder: ~/workspace/test
$ ~/workspace/yarn/bin/yarn install --prefer-offline
yarn install v1.2.1
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 2.04s.
```
