### PR TITLE
feat(cli): error on missing workspace directory (#5206)

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -96,14 +96,14 @@ test.concurrent('adds any new package to the current workspace, but install from
     expect(await fs.exists(`${config.cwd}/yarn.lock`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/packages/package-b/yarn.lock`)).toEqual(false);
 
-    await add(await makeConfigFromDirectory(`${config.cwd}/non-packages/package-c`, reporter), reporter, {}, [
+    await add(await makeConfigFromDirectory(`${config.cwd}/non-package/package-c`, reporter), reporter, {}, [
       'isarray',
     ]);
 
     expect(await fs.exists(`${config.cwd}/node_modules/isarray`)).toEqual(false);
-    expect(await fs.exists(`${config.cwd}/non-packages/package-c/node_modules/isarray`)).toEqual(true);
+    expect(await fs.exists(`${config.cwd}/non-package/package-c/node_modules/isarray`)).toEqual(true);
 
-    expect(await fs.exists(`${config.cwd}/non-packages/package-c/yarn.lock`)).toEqual(true);
+    expect(await fs.exists(`${config.cwd}/non-package/package-c/yarn.lock`)).toEqual(true);
   });
 });
 

--- a/src/config.js
+++ b/src/config.js
@@ -612,6 +612,9 @@ export default class Config {
   async findWorkspaceRoot(initial: string): Promise<?string> {
     let previous = null;
     let current = path.normalize(initial);
+    if (!await fs.exists(current)) {
+      throw new MessageError(this.reporter.lang('folderMissing', current));
+    }
 
     do {
       const manifest = await this.findManifest(current, true);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -374,6 +374,7 @@ const messages = {
   verboseUpgradeBecauseOutdated: 'Considering upgrade of $0 to $1 because a newer version exists in the registry.',
   verboseUpgradeNotUnlocking: 'Not unlocking $0 in the lockfile because it is a new or direct dependency.',
   verboseUpgradeUnlocking: 'Unlocking $0 in the lockfile.',
+  folderMissing: "Directory $0 doesn't exist",
 };
 
 export type LanguageKeys = $Keys<typeof messages>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Add an error when the working directory doesn't exist (most probably when `--cwd` option points to the wrong directory)

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

As a side effect, this PR detects typo in one of the tests. Path "non-packages" should be "non-package". That test was passing because the yarn was creating target directory.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`yarn add bluebird --cwd /wrong-path`
current behavior: creates `/wrong-path` directory
expected: Error message
