### PR TITLE
ci(circle): Run deploy tasks on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,8 @@ workflows:
           filters:
             <<: *default_filters
             branches:
-              ignore: '/.*/'
+              only:
+                - master
           requires:
             - test
             - lint


### PR DESCRIPTION
**Summary**

CircleCI is not deploying the build artifacts anymore. This PR tries to fix that by using the `only` field to explicitly say that the deploy should run on master (not sure it will have an effect).

https://circleci.com/docs/2.0/workflows/#branch-level-job-execution

cc #4271
