### PR TITLE
chore(eslint): ignore packages dir

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ scripts
 updates
 artifacts
 dist
+packages


### PR DESCRIPTION
**Summary**

`build-dist` generates a `packages/lockfile/index.js` file that eslint should ignore.

**Test plan**

Run `yarn build-dist`, then `yarn lint`, and expect not to see a ton of errors.