### PR TITLE
fix(config): Use boolifyWithDefault() for bools from environment

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -204,7 +204,7 @@ export function main({
     emoji: process.stdout.isTTY && commander.emoji,
     verbose: commander.verbose,
     noProgress: !commander.progress,
-    isSilent: process.env.YARN_SILENT === '1' || commander.silent,
+    isSilent: boolifyWithDefault(process.env.YARN_SILENT, false) || commander.silent,
   });
 
   const exit = exitCode => {
@@ -550,7 +550,7 @@ async function start(): Promise<void> {
   const rc = getRcConfigForCwd(process.cwd());
   const yarnPath = rc['yarn-path'];
 
-  if (yarnPath && process.env.YARN_IGNORE_PATH !== '1') {
+  if (yarnPath && !boolifyWithDefault(process.env.YARN_IGNORE_PATH, false)) {
     const argv = process.argv.slice(2);
     const opts = {stdio: 'inherit', env: Object.assign({}, process.env, {YARN_IGNORE_PATH: 1})};
     let exitCode = 0;


### PR DESCRIPTION
**Summary**

Use `boolifyWithDefault()` to determine if environment variable values are `true` or `false`. This ensures that all environment variables interpret the same values the same way.

This changes the behavior of `YARN_SILENT` and `YARN_IGNORE_PATH` if they have "unexpected" values, all nonempty stings beside `"0"` and `"false"` are now interpreted as `true`. For example `YARN_SILENT=hello` was interpreted as `false` before, now it is `true`. This makes some sense since those values are truthy in Javascript, but generally makes things more predictable if it works like that for all yarn environment variables.

`YARN_SILENT=true` was also interpreted as `false`. This now definitely makes more sense since it will be interpreted as `true`.

See also [#4811](https://github.com/yarnpkg/yarn/pull/4811#issuecomment-340830589).

**Test plan**

There should be no change to the existing intended functionality and the existing tests still pass.