### PR TITLE
fix(CLI): Use process exit instead of exitCode for node < 4

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -9,7 +9,7 @@ var majorVer = parseInt(ver.split('.')[0], 10);
 
 if (majorVer < 4) {
   console.error('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.');
-  process.exit(1);
+  process.exit(1); // eslint-disable-line no-process-exit
 } else {
   var dirPath = '../lib/';
   var v8CompileCachePath = dirPath + 'v8-compile-cache';

--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -9,7 +9,7 @@ var majorVer = parseInt(ver.split('.')[0], 10);
 
 if (majorVer < 4) {
   console.error('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.');
-  process.exitCode = 1;
+  process.exit(1);
 } else {
   var dirPath = '../lib/';
   var v8CompileCachePath = dirPath + 'v8-compile-cache';


### PR DESCRIPTION
Since node 0.10.x doesn't support process.exitCode, use process.exit for terminating when yarn is incompatible.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes https://github.com/yarnpkg/yarn/issues/5258

We have a rule to not use process.exit whenever possible, but since this particular command is specifically for determining node version compatibility (currently we don't support 0.12.x or 0.10.x) we should default back to process.exit.

**Test plan**
run `yarn` on node .10.x then `echo $?`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
