### PR TITLE
Fixes scoped packages cache and their offline installation

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -76,7 +76,7 @@ addTest(
   '@foo/bar@1.2.3',
   'npm',
   async cacheFolder => {
-    const folder = path.join(cacheFolder, 'npm-@foo', 'bar');
+    const folder = path.join(cacheFolder, 'npm-@foo-bar-1.2.3-cafebabecafebabecafebabecafebabecafebabe');
     await fs.mkdirp(folder);
     await fs.writeFile(
       path.join(folder, constants.METADATA_FILENAME),

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ import * as constants from './constants.js';
 import ConstraintResolver from './package-constraint-resolver.js';
 import RequestManager from './util/request-manager.js';
 import {registries, registryNames} from './registries/index.js';
+import NpmRegistry, {SCOPE_SEPARATOR} from './registries/npm-registry.js';
 import {NoopReporter} from './reporters/index.js';
 import map from './util/map.js';
 
@@ -400,6 +401,9 @@ export default class Config {
     }
 
     let name = pkg.name;
+    if (this.registries.npm.isScopedPackage(name)) {
+      name = NpmRegistry.escapeName(name).replace(SCOPE_SEPARATOR, '-');
+    }
     let uid = pkg.uid;
     if (pkg.registry) {
       name = `${pkg.registry}-${name}`;

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -100,10 +100,12 @@ export default class NpmResolver extends RegistryResolver {
     const scope = this.config.registries.npm.getScope(escapedName);
 
     // find modules of this name
-    const prefix = scope ? escapedName.split(SCOPE_SEPARATOR)[1] : `${NPM_REGISTRY_ID}-${this.name}-`;
+    const prefix = scope
+      ? `${NPM_REGISTRY_ID}-${escapedName.replace(SCOPE_SEPARATOR, '-')}-`
+      : `${NPM_REGISTRY_ID}-${this.name}-`;
 
     invariant(this.config.cacheFolder, 'expected packages root');
-    const cacheFolder = path.join(this.config.cacheFolder, scope ? `${NPM_REGISTRY_ID}-${scope}` : '');
+    const cacheFolder = this.config.cacheFolder;
 
     const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
       const files = await fs.readdir(cacheFolder);


### PR DESCRIPTION
**Summary**
Fixes #4266. I flattened the cache folder (no more nesting of scoped packages in a scope folder) and included the scope in the name of the folder in cache.

**Test plan**
I can add tests to integration for testing the issue with installing offline packages. But want to make sure that this solution makes sense first.