### PR TITLE
Unescape npm tarball urls for scoped packages

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -195,8 +195,11 @@ export default class NpmResolver extends RegistryResolver {
     }
 
     if (dist != null && dist.tarball) {
+      // The resolved tarball url needs to be un-escaped.
+      // Refer to the SCOPED_PKG_REGEXP docs in npm-registry for more info.
+      const resolved = `${this.cleanRegistry(dist.tarball).replace('%2f', '/')}#${dist.shasum}`;
       info._remote = {
-        resolved: `${this.cleanRegistry(dist.tarball)}#${dist.shasum}`,
+        resolved,
         type: 'tarball',
         reference: this.cleanRegistry(dist.tarball),
         hash: dist.shasum,


### PR DESCRIPTION
**Summary**
Prior to this PR, npm tarball urls for scoped packages were using escaped URLs which contradicts the documentation in npm-registry.
The `yarn.lock` entry prior to this PR was:
```
"@types/react@^16.0.22":
  version "16.0.22"
  resolved "https://npm.d.musta.ch/@types%2freact/-/react-16.0.22.tgz#19ad106e124aceebd2b4d430a278d55413ee8759"
```
and is now:
```
"@types/react@^16.0.22":
  version "16.0.22"
  resolved "https://npm.d.musta.ch/@types/react/-/react-16.0.22.tgz#19ad106e124aceebd2b4d430a278d55413ee8759"
```

The following is the documentation for `SCOPED_PKG_REGEXP` in `npm-registry`:

> All scoped package names are of the format `@scope%2fpkg` from the use of NpmRegistry.escapeName `(?:^|\/)` Match either the start of the string or a `/` but don't capture `[^\/?]+?` Match any character that is not '/' or '?' and capture, up until the first occurance of: `(?=%2f|\/)` Match SCOPE_SEPARATOR, the escaped '/', or a raw `/` and don't capture.
The reason for matching a plain `/` is NPM registry being inconsistent about escaping `/` in scoped package names: when you're fetching a tarball, it is not escaped, when you want info about the package, it is escaped.

It turns out that you can download the tarball from either url. However, when using an offline mirror, the %2f will wind up in the filename instead of a `-` (slashes get converted to dashes for tarball filenames in the offline mirror).
In addition, if pruning is enabled, the tarball will get pruned because the filename is not what it expected.

I created a [sample project](https://github.com/yarnpkg/yarn/files/1465679/yarn-test.zip). It has a yarn.js with the change in this PR marked with `@edit`. 
Run `./yarn.js cache clean  && rm -rf node_modules/ && rm -rf npm-packages-offline-cache/ && ./yarn.js install` with and without my change. Delete `yarn.lock` after changing it because the resolved url in `yarn.lock` changes.

**Test plan**
See sample project.
