### PR TITLE
feat(cli): sort by version when asking user to select a package version (#5220)

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -67,7 +67,7 @@ export default class NpmResolver extends RegistryResolver {
           name: 'package',
           type: 'list',
           message: config.reporter.lang('chooseVersionFromList', body.name),
-          choices: Object.keys(body.versions).reverse(),
+          choices: Object.keys(body.versions).sort(semver.rcompare),
           pageSize,
         },
       ]);

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -67,7 +67,7 @@ export default class NpmResolver extends RegistryResolver {
           name: 'package',
           type: 'list',
           message: config.reporter.lang('chooseVersionFromList', body.name),
-          choices: Object.keys(body.versions).sort(semver.rcompare),
+          choices: (semver: Object).rsort(Object.keys(body.versions)),
           pageSize,
         },
       ]);


### PR DESCRIPTION
**Summary**

When prompting the user to select a package version to install sort the options by version number.

Closes #5220

**Test plan**

* Create a package and add `"@types/react": "15.4.0"` (or another non-existent package version) to `package.json`
* Run `yarn` and when prompted to select a package version observe that the list is sorted by version (according to semver rules) in descending order