### PR TITLE
Fix scoped pkg auth when using npm private pkgs via npm login --scope

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -286,6 +286,18 @@ describe('request', () => {
     const requestParams = createRegistry(config).request(url);
     expect(requestParams.headers.authorization).toBe('Bearer testScopedAuthToken');
   });
+
+  test('should add authorization header if pathname does not match but custom-host-suffix is used', () => {
+    const url = 'https://some.other.registry/tarball/path/@testScope%2fyarn.tgz';
+    const config = {
+      '//some.other.registry/some/path/:_authToken': 'testScopedAuthToken',
+      '@testScope:registry': 'https://some.other.registry/some/path/',
+      'custom-host-suffix': 'some.other.registry',
+    };
+
+    const requestParams = createRegistry(config).request(url);
+    expect(requestParams.headers.authorization).toBe('Bearer testScopedAuthToken');
+  });
 });
 
 const packageIdents = [

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -99,7 +99,6 @@ export default class NpmRegistry extends Registry {
   }
 
   request(pathname: string, opts?: RegistryRequestOptions = {}, packageName: ?string): Promise<*> {
-    // packageName needs to be escaped when if it is passed
     const packageIdent = (packageName && NpmRegistry.escapeName(packageName)) || pathname;
     const registry = this.getRegistry(packageIdent);
     const requestUrl = this.getRequestUrl(registry, pathname);
@@ -333,9 +332,6 @@ export default class NpmRegistry extends Registry {
 
   getAvailableRegistries(): Array<string> {
     const availableRegistries = super.getAvailableRegistries();
-    if (availableRegistries.indexOf(YARN_REGISTRY) === -1) {
-      availableRegistries.push(YARN_REGISTRY);
-    }
     if (availableRegistries.indexOf(DEFAULT_REGISTRY) === -1) {
       availableRegistries.push(DEFAULT_REGISTRY);
     }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -13,7 +13,6 @@ import envReplace from '../util/env-replace.js';
 import Registry from './base-registry.js';
 import {addSuffix} from '../util/misc';
 import {getPosixPath, resolveWithHome} from '../util/path';
-import normalizeUrl from 'normalize-url';
 import {default as userHome, home} from '../util/user-home-dir';
 import path from 'path';
 import url from 'url';
@@ -99,32 +98,13 @@ export default class NpmRegistry extends Registry {
     }
   }
 
-  isRequestToRegistry(requestUrl: string, registryUrl: string): boolean {
-    const normalizedRequestUrl = normalizeUrl(requestUrl);
-    const normalizedRegistryUrl = normalizeUrl(registryUrl);
-    const requestParsed = url.parse(normalizedRequestUrl);
-    const registryParsed = url.parse(normalizedRegistryUrl);
-    const requestHost = requestParsed.host || '';
-    const registryHost = registryParsed.host || '';
-    const requestPath = requestParsed.path || '';
-    const registryPath = registryParsed.path || '';
-    const customHostSuffix = this.getRegistryOrGlobalOption(registryUrl, 'custom-host-suffix');
-
-    return (
-      requestHost === registryHost &&
-      (requestPath.startsWith(registryPath) ||
-        // For some registries, the package path does not prefix with the registry path
-        (typeof customHostSuffix === 'string' && requestHost.endsWith(customHostSuffix)))
-    );
-  }
-
   request(pathname: string, opts?: RegistryRequestOptions = {}, packageName: ?string): Promise<*> {
     // packageName needs to be escaped when if it is passed
     const packageIdent = (packageName && NpmRegistry.escapeName(packageName)) || pathname;
     const registry = this.getRegistry(packageIdent);
     const requestUrl = this.getRequestUrl(registry, pathname);
 
-    const alwaysAuth = this.getRegistryOrGlobalOption(registry, 'always-auth');
+    const alwaysAuth = registry && this.getRegistryOrGlobalOption(registry, 'always-auth');
 
     const headers = Object.assign(
       {
@@ -133,10 +113,8 @@ export default class NpmRegistry extends Registry {
       opts.headers,
     );
 
-    const isToRegistry = this.isRequestToRegistry(requestUrl, registry);
-
     // this.token must be checked to account for publish requests on non-scopped packages
-    if (this.token || (isToRegistry && (alwaysAuth || this.isScopedPackage(packageIdent)))) {
+    if (this.token || alwaysAuth || this.isScopedPackage(packageIdent)) {
       const authorization = this.getAuth(packageIdent);
       if (authorization) {
         headers.authorization = authorization;
@@ -271,6 +249,7 @@ export default class NpmRegistry extends Registry {
       if (registry) {
         return String(registry);
       }
+      return '';
     }
 
     for (const scope of [this.getScope(packageIdent), '']) {
@@ -290,6 +269,11 @@ export default class NpmRegistry extends Registry {
     }
 
     const baseRegistry = this.getRegistry(packageIdent);
+
+    if (!baseRegistry) {
+      return '';
+    }
+
     const registries = [baseRegistry];
 
     // If sending a request to the Yarn registry, we must also send it the auth token for the npm registry
@@ -345,5 +329,16 @@ export default class NpmRegistry extends Registry {
 
   getRegistryOrGlobalOption(registry: string, option: string): mixed {
     return this.getRegistryOption(registry, option) || this.getOption(option);
+  }
+
+  getAvailableRegistries(): Array<string> {
+    const availableRegistries = super.getAvailableRegistries();
+    if (availableRegistries.indexOf(YARN_REGISTRY) === -1) {
+      availableRegistries.push(YARN_REGISTRY);
+    }
+    if (availableRegistries.indexOf(DEFAULT_REGISTRY) === -1) {
+      availableRegistries.push(DEFAULT_REGISTRY);
+    }
+    return availableRegistries;
   }
 }


### PR DESCRIPTION
Fixes #4157, #4451

**Summary**

This attempts to squash one of the last remaining auth bugs in yarn (🤞). There currently exists an edge case where if you login to the registry using `npm login --scope=@foo`, the contents of .npmrc become 

```
@foo:registry=https://registry.npmjs.org/
//registry.npmjs.org/:_authToken=xxxxxx
```

Installing pkgs from @foo however does not work. That's because the request URL is being made to `https://registry.yarnpkg.com` and `isRequestToRegistry` returns false because the args to it are `isRequestToRegistry('https://registry.yarnpkg.com/@foo/pkg', 'https://registry.npmjs.org')`.

This PR attempts to remove `isRequestToRegistry` entirely, because I believe at this stage it is no longer needed. The only purpose of this function is to make sure that auth tokens for registry X are only sent with requests to registry X. This is now ensured by `getAuth` function which looks at the request url or package identifier and decides what token to use.

Before this PR, `getAuth('http://Y)` would sometimes return the auth token for `registry.npmjs.org` since that's the default registry. Instead, it now returns no token since the request url does not match the registry.

Let me know if I can clarify something further.

**Test plan**

I've tested this manually using my own npm private account. It would be great to get that e2e test going as discussed here: https://github.com/yarnpkg/yarn/issues/4186. I could try working on that next if there's interest, but I'd do that in a separate PR.

I've also added a new unit test for this edge case `npm login --scope=@foo`. In other words, all existing tests pass (with a small exception - see `should add authorization header with token for custom registries with a scoped package` test) + I've added a new test to cover for the edge case in question.