### PR TITLE
Horizontal rule fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://discord.gg/yarnpkg"><img alt="Discord Chat" src="https://img.shields.io/discord/226791405589233664.svg"></a>
   <a href="http://commitizen.github.io/cz-cli/"><img alt="Commitizen friendly" src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg"></a>
 </p>
+
 ---
 
 **Fast:** Yarn caches every package it has downloaded, so it never needs to download the same package again. It also does almost everything concurrently to maximize resource utilization. This means even faster installs.


### PR DESCRIPTION
**Summary**

The horizontal rule had no empty space between it and the previous paragraph, and as such was rendered as '---' in the markdown, rather than the intended horizontal rule.

This is not a substantial feature pull request.

Motivation: it will look better.

**Test plan**

Not relevant.
