### PR TITLE
ci(travis): Increase RAMDISK size for macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      RAMDISK_SIZE=330;
+      RAMDISK_SIZE=350;
       RAMDISK_SECTORS=$(( $RAMDISK_SIZE * 1024 * 1024 / 512 ));
       RAMDISK=$(hdiutil attach -nomount ram://$RAMDISK_SECTORS);
       newfs_hfs -v yarn_ramfs $RAMDISK;


### PR DESCRIPTION
**Summary**

We have some flakiness on our macOS Node 6 builds with ENOSPC errors so increase the RAMDISK size to
avoid these.

**Test plan**

TravisCI macOS builds should pass.