### PR TITLE
test(integration): Fix left-pad version used in a test with snapshots

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -244,7 +244,7 @@ test('yarnrc arguments', async () => {
   );
   await fs.writeFile(`${cwd}/package.json`, JSON.stringify({name: 'test', license: 'ISC', version: '1.0.0'}));
 
-  const [stdoutOutput] = await runYarn(['add', 'left-pad'], {cwd});
+  const [stdoutOutput] = await runYarn(['add', 'left-pad@1.1.3'], {cwd});
   expect(stdoutOutput).toMatchSnapshot('yarnrc-args');
   expect(JSON.parse(await fs.readFile(`${cwd}/package.json`)).dependencies['left-pad']).toMatch(/^\d+\./);
   expect((await fs.stat(`${cwd}/yarn-cache`)).isDirectory()).toBe(true);


### PR DESCRIPTION
**Summary**

We had a test using left-pad without pinning its version and since now there's a new version of
left-pad, the snapshots are failing. This PR fixes the issue by pinning the version of left-pad in
the test.

**Test plan**

Tests should pass.