### PR TITLE
Add latest flag to global upgrade interactive

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -287,4 +287,5 @@ export {run};
 export function setFlags(commander: Object) {
   _setFlags(commander);
   commander.option('--prefix <prefix>', 'bin prefix to use to install binaries');
+  commander.option('--latest', 'upgrade to the latest version of packages');
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes https://github.com/yarnpkg/yarn/issues/4500#issuecomment-342616138.

The global subcommands currently only allow flags from the two places below to be passed from the CLI
https://github.com/yarnpkg/yarn/blob/8918b6cff99e037f3ab56523ebfde96e0c19cdae/src/cli/index.js#L65-L113 and https://github.com/yarnpkg/yarn/blob/8918b6cff99e037f3ab56523ebfde96e0c19cdae/src/cli/commands/global.js#L289

which meant [by the time it gets to upgrade interactive](https://github.com/yarnpkg/yarn/blob/8918b6cff99e037f3ab56523ebfde96e0c19cdae/src/cli/commands/upgrade-interactive.js#L37-L38), commander didn't correctly pass in `latest` as a valid key in the flags object. As a result, whenever `yarn global upgrade-interactive` was called, `--latest` was ignored.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
This is a pretty low risk change given that global modules don't need to read off package.json or a lockfile, but the issue did reveal some future tasks for a) cleaning up flags for each command and b) finding a better testing strategy for upgrade interactive as these tests are pretty sparse.

*BEFORE*
<img width="715" alt="screen shot 2017-11-13 at 4 43 00 pm" src="https://user-images.githubusercontent.com/18429494/32757284-a6d333ee-c893-11e7-9e6d-f79480be2d64.png">
*AFTER*
<img width="713" alt="screen shot 2017-11-13 at 4 42 50 pm" src="https://user-images.githubusercontent.com/18429494/32757285-a6eda8dc-c893-11e7-8062-169c7c6f0340.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
