### PR TITLE
fix(fetching): Moved "link:" logic to LinkFetcher. Fix bug: bin links for "link:" type deps

### DIFF
--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -154,3 +154,11 @@ test('Only top level (after hoisting) bin links should be linked', (): Promise<v
     expect(stdout[0]).toEqual('uglify-js 3.0.14');
   });
 });
+
+// Because of the way Yarn created symlinks, a link to a link will instead point to the actual destination,
+// which is why we expect the script to point to `../../` outside of `node_modules/`.
+test('link type dependencies have bin links created', (): Promise<void> => {
+  return runInstall({binLinks: true}, 'install-bin-links-for-link-deps', async config => {
+    expect(await linkAt(config, 'node_modules', '.bin', 'scriptA')).toEqual('../../depA/scriptA.js');
+  });
+});

--- a/__tests__/fixtures/install/install-bin-links-for-link-deps/depA/package.json
+++ b/__tests__/fixtures/install/install-bin-links-for-link-deps/depA/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "bin": {
+    "scriptA": "./scriptA.js"
+  }
+}

--- a/__tests__/fixtures/install/install-bin-links-for-link-deps/depA/scriptA.js
+++ b/__tests__/fixtures/install/install-bin-links-for-link-deps/depA/scriptA.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+let test = true;

--- a/__tests__/fixtures/install/install-bin-links-for-link-deps/package.json
+++ b/__tests__/fixtures/install/install-bin-links-for-link-deps/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "devDependencies": {
+    "depA": "link:./depA"
+  }
+}

--- a/src/fetchers/index.js
+++ b/src/fetchers/index.js
@@ -5,13 +5,15 @@ import CopyFetcher from './copy-fetcher.js';
 import GitFetcher from './git-fetcher.js';
 import TarballFetcher from './tarball-fetcher.js';
 import WorkspaceFetcher from './workspace-fetcher.js';
+import LinkFetcher from './link-fetcher.js';
 
 export {BaseFetcher as base};
 export {CopyFetcher as copy};
 export {GitFetcher as git};
 export {TarballFetcher as tarball};
 export {WorkspaceFetcher as workspace};
+export {LinkFetcher as link};
 
-export type Fetchers = BaseFetcher | CopyFetcher | GitFetcher | TarballFetcher | WorkspaceFetcher;
+export type Fetchers = BaseFetcher | CopyFetcher | GitFetcher | TarballFetcher | WorkspaceFetcher | LinkFetcher;
 
-export type FetcherNames = 'base' | 'copy' | 'git' | 'link' | 'tarball' | 'workspace';
+export type FetcherNames = 'base' | 'copy' | 'git' | 'tarball' | 'workspace' | 'link';

--- a/src/fetchers/link-fetcher.js
+++ b/src/fetchers/link-fetcher.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+import type {PackageRemote, FetchedMetadata, Manifest} from '../types.js';
+import type Config from '../config.js';
+import type {RegistryNames} from '../registries/index.js';
+import * as fs from '../util/fs.js';
+
+export default class LinkFetcher {
+  constructor(dest: string, remote: PackageRemote, config: Config) {
+    this.config = config;
+    this.dest = dest;
+    this.reference = remote.reference;
+    this.registry = remote.registry;
+  }
+
+  config: Config;
+  dest: string;
+  registry: RegistryNames;
+  reference: string;
+
+  setupMirrorFromCache(): Promise<?string> {
+    return Promise.resolve();
+  }
+
+  async fetch(): Promise<FetchedMetadata> {
+    const sourceExists = await fs.exists(this.reference);
+    let pkg: Manifest = {_uid: '', name: '', version: '0.0.0'};
+
+    if (sourceExists) {
+      try {
+        pkg = await this.config.readManifest(this.reference, this.registry);
+      } catch (ex) {
+        // pkg will remain the fake Manifest
+      }
+    }
+
+    return {
+      resolved: null,
+      hash: '',
+      cached: false,
+      dest: this.dest,
+      package: {
+        ...pkg,
+        _uid: pkg.version,
+      },
+    };
+  }
+}

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -22,15 +22,9 @@ async function fetchCache(dest: string, fetcher: Fetchers, config: Config): Prom
 
 async function fetchOne(ref: PackageReference, config: Config): Promise<FetchedMetadata> {
   const dest = config.generateHardModulePath(ref);
-
   const remote = ref.remote;
-  // Mock metedata for symlinked dependencies
-  if (remote.type === 'link') {
-    const mockPkg: Manifest = {_uid: '', name: '', version: '0.0.0'};
-    return Promise.resolve({resolved: null, hash: '', dest, package: mockPkg, cached: false});
-  }
-
   const Fetcher = fetchers[remote.type];
+
   if (!Fetcher) {
     throw new MessageError(config.reporter.lang('unknownFetcherFor', remote.type));
   }


### PR DESCRIPTION
**Summary**

Previously there was logic specific to the "link:" type in `PackageFetcher`. This violates
single-responsibity and open-closed principles. This was moved to a new `LinkFetcher` class to align with the other `*Fetcher` classes that house logic specific to dep types.

There was also a bug where no `Manifest` (package.json) was loaded for "link:" deps, which led to bin links not being created, engines ignored, etc. The Manifest is now loaded from the linked dependency if it exists, so these bugs no longer happen.

**Test plan**

Added a test to make sure that .bin links in a "link:" type dep are created now.
