### PR TITLE
 feat(cli): allow running scripts with custom shell (#4248)

### DIFF
--- a/__tests__/fixtures/run/script-shell/package.json
+++ b/__tests__/fixtures/run/script-shell/package.json
@@ -1,0 +1,6 @@
+{
+  "license": "MIT",
+  "scripts": {
+    "start": "echo $SHELL"
+  }
+}

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -81,7 +81,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       for (const [stage, cmd] of cmds) {
         // only tack on trailing arguments for default script, ignore for pre and post - #1595
         const cmdWithArgs = stage === action ? sh`${unquoted(cmd)} ${args}` : cmd;
-        await execCommand(stage, config, cmdWithArgs, config.cwd);
+        const customShell = config.getOption('script-shell');
+        if (customShell) {
+          await execCommand(stage, config, cmdWithArgs, config.cwd, String(customShell));
+        } else {
+          await execCommand(stage, config, cmdWithArgs, config.cwd);
+        }
       }
     } else if (action === 'env') {
       reporter.log(JSON.stringify(await makeEnv('env', config.cwd, config), null, 2), {force: true});

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -171,6 +171,7 @@ export async function executeLifecycleScript(
   cwd: string,
   cmd: string,
   spinner?: ReporterSpinner,
+  customShell?: string,
 ): LifecycleReturn {
   // if we don't have a spinner then pipe everything to the terminal
   const stdio = spinner ? undefined : 'inherit';
@@ -183,11 +184,10 @@ export async function executeLifecycleScript(
   let sh = 'sh';
   let shFlag = '-c';
 
-  const customShell = config.getOption('script-shell');
   let windowsVerbatimArguments = undefined;
 
   if (customShell) {
-    sh = String(customShell);
+    sh = customShell;
   } else if (process.platform === 'win32') {
     sh = process.env.comspec || 'cmd';
     shFlag = '/d /s /c';
@@ -271,11 +271,17 @@ export async function execFromManifest(config: Config, commandName: string, cwd:
   }
 }
 
-export async function execCommand(stage: string, config: Config, cmd: string, cwd: string): Promise<void> {
+export async function execCommand(
+  stage: string,
+  config: Config,
+  cmd: string,
+  cwd: string,
+  customShell?: string,
+): Promise<void> {
   const {reporter} = config;
   try {
     reporter.command(cmd);
-    await executeLifecycleScript(stage, config, cwd, cmd);
+    await executeLifecycleScript(stage, config, cwd, cmd, undefined, customShell);
     return Promise.resolve();
   } catch (err) {
     if (err instanceof ProcessTermError) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes issue #4248, based off of [what NPM does](https://github.com/npm/npm/blob/07d2296b10e3d8d6f079eba3a61f0258501d7161/lib/utils/lifecycle.js#L264).

**Test plan**

I'm not actually sure how to write a test suite for this (as testing any alternate shell would involve additional installations), but it passes all of the current tests. Any feedback/advice would be appreciated!

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Here's how I am manually confirming that the change works (see the `echo $SHELL` output):

![image](https://i.imgur.com/bUOwAPC.png)

The Windows terminal emulator (which I am using) doesn't support emojis, which causes the weird characters before the Done message. However, MinTTY should.