### PR TITLE
fix(cli): Run version script hook AFTER bumping the package version, …

### DIFF
--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -116,6 +116,8 @@ export async function setVersion(
   }
   await config.saveRootManifests(manifests);
 
+  await runLifecycle('version');
+
   // check if committing the new version to git is overriden
   if (!flags.gitTagVersion || !config.getOption('version-git-tag')) {
     // Don't tag the version in Git
@@ -136,8 +138,6 @@ export async function setVersion(
         parts.pop();
       }
     }
-
-    await runLifecycle('version');
 
     if (isGit) {
       const message = (flags.message || String(config.getOption('version-git-message'))).replace(/%s/g, newVersion);


### PR DESCRIPTION
…but BEFORE commit.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes #4744
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Running yarn version --no-git-tag-version does not run the script hook version.
According to the [npm documentation](https://docs.npmjs.com/misc/scripts) the version script hook should `Run AFTER bumping the package version, but BEFORE commit.`
