### PR TITLE
feat(cli): include notice with license when generating disclaimer (#5072)

### DIFF
--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -121,16 +121,23 @@ export const {run, examples} = buildSubCommands('licenses', {
     // the same license text are grouped together.
     const manifestsByLicense: Map<string, Map<string, Manifest>> = new Map();
     for (const manifest of manifests) {
-      const {licenseText} = manifest;
+      const {licenseText, noticeText} = manifest;
+      let licenseKey;
       if (!licenseText) {
         continue;
       }
 
-      if (!manifestsByLicense.has(licenseText)) {
-        manifestsByLicense.set(licenseText, new Map());
+      if (!noticeText) {
+        licenseKey = licenseText;
+      } else {
+        licenseKey = `${licenseText}\n\nNOTICE\n\n${noticeText}`;
       }
 
-      const byLicense = manifestsByLicense.get(licenseText);
+      if (!manifestsByLicense.has(licenseKey)) {
+        manifestsByLicense.set(licenseKey, new Map());
+      }
+
+      const byLicense = manifestsByLicense.get(licenseKey);
       invariant(byLicense, 'expected value');
       byLicense.set(manifest.name, manifest);
     }
@@ -141,7 +148,7 @@ export const {run, examples} = buildSubCommands('licenses', {
     );
     console.log();
 
-    for (const [licenseText, manifests] of manifestsByLicense) {
+    for (const [licenseKey, manifests] of manifestsByLicense) {
       console.log('-----');
       console.log();
 
@@ -164,8 +171,8 @@ export const {run, examples} = buildSubCommands('licenses', {
       console.log(heading.join(' '));
       console.log();
 
-      if (licenseText) {
-        console.log(licenseText.trim());
+      if (licenseKey) {
+        console.log(licenseKey.trim());
       } else {
         // what do we do here? base it on `license`?
       }

--- a/src/types.js
+++ b/src/types.js
@@ -68,6 +68,7 @@ export type Manifest = {
   flat?: boolean,
   license?: string,
   licenseText?: string,
+  noticeText?: string,
 
   readme?: string,
   readmeFilename?: string,

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -308,6 +308,19 @@ export default (async function(
     }
   }
 
+  // get notice file
+  const noticeFile = files.find((filename): boolean => {
+    const lower = filename.toLowerCase();
+    return lower === 'notice' || lower.startsWith('notice.');
+  });
+  if (noticeFile) {
+    const noticeFilepath = path.join(moduleLoc, noticeFile);
+    const noticeFileStats = await fs.stat(noticeFilepath);
+    if (noticeFileStats.isFile()) {
+      info.noticeText = await fs.readFile(noticeFilepath);
+    }
+  }
+
   for (const dependencyType of MANIFEST_FIELDS) {
     const dependencyList = info[dependencyType];
     if (dependencyList && typeof dependencyList === 'object') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Include NOTICE file (if present) along with LICENSE when running `yarn licenses generate-disclaimer`.

Fixes #5072 

**Test plan**

* Create a package and add `json2array` (or any package with a NOTICE file) as a dependency
* Run `yarn licenses generate-disclaimer` and observe that the NOTICE text is included after the LICENSE text