### PR TITLE
fix(pack): make globs match dotfiles

### DIFF
--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -164,3 +164,15 @@ test.skip('pack should include bundled dependencies', (): Promise<void> => {
     expect(files.sort()).toEqual(expected.sort());
   });
 });
+
+test.concurrent('pack should match dotfiles with globs', (): Promise<void> => {
+  return runPack([], {}, 'glob-dotfile', async (config): Promise<void> => {
+    const {cwd} = config;
+    const files = await getFilesFromArchive(
+      path.join(cwd, 'glob-dotfile-v1.0.0.tgz'),
+      path.join(cwd, 'glob-dotfile-v1.0.0'),
+    );
+    const expected = ['index.js', 'package.json', 'dir', path.join('dir', '.dotfile')];
+    expect(files.sort()).toEqual(expected.sort());
+  });
+});

--- a/__tests__/fixtures/pack/glob-dotfile/a.js
+++ b/__tests__/fixtures/pack/glob-dotfile/a.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/glob-dotfile/index.js
+++ b/__tests__/fixtures/pack/glob-dotfile/index.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/glob-dotfile/package.json
+++ b/__tests__/fixtures/pack/glob-dotfile/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "glob-dotfile",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "files": ["index.js", "dir/*"]
+}

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -75,7 +75,6 @@ export async function packTarball(
   if (onlyFiles) {
     let lines = [
       '*', // ignore all files except those that are explicitly included with a negation filter
-      '.*', // files with "." as first character have to be excluded explicitly
     ];
     lines = lines.concat(
       onlyFiles.map((filename: string): string => `!${filename}`),

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -98,6 +98,8 @@ export function matchesFilter(filter: IgnoreFilter, basename: string, loc: strin
   if (filter.base && filter.base !== '.') {
     loc = path.relative(filter.base, loc);
   }
+  // the micromatch regex expects unix path separators
+  loc = loc.replace('\\', '/');
   return (
     filter.regex.test(loc) ||
     filter.regex.test(`/${loc}`) ||
@@ -129,7 +131,7 @@ export function ignoreLinesToRegex(lines: Array<string>, base: string = '.'): Ar
         // remove trailing slash
         pattern = removeSuffix(pattern, '/');
 
-        const regex: ?RegExp = mm.makeRe(pattern.trim(), {nocase: true});
+        const regex: ?RegExp = mm.makeRe(pattern.trim(), {dot: true, nocase: true});
 
         if (regex) {
           return {


### PR DESCRIPTION
**Summary**

This makes globs in the files array in package.json and in .*ignore files match dotfiles, consistent with npm's behavior and how git processes .gitignore lines.

**Test plan**

See automated test.