### PR TITLE
feat(install): Implement a very basic hook system

### DIFF
--- a/__tests__/hooks.js
+++ b/__tests__/hooks.js
@@ -1,11 +1,12 @@
-import * as fs from '../../../src/util/fs.js';
+/* @flow */
+
 import {runInstall} from './commands/_helpers.js';
 
 test('install should call the resolveStep hook', async () => {
   global.experimentalYarnHooks = {
     resolveStep: jest.fn(cb => cb()),
   };
-  await runInstall({}, 'install-production', async (config): Promise<void> => {
+  await runInstall({}, 'install-production', config => {
     expect(global.experimentalYarnHooks.resolveStep.mock.calls.length).toEqual(1);
   });
   delete global.experimentalYarnHooks;
@@ -15,7 +16,7 @@ test('install should call the fetchStep hook', async () => {
   global.experimentalYarnHooks = {
     fetchStep: jest.fn(cb => cb()),
   };
-  await runInstall({}, 'install-production', async (config): Promise<void> => {
+  await runInstall({}, 'install-production', config => {
     expect(global.experimentalYarnHooks.fetchStep.mock.calls.length).toEqual(1);
   });
   delete global.experimentalYarnHooks;
@@ -25,7 +26,7 @@ test('install should call the linkStep hook', async () => {
   global.experimentalYarnHooks = {
     linkStep: jest.fn(cb => cb()),
   };
-  await runInstall({}, 'install-production', async (config): Promise<void> => {
+  await runInstall({}, 'install-production', config => {
     expect(global.experimentalYarnHooks.linkStep.mock.calls.length).toEqual(1);
   });
   delete global.experimentalYarnHooks;
@@ -35,7 +36,7 @@ test('install should call the buildStep hook', async () => {
   global.experimentalYarnHooks = {
     buildStep: jest.fn(cb => cb()),
   };
-  await runInstall({}, 'install-production', async (config): Promise<void> => {
+  await runInstall({}, 'install-production', config => {
     expect(global.experimentalYarnHooks.buildStep.mock.calls.length).toEqual(1);
   });
   delete global.experimentalYarnHooks;

--- a/__tests__/hooks.js
+++ b/__tests__/hooks.js
@@ -1,0 +1,42 @@
+import * as fs from '../../../src/util/fs.js';
+import {runInstall} from './commands/_helpers.js';
+
+test('install should call the resolveStep hook', async () => {
+  global.experimentalYarnHooks = {
+    resolveStep: jest.fn(cb => cb()),
+  };
+  await runInstall({}, 'install-production', async (config): Promise<void> => {
+    expect(global.experimentalYarnHooks.resolveStep.mock.calls.length).toEqual(1);
+  });
+  delete global.experimentalYarnHooks;
+});
+
+test('install should call the fetchStep hook', async () => {
+  global.experimentalYarnHooks = {
+    fetchStep: jest.fn(cb => cb()),
+  };
+  await runInstall({}, 'install-production', async (config): Promise<void> => {
+    expect(global.experimentalYarnHooks.fetchStep.mock.calls.length).toEqual(1);
+  });
+  delete global.experimentalYarnHooks;
+});
+
+test('install should call the linkStep hook', async () => {
+  global.experimentalYarnHooks = {
+    linkStep: jest.fn(cb => cb()),
+  };
+  await runInstall({}, 'install-production', async (config): Promise<void> => {
+    expect(global.experimentalYarnHooks.linkStep.mock.calls.length).toEqual(1);
+  });
+  delete global.experimentalYarnHooks;
+});
+
+test('install should call the buildStep hook', async () => {
+  global.experimentalYarnHooks = {
+    buildStep: jest.fn(cb => cb()),
+  };
+  await runInstall({}, 'install-production', async (config): Promise<void> => {
+    expect(global.experimentalYarnHooks.buildStep.mock.calls.length).toEqual(1);
+  });
+  delete global.experimentalYarnHooks;
+});

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -7,6 +7,7 @@ import type {Manifest, DependencyRequestPatterns} from '../../types.js';
 import type Config from '../../config.js';
 import type {RegistryNames} from '../../registries/index.js';
 import type {LockfileObject} from '../../lockfile';
+import {callThroughHook} from '../../util/hooks.js';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
 import {MessageError} from '../../errors.js';
 import InstallationIntegrityChecker from '../../integrity-checker.js';
@@ -531,56 +532,64 @@ export class Install {
       });
     }
 
-    steps.push(async (curr: number, total: number) => {
-      this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));
-      this.resolutionMap.setTopLevelPatterns(rawPatterns);
-      await this.resolver.init(this.prepareRequests(depRequests), {
-        isFlat: this.flags.flat,
-        isFrozen: this.flags.frozenLockfile,
-        workspaceLayout,
-      });
-      topLevelPatterns = this.preparePatterns(rawPatterns);
-      flattenedTopLevelPatterns = await this.flatten(topLevelPatterns);
-      return {bailout: await this.bailout(topLevelPatterns, workspaceLayout)};
-    });
+    steps.push((curr: number, total: number) =>
+      callThroughHook('resolveStep', async () => {
+        this.reporter.step(curr, total, this.reporter.lang('resolvingPackages'), emoji.get('mag'));
+        this.resolutionMap.setTopLevelPatterns(rawPatterns);
+        await this.resolver.init(this.prepareRequests(depRequests), {
+          isFlat: this.flags.flat,
+          isFrozen: this.flags.frozenLockfile,
+          workspaceLayout,
+        });
+        topLevelPatterns = this.preparePatterns(rawPatterns);
+        flattenedTopLevelPatterns = await this.flatten(topLevelPatterns);
+        return {bailout: await this.bailout(topLevelPatterns, workspaceLayout)};
+      }),
+    );
 
-    steps.push(async (curr: number, total: number) => {
-      this.markIgnored(ignorePatterns);
-      this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
-      const manifests: Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
-      this.resolver.updateManifests(manifests);
-      await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
-    });
+    steps.push((curr: number, total: number) =>
+      callThroughHook('fetchStep', async () => {
+        this.markIgnored(ignorePatterns);
+        this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
+        const manifests: Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
+        this.resolver.updateManifests(manifests);
+        await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
+      }),
+    );
 
-    steps.push(async (curr: number, total: number) => {
-      // remove integrity hash to make this operation atomic
-      await this.integrityChecker.removeIntegrityFile();
-      this.reporter.step(curr, total, this.reporter.lang('linkingDependencies'), emoji.get('link'));
-      flattenedTopLevelPatterns = this.preparePatternsForLinking(
-        flattenedTopLevelPatterns,
-        manifest,
-        this.config.lockfileFolder === this.config.cwd,
-      );
-      await this.linker.init(flattenedTopLevelPatterns, workspaceLayout, {
-        linkDuplicates: this.flags.linkDuplicates,
-        ignoreOptional: this.flags.ignoreOptional,
-      });
-    });
+    steps.push((curr: number, total: number) =>
+      callThroughHook('linkStep', async () => {
+        // remove integrity hash to make this operation atomic
+        await this.integrityChecker.removeIntegrityFile();
+        this.reporter.step(curr, total, this.reporter.lang('linkingDependencies'), emoji.get('link'));
+        flattenedTopLevelPatterns = this.preparePatternsForLinking(
+          flattenedTopLevelPatterns,
+          manifest,
+          this.config.lockfileFolder === this.config.cwd,
+        );
+        await this.linker.init(flattenedTopLevelPatterns, workspaceLayout, {
+          linkDuplicates: this.flags.linkDuplicates,
+          ignoreOptional: this.flags.ignoreOptional,
+        });
+      }),
+    );
 
-    steps.push(async (curr: number, total: number) => {
-      this.reporter.step(
-        curr,
-        total,
-        this.flags.force ? this.reporter.lang('rebuildingPackages') : this.reporter.lang('buildingFreshPackages'),
-        emoji.get('page_with_curl'),
-      );
+    steps.push((curr: number, total: number) =>
+      callThroughHook('buildStep', async () => {
+        this.reporter.step(
+          curr,
+          total,
+          this.flags.force ? this.reporter.lang('rebuildingPackages') : this.reporter.lang('buildingFreshPackages'),
+          emoji.get('page_with_curl'),
+        );
 
-      if (this.flags.ignoreScripts) {
-        this.reporter.warn(this.reporter.lang('ignoredScripts'));
-      } else {
-        await this.scripts.init(flattenedTopLevelPatterns);
-      }
-    });
+        if (this.flags.ignoreScripts) {
+          this.reporter.warn(this.reporter.lang('ignoredScripts'));
+        } else {
+          await this.scripts.init(flattenedTopLevelPatterns);
+        }
+      }),
+    );
 
     if (this.flags.har) {
       steps.push(async (curr: number, total: number) => {

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,0 +1,21 @@
+/* @flow */
+
+const YARN_HOOKS_KEY = 'experimentalYarnHooks';
+
+export function callThroughHook<T>(type: string, fn: () => T): T {
+  if (typeof global === 'undefined') {
+    return fn();
+  }
+
+  if (typeof global[YARN_HOOKS_KEY] !== 'object' || !global[YARN_HOOKS_KEY]) {
+    return fn();
+  }
+
+  const hook: (() => T) => T = global[YARN_HOOKS_KEY][type];
+
+  if (!hook) {
+    return fn();
+  }
+
+  return hook(fn);
+}

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,8 +1,10 @@
 /* @flow */
 
+export type YarnHook = 'resolveStep' | 'fetchStep' | 'linkStep' | 'buildStep';
+
 const YARN_HOOKS_KEY = 'experimentalYarnHooks';
 
-export function callThroughHook<T>(type: string, fn: () => T): T {
+export function callThroughHook<T>(type: YarnHook, fn: () => T): T {
   if (typeof global === 'undefined') {
     return fn();
   }


### PR DESCRIPTION
**Disclaimer:** This is NOT a public feature, we reserve the right to change it as we wish, including between patch releases.

---

This PR adds a very basic and undocumented hook system. I plan to use it internally to get better
stats on how Yarn performs, and how much time is spent on the linking step.

**Test plan**

I tested this PR by adding the following code to the beginning of a custom build:

```js
let trace = name => {
    return async fn => {
        let x = Date.now();
        let r = await fn();
        console.log(`step ${name}: ${Date.now() - x}`);
        return r;
    };
};

global.experimentalYarnHooks = {

    resolveStep: trace('resolve'),
    fetchStep: trace('fetch'),
    linkStep: trace('link'),
    buildStep: trace('build'),

};
```

More comprehensive tests are on their way.
