### PR TITLE
fixed

### DIFF
--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -39,7 +39,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         colorizeName(info),
         info.current,
         colorizeDiff(info.current, info.wanted, reporter),
-        reporter.format.green(info.latest),
+        reporter.format.cyan(info.latest),
         info.workspaceName || '',
         getNameFromHint(info.hint),
         reporter.format.cyan(info.url),

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -39,7 +39,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         colorizeName(info),
         info.current,
         colorizeDiff(info.current, info.wanted, reporter),
-        reporter.format.magenta(info.latest),
+        reporter.format.green(info.latest),
         info.workspaceName || '',
         getNameFromHint(info.hint),
         reporter.format.cyan(info.url),


### PR DESCRIPTION
Resolves  #4758

Summary #4758 states that when typing  yarn outdated, the latest version column is invisible in powershell.

This pull request makes use of the setFlags function and the commander.description method to add and print the description of every documented command. magenta wasn't supported by powershell so color was changed to green.

Test plan yarn run test-only run tests for listing cached packages, removing all packages, removing a specific package by name



