### PR TITLE
test(util): Add tests for boolify() and boolifyWithDefault()

### DIFF
--- a/__tests__/util/conversion.js
+++ b/__tests__/util/conversion.js
@@ -33,7 +33,7 @@ describe('boolifyWithDefault', () => {
     expect(boolifyWithDefault('', false)).toBe(false);
   });
 
-  test('should be consistent with boolify()', () => {
+  test('should be consistent with boolify() for non-empty values', () => {
     for (const value of [1, '1', true, 'true', 0, '0', false, 'false', 'randomstringlkjsaljdja', 649815]) {
       for (const defaultResult of [true, false]) {
         expect(boolifyWithDefault(value, defaultResult)).toBe(boolify(value));

--- a/__tests__/util/conversion.js
+++ b/__tests__/util/conversion.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+import {boolify, boolifyWithDefault} from '../../src/util/conversion.js';
+
+describe('boolify', () => {
+  test('should recognize "true" values', () => {
+    expect(boolify('1')).toBe(true);
+    expect(boolify(1)).toBe(true);
+    expect(boolify('true')).toBe(true);
+    expect(boolify(true)).toBe(true);
+  });
+
+  test('should recognize "false" values', () => {
+    expect(boolify('0')).toBe(false);
+    expect(boolify(0)).toBe(false);
+    expect(boolify('false')).toBe(false);
+    expect(boolify(false)).toBe(false);
+  });
+
+  // Not sure if that's really a requirement, but it's how it currently works
+  test('should treat unrecognized values as "true"', () => {
+    expect(boolify('randomstringdfkjh')).toBe(true);
+  });
+});
+
+describe('boolifyWithDefault', () => {
+  test('should return the default for empty values', () => {
+    expect(boolifyWithDefault(undefined, true)).toBe(true);
+    expect(boolifyWithDefault(undefined, false)).toBe(false);
+    expect(boolifyWithDefault(null, true)).toBe(true);
+    expect(boolifyWithDefault(null, false)).toBe(false);
+    expect(boolifyWithDefault('', true)).toBe(true);
+    expect(boolifyWithDefault('', false)).toBe(false);
+  });
+
+  test('should be consistent with boolify()', () => {
+    for (const value of [1, '1', true, 'true', 0, '0', false, 'false', 'randomstringlkjsaljdja', 649815]) {
+      for (const defaultResult of [true, false]) {
+        expect(boolifyWithDefault(value, defaultResult)).toBe(boolify(value));
+      }
+    }
+  });
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -23,6 +23,7 @@ import {getRcConfigForCwd, getRcArgs} from '../rc.js';
 import {spawnp, forkp} from '../util/child.js';
 import {version} from '../util/yarn-version.js';
 import handleSignals from '../util/signal-handler.js';
+import {boolify, boolifyWithDefault} from '../util/conversion.js';
 
 function findProjectRoot(base: string): string {
   let prev = null;
@@ -38,16 +39,6 @@ function findProjectRoot(base: string): string {
   } while (dir !== prev);
 
   return base;
-}
-
-const boolify = val => val.toString().toLowerCase() !== 'false' && val !== '0';
-
-function boolifyWithDefault(val: any, defaultResult: boolean): boolean {
-  if (val === undefined || val === null || val === '') {
-    return defaultResult;
-  } else {
-    return boolify(val);
-  }
 }
 
 export function main({

--- a/src/util/conversion.js
+++ b/src/util/conversion.js
@@ -1,8 +1,9 @@
 /* @flow */
 
+const FALSY_STRINGS = new Set(['0', 'false']);
+
 export function boolify(val: string | number | boolean): boolean {
-  const strVal = val.toString().toLowerCase();
-  return strVal !== 'false' && strVal !== '0';
+  return !FALSY_STRINGS.has(val.toString().toLowerCase());
 }
 
 export function boolifyWithDefault(val: ?(string | number | boolean), defaultResult: boolean): boolean {

--- a/src/util/conversion.js
+++ b/src/util/conversion.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-export function boolify(val: string|number|boolean): boolean {
+export function boolify(val: string | number | boolean): boolean {
   const strVal = val.toString().toLowerCase();
   return strVal !== 'false' && strVal !== '0';
 }
 
-export function boolifyWithDefault(val: ?(string|number|boolean), defaultResult: boolean): boolean {
+export function boolifyWithDefault(val: ?(string | number | boolean), defaultResult: boolean): boolean {
   if (val === undefined || val === null || val === '') {
     return defaultResult;
   } else {

--- a/src/util/conversion.js
+++ b/src/util/conversion.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+export function boolify(val: any): boolean {
+  return val.toString().toLowerCase() !== 'false' && val !== '0';
+}
+
+export function boolifyWithDefault(val: any, defaultResult: boolean): boolean {
+  if (val === undefined || val === null || val === '') {
+    return defaultResult;
+  } else {
+    return boolify(val);
+  }
+}

--- a/src/util/conversion.js
+++ b/src/util/conversion.js
@@ -1,7 +1,8 @@
 /* @flow */
 
 export function boolify(val: string|number|boolean): boolean {
-  return val.toString().toLowerCase() !== 'false' && val !== '0';
+  const strVal = val.toString().toLowerCase();
+  return strVal !== 'false' && strVal !== '0';
 }
 
 export function boolifyWithDefault(val: ?(string|number|boolean), defaultResult: boolean): boolean {

--- a/src/util/conversion.js
+++ b/src/util/conversion.js
@@ -7,9 +7,5 @@ export function boolify(val: string | number | boolean): boolean {
 }
 
 export function boolifyWithDefault(val: ?(string | number | boolean), defaultResult: boolean): boolean {
-  if (val === undefined || val === null || val === '') {
-    return defaultResult;
-  } else {
-    return boolify(val);
-  }
+  return val === '' || val === null || val === undefined ? defaultResult : boolify(val);
 }

--- a/src/util/conversion.js
+++ b/src/util/conversion.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-export function boolify(val: any): boolean {
+export function boolify(val: string|number|boolean): boolean {
   return val.toString().toLowerCase() !== 'false' && val !== '0';
 }
 
-export function boolifyWithDefault(val: any, defaultResult: boolean): boolean {
+export function boolifyWithDefault(val: ?(string|number|boolean), defaultResult: boolean): boolean {
   if (val === undefined || val === null || val === '') {
     return defaultResult;
   } else {


### PR DESCRIPTION
**Summary**

This adds tests for `boolify()` and `boolifyWithDefault()`. It also fixes a bug in `boolify()` discovered in the process: the number `0` should evaluate to `false`, not `true`. 

The functions are moved from cli/index.js to util/conversion.js since they can be generally useful.

**Test plan**

Adding tests is the main point.