### PR TITLE
fix(add): Make semver flags compatible with versioned requests

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -147,6 +147,16 @@ test.concurrent('install with --optional flag', (): Promise<void> => {
   });
 });
 
+test.concurrent('install with --tilde flag', (): Promise<void> => {
+  return runAdd(['isarray@2.0.1'], {tilde: true}, 'add-with-flag', async config => {
+    const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+
+    expect(lockfile.indexOf('isarray@~2.0.1:')).toEqual(0);
+    expect(pkg.dependencies).toEqual({isarray: '~2.0.1'});
+  });
+});
+
 // Test if moduleAlreadyInManifest warning is displayed
 const moduleAlreadyInManifestChecker = ({expectWarnings}: {expectWarnings: boolean}) => async (
   args,

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -74,10 +74,11 @@ export class Add extends Install {
     }
 
     if (!version || semver.valid(version)) {
-      let prefix = version ? '' : configPrefix || '^';
+      let prefix = configPrefix || '^';
+
       if (tilde) {
         prefix = '~';
-      } else if (exact) {
+      } else if (version || exact) {
         prefix = '';
       }
       version = `${prefix}${pkg.version}`;

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -71,18 +71,18 @@ export class Add extends Install {
     } else if (hasVersion && range && (semver.satisfies(pkg.version, range) || getExoticResolver(range))) {
       // if the user specified a range then use it verbatim
       version = range;
-    } else {
-      let prefix;
+    }
+
+    if (!version || semver.valid(version)) {
+      let prefix = configPrefix || '^';
       if (tilde) {
         prefix = '~';
       } else if (exact) {
         prefix = '';
-      } else {
-        prefix = configPrefix || '^';
       }
-
       version = `${prefix}${pkg.version}`;
     }
+
     return version;
   }
 

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -74,7 +74,7 @@ export class Add extends Install {
     }
 
     if (!version || semver.valid(version)) {
-      let prefix = configPrefix || '^';
+      let prefix = version ? '' : configPrefix || '^';
       if (tilde) {
         prefix = '~';
       } else if (exact) {


### PR DESCRIPTION
**Summary**

Fixes #4978

Previously, there was logic in add command that [uses user-specified range out of the box](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/add.js#L71-L72), resulting in the issue above. For example, if the user ran `yarn add left-pad@1.0.0` the pattern parser skipped `--exact` or `--tilde flags`, as well as saved prefix config options.

This change updates it so that if the user specifies a valid numeric version, then these flags still have an effect. These cases don't cover `yarn add left-pad@~1.0.0` or `yarn add left-pad@^1.0.0` since I think the confusion only arises from when the user enters `exact` pattern (just the number).

**Test plan**

Added a test case that fails on master
