### PR TITLE
Issue 4769- license disclaimer in JSON output 

### DIFF
--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -49,11 +49,9 @@ async function getManifests(config: Config, flags: Object): Promise<Array<Manife
 
 async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const manifests: Array<Manifest> = await getManifests(config, flags);
-//TODO: invoke a function to get the licenseText, see function generateDisclaimer below and extract a new function from there
   if (flags.json) {
     const body = [];
-
-    for (const {name, version, license, repository, homepage, author} of manifests) {
+    for (const {name, version, license, licenseText, repository, homepage, author} of manifests) {
       const url = repository ? repository.url : homepage;
       const vendorUrl = homepage || (author && author.url);
       const vendorName = author && author.name;
@@ -61,7 +59,7 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
         name,
         version,
         license || 'Unknown',
-        licenseText || 'Unknown',//TODO: make this variable exist
+        licenseText || 'Unknown',
         url || 'Unknown',
         vendorUrl || 'Unknown',
         vendorName || 'Unknown',
@@ -136,7 +134,9 @@ export const {run, setFlags, examples} = buildSubCommands('licenses', {
 
     console.log(
       'THE FOLLOWING SETS FORTH ATTRIBUTION NOTICES FOR THIRD PARTY SOFTWARE THAT MAY BE CONTAINED ' +
-        `IN PORTIONS OF THE ${String(manifest.name).toUpperCase().replace(/-/g, ' ')} PRODUCT.`,
+        `IN PORTIONS OF THE ${String(manifest.name)
+          .toUpperCase()
+          .replace(/-/g, ' ')} PRODUCT.`,
     );
     console.log();
 

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -49,7 +49,7 @@ async function getManifests(config: Config, flags: Object): Promise<Array<Manife
 
 async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const manifests: Array<Manifest> = await getManifests(config, flags);
-
+//TODO: invoke a function to get the licenseText, see function generateDisclaimer below and extract a new function from there
   if (flags.json) {
     const body = [];
 
@@ -61,13 +61,14 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
         name,
         version,
         license || 'Unknown',
+        licenseText || 'Unknown',//TODO: make this variable exist
         url || 'Unknown',
         vendorUrl || 'Unknown',
         vendorName || 'Unknown',
       ]);
     }
 
-    reporter.table(['Name', 'Version', 'License', 'URL', 'VendorUrl', 'VendorName'], body);
+    reporter.table(['Name', 'Version', 'License', 'Disclaimer', 'URL', 'VendorUrl', 'VendorName'], body);
   } else {
     const trees = [];
 
@@ -125,7 +126,7 @@ export const {run, setFlags, examples} = buildSubCommands('licenses', {
       }
 
       if (!manifestsByLicense.has(licenseText)) {
-        manifestsByLicense.set(licenseText, new Map());
+        manifestsByLicenes.set(licenseText, new Map());
       }
 
       const byLicense = manifestsByLicense.get(licenseText);

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -134,9 +134,7 @@ export const {run, setFlags, examples} = buildSubCommands('licenses', {
 
     console.log(
       'THE FOLLOWING SETS FORTH ATTRIBUTION NOTICES FOR THIRD PARTY SOFTWARE THAT MAY BE CONTAINED ' +
-        `IN PORTIONS OF THE ${String(manifest.name)
-          .toUpperCase()
-          .replace(/-/g, ' ')} PRODUCT.`,
+        `IN PORTIONS OF THE ${String(manifest.name).toUpperCase().replace(/-/g, ' ')} PRODUCT.`,
     );
     console.log();
 

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -65,7 +65,6 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
         vendorName || 'Unknown',
       ]);
     }
-
     reporter.table(['Name', 'Version', 'License', 'Disclaimer', 'URL', 'VendorUrl', 'VendorName'], body);
   } else {
     const trees = [];

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -126,7 +126,7 @@ export const {run, setFlags, examples} = buildSubCommands('licenses', {
       }
 
       if (!manifestsByLicense.has(licenseText)) {
-        manifestsByLicenes.set(licenseText, new Map());
+        manifestsByLicense.set(licenseText, new Map());
       }
 
       const byLicense = manifestsByLicense.get(licenseText);


### PR DESCRIPTION
### Summary

With this pull request, we present a solution for issue [#4769](https://github.com/yarnpkg/yarn/issues/4769). 

**Motivation:** Besides being a good beginner issue to start understanding yarn, this PR is useful for users trying to consume the json output of `yarn licenses list --json --no-progress` or `yarn licenses list --json` by including the license disclaimer text in the JSON output. 
**Solves:** Issue [#4769](https://github.com/yarnpkg/yarn/issues/4769). According to which users should also receive the license text in the licenses listing in JSON format. 
### Test plan
The changes were simple enough and it was tested on yarn itself, returning the license text where present and Undefined otherwise.