### PR TITLE
test(package-resolver): fix hash and no ".git" extension tests

### DIFF
--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -9,7 +9,7 @@ import makeTemp from './_temp.js';
 import * as fs from '../src/util/fs.js';
 import * as constants from '../src/constants.js';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 
 const path = require('path');
 
@@ -51,10 +51,9 @@ function addTest(pattern, registry = 'npm', init: ?(cacheFolder: string) => Prom
   });
 }
 
-// TODO Got broken for some time, needs revision
-// addTest('https://github.com/npm-ml/re'); // git url with no .git
-// addTest('git+https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // git+hash
-// addTest('https://github.com/npm-ml/ocaml.git#npm-4.02.3'); // hash
+addTest('https://github.com/ocaml/ocaml-re'); // git url with no .git
+addTest('git+https://github.com/ocaml/ocaml.git#4.02.3'); // git+hash
+addTest('https://github.com/ocaml/ocaml.git#4.02.3'); // hash
 addTest('https://git@github.com/stevemao/left-pad.git'); // git url, with username
 addTest('https://bitbucket.org/hgarcia/node-bitbucket-api.git'); // hosted git url
 addTest('https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-v0.18.1.tar.gz'); // tarball


### PR DESCRIPTION
**Summary**
OCaml repos has been moved so URLs had to be updated. 

I have also extended timeout from 60 s to 90 s because 2 out of 9 test runs failed with default value on my machine while fetching OCaml. By tweaking this value I have achieved 100% success rate.