### PR TITLE
fix(cli): allow GitHub project names that contain the string .git (#5117)

### DIFF
--- a/__tests__/resolvers/exotics/hosted-git-resolver.js
+++ b/__tests__/resolvers/exotics/hosted-git-resolver.js
@@ -42,3 +42,15 @@ test('explodeHostedGitFragment should work identical with and without .git suffi
   expect(explodeHostedGitFragment(fragmentWithoutGit, reporter)).toEqual(expectedFragment);
   expect(explodeHostedGitFragment(fragmentWithGit, reporter)).toEqual(expectedFragment);
 });
+
+test('explodeHostedGitFragment should allow the project name to contain .git', () => {
+  const fragmentString = 'jure/lens.github';
+
+  const expectedFragment: ExplodedFragment = {
+    user: 'jure',
+    repo: 'lens.github',
+    hash: '',
+  };
+
+  expect(explodeHostedGitFragment(fragmentString, reporter)).toEqual(expectedFragment);
+});

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -55,7 +55,7 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
     if (repoParts.length <= 3) {
       return {
         user,
-        repo: repoParts[0].replace('.git$', ''),
+        repo: repoParts[0].replace(/\.git$/, ''),
         hash: repoParts[1] || '',
       };
     }

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -55,7 +55,7 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
     if (repoParts.length <= 3) {
       return {
         user,
-        repo: repoParts[0].replace('.git', ''),
+        repo: repoParts[0].replace('.git$', ''),
         hash: repoParts[1] || '',
       };
     }


### PR DESCRIPTION
**Summary**

The GitHub resolver incorrectly removes `.git` from anywhere in the project name. For examplee, the project `linagora.esn.unifiedinbox.github` becomes `linagora.esn.unifiedinboxhub`. The GitHub resolver should only remove `.git` from the end of the name.

Fixes #5117 

**Test plan**

* Run `yarn add lenagora/linagora.esn.unifiedinbox.github`
* Observe that the package is installed and no error is shown