### PR TITLE
Speed up global list command

### DIFF
--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -199,7 +199,7 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
 
   // install so we get hard file paths
   const lockfile = await Lockfile.fromDirectory(config.cwd);
-  const install = new Install({skipIntegrityCheck: true}, config, new NoopReporter(), lockfile);
+  const install = new Install({skipIntegrityCheck: true, ignoreScripts: true}, config, new NoopReporter(), lockfile);
   const patterns = await install.init();
 
   // dump global modules


### PR DESCRIPTION
**Summary**

`global list` command is a bit lazy - it gets the number of installed dependencies by running a full install.
I am not ready to send a proper fix yet but at least we should not execute all install scripts every time we run `yarn global list` because very often globally installed dependencies have heavy install scripts.

**Test plan**

```
./bin/yarn global list
yarn global v1.3.2
warning "exp > xdl > react-redux@5.0.6" has unmet peer dependency "react@^0.14.0 || ^15.0.0-0 || ^16.0.0-0".
info "bs-platform@2.1.0" has binaries:
   - bsb
   - bsc
   - bsrefmt
info "exp@44.0.0" has binaries:
   - exp
info "reason-cli@3.0.1" has binaries:
   - ocamlmerlin
   - ocamlmerlin-reason
   - ocamlrun
   - ocamlc
   - ocamlc.opt
   - ocamlopt
   - ocamlopt.opt
   - ocaml
   - rtop
   - utop
   - refmt
   - refmttype
   - reopt
   - rebuild
   - reactjs_jsx_ppx
   - reactjs_jsx_ppx_2
   - menhir
   - ocamlfind
   - reason-cli-esy-sandbox
✨  Done in 4.10s.
```
