### PR TITLE
fix(git): Ignores irrelevant output from ls-remote

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -4,7 +4,8 @@ jest.mock('../../src/util/git/git-spawn.js', () => ({
   spawn: jest.fn(([command]) => {
     switch (command) {
       case 'ls-remote':
-        return `ref: refs/heads/master  HEAD
+        return `Identity added: /Users/example/.ssh/id_dsa (/Users/example/.ssh/id_dsa)
+ref: refs/heads/master  HEAD
 7a053e2ca07d19b2e2eebeeb0c27edaacfd67904        HEAD`;
       case 'rev-list':
         return Promise.resolve('7a053e2ca07d19b2e2eebeeb0c27edaacfd67904 Fix ...');


### PR DESCRIPTION
Fixes #5077

**Summary**

Added a regex to filter output lines from `git ls-remote`.

**Test plan**

Modified mock `git ls-remote` output to include an additional line of output 
Ran `yarn run test`
Tested install on local application