### PR TITLE
feat(workspaces): Adds a `workspaces` command

### DIFF
--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -1,0 +1,40 @@
+// @flow
+
+import {BufferReporter} from '../../src/reporters/index.js';
+import {run as workspace} from '../../src/cli/commands/workspaces.js';
+import * as reporters from '../../src/reporters/index.js';
+import Config from '../../src/config.js';
+import path from 'path';
+
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'workspace');
+
+async function runWorkspaces(
+  flags: Object,
+  args: Array<string>,
+  name: string,
+  checkSteps?: ?(config: Config, reporter: BufferReporter) => ?Promise<void>,
+): Promise<void> {
+  const cwd = path.join(fixturesLoc, name);
+  const reporter = new reporters.BufferReporter({stdout: null, stdin: null, isSilent: true});
+
+  const config = await Config.create({cwd}, reporter);
+
+  await workspace(config, reporter, flags, args);
+
+  if (checkSteps) {
+    await checkSteps(config, reporter);
+  }
+}
+
+test('workspaces should list the workspaces', (): Promise<void> => {
+  return runWorkspaces({}, ['info'], 'run-basic', (config, reporter) => {
+    expect(reporter.getBufferJson()).toEqual({
+      'workspace-1': {
+        location: 'packages/workspace-child-1',
+      },
+      'workspace-2': {
+        location: 'packages/workspace-child-2',
+      },
+    });
+  });
+});

--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -26,7 +26,7 @@ async function runWorkspaces(
   }
 }
 
-test('workspaces should list the workspaces', (): Promise<void> => {
+test('workspaces info should list the workspaces', (): Promise<void> => {
   return runWorkspaces({}, ['info'], 'run-basic', (config, reporter) => {
     expect(reporter.getBufferJson()).toEqual({
       'workspace-1': {

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -40,6 +40,7 @@ import * as upgrade from './upgrade.js';
 import * as version from './version.js';
 import * as versions from './versions.js';
 import * as why from './why.js';
+import * as workspaces from './workspaces.js';
 import * as workspace from './workspace.js';
 import * as upgradeInteractive from './upgrade-interactive.js';
 
@@ -83,6 +84,7 @@ const commands = {
   version,
   versions,
   why,
+  workspaces,
   workspace,
   upgradeInteractive,
 };

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -35,7 +35,7 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
   reporter.log(JSON.stringify(publicData, null, 2), {force: true});
 }
 
-const {run, setFlags, examples} = buildSubCommands('cache', {
+const {run, setFlags, examples} = buildSubCommands('workspaces', {
   async info(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
     await info(config, reporter, flags, args);
   },

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -1,0 +1,44 @@
+// @flow
+
+import type Config from '../../config.js';
+import {MessageError} from '../../errors.js';
+import type {Reporter} from '../../reporters/index.js';
+import buildSubCommands from './_build-sub-commands.js';
+
+const invariant = require('invariant');
+const path = require('path');
+
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
+  return true;
+}
+
+export async function info(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  const {workspaceRootFolder} = config;
+
+  if (!workspaceRootFolder) {
+    throw new MessageError(reporter.lang('workspaceRootNotFound', config.cwd));
+  }
+
+  const manifest = await config.findManifest(workspaceRootFolder, false);
+  invariant(manifest && manifest.workspaces, 'We must find a manifest with a "workspaces" property');
+
+  const workspaces = await config.resolveWorkspaces(workspaceRootFolder, manifest);
+
+  const publicData = {};
+
+  for (const workspaceName of Object.keys(workspaces)) {
+    publicData[workspaceName] = {
+      location: path.relative(config.lockfileFolder, workspaces[workspaceName].loc),
+    };
+  }
+
+  reporter.log(JSON.stringify(publicData, null, 2), {force: true});
+}
+
+const {run, setFlags, examples} = buildSubCommands('cache', {
+  async info(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    await info(config, reporter, flags, args);
+  },
+});
+
+export {run, setFlags, examples};

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -28,7 +28,7 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
 
   for (const workspaceName of Object.keys(workspaces)) {
     publicData[workspaceName] = {
-      location: path.relative(config.lockfileFolder, workspaces[workspaceName].loc),
+      location: path.relative(config.lockfileFolder, workspaces[workspaceName].loc).replace(/\\/g, '/'),
     };
   }
 

--- a/src/reporters/buffer-reporter.js
+++ b/src/reporters/buffer-reporter.js
@@ -27,4 +27,12 @@ export default class BufferReporter extends JSONReporter {
   getBuffer(): Buffer {
     return this._buffer;
   }
+
+  getBufferText(): string {
+    return this._buffer.map(({data}) => String(data)).join(``);
+  }
+
+  getBufferJson(): any {
+    return JSON.parse(this.getBufferText());
+  }
 }


### PR DESCRIPTION
**Summary**

Adds a command name `workspaces` that display useful data about the workspaces layout. Can be used for debugging, or for integrating other tools on top of Yarn itself. Currently only expose the two following information, but can be easily expanded if we need to add more fields:

- Workspace name
- Workspace location

**Test plan**

Added an automated test.
