### PR TITLE
feat(cli): improve error message when file resolver can't find file (#5134)

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -80,7 +80,8 @@ const messages = {
   invalidVersion: 'Invalid version supplied.',
   requiredVersionInRange: 'Required version in range.',
   packageNotFoundRegistry: "Couldn't find package $0 on the $1 registry.",
-  doesntExist: "$0 doesn't exist.",
+  doesntExist:
+    "$0 doesn't exist. It may have been moved or deleted. You can remove the package with the command: `yarn remove $1`",
   missingRequiredPackageKey: `Package $0 doesn't have a $1.`,
   invalidAccess: 'Invalid argument for access, expected public or restricted.',
   invalidCommand: 'Invalid subcommand. Try $0',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -80,8 +80,7 @@ const messages = {
   invalidVersion: 'Invalid version supplied.',
   requiredVersionInRange: 'Required version in range.',
   packageNotFoundRegistry: "Couldn't find package $0 on the $1 registry.",
-  doesntExist:
-    "$0 doesn't exist. It may have been moved or deleted. You can remove the package with the command: `yarn remove $1`",
+  doesntExist: "Package $1 refer to a non-existing file '$0'.",
   missingRequiredPackageKey: `Package $0 doesn't have a $1.`,
   invalidAccess: 'Invalid argument for access, expected public or restricted.',
   invalidCommand: 'Invalid subcommand. Try $0',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -80,7 +80,7 @@ const messages = {
   invalidVersion: 'Invalid version supplied.',
   requiredVersionInRange: 'Required version in range.',
   packageNotFoundRegistry: "Couldn't find package $0 on the $1 registry.",
-  doesntExist: "Package $1 refer to a non-existing file '$0'.",
+  doesntExist: "Package $1 refers to a non-existing file '$0'.",
   missingRequiredPackageKey: `Package $0 doesn't have a $1.`,
   invalidAccess: 'Invalid argument for access, expected public or restricted.',
   invalidCommand: 'Invalid subcommand. Try $0',

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -49,7 +49,7 @@ export default class FileResolver extends ExoticResolver {
       return manifest;
     }
     if (!await fs.exists(loc)) {
-      throw new MessageError(this.reporter.lang('doesntExist', loc));
+      throw new MessageError(this.reporter.lang('doesntExist', loc, this.pattern.split('@')[0]));
     }
 
     const manifest: Manifest = await (async () => {


### PR DESCRIPTION
**Summary**

Improve the error message when the file resolver can't find the specified file.

**Test plan**

* Create a `package.json` with a dependency that points to a non-existent file (`file://noexist`)
* Run `yarn`
* Observe that the error message says what the problem is and provides a command to resolve the issue
