### PR TITLE
Enable curl `--compressed` option to speed up request

### DIFF
--- a/scripts/install-latest.sh
+++ b/scripts/install-latest.sh
@@ -5,4 +5,4 @@ reset="\e[0m"
 red="\e[0;31m"
 
 printf "${red}This script has moved to https://yarnpkg.com/install.sh, please update your URL!$reset\n"
-curl -o- -L https://yarnpkg.com/install.sh | bash -s -- "$@"
+curl --compressed -o- -L https://yarnpkg.com/install.sh | bash -s -- "$@"

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -12,7 +12,7 @@ fi;
 # number from Yarn site
 if [ -z "$YARN_VERSION" ]; then
   echo 'Getting Yarn version from https://yarnpkg.com/latest-version'
-  version=`curl --fail https://yarnpkg.com/latest-version`
+  version=`curl --compressed --fail https://yarnpkg.com/latest-version`
 else
   version="$YARN_VERSION"
 fi
@@ -38,7 +38,7 @@ popd
 # Grab latest Yarn release so we can hash it
 url=https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz
 tempfile=`mktemp -t 'yarn-release-XXXXXXXX.tar.gz'`
-curl --fail -L -o $tempfile $url
+curl --compressed --fail -L -o $tempfile $url
 hash=`sha256sum $tempfile | head -c 64`
 
 # Update the formula!

--- a/scripts/update-npm.sh
+++ b/scripts/update-npm.sh
@@ -21,7 +21,7 @@ if [ "`npm view yarn@$version name`" = 'yarn' ]; then
 fi;
 
 # Determine if this is an RC or a stable release
-release_type=`curl --fail https://release.yarnpkg.com/release_type/$version`
+release_type=`curl --compressed --fail https://release.yarnpkg.com/release_type/$version`
 npm_flags=''
 if [ "$release_type" = "rc" ]; then
   npm_flags='--tag rc'

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -84,7 +84,7 @@ type Flags = {
 
 function getUpdateCommand(installationMethod: InstallationMethod): ?string {
   if (installationMethod === 'tar') {
-    return `curl -o- -L ${constants.YARN_INSTALLER_SH} | bash`;
+    return `curl --compressed -o- -L ${constants.YARN_INSTALLER_SH} | bash`;
   }
 
   if (installationMethod === 'homebrew') {


### PR DESCRIPTION
This will let `curl` automatically to send `Accept-Encoding` header to include the compression methods such like `deflate`, `gzip`, etc, to request compressed data from server, and automatically decompress the data if it's compressed, I believe that this is very like(pretty the same) what commit 0829a745ae5d6948d939d0c181bbb7bb2cd1686a / PR #1083 did, will save the time and bandwidth on transferring data.

The output and other behavior should be the same as `curl` will automatically handle the process to add header and to decompress.

My first PR to this project, let me know if I need to revise/improve anything, thanks a lot!