### PR TITLE
default option for report in non-interactive terminals

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -206,6 +206,7 @@ export function main({
     verbose: commander.verbose,
     noProgress: !commander.progress,
     isSilent: boolifyWithDefault(process.env.YARN_SILENT, false) || commander.silent,
+    nonInteractive: commander.nonInteractive,
   });
 
   const exit = exitCode => {

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -60,7 +60,8 @@ export default class BaseReporter {
     this.stderr = opts.stderr || process.stderr;
     this.stdin = opts.stdin || this._getStandardInput();
     this.emoji = !!opts.emoji;
-    this.noProgress = !!opts.noProgress || isCI;
+    this.isCI = isCI;
+    this.noProgress = !!opts.noProgress || this.isCI;
     this.isVerbose = !!opts.verbose;
 
     // $FlowFixMe: this is valid!
@@ -77,6 +78,7 @@ export default class BaseReporter {
   stderr: Stdout;
   stdin: Stdin;
   isTTY: boolean;
+  isCi: boolean;
   emoji: boolean;
   noProgress: boolean;
   isVerbose: boolean;
@@ -244,7 +246,7 @@ export default class BaseReporter {
   //
   async questionAffirm(question: string): Promise<boolean> {
     const condition = true; // trick eslint
-    if (this.isTTY || isCi) {//non-interactive terminals
+    if (this.isCi) {//non-interactive terminals
       return true;
     }
 

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -244,6 +244,9 @@ export default class BaseReporter {
   //
   async questionAffirm(question: string): Promise<boolean> {
     const condition = true; // trick eslint
+    if (this.isTTY || isCi) {//non-interactive terminals
+      return true;
+    }
 
     while (condition) {
       let answer = await this.question(question);

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -32,6 +32,7 @@ export type ReporterOptions = {
   emoji?: boolean,
   noProgress?: boolean,
   silent?: boolean,
+  nonInteractive?: boolean,
 };
 
 export function stringifyLangArgs(args: Array<any>): Array<string> {

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -60,8 +60,8 @@ export default class BaseReporter {
     this.stderr = opts.stderr || process.stderr;
     this.stdin = opts.stdin || this._getStandardInput();
     this.emoji = !!opts.emoji;
-    this.isCI = isCI;
-    this.noProgress = !!opts.noProgress || this.isCI;
+    this.nonInteractive = !!opts.nonInteractive;
+    this.noProgress = !!opts.noProgress || isCI;
     this.isVerbose = !!opts.verbose;
 
     // $FlowFixMe: this is valid!
@@ -78,11 +78,11 @@ export default class BaseReporter {
   stderr: Stdout;
   stdin: Stdin;
   isTTY: boolean;
-  isCi: boolean;
   emoji: boolean;
   noProgress: boolean;
   isVerbose: boolean;
   isSilent: boolean;
+  nonInteractive: boolean;
   format: Formatter;
 
   peakMemoryInterval: ?number;
@@ -246,7 +246,7 @@ export default class BaseReporter {
   //
   async questionAffirm(question: string): Promise<boolean> {
     const condition = true; // trick eslint
-    if (this.isCi) {//non-interactive terminals
+    if (this.nonInteractive) {//non-interactive terminals
       return true;
     }
 

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -246,7 +246,7 @@ export default class BaseReporter {
   //
   async questionAffirm(question: string): Promise<boolean> {
     const condition = true; // trick eslint
-    if (this.nonInteractive) {//non-interactive terminals
+    if (this.nonInteractive) {
       return true;
     }
 


### PR DESCRIPTION
**Summary**
This PR attempts to fic issue [5067](https://github.com/yarnpkg/yarn/issues/5067)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently `questionAffirm` in [base-reporter.js](https://github.com/yarnpkg/yarn/blob/master/src/reporters/base-reporter.js) is not prepared to handle the [`--non-interactive`](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-non-interactive) flag. 
This PR makes it so that `questionAffirm` should, by default, handle the specification of this term by assuming the answer to be, for instance, yes. This would allow the implementation of user prompts more easily and in a cleaner manner.

**Please mention your node.js, yarn and operating system version.**
Non-applicable

**Test plan**
There are still some tests need, but I would like to get some feedback on the way of accessing `--non-interactive` flag
