### PR TITLE
fix: connectionOptions passes in localhost as its host to prevent pop up on MacOsx

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -286,6 +286,7 @@ export function main({
     return new Promise((resolve, reject) => {
       const connectionOptions = {
         port: +mutexPort || constants.SINGLE_INSTANCE_PORT,
+        host: 'localhost',
       };
 
       function startServer() {


### PR DESCRIPTION
**Summary**
This is to fix https://github.com/yarnpkg/yarn/issues/4983 to prevent the firewall popup on Mac OSX.

**Test plan**
Ran the following tasks
```bash
yarn run test
yarn run lint
```

Also validated that the popup no longer occurs by setting the alias
`alias yarn="node /path/to/my/yarn/lib/cli/index.js"`
and running `yarn install --mutex network`
