### PR TITLE
Add npm metadata to installed packages (#5240)

### DIFF
--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -77,6 +77,20 @@ export default class BaseFetcher {
         ),
       );
 
+      await fs.writeFile(
+        path.join(this.dest, constants.NODE_PACKAGE_JSON),
+        JSON.stringify(
+          {
+            ...pkg,
+            _from: this.remote.pattern,
+            _resolved: this.remote.reference,
+            _shasum: hash,
+          },
+          null,
+          '  ',
+        ),
+      );
+
       return {
         hash,
         dest: this.dest,

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -24,6 +24,11 @@ async function fetchOne(ref: PackageReference, config: Config): Promise<FetchedM
   const dest = config.generateHardModulePath(ref);
 
   const remote = ref.remote;
+
+  if (ref.patterns && ref.patterns[0]) {
+    remote.pattern = ref.patterns[0];
+  }
+
   // Mock metedata for symlinked dependencies
   if (remote.type === 'link') {
     const mockPkg: Manifest = {_uid: '', name: '', version: '0.0.0'};

--- a/src/types.js
+++ b/src/types.js
@@ -41,6 +41,7 @@ export type PackageRemote = {
   resolved?: ?string,
   hash: ?string,
   packageName?: string,
+  pattern?: string,
 };
 
 // `dependencies` field in package info


### PR DESCRIPTION
**Summary**

**Work in Progress**

Running `npm install` in a yarn-based project results in npm deleting all packages installed by yarn. It sounds like we can prevent this by adding a couple of pieces of metadata to the `package.json` of installed packages.

Closes #5240 

**Test plan**

1. Run `yarn add react-scripts`
2. Run `npm install react`
3. npm should not delete (almost) everything in `node_modules`