### PR TITLE
fix(request) Fix https_proxy env var

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -148,6 +148,8 @@ export default class RequestManager {
 
     if (opts.httpsProxy === '') {
       this.httpsProxy = opts.httpProxy || '';
+    } else if (opts.httpsProxy === false) {
+      this.httpsProxy = false;
     } else {
       this.httpsProxy = opts.httpsProxy || '';
     }
@@ -412,7 +414,14 @@ export default class RequestManager {
     if (params.url.startsWith('https:')) {
       proxy = this.httpsProxy;
     }
-    params.proxy = String(proxy);
+
+    if (proxy) {
+      params.proxy = String(proxy);
+    } else if (proxy === false) {
+      // passign empty string prevents the underlying library from falling back to the env vars.
+      // an explicit false in the yarn config should override the env var. See #4546.
+      params.proxy = '';
+    }
 
     if (this.ca != null) {
       params.ca = this.ca;

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -416,9 +416,11 @@ export default class RequestManager {
     }
 
     if (proxy) {
+      // if no proxy is set, do not pass a proxy down to request.
+      // the request library will internally check the HTTP_PROXY and HTTPS_PROXY env vars.
       params.proxy = String(proxy);
     } else if (proxy === false) {
-      // passign empty string prevents the underlying library from falling back to the env vars.
+      // passing empty string prevents the underlying library from falling back to the env vars.
       // an explicit false in the yarn config should override the env var. See #4546.
       params.proxy = '';
     }


### PR DESCRIPTION
**Summary**

Fixes #4885. In #4761 I started always passing the proxy to the `request` library to prevent it from falling back to env vars HTTPS_PROXY and HTTP_PROXY. At the time I thought that Yarn would pick up these env vars through its config system and pass them down itself.

It turns out this was not true and caused #4885. Now handling an explicit `false` in the request-manager to allow it to override the `https_proxy` if set. Otherwise, resume allowing request library to pick up the env vars.

**Test plan**

Manually tested. Since the actual requests are proxies under unit test, this is difficult to unit test.
