### PR TITLE
ci(circle): Fix deploy job so it only runs on version tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,6 @@ defaults: &defaults
   docker:
     - image: yarnpkg/dev:latest
 
-default_filters: &default_filters
-  tags:
-    only: '/^v[0-9]\+\.[0-9]\+\.[0-9]\+$/'
-
 restore_node_modules: &restore_node_modules
   restore_cache:
     name: Restore node_modules cache
@@ -90,14 +86,14 @@ jobs:
           root: ~/project
           paths:
             - yarn
-  deploy:
+  publish:
     <<: *defaults
     steps:
       - attach_workspace:
           at: ~/project
       - *restore_node_modules
       - run:
-          name: Deploy
+          name: Publish
           command: |
             # Only NPM is handled here - All other release files are handled in a webhook.
             if [ "${CIRCLE_PROJECT_USERNAME}" == "yarnpkg" ]; then
@@ -114,28 +110,22 @@ notify:
 
 workflows:
   version: 2
-  install-test-build-and-deploy:
+  install-test-build-and-publish:
     jobs:
-      - install:
-          filters: *default_filters
+      - install
       - test:
-          filters: *default_filters
           requires:
             - install
       - lint:
-          filters: *default_filters
           requires:
             - install
       - build:
-          filters: *default_filters
           requires:
             - install
-      - deploy:
+      - publish:
           filters:
-            <<: *default_filters
-            branches:
-              only:
-                - master
+            tags:
+              only: '/^v[0-9]\+\.[0-9]\+\.[0-9]\+$/'
           requires:
             - test
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ workflows:
       - publish:
           filters:
             tags:
-              only: '/^v[0-9]\+\.[0-9]\+\.[0-9]\+$/'
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
             - test
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
           filters:
             <<: *default_filters
             branches:
-              ignore: '/.*/'
+              ignore: /.*/
           requires:
             - test
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ defaults: &defaults
   docker:
     - image: yarnpkg/dev:latest
 
+default_filters: &default_filters
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
 restore_node_modules: &restore_node_modules
   restore_cache:
     name: Restore node_modules cache
@@ -112,20 +116,25 @@ workflows:
   version: 2
   install-test-build-and-publish:
     jobs:
-      - install
+      - install:
+          filters: *default_filters
       - test:
+          filters: *default_filters
           requires:
             - install
       - lint:
+          filters: *default_filters
           requires:
             - install
       - build:
+          filters: *default_filters
           requires:
             - install
       - publish:
           filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+            <<: *default_filters
+            branches:
+              ignore: '/.*/'
           requires:
             - test
             - lint


### PR DESCRIPTION
**Summary**

This PR fixes the deploy job to only run for version tags. It also renames it to "Publish" to convey
the actual task being performed since this job only publishes to NPM. Everything else is handled by
our webhooks.

Source: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution

**Test plan**

Builds on master should be fixed and when something is tagged, it should be deployed to NPM.