### PR TITLE
fix(build): add sourceRoot to sourcemaps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ const build = (lib, opts) =>
       .pipe(newer(lib))
       .pipe(gulpif(argv.sourcemaps, sourcemaps.init()))
       .pipe(babel(opts))
-      .pipe(gulpif(argv.sourcemaps, sourcemaps.write('.')))
+      .pipe(gulpif(argv.sourcemaps, sourcemaps.write('.', {sourceRoot: '../src'})))
       .pipe(gulp.dest(lib));
 
 gulp.task('default', ['build']);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Add `sourceRoot` to sourcemaps config in the gulpfile.js. Fixes: #5319.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Without this a developer who wants to debug the yarn src would have to manually configure a mapping between the lib/**/*.map files and the src/**/*.js files so that the breakpoints get hit. With this fix this manual configuration step is not necessary.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```shell
yarn run build --sourcemaps
rg -i "sourceRoot" lib/*.map # should get some output from ripgrep listing sourceRoots in .map files.
```
