### PR TITLE
Improves "yarn workspaces info"

### DIFF
--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -31,9 +31,13 @@ test('workspaces info should list the workspaces', (): Promise<void> => {
     expect(reporter.getBufferJson()).toEqual({
       'workspace-1': {
         location: 'packages/workspace-child-1',
+        workspaceDependencies: [],
+        mismatchedWorkspaceDependencies: [],
       },
       'workspace-2': {
         location: 'packages/workspace-child-2',
+        workspaceDependencies: ['workspace-1'],
+        mismatchedWorkspaceDependencies: [],
       },
     });
   });

--- a/__tests__/fixtures/workspace/run-basic/packages/workspace-child-2/package.json
+++ b/__tests__/fixtures/workspace/run-basic/packages/workspace-child-2/package.json
@@ -5,5 +5,8 @@
     "prescript": "echo workspace-2 prescript",
     "script": "echo workspace-2 script",
     "postscript": "echo workspace-2 postscript"
+  },
+  "dependencies": {
+    "workspace-1": "1.0.0"
   }
 }

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -38,7 +38,7 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
       if (dependencyType !== 'peerDependencies') {
         for (const dependencyName of Object.keys(manifest[dependencyType] || {})) {
           if (Object.prototype.hasOwnProperty.call(workspaces, dependencyName)) {
-            invariant(manifest, manifest[dependencyType], 'The request should exist');
+            invariant(manifest && manifest[dependencyType], 'The request should exist');
             const request = manifest[dependencyType][dependencyName];
             if (semver.satisfies(workspaces[dependencyName].manifest.version, request)) {
               workspaceDependencies.add(dependencyName);

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -38,6 +38,7 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
       if (dependencyType !== 'peerDependencies') {
         for (const dependencyName of Object.keys(manifest[dependencyType] || {})) {
           if (Object.prototype.hasOwnProperty.call(workspaces, dependencyName)) {
+            invariant(manifest, manifest[dependencyType], 'The request should exist');
             const request = manifest[dependencyType][dependencyName];
             if (semver.satisfies(workspaces[dependencyName].manifest.version, request)) {
               workspaceDependencies.add(dependencyName);

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -39,8 +39,8 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
         for (const dependencyName of Object.keys(manifest[dependencyType] || {})) {
           if (Object.prototype.hasOwnProperty.call(workspaces, dependencyName)) {
             invariant(manifest && manifest[dependencyType], 'The request should exist');
-            const request = manifest[dependencyType][dependencyName];
-            if (semver.satisfies(workspaces[dependencyName].manifest.version, request)) {
+            const requestedRange = manifest[dependencyType][dependencyName];
+            if (semver.satisfies(workspaces[dependencyName].manifest.version, requestedRange)) {
               workspaceDependencies.add(dependencyName);
             } else {
               mismatchedWorkspaceDependencies.add(dependencyName);


### PR DESCRIPTION
**Summary**

Running `yarn workspaces info` will now yield information to reconstruct the workspace dependency tree. This information can then be feed to other build systems.

**Test plan**

Updated the tests to include the new fields