### PR TITLE
ci(circle): Fix cache key setup for proper node_modules sharing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,7 @@ restore_cache: &restore_cache
   restore_cache:
     name: Restore node_modules cache
     keys:
-      - v1-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - v1-node-{{ arch }}-{{ .Branch }}-
-      - v1-node-{{ arch }}-
+      - v1-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
 install_steps: &install_steps
   steps:
@@ -32,7 +30,7 @@ install_steps: &install_steps
         command: yarn install --frozen-lockfile
     - save_cache:
         name: Save node_modules cache
-        key: v1-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+        key: v1-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
         paths:
           - node_modules/
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ install_steps: &install_steps
     - restore_cache:
         name: Restore node_modules cache
         keys:
+        # WARNING: add `{{ arch }}` into the keys below and separate the installation steps
+        #          for Linux and macOS if you ever need platform-specific dependencies
+        #          (anything using node-gyp etc.)
           - v2-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
           - v2-node-{{ .Branch }}-
           - v2-node-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,28 +14,24 @@ attach_workspace: &attach_workspace
   attach_workspace:
       at: ~/project
 
-restore_cache: &restore_cache
-  restore_cache:
-    name: Restore node_modules cache
-    keys:
-      - v1-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
-
 install_steps: &install_steps
   steps:
     - checkout
     - *attach_workspace
-    - *restore_cache
+    - restore_cache:
+        name: Restore node_modules cache
+        keys:
+          - v2-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          - v2-node-{{ .Branch }}-
+          - v2-node-
     - run:
         name: Install Dependencies
         command: yarn install --frozen-lockfile
     - save_cache:
         name: Save node_modules cache
-        key: v1-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
+        key: v2-node-{{ .Branch }}-{{ checksum "yarn.lock" }}
         paths:
           - node_modules/
-    - run:
-        name: Remove node_modules to cleanup workspace
-        command: rm -r node_modules/
     - persist_to_workspace:
         root: ~/project
         paths:
@@ -60,7 +56,6 @@ test_run: &test_run
 test_steps: &test_steps
   steps:
     - *attach_workspace
-    - *restore_cache
     - *test_build
     - *test_run
 
@@ -76,7 +71,6 @@ jobs:
     <<: *docker_defaults
     steps:
       - *attach_workspace
-      - *restore_cache
       - run:
           name: Lint
           command: yarn lint
@@ -84,7 +78,6 @@ jobs:
     <<: *docker_defaults
     steps:
       - *attach_workspace
-      - *restore_cache
       - run:
           name: Build distribution
           command: |
@@ -123,7 +116,6 @@ jobs:
             HOMEBREW_NO_AUTO_UPDATE=1 brew install node@8
             yarn global add node-gyp
       - *attach_workspace
-      - *restore_cache
       - *test_build
       - *test_run
   test-macos-node6:
@@ -137,7 +129,6 @@ jobs:
             brew link --force node@6
             yarn global add node-gyp
       - *attach_workspace
-      - *restore_cache
       - *test_build
       - *test_run
 
@@ -145,7 +136,6 @@ jobs:
     <<: *docker_defaults
     steps:
       - *attach_workspace
-      - *restore_cache
       - run:
           name: Publish
           command: |


### PR DESCRIPTION
**Summary**

We had a tiered cache key setup for some reason (probably remnant of the pre-macOS builds config) which was breaking macOS builds when a new dependency was introduced due to common install was done on a Docker machine and cached with a key including the architecture. This patch changes that and ties everything to a single cache key.

**Test plan**

CircleCI builds should pass without issues.