### PR TITLE
feat: better error when package is not found

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -111,7 +111,18 @@ export default class PackageRequest {
 
     const Resolver = this.getRegistryResolver();
     const resolver = new Resolver(this, name, range);
-    return resolver.resolve();
+    try {
+      return await resolver.resolve();
+    } catch (err) {
+      // if it is not an error thrown by yarn and it has a parent request,
+      // thow a more readable error
+      if (!(err instanceof MessageError) && this.parentRequest && this.parentRequest.pattern) {
+        throw new MessageError(
+          this.reporter.lang('requiredPackageNotFoundRegistry', pattern, this.parentRequest.pattern, this.registry),
+        );
+      }
+      throw err;
+    }
   }
 
   /**

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -80,6 +80,7 @@ const messages = {
   invalidVersion: 'Invalid version supplied.',
   requiredVersionInRange: 'Required version in range.',
   packageNotFoundRegistry: "Couldn't find package $0 on the $1 registry.",
+  requiredPackageNotFoundRegistry: "Couldn't find package $0 required by $1 on the $2 registry.",
   doesntExist: "Package $1 refers to a non-existing file '$0'.",
   missingRequiredPackageKey: `Package $0 doesn't have a $1.`,
   invalidAccess: 'Invalid argument for access, expected public or restricted.',


### PR DESCRIPTION
**Summary**

When a package is not found during installation, show which package is requiring it (if any) in the
error message. If there is no parent request, throw the same error as before.

Add new localized string 'requiredPackageNotFoundRegistry' which is the same 'packageNotFoundRegistry', but includes the parent package pattern. 
Add isMessageError boolean value to MessageError class to distinguish
between errors thrown by yarn from errors thrown by yarn dependencies.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->



<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Use a workspace with at least 2 packages `foo` and `bar`. `bar` depends on `foo`. If you manually bump the package version of `foo`, running the install command will fail because the npm registry doesn't have the latest `foo` version that was just created. 

**Error shown (Before)**

![screenshot from 2018-01-13 17-42-27](https://user-images.githubusercontent.com/5729175/34910740-bb8a2178-f889-11e7-9616-275e266f079a.png)

**Error shown (After)**

![screenshot from 2018-01-13 17-42-46](https://user-images.githubusercontent.com/5729175/34910744-c5a32042-f889-11e7-8b62-ef7be578c1be.png)


To implement this I decided to put a try catch statement in `PackageRequest`'s `findVersionOnRegistry` method. I think the error is actually thrown by the `request` module but I decided to catch the error here because I still have access to the reference to the parent request. I didn't want to hide any `MessageError` errors that may be thrown in the underlying function so I added a `isMessageError`  attribute to that class so that I can identify such errors. 

Please let me know if there is a better way to implement this feature.