### PR TITLE
test(integration): Fix react-scripts test due to unexpected warning

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -12,7 +12,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
 const path = require('path');
 
-function addTest(pattern, {strict} = {strict: false}, yarnArgs: Array<string> = []) {
+function addTest(pattern, {strictPeers} = {strictPeers: false}, yarnArgs: Array<string> = []) {
   test.concurrent(`yarn add ${pattern}`, async () => {
     const cwd = await makeTemp();
     const cacheFolder = path.join(cwd, 'cache');
@@ -31,8 +31,8 @@ function addTest(pattern, {strict} = {strict: false}, yarnArgs: Array<string> = 
     );
 
     const result = await execa(command, ['add', pattern].concat(args), options);
-    if (strict) {
-      expect(result.stderr).not.toMatch(/^warning /gm);
+    if (strictPeers) {
+      expect(result.stderr).not.toMatch(/^warning .+ peer dependency/gm);
     }
 
     await fs.unlink(cwd);
@@ -60,7 +60,7 @@ addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with userna
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball
 addTest('https://github.com/bestander/chrome-app-livereload.git'); // no package.json
 addTest('bestander/chrome-app-livereload'); // no package.json, github, tarball
-addTest('react-scripts@1.0.13', {strict: true}, ['--no-node-version-check', '--ignore-engines']); // many peer dependencies, there shouldn't be any peerDep warnings
+addTest('react-scripts@1.0.13', {strictPeers: true}, ['--no-node-version-check', '--ignore-engines']); // many peer dependencies, there shouldn't be any peerDep warnings
 
 const MIN_PORT_NUM = 56000;
 const MAX_PORT_NUM = 65535;


### PR DESCRIPTION
**Summary**

We don't expect any warnings when installing high-profile and well-tested packages like
react-scripts so we have an integration test that enforces 0 warnings. Unfortunately a package got renamed and started producing a warning about this so the tests started failing. This PR relaxes the test to only fail on peer dependency warnings.

**Test plan**

All builds and tests should pass.