### PR TITLE
break semver for engine check by allowing prereleases

### DIFF
--- a/__tests__/package-compatibility.js
+++ b/__tests__/package-compatibility.js
@@ -13,4 +13,9 @@ test('node semver semantics', () => {
   expect(testEngine('node', '^0.9.0', {node: '5.0.0'}, true)).toEqual(false);
   expect(testEngine('node', '^0.12.0', {node: '0.12.0'}, true)).toEqual(true);
   expect(testEngine('node', '^0.12.0', {node: '0.11.0'}, true)).toEqual(false);
+  expect(testEngine('node', '^1.3.0', {node: '1.4.1-20180208.2355'}, true)).toEqual(false);
+});
+
+test('ignore semver prerelease semantics for yarn', () => {
+  expect(testEngine('yarn', '^1.3.0', {yarn: '1.4.1-20180208.2355'}, true)).toEqual(true);
 });

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -6,6 +6,7 @@ import {MessageError} from './errors.js';
 import map from './util/map.js';
 import {entries} from './util/misc.js';
 import {version as yarnVersion} from './util/yarn-version.js';
+import {satisfiesWithPreleases} from './util/semver.js';
 
 const invariant = require('invariant');
 const semver = require('semver');
@@ -67,6 +68,10 @@ export function testEngine(name: string, range: string, versions: Versions, loos
   }
 
   if (semver.satisfies(actual, range, looseSemver)) {
+    return true;
+  }
+
+  if (name === 'yarn' && satisfiesWithPreleases(actual, range, looseSemver)) {
     return true;
   }
 


### PR DESCRIPTION
**Summary**
Addresses #2172 
When trying to run a prerelease version of yarn, packages that specify versions of yarn in their engine requirements in package.json cause installation to fail. When running prerelease versions of yarn, you most likely don't want this engine check to fail because you have already signed up for potentially unexpected behavior by using a prerelease version.

**Test plan**
[rollup-plugin-rebase](https://github.com/sebastian-software/rollup-plugin-rebase/blob/master/package.json) has an engine requirement of `>=1.0.0`

Install nightly build (1.4.1-20180211.2236)
`yarn add rollup-plugin-rebase`  (fails engine check)

alias local copy of yarn (1.4.1-20180208.2355)
`yarn add rollup-plugin-rebase`  (success)
