### PR TITLE
feat(cli): outdated - flags for scope filtering

### DIFF
--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -228,5 +228,5 @@ test.concurrent('multiple flags: should throw console error', async (): Promise<
     error = e.message;
   }
 
-  expect(error).toContain('You can use only one flag at the time.');
+  expect(error).toContain('You can use only one flag at a time.');
 });

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -29,7 +29,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const {main, dev, optional} = flags;
   let deps = await PackageRequest.getOutdatedPackages(lockfile, install, config, reporter);
 
-  if ((main && dev) || (main && optional) || (dev && optional)) {
+  if ([main, dev, optional].filter(Boolean).length > 1) {
     throw new MessageError(reporter.lang('yarnOutdatedMultipleFlags', config.cwd));
   }
 
@@ -37,10 +37,6 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const requested = new Set(args);
 
     deps = deps.filter(({name}) => requested.has(name));
-
-    if (main || dev || optional) {
-      reporter.info(reporter.lang('yarnOutdatedFlagsWithPackage'));
-    }
   } else {
     if (main) {
       deps = deps.filter(({hint}) => !hint);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -128,6 +128,8 @@ const messages = {
   yarnOutdated: "Your current version of Yarn is out of date. The latest version is $0 while you're on $1.",
   yarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',
   yarnOutdatedCommand: 'To upgrade, run the following command:',
+  yarnOutdatedMultipleFlags: 'You can use only one flag at the time.',
+  yarnOutdatedFlagsWithPackage: "When package specified flags won't have effect.",
 
   tooManyArguments: 'Too many arguments, maximum of $0.',
   tooFewArguments: 'Not enough arguments, expected at least $0.',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -128,8 +128,7 @@ const messages = {
   yarnOutdated: "Your current version of Yarn is out of date. The latest version is $0 while you're on $1.",
   yarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',
   yarnOutdatedCommand: 'To upgrade, run the following command:',
-  yarnOutdatedMultipleFlags: 'You can use only one flag at the time.',
-  yarnOutdatedFlagsWithPackage: "When package specified flags won't have effect.",
+  yarnOutdatedMultipleFlags: 'You can use only one flag at a time.',
 
   tooManyArguments: 'Too many arguments, maximum of $0.',
   tooFewArguments: 'Not enough arguments, expected at least $0.',


### PR DESCRIPTION
**Summary**

Small but handy (IMO) feature. Three flags has been added to `outdated` script to filter list to specified scope:
- `-M | --main` - filters list to "dependencies" only 
(I have though about the name a while, started with `-P | --package ` but that seems more confusing. I will be glad if you have a better alternative.)
- `-D | --dev` - filters list to "devDependencies" only
- `-O | --optional` - filters list to "optionalDependencies" only

There is no "peerDependencies" flag because they don't appear on `outdated` list.
Flags are ignored when package name/names are specified.

I've also decided to not to support multiple flags to avoid confusion.

I'm also not happy about quality of added user messages, hope someone can rephrase them better.

If you have any questions, comments or advices feel free to share them.

**Test**

Tests for every flag and multiple flags error included.
