### PR TITLE
fix(util): Allow git tag and branch name with hash

### DIFF
--- a/__tests__/util/version.js
+++ b/__tests__/util/version.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+import {explodeHashedUrl} from '../../src/util/version.js';
+
+test('explodeHashedUrl', () => {
+  expect(explodeHashedUrl('https://github.com/yarnpkg/yarn.git#v1.2.3')).toEqual({
+    url: 'https://github.com/yarnpkg/yarn.git',
+    hash: 'v1.2.3',
+  });
+
+  expect(explodeHashedUrl('https://github.com/yarnpkg/yarn.git')).toEqual({
+    url: 'https://github.com/yarnpkg/yarn.git',
+    hash: '',
+  });
+
+  expect(explodeHashedUrl('https://github.com/yarnpkg/yarn.git#')).toEqual({
+    url: 'https://github.com/yarnpkg/yarn.git',
+    hash: '',
+  });
+
+  expect(explodeHashedUrl('https://github.com/yarnpkg/yarn.git#v1.2.007#secret-version')).toEqual({
+    url: 'https://github.com/yarnpkg/yarn.git',
+    hash: 'v1.2.007#secret-version',
+  });
+});

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -1,10 +1,9 @@
 /* @flow */
 
 export function explodeHashedUrl(url: string): {url: string, hash: string} {
-  const parts = url.split('#');
-
+  const pos = url.indexOf('#');
   return {
-    hash: parts[1] || '',
-    url: parts[0],
+    hash: pos > -1 ? url.substring(pos + 1) : '',
+    url: pos > -1 ? url.substring(0, pos) : url,
   };
 }


### PR DESCRIPTION
**Summary**

In **Git** `#` is a valid character for `tag` and `branch`

```sh
git check-ref-format "tags/v1.1.2-#279-require-twice-protection" && echo "Valid tag" || echo "Invalid tag"
```

Fixes #4880