### PR TITLE
Fix transient bin links overriding direct ones

### DIFF
--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -145,6 +145,17 @@ test('first dep is installed when same level and reference count and one is a de
   });
 });
 
+// Scenario: Transitive dependency having bin link with a name that's conflicting with that of a direct dependency.
+// Behavior: a-dep and b-dep is linked in node_modules/.bin rather than c-dep and d-dep
+test('direct dependency is linked when bin name conflicts with transitive dependency', (): Promise<void> => {
+  return runInstall({binLinks: true}, 'install-bin-links-conflicting-names', async config => {
+    const stdout1 = await execCommand(config.cwd, ['node_modules', '.bin', 'binlink1'], []);
+    const stdout2 = await execCommand(config.cwd, ['node_modules', '.bin', 'binlink2'], []);
+    expect(stdout1[0]).toEqual('direct a-dep');
+    expect(stdout2[0]).toEqual('direct b-dep');
+  });
+});
+
 // fixes https://github.com/yarnpkg/yarn/issues/3535
 // quite a heavy test, did not find a way to isolate
 test('Only top level (after hoisting) bin links should be linked', (): Promise<void> => {

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/bin
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/bin
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('direct a-dep');

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/c-dep/bin
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/c-dep/bin
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('transient c-dep');

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/c-dep/package.json
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/c-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "c-dep",
+  "version": "0.0.1",
+  "bin": {
+    "binlink2": "./bin"
+  }
+}

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/package.json
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/a-dep/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "a-dep",
+  "version": "0.0.1",
+  "bin": {
+    "binlink1": "./bin"
+  },
+  "dependencies": {
+    "c-dep": "file:c-dep"
+  }
+}

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/bin
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/bin
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('direct b-dep');

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/d-dep/bin
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/d-dep/bin
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('transient d-dep');

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/d-dep/package.json
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/d-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "d-dep",
+  "version": "0.0.1",
+  "bin": {
+    "binlink1": "./bin"
+  }
+}

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/package.json
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/b-dep/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "b-dep",
+  "version": "0.0.1",
+  "bin": {
+    "binlink2": "./bin"
+  },
+  "dependencies": {
+    "d-dep": "file:d-dep"
+  }
+}

--- a/__tests__/fixtures/install/install-bin-links-conflicting-names/package.json
+++ b/__tests__/fixtures/install/install-bin-links-conflicting-names/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "a-dep": "file:a-dep",
+    "b-dep": "file:b-dep"
+  }
+}

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -73,6 +73,9 @@ export default class PackageLinker {
     for (const [scriptName, scriptCmd] of entries(pkg.bin)) {
       const dest = path.join(targetBinLoc, scriptName);
       const src = path.join(pkgLoc, scriptCmd);
+      if (await fs.exists(dest)) {
+        continue;
+      }
       if (!await fs.exists(src)) {
         // TODO maybe throw an error
         continue;


### PR DESCRIPTION
**Summary**

This fixes #4937

The problem still exists when doing `yarn add` in an already installed module however, but that is unaffected by this patch as far as I can tell, and all tests pass.

This is my very first foray into the yarn code base, so please feel free to comment on anything in here. However petty it might seem to you!

**Test plan**

Run the test suite.