### PR TITLE
fix(cli): check if workspaces setting in package.json is an array (#5089)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -640,6 +640,9 @@ export default class Config {
     if (!rootManifest.private && patterns.length > 0) {
       throw new MessageError(this.reporter.lang('workspacesRequirePrivateProjects'));
     }
+    if (!Array.isArray(patterns)) {
+      throw new MessageError(this.reporter.lang('workspacesSettingMustBeArray'));
+    }
 
     const registryFilenames = registryNames
       .map(registryName => this.registries[registryName].constructor.filename)

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -182,7 +182,7 @@ const messages = {
   workspacesAddRootCheck:
     'Running this command will add the dependency to the workspace root rather than workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
   workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects.',
-  workspacesSettingMustBeArray: 'The workspaces setting in package.json must be an array.',
+  workspacesSettingMustBeArray: 'The workspaces field in package.json must be an array.',
   workspacesDisabled:
     'Your project root defines workspaces but the feature is disabled in your Yarn config. Please check "workspaces-experimental" in your .yarnrc file.',
   workspaceRootNotFound: "Cannot find the root of your workspace - are you sure you're currently in a workspace?",

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -182,6 +182,7 @@ const messages = {
   workspacesAddRootCheck:
     'Running this command will add the dependency to the workspace root rather than workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
   workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects',
+  workspacesSettingMustBeArray: 'The workspaces setting in package.json must be an array',
   workspacesDisabled:
     'Your project root defines workspaces but the feature is disabled in your Yarn config. Please check "workspaces-experimental" in your .yarnrc file.',
   workspaceRootNotFound: "Cannot find the root of your workspace - are you sure you're currently in a workspace?",

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -181,8 +181,8 @@ const messages = {
 
   workspacesAddRootCheck:
     'Running this command will add the dependency to the workspace root rather than workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
-  workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects',
-  workspacesSettingMustBeArray: 'The workspaces setting in package.json must be an array',
+  workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects.',
+  workspacesSettingMustBeArray: 'The workspaces setting in package.json must be an array.',
   workspacesDisabled:
     'Your project root defines workspaces but the feature is disabled in your Yarn config. Please check "workspaces-experimental" in your .yarnrc file.',
   workspaceRootNotFound: "Cannot find the root of your workspace - are you sure you're currently in a workspace?",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Display a helpful error message if `workspaces` in `package.json` is not an array. Currently just displays: `error An unexpected error occurred: "patterns.map is not a function".`

Fixes #5089 

**Test plan**

* Create a `package.json` file with `workspaces: "packages/*"`
* Run `yarn` and observe that this error message is shown: `The workspaces setting in package.json must be an array.`
