### PR TITLE
chore(add): Reword warning for existing dependency type

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -181,13 +181,13 @@ const moduleAlreadyInManifestChecker = ({expectWarnings}: {expectWarnings: boole
   const output = reporter.getBuffer();
   const warnings = output.filter(entry => entry.type === 'warning');
 
-  expect(warnings.some(warning => warning.data.toString().toLowerCase().indexOf('is already in') > -1)).toEqual(
+  expect(warnings.some(warning => warning.data.toString().toLowerCase().indexOf('existing version of') > -1)).toEqual(
     expectWarnings,
   );
 
   expect(
     warnings.some(
-      warning => warning.data.toString().toLowerCase().indexOf('please remove existing entry first before adding') > -1,
+      warning => warning.data.toString().toLowerCase().indexOf('please remove the existing entry first') > -1,
     ),
   ).toEqual(expectWarnings);
 };

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -69,7 +69,8 @@ const messages = {
   couldntFindVersionThatMatchesRange: "Couldn't find any versions for $0 that matches $1",
   chooseVersionFromList: 'Please choose a version of $0 from this list:',
   moduleNotInManifest: "This module isn't specified in a manifest.",
-  moduleAlreadyInManifest: 'The existing version of $0 in $1 has been updated. If you would like to add it to $2, please remove the existing entry first with `yarn remove $0`.',
+  moduleAlreadyInManifest:
+    'The existing version of $0 in $1 has been updated. If you would like to add it to $2, please remove the existing entry first with `yarn remove $0`.',
   unknownFolderOrTarball: "Passed folder/tarball doesn't exist,",
   unknownPackage: "Couldn't find package $0.",
   unknownPackageName: "Couldn't find package name.",

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -69,7 +69,7 @@ const messages = {
   couldntFindVersionThatMatchesRange: "Couldn't find any versions for $0 that matches $1",
   chooseVersionFromList: 'Please choose a version of $0 from this list:',
   moduleNotInManifest: "This module isn't specified in a manifest.",
-  moduleAlreadyInManifest: '$0 is already in $1. Please remove existing entry first before adding it to $2.',
+  moduleAlreadyInManifest: 'The existing version of $0 in $1 has been updated. If you would like to add it to $2, please remove the existing entry first with `yarn remove $0`.',
   unknownFolderOrTarball: "Passed folder/tarball doesn't exist,",
   unknownPackage: "Couldn't find package $0.",
   unknownPackageName: "Couldn't find package name.",


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When `yarn add` (which acts as `upgrade` if the dependency already exists) is ran with flags that are different from the original dependency, clarify that the existing dependency type has been updated and provide a way for users to replace the dependency type in the warning

Closes https://github.com/yarnpkg/yarn/issues/5003
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

*before*
```
yarn add v1.5.0
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
warning " > @angular/core@5.2.4" has unmet peer dependency "rxjs@^5.5.0".
warning " > @angular/core@5.2.4" has unmet peer dependency "zone.js@^0.8.4".
[5/5] 📃  Building fresh packages...
warning Your current version of Yarn is out of date. The latest version is "1.5.1", while you're on "1.5.0".
success Saved 1 new dependency.
info Direct dependencies
└─ nock@9.2.3
info All dependencies
└─ nock@9.2.3
warning "nock" is already in "devDependencies". Please remove existing entry first before adding it to "dependencies".
✨  Done in 0.75s.
```
*after*
```
yarn add v1.5.0
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
warning " > @angular/core@5.2.4" has unmet peer dependency "rxjs@^5.5.0".
warning " > @angular/core@5.2.4" has unmet peer dependency "zone.js@^0.8.4".
[5/5] 📃  Building fresh packages...
warning Your current version of Yarn is out of date. The latest version is "1.5.1", while you're on "1.5.0".
success Saved 1 new dependency.
info Direct dependencies
└─ nock@9.2.3
info All dependencies
└─ nock@9.2.3
warning The existing version of "nock" in "devDependencies" has been updated. If you would like to add it to "dependencies", please remove the existing entry first with `yarn remove "nock"`.
✨  Done in 0.88s.
```