### PR TITLE
Implements "yarn node"

### DIFF
--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -27,6 +27,7 @@ import * as link from './link.js';
 import * as login from './login.js';
 import * as logout from './logout.js';
 import * as list from './list.js';
+import * as node from './node.js';
 import * as outdated from './outdated.js';
 import * as owner from './owner.js';
 import * as pack from './pack.js';
@@ -70,6 +71,7 @@ const commands = {
   login,
   logout,
   list,
+  node,
   outdated,
   owner,
   pack,

--- a/src/cli/commands/node.js
+++ b/src/cli/commands/node.js
@@ -1,0 +1,23 @@
+// @flow
+
+import type Config from '../../config.js';
+import type {Reporter} from '../../reporters/index.js';
+import * as child from '../../util/child.js';
+import {NODE_BIN_PATH} from '../../constants';
+
+export function setFlags(commander: Object) {}
+
+export function hasWrapper(commander: Object, args: Array<string>): boolean {
+  return true;
+}
+
+export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  try {
+    await child.spawn(NODE_BIN_PATH, args, {
+      stdio: 'inherit',
+      cwd: config.cwd,
+    });
+  } catch (err) {
+    throw err;
+  }
+}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -172,10 +172,18 @@ export function main({
   const command = commands[commandName];
 
   let warnAboutRunDashDash = false;
-  // we are using "yarn <script> -abc" or "yarn run <script> -abc", we want -abc to be script options, not yarn options
-  if (command === commands.run || command === commands.create) {
+  // we are using "yarn <script> -abc", "yarn run <script> -abc", or "yarn node -abc", we want -abc
+  // to be script options, not yarn options
+  const PROXY_COMMANDS = new Set([`run`, `create`, `node`]);
+  if (PROXY_COMMANDS.has(commandName)) {
     if (endArgs.length === 0) {
-      endArgs = ['--', ...args.splice(1)];
+      // the "run" and "create" command take one argument that we want to parse as usual (the
+      // script/package name), hence the splice(1)
+      if (command === commands.run || command === commands.create) {
+        endArgs = ['--', ...args.splice(1)];
+      } else {
+        endArgs = ['--', ...args];
+      }
     } else {
       warnAboutRunDashDash = true;
     }


### PR DESCRIPTION
**Summary**

This PR implements a new command called `yarn node`. It is meant to call Node with the correct environment to run the application. The main difference with running Node directly is that Yarn will automatically "cd" to the right directory.

**Test plan**

I manually ran the following commands and checked their outputs:

```
yarn node
yarn node -p 42
yarn node -- -p 42
yarn node script.js
```

I haven't written unit tests for this feature because it is relatively small and self-contained, and because I'm currently designing a new architecture for our tests, which will include tests for this feature. I prefer to spend time on this 🙂 
