### PR TITLE
feat(cli): group by license in licenses list (#5074)

### DIFF
--- a/__tests__/commands/__snapshots__/licenses.js.snap
+++ b/__tests__/commands/__snapshots__/licenses.js.snap
@@ -3,7 +3,7 @@
 exports[`lists all licenses of the dependencies with the --json argument 1`] = `
 "{\\"type\\":\\"warning\\",\\"data\\":\\"package.json: No license field\\"}
 {\\"type\\":\\"warning\\",\\"data\\":\\"No license field\\"}
-{\\"type\\":\\"tree\\",\\"data\\":{\\"type\\":\\"licenses\\",\\"trees\\":[{\\"name\\":\\"is-plain-obj@1.1.0\\",\\"children\\":[{\\"name\\":\\"License: MIT\\"},{\\"name\\":\\"URL: https://github.com/sindresorhus/is-plain-obj.git\\"}]}]}}
+{\\"type\\":\\"tree\\",\\"data\\":{\\"type\\":\\"licenses\\",\\"trees\\":[{\\"name\\":\\"MIT\\",\\"children\\":[{\\"name\\":\\"is-plain-obj@1.1.0\\",\\"children\\":[{\\"name\\":\\"URL: https://github.com/sindresorhus/is-plain-obj.git\\"},{\\"name\\":\\"VendorUrl: sindresorhus.com\\"},{\\"name\\":\\"VendorName: Sindre Sorhus\\"}]}]}]}}
 "
 `;
 

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -49,44 +49,71 @@ async function getManifests(config: Config, flags: Object): Promise<Array<Manife
 
 async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const manifests: Array<Manifest> = await getManifests(config, flags);
+  const manifestsByLicense = new Map();
+
+  for (const {name, version, license, repository, homepage, author} of manifests) {
+    const licenseKey = license || 'UNKNOWN';
+    const url = repository ? repository.url : homepage;
+    const vendorUrl = homepage || (author && author.url);
+    const vendorName = author && author.name;
+
+    if (!manifestsByLicense.has(licenseKey)) {
+      manifestsByLicense.set(licenseKey, new Map());
+    }
+
+    const byLicense = manifestsByLicense.get(licenseKey);
+    invariant(byLicense, 'expected value');
+    byLicense.set(`${name}@${version}`, {
+      name,
+      version,
+      url,
+      vendorUrl,
+      vendorName,
+    });
+  }
 
   if (flags.json) {
     const body = [];
 
-    for (const {name, version, license, repository, homepage, author} of manifests) {
-      const url = repository ? repository.url : homepage;
-      const vendorUrl = homepage || (author && author.url);
-      const vendorName = author && author.name;
-      body.push([
-        name,
-        version,
-        license || 'Unknown',
-        url || 'Unknown',
-        vendorUrl || 'Unknown',
-        vendorName || 'Unknown',
-      ]);
-    }
+    manifestsByLicense.forEach((license, licenseKey) => {
+      license.forEach(({name, version, url, vendorUrl, vendorName}) => {
+        body.push([name, version, licenseKey, url || 'Unknown', vendorUrl || 'Unknown', vendorName || 'Unknown']);
+      });
+    });
 
     reporter.table(['Name', 'Version', 'License', 'URL', 'VendorUrl', 'VendorName'], body);
   } else {
     const trees = [];
 
-    for (const {name, version, license, repository, homepage} of manifests) {
-      const children = [];
-      children.push({
-        name: `${reporter.format.bold('License:')} ${license || reporter.format.red('UNKNOWN')}`,
-      });
+    manifestsByLicense.forEach((license, licenseKey) => {
+      const licenseTree = [];
 
-      const url = repository ? repository.url : homepage;
-      if (url) {
-        children.push({name: `${reporter.format.bold('URL:')} ${url}`});
-      }
+      license.forEach(({name, version, url, vendorUrl, vendorName}) => {
+        const children = [];
+
+        if (url) {
+          children.push({name: `${reporter.format.bold('URL:')} ${url}`});
+        }
+
+        if (vendorUrl) {
+          children.push({name: `${reporter.format.bold('VendorUrl:')} ${vendorUrl}`});
+        }
+
+        if (vendorName) {
+          children.push({name: `${reporter.format.bold('VendorName:')} ${vendorName}`});
+        }
+
+        licenseTree.push({
+          name: `${name}@${version}`,
+          children,
+        });
+      });
 
       trees.push({
-        name: `${name}@${version}`,
-        children,
+        name: licenseKey,
+        children: licenseTree,
       });
-    }
+    });
 
     reporter.tree('licenses', trees);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Group packages by license when running `yarn license list` as requested in #5074.

**Test plan**

Run `yarn license list` in an existing package and observe that packages are grouped by license.