### PR TITLE
Fix test for `yarn licenses generate-disclaimer` output

### DIFF
--- a/__tests__/commands/__snapshots__/licenses.js.snap
+++ b/__tests__/commands/__snapshots__/licenses.js.snap
@@ -13,3 +13,35 @@ exports[`should generate disclaimer on demand 1`] = `
 {\\"type\\":\\"warning\\",\\"data\\":\\"package.json: No license field\\"}
 "
 `;
+
+exports[`should generate disclaimer on demand 2`] = `
+"THE FOLLOWING SETS FORTH ATTRIBUTION NOTICES FOR THIRD PARTY SOFTWARE THAT MAY BE CONTAINED IN PORTIONS OF THE  PRODUCT.
+
+-----
+
+The following software may be included in this product: is-plain-obj. A copy of the source code may be downloaded from https://github.com/sindresorhus/is-plain-obj.git. This software contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+"
+`;

--- a/__tests__/commands/__snapshots__/licenses.js.snap
+++ b/__tests__/commands/__snapshots__/licenses.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lists all licenses of the dependencies with the --json argument 1`] = `
+exports[`list should show licenses of dependencies 1`] = `
 "{\\"type\\":\\"warning\\",\\"data\\":\\"package.json: No license field\\"}
 {\\"type\\":\\"warning\\",\\"data\\":\\"No license field\\"}
 {\\"type\\":\\"tree\\",\\"data\\":{\\"type\\":\\"licenses\\",\\"trees\\":[{\\"name\\":\\"MIT\\",\\"children\\":[{\\"name\\":\\"is-plain-obj@1.1.0\\",\\"children\\":[{\\"name\\":\\"URL: https://github.com/sindresorhus/is-plain-obj.git\\"},{\\"name\\":\\"VendorUrl: sindresorhus.com\\"},{\\"name\\":\\"VendorName: Sindre Sorhus\\"}]}]}]}}
 "
 `;
 
-exports[`should generate disclaimer on demand 1`] = `
+exports[`generate-disclaimer should show license texts of dependencies 1`] = `
 "{\\"type\\":\\"warning\\",\\"data\\":\\"package.json: No license field\\"}
 {\\"type\\":\\"warning\\",\\"data\\":\\"No license field\\"}
 {\\"type\\":\\"warning\\",\\"data\\":\\"package.json: No license field\\"}
 "
 `;
 
-exports[`should generate disclaimer on demand 2`] = `
+exports[`generate-disclaimer should show license texts of dependencies 2`] = `
 "THE FOLLOWING SETS FORTH ATTRIBUTION NOTICES FOR THIRD PARTY SOFTWARE THAT MAY BE CONTAINED IN PORTIONS OF THE  PRODUCT.
 
 -----

--- a/__tests__/commands/licenses.js
+++ b/__tests__/commands/licenses.js
@@ -3,6 +3,7 @@
 import {JSONReporter} from '../../src/reporters/index.js';
 import {run as buildRun} from './_helpers.js';
 import {run as licenses} from '../../src/cli/commands/licenses.js';
+import Config from '../../src/config.js';
 
 const path = require('path');
 
@@ -19,7 +20,17 @@ const runLicenses = buildRun.bind(
   },
 );
 
-async function runLicensesWithConsole(args, flags, name, callback): Promise<void> {
+type Outputs = {
+  stdout: string,
+  consoleout: string,
+};
+
+async function runLicensesWithConsole(
+  args: Array<string>,
+  flags: Object,
+  name: string,
+  callback: (Config, JSONReporter, Outputs) => void,
+): Promise<void> {
   let consoleout = '';
   const console_log = jest.spyOn(console, 'log').mockImplementation(line => {
     consoleout += (line || '') + '\n';
@@ -28,7 +39,7 @@ async function runLicensesWithConsole(args, flags, name, callback): Promise<void
     await buildRun(
       JSONReporter,
       fixturesLoc,
-      async (args, flags, config, reporter, lockfile, getStdout): Promise<{stdout: string, consoleout: string}> => {
+      async (args, flags, config, reporter, lockfile, getStdout): Promise<Outputs> => {
         reporter.disableProgress();
         await licenses(config, reporter, flags, args);
         console_log.mockRestore();

--- a/__tests__/commands/licenses.js
+++ b/__tests__/commands/licenses.js
@@ -56,13 +56,13 @@ async function runLicensesWithConsole(
   }
 }
 
-test('lists all licenses of the dependencies with the --json argument', async (): Promise<void> => {
+test('list should show licenses of dependencies', async (): Promise<void> => {
   await runLicenses(['list'], {}, '', (config, reporter, stdout) => {
     expect(stdout).toMatchSnapshot();
   });
 });
 
-test('should generate disclaimer on demand', async (): Promise<void> => {
+test('generate-disclaimer should show license texts of dependencies', async (): Promise<void> => {
   await runLicensesWithConsole(['generate-disclaimer'], {}, '', (config, reporter, output) => {
     expect(output.stdout).toMatchSnapshot();
     expect(output.consoleout).toMatchSnapshot();


### PR DESCRIPTION
**Summary**

There is [a test][testcase] that attempts to test that license files are show correctly for `yarn licenses generate-disclaimer`. The test currently just prints the license files to the console and doesn't verify what was printed. This pull request modifies the test to not show unwanted output during testing and to actually test that the output is correct.

**Implementation**

The normal method of capturing output isn't sufficient to capture the output of `yarn licenses generate-disclaimer`, since that command [intentionally][1] uses `console.log()` directly. Because of this a special helper function is used that mocks `console.log()` and lets the test verify what was written.

**Test plan**

The `licenses.js.snap`, which is used to verify the commands output, now contains the license text we expect to be printed. The test passes using this .snap file.

**Additional change**

I also renamed the "lists all licenses of the dependencies with the --json argument" test in the same file because it doesn't seem to involve any --json argument.

  [testcase]: https://github.com/yarnpkg/yarn/blob/1a4e9ff4128b3aefe6b57e77a3456813dea6f28a/__tests__/commands/licenses.js#L28
  [1]: https://github.com/yarnpkg/yarn/blob/1a4e9ff4128b3aefe6b57e77a3456813dea6f28a/src/cli/commands/licenses.js#L137