### PR TITLE
chore(cli): don't ask questions during publish when --non-interactive is specified (#5002)

### DIFF
--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -50,6 +50,24 @@ test('run version with no arguments, --new-version flag where version is same as
   });
 });
 
+test('run version with --non-interactive and --new-version should succeed', (): Promise<void> => {
+  return runRun([], {nonInteractive: true, newVersion}, 'no-args', async (config, reporter): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+
+    expect(pkg.version).toEqual(newVersion);
+  });
+});
+
+test('run version with --non-interactive and without --new-version should fail', async (): Promise<void> => {
+  let thrown = false;
+  try {
+    await runRun([], {nonInteractive: true}, 'no-args');
+  } catch (e) {
+    thrown = true;
+  }
+  expect(thrown).toEqual(true);
+});
+
 test('run version and make sure all lifecycle steps are executed', (): Promise<void> => {
   return runRun([], {newVersion, gitTagVersion}, 'no-args', async (config): ?Promise<void> => {
     const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -208,7 +208,10 @@ test.concurrent('should show version of yarn with -v', async () => {
 });
 
 test.concurrent('should run version command', async () => {
-  await expectAnErrorMessage(execCommand('version', [], 'run-version'), "Can't answer a question unless a user TTY");
+  await expectAnErrorMessage(
+    execCommand('version', [], 'run-version'),
+    'You must specify a new version with --new-version when running with --non-interactive.',
+  );
 });
 
 test.concurrent('should run --version command', async () => {

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -36,7 +36,12 @@ async function getCredentials(
   return {username, email};
 }
 
-export async function getToken(config: Config, reporter: Reporter, name: string = ''): Promise<() => Promise<void>> {
+export async function getToken(
+  config: Config,
+  reporter: Reporter,
+  name: string = '',
+  flags: Object = {},
+): Promise<() => Promise<void>> {
   const auth = config.registries.npm.getAuth(name);
   if (auth) {
     config.registries.npm.setToken(auth);
@@ -53,6 +58,11 @@ export async function getToken(config: Config, reporter: Reporter, name: string 
       reporter.info(reporter.lang('notRevokingEnvToken'));
       return Promise.resolve();
     };
+  }
+
+  // make sure we're not running in non-interactive mode before asking for login
+  if (flags.nonInteractive || config.nonInteractive) {
+    throw new MessageError(reporter.lang('nonInteractiveNoToken'));
   }
 
   //

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -134,7 +134,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
   //
   reporter.step(2, 4, reporter.lang('loggingIn'));
-  const revoke = await getToken(config, reporter, pkg.name);
+  const revoke = await getToken(config, reporter, pkg.name, flags);
 
   //
   reporter.step(3, 4, reporter.lang('publishing'));

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -74,6 +74,11 @@ export async function setVersion(
 
   // wasn't passed a version arg so ask interactively
   while (!newVersion) {
+    // make sure we're not running in non-interactive mode before asking for new version
+    if (flags.nonInteractive || config.nonInteractive) {
+      throw new MessageError(reporter.lang('nonInteractiveNoVersionSpecified'));
+    }
+
     newVersion = await reporter.question(reporter.lang('newVersion'));
 
     if (!required && !newVersion) {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -308,6 +308,10 @@ const messages = {
   published: 'Published.',
   publishing: 'Publishing',
 
+  nonInteractiveNoVersionSpecified:
+    'You must specify a new version with --new-version when running with --non-interactive.',
+  nonInteractiveNoToken: "No token found and can't prompt for login when running with --non-interactive.",
+
   infoFail: 'Received invalid response from npm.',
   malformedRegistryResponse: 'Received malformed response from registry for $0. The registry may be down.',
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Running `publish` with `--non-interactive` should not prompt for input and should fail if required args like `--new-version` are not provided.

Fixes #5002 

**Test plan**

* Run `yarn publish --non-interactive` and see error message about not providing `--new-version`
* Delete NPM token, run `yarn publish --non-interactive --new-version=1.0.1` and see error message about not being able to ask for login due to `--non-interactive` flag