### PR TITLE
Implementation of small feature suggested in issue #624

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -8,7 +8,6 @@ import {registries} from '../../resolvers/index.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
-const os = require('os');
 const leven = require('leven');
 const path = require('path');
 const {quoteForShell, sh, unquoted} = require('puka');
@@ -31,18 +30,17 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     if (!visitedBinFolders.has(binFolder)) {
       if (await fs.exists(binFolder)) {
         for (const name of await fs.readdir(binFolder)) {
-		  //consider only .cmd scripts on Windows and show them without the extension - #624
-		  if (process.platform === 'win32') {
-			  if (name.indexOf(".cmd") !== -1) {
-				let strippedName = name.substring(0, name.indexOf(".cmd"));
-			  	binCommands.push(strippedName);
-				scripts[name] = quoteForShell(path.join(binFolder, name));
-			}
-		  }
-		  else {
-	          binCommands.push(name);
-	          scripts[name] = quoteForShell(path.join(binFolder, name));
-	  	  }
+          //consider only .cmd scripts on Windows and show them without the extension - #624
+          if (process.platform === 'win32') {
+            if (name.indexOf('.cmd') !== -1) {
+              const strippedName = name.substring(0, name.indexOf('.cmd'));
+              binCommands.push(strippedName);
+              scripts[name] = quoteForShell(path.join(binFolder, name));
+            }
+          } else {
+            binCommands.push(name);
+            scripts[name] = quoteForShell(path.join(binFolder, name));
+          }
         }
       }
       visitedBinFolders.add(binFolder);
@@ -83,11 +81,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     } else if (scripts[action]) {
       cmds.push([action, scripts[action]]);
     } else if (process.platform === 'win32') {
-	  //Since input free of the .cmd extension was allowed, add it now - #624
-	  let cmdAction = action.concat(".cmd");
-	  if (scripts[cmdAction]) {
-		  cmds.push([cmdAction, scripts[cmdAction]]);
-	  }
+      //Since input free of the .cmd extension was allowed, add it now - #624
+      const cmdAction = action.concat('.cmd');
+      if (scripts[cmdAction]) {
+        cmds.push([cmdAction, scripts[cmdAction]]);
+      }
     }
 
     if (cmds.length) {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -31,8 +31,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     if (!visitedBinFolders.has(binFolder)) {
       if (await fs.exists(binFolder)) {
         for (const name of await fs.readdir(binFolder)) {
-		  if (process.platform === 'win32'){
-			  if (name.indexOf(".cmd") !== -1){
+		  //consider only .cmd scripts on Windows and show them without the extension - #624
+		  if (process.platform === 'win32') {
+			  if (name.indexOf(".cmd") !== -1) {
 				let strippedName = name.substring(0, name.indexOf(".cmd"));
 			  	binCommands.push(strippedName);
 				scripts[name] = quoteForShell(path.join(binFolder, name));
@@ -81,6 +82,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       }
     } else if (scripts[action]) {
       cmds.push([action, scripts[action]]);
+    } else if (process.platform === 'win32') {
+	  //Since input free of the .cmd extension was allowed, add it now - #624
+	  let cmdAction = action.concat(".cmd");
+	  if (scripts[cmdAction]) {
+		  cmds.push([cmdAction, scripts[cmdAction]]);
+	  }
     }
 
     if (cmds.length) {

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -8,6 +8,7 @@ import {registries} from '../../resolvers/index.js';
 import * as fs from '../../util/fs.js';
 import map from '../../util/map.js';
 
+const os = require('os');
 const leven = require('leven');
 const path = require('path');
 const {quoteForShell, sh, unquoted} = require('puka');
@@ -30,8 +31,17 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     if (!visitedBinFolders.has(binFolder)) {
       if (await fs.exists(binFolder)) {
         for (const name of await fs.readdir(binFolder)) {
-          binCommands.push(name);
-          scripts[name] = quoteForShell(path.join(binFolder, name));
+		  if (process.platform === 'win32'){
+			  if (name.indexOf(".cmd") !== -1){
+				let strippedName = name.substring(0, name.indexOf(".cmd"));
+			  	binCommands.push(strippedName);
+				scripts[name] = quoteForShell(path.join(binFolder, name));
+			}
+		  }
+		  else {
+	          binCommands.push(name);
+	          scripts[name] = quoteForShell(path.join(binFolder, name));
+	  	  }
         }
       }
       visitedBinFolders.add(binFolder);

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -32,8 +32,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         for (const name of await fs.readdir(binFolder)) {
           //consider only .cmd scripts on Windows and show them without the extension - #624
           if (process.platform === 'win32') {
-            if (name.indexOf('.cmd') !== -1) {
-              const strippedName = name.substring(0, name.indexOf('.cmd'));
+            if (name.match(/\.cmd$/) !== null) {
+              const strippedName = name.slice(0, -4);
               binCommands.push(strippedName);
               scripts[name] = quoteForShell(path.join(binFolder, name));
             }


### PR DESCRIPTION
fixes #624 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pull request aims to fix issue #624 . It was suggested on that issue's discussion that when running the `run` command on Windows only `.cmd` scripts should be considered, and that these should show up without the extension when displayed and allow the user to write the name of the command without writing the extension.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The code has undergone successful manual tests and passes the lint tests. An example of the new usage of the `run` command on Windows (using `flow` as an arbitrary script) can be the following:

```
E:\Git\yarn\bin>yarn run
yarn run v1.3.2
error No command specified.
info Commands available from binary scripts: acorn, atob, babylon, browserslist, commitizen, errno, escodegen, esgenerate, eslint, esparse, esvalidate, flow, git-cz, gulp, gunzip-maybe, handlebars, jest-runtime, jest, js-yaml, jsesc, jsinspect, json5, loose-envify, miller-rabin, mkdirp, prettier, regjsparser, rimraf, sane, semver, sha.js, shjs, sshpk-conv, sshpk-sign, sshpk-verify, strip-indent, strip-json-comments, uglifyjs, user-home, uuid, webpack, which
info Project commands
   - build
      gulp build
   - build-bundle
      node ./scripts/build-webpack.js
   - build-chocolatey
      powershell ./scripts/build-chocolatey.ps1
   - build-deb
      ./scripts/build-deb.sh
   - build-dist
      bash ./scripts/build-dist.sh
   - build-win-installer
      scripts\build-windows-installer.bat
   - commit
      git-cz
   - dupe-check
      yarn jsinspect ./src
   - lint
      eslint . && flow check
   - prettier
      eslint src __tests__ --fix
   - release-branch
      ./scripts/release-branch.sh
   - test
      yarn lint && yarn test-only
   - test-coverage
      node --max_old_space_size=4096 node_modules/jest/bin/jest.js --coverage --verbose
   - test-only
      node --max_old_space_size=4096 node_modules/jest/bin/jest.js --verbose
   - watch
      gulp watch
question Which command would you like to run?: flow
$ E:\Git\yarn\node_modules\.bin\flow.cmd
Launching Flow server for E:\Git\yarn
Spawned flow server (pid=6504)
... (rest of the output doesn't matter)
```

