### PR TITLE
fix(build): Use `tar --strip-components=1` instead of `--strip`

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -36,7 +36,7 @@ PACKAGE_TMPDIR_ABSOLUTE=$(readlink -f $PACKAGE_TMPDIR)
 # Create Linux package structure
 mkdir -p $PACKAGE_TMPDIR/usr/share/yarn/
 mkdir -p $PACKAGE_TMPDIR/usr/share/doc/yarn/
-tar zxf $TARBALL_NAME -C $PACKAGE_TMPDIR/usr/share/yarn/ --strip 1
+tar zxf $TARBALL_NAME -C $PACKAGE_TMPDIR/usr/share/yarn/ --strip-components=1
 cp resources/debian/copyright $PACKAGE_TMPDIR/usr/share/doc/yarn/copyright
 
 # The Yarn executable expects to be in the same directory as the libraries, so


### PR DESCRIPTION
**Summary**

`tar ... --strip 1` is incorrect; should be `tar ... --strip-components=1`

* https://www.freebsd.org/cgi/man.cgi?tar(1)
* https://linux.die.net/man/1/tar

**Test plan**

Manually verified. Also builds should still succeed.
