### PR TITLE
chore(config): Use config.production instead of isProduction()

### DIFF
--- a/__tests__/commands/list.js
+++ b/__tests__/commands/list.js
@@ -166,10 +166,7 @@ describe('list', () => {
   });
 
   test('does not list devDependencies when production', (): Promise<void> => {
-    const isProduction: $FlowFixMe = require('../../src/constants').isProduction;
-    isProduction.mockReturnValue(true);
-
-    return runList([], {}, 'dev-deps-prod', (config, reporter): ?Promise<void> => {
+    return runList([], {production: true}, 'dev-deps-prod', (config, reporter): ?Promise<void> => {
       expect(reporter.getBuffer()).toMatchSnapshot();
     });
   });

--- a/__tests__/constants.js
+++ b/__tests__/constants.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {getPathKey, isProduction} from '../src/constants.js';
+import {getPathKey} from '../src/constants.js';
 
 test('getPathKey', () => {
   expect(getPathKey('win32', {PATH: 'foobar'})).toBe('PATH');
@@ -9,19 +9,4 @@ test('getPathKey', () => {
   expect(getPathKey('win32', {})).toBe('Path');
   expect(getPathKey('linux', {})).toBe('PATH');
   expect(getPathKey('darwin', {})).toBe('PATH');
-});
-
-describe('isProduction', () => {
-  const env = {
-    NODE_ENV: '',
-  };
-  test('passing "development" should return false', () => {
-    env.NODE_ENV = 'development';
-    expect(isProduction(env)).toBe(false);
-  });
-
-  test('passing "production" should return true', () => {
-    env.NODE_ENV = 'production';
-    expect(isProduction(env)).toBe(true);
-  });
 });

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -8,7 +8,6 @@ import type {Tree, Trees} from '../../reporters/types.js';
 import {Install} from './install.js';
 
 import Lockfile from '../../lockfile';
-import {isProduction} from '../../constants';
 
 const invariant = require('invariant');
 const micromatch = require('micromatch');
@@ -199,7 +198,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   });
 
   let activePatterns = [];
-  if (isProduction()) {
+  if (config.production) {
     const devDeps = getDevDeps(manifest);
     activePatterns = patterns.filter(pattern => !devDeps.has(pattern));
   } else {

--- a/src/constants.js
+++ b/src/constants.js
@@ -103,10 +103,6 @@ export const SINGLE_INSTANCE_FILENAME = '.yarn-single-instance';
 
 export const ENV_PATH_KEY = getPathKey(process.platform, process.env);
 
-export function isProduction(env: Object = process.env): boolean {
-  return env.NODE_ENV === 'production';
-}
-
 export function getPathKey(platform: string, env: Env): string {
   let pathKey = 'PATH';
 


### PR DESCRIPTION
**Summary**

[config.js](https://github.com/yarnpkg/yarn/blob/389e02979a1ffe803ab95cbea1ad7b6bcdfa42a7/src/config.js#L336) determines if yarn runs in a production environment and sets a `production` config variable accordingly. The list command wants to know if it runs in a production environment and uses `isProduction()` to do so, which does look at environment variables, slightly different than the code in `config.js`, leading to inconsistencies in some corner cases. It should just use `config.production` instead.

`isProduction()` isn't used anywhere else and `config.production` should always be preferred, so I removed the whole function. I planned to adapt the tests of `isProduction()` for `config.production`, but the [existing tests](https://github.com/yarnpkg/yarn/blob/389e02979a1ffe803ab95cbea1ad7b6bcdfa42a7/__tests__/integration.js#L82) for `config.production` already cover all those cases.

**Test plan**
The existing tests for the `list` command still pass when they use `config.production`.