### PR TITLE
fix(cli): Use correct directory for upgrade-interactive

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -169,13 +169,17 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
           acc[workspaceLoc] = xs.concat(dep);
           return acc;
         }, {});
+        const cwd = config.cwd;
         for (const loc of Object.keys(depsByWorkspace)) {
           const patterns = depsByWorkspace[loc].map(getPattern);
           cleanLockfile(lockfile, deps, packagePatterns, reporter);
           reporter.info(reporter.lang('updateInstalling', getNameFromHint(hint)));
-          config.cwd = path.resolve(path.dirname(loc));
+          if (loc !== '') {
+            config.cwd = path.resolve(path.dirname(loc));
+          }
           const add = new Add(patterns, flags, config, reporter, lockfile);
           await add.init();
+          config.cwd = cwd;
         }
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`upgrade-interactive` was updating the `package.json` in the current directory (where Yarn was run) instead of where the upgrades were made. The most notable occurrence of this was `global upgrade-interactive`, but it also happened by using the `--cwd` option.

When the location was not a workspace, it resolved to the current directory instead of using the previously configured one. Additionally, `config.cwd` was changed without being cleaned up, so it contained the last processed workspace, which affected anything that used it afterwards (e.g. symlinking binaries).

Fixes #4728 
Fixes #4952 
Fixes #4922 

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Install any package globally, then upgrade it interactively without being in the global directory. (or with `--cwd`). The binary of the package that is being upgraded was symlinked again, but all other symlinks were removed.

**Before**

```sh
# Outdated version of `serve`, `prettier` for an extra binary
$ ~/some-dir ➜  yarn global add prettier serve@6.0.0
yarn global v1.4.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed "prettier@1.10.2" with binaries:
      - prettier
success Installed "serve@6.0.0" with binaries:
      - serve
Done in 1.65s.

# Prettier binary is available
$ ~/some-dir ➜  prettier --version
1.10.2

$ ~/some-dir ➜  cat package.json
cat: package.json: No such file or directory

$ ~/some-dir ➜  cat $(yarn global dir)/package.json
{
  "dependencies": {
    "prettier": "^1.10.2",
    "serve": "6.0.0"
  }
}

# Upgrade `serve` to the latest version
$ ~/some-dir ➜  yarn global upgrade-interactive --latest
yarn global v1.4.1
info Color legend :
 "<red>"    : Major Update backward-incompatible updates
 "<yellow>" : Minor Update backward-compatible features
 "<green>"  : Patch Update backward-compatible bug fixes
? Choose which packages to update.
? Choose which packages to update. serve@6.4.9
info Installing "dependencies"...
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 35 new dependencies.
├─ @zeit/check-updates@1.0.5
├─ arch@2.1.0
├─ args@3.0.8
├─ basic-auth@2.0.0
├─ bluebird@3.5.1
├─ boxen@1.3.0
├─ chalk@2.3.0
├─ clipboardy@1.2.2
├─ content-type@1.0.4
├─ depd@1.1.2
├─ detect-port@1.2.2
├─ etag@1.8.1
├─ execa@0.8.0
├─ filesize@3.5.11
├─ fresh@0.5.2
├─ fs-extra@5.0.0
├─ global-dirs@0.1.1
├─ handlebars@4.0.11
├─ http-errors@1.6.2
├─ iconv-lite@0.4.19
├─ is-installed-globally@0.1.0
├─ is-path-inside@1.0.1
├─ jsonfile@4.0.0
├─ micro@9.1.0
├─ mime@1.4.1
├─ node-version@1.1.0
├─ openssl-self-signed-certificate@1.1.6
├─ path-is-inside@1.0.2
├─ path-type@3.0.0
├─ pkginfo@0.4.1
├─ raw-body@2.3.2
├─ send@0.16.1
├─ serve@6.4.9
├─ string-similarity@1.2.0
└─ update-notifier@2.3.0
Done in 3.69s.

# Prettier binary no longer exists
$ ~/some-dir ➜  prettier --version
-bash: prettier: command not found

# Suddenly, there is a package.json in the current directory
$ ~/some-dir ➜  cat package.json
{
  "dependencies": {
    "serve": "6.4.9"
  }
}

# Global package.json did not update
$ ~/some-dir ➜  cat $(yarn global dir)/package.json
warning package.json: No license field
{
  "dependencies": {
    "prettier": "^1.10.2",
    "serve": "6.0.0"
  }
}
```

**After**

```sh
# Outdated version of `serve`, `prettier` for an extra binary
$ ~/some-dir ➜  yarn global add prettier serve@6.0.0
yarn global v1.4.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed "prettier@1.10.2" with binaries:
      - prettier
success Installed "serve@6.0.0" with binaries:
      - serve
Done in 1.92s.

# Prettier binary is available
$ ~/some-dir ➜  prettier --version
1.10.2

$ ~/some-dir ➜  cat package.json
cat: package.json: No such file or directory

$ ~/some-dir ➜  cat $(yarn global dir)/package.json
{
  "dependencies": {
    "prettier": "^1.10.2",
    "serve": "6.0.0"
  }
}

# Upgrade `serve` to the latest version
$ ~/some-dir ➜  yarn global upgrade-interactive --latest
yarn global v1.4.1
info Color legend :
 "<red>"    : Major Update backward-incompatible updates
 "<yellow>" : Minor Update backward-compatible features
 "<green>"  : Patch Update backward-compatible bug fixes
? Choose which packages to update.
? Choose which packages to update. serve@6.4.9
info Installing "dependencies"...
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 34 new dependencies.
├─ @zeit/check-updates@1.0.5
├─ arch@2.1.0
├─ args@3.0.8
├─ basic-auth@2.0.0
├─ bluebird@3.5.1
├─ boxen@1.3.0
├─ clipboardy@1.2.2
├─ content-type@1.0.4
├─ depd@1.1.2
├─ detect-port@1.2.2
├─ etag@1.8.1
├─ execa@0.8.0
├─ filesize@3.5.11
├─ fresh@0.5.2
├─ fs-extra@5.0.0
├─ global-dirs@0.1.1
├─ handlebars@4.0.11
├─ http-errors@1.6.2
├─ iconv-lite@0.4.19
├─ is-installed-globally@0.1.0
├─ is-path-inside@1.0.1
├─ jsonfile@4.0.0
├─ micro@9.1.0
├─ mime@1.4.1
├─ node-version@1.1.0
├─ openssl-self-signed-certificate@1.1.6
├─ path-is-inside@1.0.2
├─ path-type@3.0.0
├─ pkginfo@0.4.1
├─ raw-body@2.3.2
├─ send@0.16.1
├─ serve@6.4.9
├─ string-similarity@1.2.0
└─ update-notifier@2.3.0
Done in 3.00s.

# Prettier is still available
$ ~/some-dir ➜  prettier --version
1.10.2

$ ~/some-dir ➜  cat package.json
cat: package.json: No such file or directory

# Global package.json was correctly updated
$ ~/some-dir ➜  cat $(yarn global dir)/package.json
{
  "dependencies": {
    "prettier": "^1.10.2",
    "serve": "6.4.9"
  }
}
```