### PR TITLE
Fix for adding remote tarball package

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -75,7 +75,19 @@ export default class TarballFetcher extends BaseFetcher {
     extractorStream
       .pipe(untarStream)
       .on('error', error => {
+        const {reporter} = this.config;
+        const {pathname} = url.parse(this.reference);
+        if (pathname == null) {
+          return null;
+        }
         error.message = `${error.message}${tarballPath ? ` (${tarballPath})` : ''}`;
+        //If error message is of type EISDIR and filetype is tar.gz
+        if (
+          error.message.indexOf('EISDIR: illegal operation on a directory') === 0 &&
+          pathname.split('/').pop().endsWith('.tar.gz')
+        ) {
+          reporter.warn(reporter.lang('tarInstallError'));
+        }
         reject(error);
       })
       .on('finish', async () => {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -371,6 +371,8 @@ const messages = {
   verboseUpgradeBecauseOutdated: 'Considering upgrade of $0 to $1 because a newer version exists in the registry.',
   verboseUpgradeNotUnlocking: 'Not unlocking $0 in the lockfile because it is a new or direct dependency.',
   verboseUpgradeUnlocking: 'Unlocking $0 in the lockfile.',
+  tarInstallError:
+    'For a .tar.gz to be used by yarn add it must have the file names starting with a "./" . This can be checked using the command "tar -tf file.tar.gz"',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
**Summary**

This change fixes the issue #3160. 

The motivation for fixing this bug was to start contributing to yarn development. Yarn throws an unexpected error while adding a remote tarball package when all files are listed are without the leading local directory ("./*"). I have added a message which informs the user of this behavior so the tar file can be called accordingly.


**Test plan**

The following command demonstrates the fix:
yarn add https://github.com/blikblum/cherrytree/releases/download/svelte-2.4.2/build.tar.gz

![image](https://user-images.githubusercontent.com/2347454/32656118-896e587e-c636-11e7-8152-6ae6c4f0fc57.png)
