### PR TITLE
fix(cli): report no valid versions for unpublished packages (#5311)

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -724,6 +724,7 @@ describe('checkOutdated functional test', () => {
     resolveConstraints(): string {
       return '2.0.0';
     },
+    reporter: new BufferReporter({verbose: true}),
   };
 
   test('homepage URL from top level', async () => {
@@ -840,5 +841,29 @@ describe('checkOutdated functional test', () => {
       wanted: '2.0.0',
       url: 'http://package.repo.com',
     });
+  });
+
+  test('unpublished package (no versions)', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+
+    mockRequestManager.request = () => {
+      return {
+        'dist-tags': {
+          latest: '2.0.0',
+        },
+        versions: {},
+      };
+    };
+
+    let message;
+    try {
+      await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0');
+    } catch (err) {
+      message = err.message;
+    }
+
+    expect(message).toEqual(expect.stringContaining('No valid versions'));
   });
 });

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -325,6 +325,7 @@ const messages = {
 
   infoFail: 'Received invalid response from npm.',
   malformedRegistryResponse: 'Received malformed response from registry for $0. The registry may be down.',
+  registryNoVersions: 'No valid versions found for $0. The package may be unpublished.',
 
   cantRequestOffline: "Can't make a request in offline mode ($0)",
   requestManagerNotSetupHAR: 'RequestManager was not setup to capture HAR files',

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -34,7 +34,11 @@ export default class NpmResolver extends RegistryResolver {
     body: RegistryResponse,
     request: ?PackageRequest,
   ): Promise<Manifest> {
-    if (!body['dist-tags']) {
+    if (body.versions && Object.keys(body.versions).length === 0) {
+      throw new MessageError(config.reporter.lang('registryNoVersions', body.name));
+    }
+
+    if (!body['dist-tags'] || !body.versions) {
       throw new MessageError(config.reporter.lang('malformedRegistryResponse', body.name));
     }
 


### PR DESCRIPTION
**Summary**
Running yarn add to install an unpublished version produces an error message suggesting that the response is malformed and the registry may be down. This fix adjusts the error to indicate that no valid versions were found. This also brings the feature more in line with the `npm install` spec.

Fixes #5311 

**Test plan**

Running:

```
$ yarn add x-iterable-tree
```

Produces:
```
yarn add v1.4.1
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
error No valid versions found for "x-iterable-tree". The package may be unpublished.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```