### PR TITLE
bug: yarn tag list prompted user for credentials removed

### DIFF
--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -31,10 +31,7 @@ export async function getName(args: Array<string>, config: Config): Promise<stri
 async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const name = await getName(args, config);
 
-  reporter.step(1, 3, reporter.lang('loggingIn'));
-  const revoke = await getToken(config, reporter, name);
-
-  reporter.step(2, 3, reporter.lang('gettingTags'));
+  reporter.step(1, 1, reporter.lang('gettingTags'));
   const tags = await config.registries.npm.request(`-/package/${name}/dist-tags`);
 
   if (tags) {
@@ -43,9 +40,7 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
       reporter.info(`${name}: ${tags[name]}`);
     }
   }
-
-  reporter.step(3, 3, reporter.lang('revokingToken'));
-  await revoke();
+  
 
   if (!tags) {
     throw new MessageError(reporter.lang('packageNotFoundRegistry', name, 'npm'));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is a bug fix for issue #5325 that caused yarn tag list to prompt user for credentials. Running `npm dist-tag ls` will not prompt for credentials.

**Test plan**
I have not tested the code yet due to an issue with babel-eslint:

```
yarn run lint
yarn run v1.4.1
$ eslint . && flow check
Cannot read property 'type' of undefined
TypeError: Cannot read property 'type' of undefined
    at isForInRef (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/rules/no-unused-vars.js:406:24)
    at variable.references.some.ref (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/rules/no-unused-vars.js:443:21)
    at Array.some (<anonymous>)
    at isUsedVariable (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/rules/no-unused-vars.js:442:40)
    at collectUnusedVariables (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/rules/no-unused-vars.js:565:26)
    at Program:exit (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/rules/no-unused-vars.js:617:36)
    at listeners.(anonymous function).forEach.listener (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.leaveNode (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/node-event-generator.js:303:14)
    at CodePathAnalyzer.leaveNode (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:630:23)
    at Traverser.leave [as _leave] (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/linter.js:1020:32)
    at Traverser._traverse (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/traverser.js:155:18)
    at Traverser.traverse (/Users/ssabour/Desktop/development/yarn/node_modules/eslint/lib/util/traverser.js:115:14)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Some searching brought me to this issue https://github.com/eslint/eslint/issues/9767

P.S my first contribution to open source, so sorry for any misunderstanding