### PR TITLE
ci(circle): Remove unnecessary `--` from test-ci invocations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
               ./scripts/set-dev-version.js
             fi;
             # Limit maxWorkers to 3 to avoid OOM on CircleCI
-            yarn test-ci -- -- --maxWorkers 3
+            yarn test-ci --maxWorkers 3
             yarn check-lockfile
   lint:
     <<: *defaults


### PR DESCRIPTION
**Summary**

After Yarn 1.0, the `--` separator to pass arguments to run scripts is no longer necessary. We still
have it in our CircleCI config and this patch removes it since Circle CI now uses Yarn 1.1.0+

**Test plan**

CircleCI builds should pass without any warnings or errors.