### PR TITLE
Add help comment to --json flag

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -69,7 +69,7 @@ export function main({
   commander.option('--offline', 'trigger an error if any required dependencies are not available in local cache');
   commander.option('--prefer-offline', 'use network only if dependencies are not available in local cache');
   commander.option('--strict-semver');
-  commander.option('--json', '');
+  commander.option('--json', 'format Yarn log messages as lines of JSON (see jsonlines.org)');
   commander.option('--ignore-scripts', "don't run lifecycle scripts");
   commander.option('--har', 'save HAR output of network traffic');
   commander.option('--ignore-platform', 'ignore platform checks');


### PR DESCRIPTION
fixes #5021

**Summary**

Added a help line to the commander output for the `--json` flag.

I didn't see any mention of `--json` on the website docs (nor are any of the "use anywhere" flags really documented) so I didn't make any changes there.