### PR TITLE
Remove unnecessary console output when running test cases

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -1140,7 +1140,7 @@ test.concurrent('installs "latest" instead of maxSatisfying if no requested patt
 });
 
 describe('nohoist', () => {
-  test.concurrent('can add nohoist pacakge from workspace', async () => {
+  test.concurrent('can add nohoist package from workspace', async () => {
     await runInstall({}, 'workspaces-install-nohoist-across-versions', async (config, reporter): Promise<void> => {
       // workspace-2 has b and c since the root has nohoist = ['a', 'b', 'c']
       expect(await fs.exists(`${config.cwd}/packages/workspace-2/node_modules/b`)).toEqual(true);
@@ -1167,7 +1167,7 @@ describe('nohoist', () => {
       expect(await fs.exists(`${config.cwd}/node_modules/c`)).toEqual(false);
     });
   });
-  test.concurrent('can add nohoist pacakge from root', async () => {
+  test.concurrent('can add nohoist package from root', async () => {
     await runInstall({}, 'workspaces-install-nohoist-across-versions', async (config, reporter): Promise<void> => {
       // prove package a does not exist in workspace-2 nor in root
       expect(await fs.exists(`${config.cwd}/packages/workspace-2/node_modules/a`)).toEqual(false);

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -1075,9 +1075,7 @@ test.concurrent('installing with --pure-lockfile and then adding should keep bui
 });
 
 test.concurrent('preserves unaffected bin links after adding to workspace package', async () => {
-  await runInstall({binLinks: true}, 'workspaces-install-bin', async (config): Promise<void> => {
-    const reporter = new ConsoleReporter({});
-
+  await runInstall({binLinks: true}, 'workspaces-install-bin', async (config, reporter): Promise<void> => {
     expect(await fs.exists(`${config.cwd}/node_modules/.bin/rimraf`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/node_modules/.bin/touch`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/node_modules/.bin/workspace-1`)).toEqual(true);
@@ -1143,9 +1141,7 @@ test.concurrent('installs "latest" instead of maxSatisfying if no requested patt
 
 describe('nohoist', () => {
   test.concurrent('can add nohoist pacakge from workspace', async () => {
-    await runInstall({}, 'workspaces-install-nohoist-across-versions', async (config): Promise<void> => {
-      const reporter = new ConsoleReporter({});
-
+    await runInstall({}, 'workspaces-install-nohoist-across-versions', async (config, reporter): Promise<void> => {
       // workspace-2 has b and c since the root has nohoist = ['a', 'b', 'c']
       expect(await fs.exists(`${config.cwd}/packages/workspace-2/node_modules/b`)).toEqual(true);
       expect(await fs.exists(`${config.cwd}/packages/workspace-2/node_modules/c`)).toEqual(true);
@@ -1172,9 +1168,7 @@ describe('nohoist', () => {
     });
   });
   test.concurrent('can add nohoist pacakge from root', async () => {
-    await runInstall({}, 'workspaces-install-nohoist-across-versions', async (config): Promise<void> => {
-      const reporter = new ConsoleReporter({});
-
+    await runInstall({}, 'workspaces-install-nohoist-across-versions', async (config, reporter): Promise<void> => {
       // prove package a does not exist in workspace-2 nor in root
       expect(await fs.exists(`${config.cwd}/packages/workspace-2/node_modules/a`)).toEqual(false);
       expect(await fs.exists(`${config.cwd}/node_modules/a`)).toEqual(false);

--- a/__tests__/commands/remove.js
+++ b/__tests__/commands/remove.js
@@ -147,9 +147,7 @@ test.concurrent('removes package installed without a manifest', (): Promise<void
 });
 
 test.concurrent('removes from workspace packages', async () => {
-  await runInstall({}, 'workspaces-install-basic', async (config): Promise<void> => {
-    const reporter = new ConsoleReporter({});
-
+  await runInstall({}, 'workspaces-install-basic', async (config, reporter): Promise<void> => {
     expect(await fs.exists(`${config.cwd}/node_modules/isarray`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/workspace-child/node_modules/isarray`)).toEqual(false);
 
@@ -173,9 +171,7 @@ test.concurrent('removes from workspace packages', async () => {
 });
 
 test.concurrent('preserves unaffected bin links after removing workspace packages', async () => {
-  await runInstall({binLinks: true}, 'workspaces-install-bin', async (config): Promise<void> => {
-    const reporter = new ConsoleReporter({});
-
+  await runInstall({binLinks: true}, 'workspaces-install-bin', async (config, reporter): Promise<void> => {
     expect(await fs.exists(`${config.cwd}/node_modules/.bin/rimraf`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/node_modules/.bin/touch`)).toEqual(true);
     expect(await fs.exists(`${config.cwd}/node_modules/.bin/workspace-1`)).toEqual(true);


### PR DESCRIPTION
**Summary**

Running the tests did, for some test cases, show yarn command output like `[1/4] Resolving packages...`. This pull request captures the command output instead of printing it to the console, the same way as this is done in many other test cases.

Unnecessary command output during testing makes the tests noisy. We are mostly only interested in test success or failure messages, not all the details of all the commands that run internally. Even *if* the command output were interesting, it usually should be captured and tested in the test, not written to console.

**Test plan**

The tests still pass, just with less random console output.