### PR TITLE
fix(cli): Write Node4+ error message to stderr

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -26,7 +26,7 @@ elif command_exists nodejs; then
   exec nodejs "$basedir/yarn.js" "$@"
   ret=$?
 else
-  echo 'Yarn requires Node.js 4.0 or higher to be installed.'
+  >&2 echo 'Yarn requires Node.js 4.0 or higher to be installed.'
   ret=1
 fi
 


### PR DESCRIPTION
**Summary**

_To be a good citizen of UNIX ecosystem._

One may write a script to add `$(yarn global bin)` to `$PATH`, but one must consider different cases depending on what this command returns in STDOUT. This is not ideal. 

And, of course, error messages such as this naturally belongs to STDERR.
 
**Test plan**

```sh-session
$ yarn global bin 2>/dev/null
$
```