### PR TITLE
Fix for 3373

### DIFF
--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -128,8 +128,6 @@ export default class Lockfile {
       //test if node_module exists
       const nodeModulesLoc = path.join(dir, NODE_MODULES_FOLDER);
       if (await fs.exists(nodeModulesLoc)) {
-        console.log();
-
         if (!isCI && !await reporter.questionAffirm(reporter.lang('lockfileModulesConflict'))) {
           reporter.footer(false);
           throw new MessageError(reporter.lang('operationAborted'));

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -25,6 +25,7 @@ const messages = {
   couldntClearPackageFromCache: "Couldn't clear package $0 from cache",
   clearedPackageFromCache: 'Cleared package $0 from cache',
   packWroteTarball: 'Wrote tarball to $0.',
+  operationAborted: 'Operation aborted.',
 
   helpExamples: '  Examples:\n$0\n',
   helpCommands: '  Commands:\n$0\n',
@@ -95,6 +96,8 @@ const messages = {
   lockfileMerged: 'Merge conflict detected in yarn.lock and successfully merged.',
   lockfileConflict:
     'A merge conflict was found in yarn.lock but it could not be successfully merged, regenerating yarn.lock from scratch.',
+  lockfileModulesConflict:
+    '\n  There is already a node_modules folder and no yarn.lock.\n  This probably means you are transitioning from npm to yarn.\n  Proceeding means the node_modules folder will be overwritten by yarn.\n  Do you want to proceed? (yes/no)',
   ignoredScripts: 'Ignored scripts due to flag.',
   missingAddDependencies: 'Missing list of packages to add to your project.',
   yesWarning:


### PR DESCRIPTION
### Summary

With this pull request, we present a solution for issue [#3373](https://github.com/yarnpkg/yarn/issues/3373). 

**Motivation:** Besides being a good first issue to start understanding yarn, this PR is useful for users transitioning from [npm](https://www.npmjs.com/) to yarn by preventing unwanted changes on the :file_folder:`node_modules`. 
**Solves:** Issue [#3373](https://github.com/yarnpkg/yarn/issues/3373). According to which users should be warned when they run `yarn` on a project that has a :file_folder:`node_modules` and does not have a :lock: `yarn.lock` file. 
### Test plan
The test environment was a project with a `node_modules` folder and no `yarn.lock` file.

After running `yarn` we present a question to the user:
```
>yarn
yarn install v1.3.2
info No lockfile found.
question
  There is already a node_modules folder and no yarn.lock.
  This probably means you are transitioning from npm to yarn.
  Proceeding means the node_modules folder will be overwritten by yarn.
  Do you want to proceed? (yes/no):
```
When the answer is `yes` (or a valid equivalent) yarn proceeds normally.

When the answer is `no` (or a valid equivalent) yarn exits normally. 

We tested with and without the `yarn.lock` file and it worked every time, the same goes for `yarn test`.
Furthermore, we took into consideration the effect of CI and non-TTY terminals for the prompt. 