### PR TITLE
fix(cli): improve guessing of package names that contain a dot (#5102)

### DIFF
--- a/__tests__/util/guess-name.js
+++ b/__tests__/util/guess-name.js
@@ -24,10 +24,25 @@ const examples = [
   'awesome-name.tar.gz',
 ];
 
+const dotExamples = [
+  'awesomename/awesome.name',
+  'awesomename/awesome.name.git',
+  'awesomename/awesome.name.tar.gz',
+  'awesomename/awesome.name.tar.bz2',
+];
+
 describe('guessName', () => {
   for (const source of examples) {
     it(`guess name of ${source}`, () => {
       expect(guessName(source)).toBe('awesome-name');
+    });
+  }
+});
+
+describe('guessName dot examples', () => {
+  for (const source of dotExamples) {
+    it(`guess name of ${source}`, () => {
+      expect(guessName(source)).toBe('awesome.name');
     });
   }
 });

--- a/src/util/guess-name.js
+++ b/src/util/guess-name.js
@@ -4,7 +4,7 @@ import url from 'url';
 
 function cleanup(name: string): string {
   name = name.replace(/-\d+\.\d+\.\d+/, '');
-  return name.split('.')[0];
+  return name.replace(/\.git$|\.zip$|\.tar\.gz$|\.tar\.bz2$/, '');
 }
 
 function guessNameFallback(source: string): string {


### PR DESCRIPTION
**Summary**

Improve guessing of package names that contain a dot. It was reported that the `scottoffen/jquery.toaster` package from GitHub was being saved as `jquery`. With this change that package is now saved as `jquery.toaster`.

Fixes #5102 

**Test plan**

1. Run `yarn add scottoffen/jquery.toaster`
2. Look in `node_modules` and observe that the package is saved as `jquery.toaster` instead of just `jquery`
