### PR TITLE
Allow scoped package as alias source

### DIFF
--- a/__tests__/resolvers/exotics/registry-resolver.js
+++ b/__tests__/resolvers/exotics/registry-resolver.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+import PackageRequest from '../../../src/package-request.js';
+import RegistryResolver from '../../../src/resolvers/exotics/registry-resolver.js';
+
+const mockPackageRequest: PackageRequest = ({}: any);
+
+test('resolves unscoped npm: package', () => {
+  const resolver = new RegistryResolver(mockPackageRequest, 'npm:foo@0.0.1');
+
+  expect(resolver.name).toEqual('foo');
+});
+
+test('resolves scoped npm: package', () => {
+  const resolver = new RegistryResolver(mockPackageRequest, 'npm:@org/foo@0.0.1');
+
+  expect(resolver.name).toEqual('@org/foo');
+});
+
+test('resolves unscoped yarn: package', () => {
+  const resolver = new RegistryResolver(mockPackageRequest, 'yarn:foo@0.0.1');
+
+  expect(resolver.name).toEqual('foo');
+});
+
+test('resolves scoped yarn: package', () => {
+  const resolver = new RegistryResolver(mockPackageRequest, 'yarn:@org/foo@0.0.1');
+
+  expect(resolver.name).toEqual('@org/foo');
+});

--- a/src/resolvers/exotics/registry-resolver.js
+++ b/src/resolvers/exotics/registry-resolver.js
@@ -9,7 +9,7 @@ export default class RegistryResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
     super(request, fragment);
 
-    const match = fragment.match(/^(\S+):(.*?)(@(.*?)|)$/);
+    const match = fragment.match(/^(\S+):(@?.*?)(@(.*?)|)$/);
     if (match) {
       this.range = match[4] || 'latest';
       this.name = match[2];


### PR DESCRIPTION
**Summary**
Yarn already supports aliasing a scoped package with an unscoped package:
```bash
yarn add @goodforonefare/left-pad@npm:left-pad@1.2.0
```

This PR adds support for aliasing any package with a scoped package:
```bash
yarn add left-pad@npm:@goodforonefare/left-pad@1.2.0
```

Note: the only documentation I can find for this feature [is a tweet from Sebastian McKenzie](https://twitter.com/sebmck/status/873958247304232961?lang=en).

**Test plan**
* `cd` to a yarn-managed repo
* Add a scoped alias for `left-pad`:
  * `yarn add left-pad@npm:@goodforonefare/left-pad`
* Verify that `left-pad` calls append my username to inputs:
```
$ node -e "console.log(require('left-pad')('test', 20))"`
GoodForOneFare                test
```
