### PR TITLE
Added logic to correctly print stringified linebreak chars

### DIFF
--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -17,6 +17,7 @@ import type {Formatter} from './format.js';
 import {defaultFormatter} from './format.js';
 import * as languages from './lang/index.js';
 import isCI from 'is-ci';
+import os from 'os';
 
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
@@ -41,9 +42,10 @@ export function stringifyLangArgs(args: Array<any>): Array<string> {
     } else {
       try {
         const str = JSON.stringify(val) || val + '';
-        // should match all "u001b" that follow an odd number of backslashes and convert them to ESC
+        // should match all literal line breaks and
+        // "u001b" that follow an odd number of backslashes and convert them to ESC
         // we do this because the JSON.stringify process has escaped these characters
-        return str.replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b');
+        return str.replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b').replace(/[\\]r[\\]n|[\\]n/g, os.EOL);
       } catch (e) {
         return util.inspect(val);
       }


### PR DESCRIPTION
**Summary**
Fixes #4158

This issue would occur, for example; while during a `yarn install` there was a `node-gyp` error - the line breaks would remain literal "\n". Example log of this:
```
/usr/src/app/node_modules/drivelist: Error: Command failed.\nExit code: 1\nCommand: prebuild-install || node-gyp rebuild\nArguments: \nDirectory: /usr/src/app/node_modules/drivelist\nOutput:\nprebuild-install info begin Prebuild-install version 2.5.1\nprebuild-install info looking for local prebuild @ prebuilds/drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz\nprebuild-install info npm cache directory missing, creating it... \nprebuild-install info looking for cached prebuild @ /root/.npm/_prebuilds/https-github.com-resin-io-modules-drivelist-releases-download-v5.2.12-drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz\nprebuild-install http request GET https://github.com/resin-io-modules/drivelist/releases/download/v5.2.12/drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz\nprebuild-install http 404 https://github.com/resin-io-modules/drivelist/releases/download/v5.2.12/drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz\nprebuild-install WARN install No prebuilt binaries found (target=8.9.4 runtime=node arch=x64 platform=linux)\ngyp info it worked if it ends with ok\ngyp info using node-gyp@3.6.2\ngyp info using node@8.9.4 | linux | x64\ngyp ERR! configure error \ngyp ERR! stack Error: Can't find Python executable \"python\", you can set the PYTHON env variable.\ngyp ERR! stack     at PythonFinder.failNoPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:483:19)\ngyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:397:16)\ngyp ERR! stack     at F (/usr/local/lib/node_modules/npm/node_modules/which/which.js:68:16)\ngyp ERR! stack     at E (/usr/local/lib/node_modules/npm/node_modules/which/which.js:80:29)\ngyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/which.js:89:16\ngyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/index.js:42:5\ngyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/mode.js:8:5\ngyp ERR! stack     at FSReqWrap.oncomplete (fs.js:152:21)\ngyp ERR! System Linux 4.9.60-linuxkit-aufs\ngyp ERR! command \"/usr/local/bin/node\" \"/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js\" \"rebuild\"\ngyp ERR! cwd /usr/src/app/node_modules/drivelist\ngyp ERR! node -v v8.9.4\ngyp ERR! node-gyp -v v3.6.2\ngyp ERR! not ok
```

This pr repairs this fix by adding to the existing string replacement logic that was not previously accounting for line breaks. Namely, this bit of code which seems to attempt what `JSON.parse` does:
```js
return str.replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b');
```

My fix involves continuing to use regex for this...however, I wonder if this would be preferred as more reliable way to deserialize:

```
return JSON.parse('"' + str + '"');
```

Since it seems to accomplish the same. Or....just not use `JSON.stringify` on this data at all if `val` is a string?

**Test plan**
With this fix, the log now reports correctly:
```
warning Error running install script for optional dependency: "/usr/src/app/node_modules/drivelist: Error: Command failed.
Exit code: 1
Command: prebuild-install || node-gyp rebuild
Arguments:
Directory: /usr/src/app/node_modules/drivelist
Output:
prebuild-install info begin Prebuild-install version 2.5.1
prebuild-install info looking for local prebuild @ prebuilds/drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz
prebuild-install info npm cache directory missing, creating it...
prebuild-install info looking for cached prebuild @ /root/.npm/_prebuilds/https-github.com-resin-io-modules-drivelist-releases-download-v5.2.12-drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz
prebuild-install http request GET https://github.com/resin-io-modules/drivelist/releases/download/v5.2.12/drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz
prebuild-install http 404 https://github.com/resin-io-modules/drivelist/releases/download/v5.2.12/drivelist-v5.2.12-node-v57-linuxmusl-x64.tar.gz
prebuild-install WARN install No prebuilt binaries found (target=8.9.4 runtime=node arch=x64 platform=linux)
gyp info it worked if it ends with ok
gyp info using node-gyp@3.6.2
gyp info using node@8.9.4 | linux | x64
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable \"python\", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:483:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:397:16)
gyp ERR! stack     at F (/usr/local/lib/node_modules/npm/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/usr/local/lib/node_modules/npm/node_modules/which/which.js:80:29)
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/which.js:89:16
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:152:21)
gyp ERR! System Linux 4.9.60-linuxkit-aufs
gyp ERR! command \"/usr/local/bin/node\" \"/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js\" \"rebuild\"
gyp ERR! cwd /usr/src/app/node_modules/drivelist
gyp ERR! node -v v8.9.4
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok"
```
