### PR TITLE
Do not check for content in publish response

### DIFF
--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -103,17 +103,13 @@ async function publish(config: Config, pkg: any, flags: Object, dir: string): Pr
   pkg.dist.tarball = url.resolve(registry, tbURI).replace(/^https:\/\//, 'http://');
 
   // publish package
-  const res = await config.registries.npm.request(NpmRegistry.escapeName(pkg.name), {
+  await config.registries.npm.request(NpmRegistry.escapeName(pkg.name), {
     method: 'PUT',
     body: root,
   });
 
-  if (res) {
-    await config.executeLifecycleScript('publish');
-    await config.executeLifecycleScript('postpublish');
-  } else {
-    throw new MessageError(config.reporter.lang('publishFail'));
-  }
+  await config.executeLifecycleScript('publish');
+  await config.executeLifecycleScript('postpublish');
 }
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -103,10 +103,14 @@ async function publish(config: Config, pkg: any, flags: Object, dir: string): Pr
   pkg.dist.tarball = url.resolve(registry, tbURI).replace(/^https:\/\//, 'http://');
 
   // publish package
-  await config.registries.npm.request(NpmRegistry.escapeName(pkg.name), {
-    method: 'PUT',
-    body: root,
-  });
+  try {
+    await config.registries.npm.request(NpmRegistry.escapeName(pkg.name), {
+      method: 'PUT',
+      body: root,
+    });
+  } catch (error) {
+    throw new MessageError(config.reporter.lang('publishFail'));
+  }
 
   await config.executeLifecycleScript('publish');
   await config.executeLifecycleScript('postpublish');


### PR DESCRIPTION
**Summary**

This is a fix for #2717 

Do not check for content in publish response - 201 and 202 are successful as well - as discussed in the thread.

This should fix support for 3rd party repositiories.

**Test plan**

Publish on VSTS code works correctly after this fix.

[3/4] Publishing...
verbose 0.691 Performing "PUT" request to "https://<mycompany>.pkgs.visualstudio.com/_packaging/<myrepo>/npm/registry/<mypackage>".
verbose 5.55 Request "https://<mycompany>.pkgs.visualstudio.com/_packaging/<myrepo>/npm/registry/<mypackage>" finished with status code 202.
success Published.

Republish which should fail is still failing correctly:
[3/4] Publishing...
verbose 1.06 Performing "PUT" request to "https://<mycompany>.pkgs.visualstudio.com/_packaging/<myrepo>/npm/registry/<mypackage>".
verbose 3.338 Request "https://<mycompany>..pkgs.visualstudio.com/_packaging/<myrepo>/npm/registry/<mypackage>" finished with status code 403.
verbose 3.352 Error: https://<mycompany>..pkgs.visualstudio.com/_packaging/<myrepo>/npm/registry/<mypackage>: Forbidden

However I can't promise it will cause no regressions on classic NPM repo, but I don't have an account.