### PR TITLE
Spelling

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -1126,7 +1126,7 @@ test.concurrent('installs "latest" instead of maxSatisfying if no requested patt
   // Scenario:
   // If a registry contains versions [1.0.0, 1.0.1, 1.0.2] and latest:1.0.1
   // If `yarn add` is run, it should choose `1.0.1` because it is "latest", not `1.0.2` even though it is newer.
-  // In other words, when no range is explicitely given, Yarn should choose "latest".
+  // In other words, when no range is explicitly given, Yarn should choose "latest".
   //
   // In this test, `ui-select` has a max version of `0.20.0` but a `latest:0.19.8`
   await runAdd(['ui-select'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -70,7 +70,7 @@ test.concurrent('--verify-tree should check skip deeper dev dependencies', async
 test.concurrent('--integrity should ignore comments and whitespaces in yarn.lock', async (): Promise<void> => {
   await runInstall({}, path.join('..', 'check', 'integrity-lock-check'), async (config, reporter): Promise<void> => {
     let lockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
-    lockfile += "\n# ADDING THIS COMMENTN WON'T AFFECT INTEGRITY CHECK \n";
+    lockfile += "\n# ADDING THIS COMMENT WON'T AFFECT INTEGRITY CHECK \n";
     await fs.writeFile(path.join(config.cwd, 'yarn.lock'), lockfile);
 
     let thrown = false;

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -95,7 +95,7 @@ test.concurrent('with two arguments and second argument "version" shows `latest`
   // Scenario:
   // If a registry contains versions [1.0.0, 1.0.1, 1.0.2] and latest:1.0.1
   // If `yarn info` is run, it should choose `1.0.1` because it is "latest", not `1.0.2` even though it is newer.
-  // In other words, when no range is explicitely given, Yarn should choose "latest".
+  // In other words, when no range is explicitly given, Yarn should choose "latest".
   //
   // In this test, `ui-select` has a max version of `0.20.0` but a `latest:0.19.8`
   jest.mock('../__mocks__/request.js');

--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -117,7 +117,7 @@ test('newer transitive dep is overridden by older direct dep', (): Promise<void>
 // Scenario: Transitive dependency having version that is conflicting with another transitive dependency version.
 // Behavior: eslint@3.10.1 is symlinked in node_modeules/.bin
 //           and eslint@3.12.2 is symlinked to node_modules/sample-dep-eslint-3.12.2/node_modules/.bin.
-//           Here it seems like NPM add the modules in alphabatical order
+//           Here it seems like NPM add the modules in alphabetical order
 //           and transitive deps of first dependency is installed at top level.
 test('first transient dep is installed when same level and reference count', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-bin-links-conflicting', async config => {

--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -87,7 +87,7 @@ test('install should respect --no-bin-links flag', (): Promise<void> => {
 });
 
 // Scenario: Transitive dependency having version that is overridden by newer version as the direct dependency.
-// Behavior: eslint@3.12.2 is symlinked in node_modeules/.bin
+// Behavior: eslint@3.12.2 is symlinked in node_modules/.bin
 //           and eslint@3.10.1 is symlinked to node_modules/sample-dep-eslint-3.10.1/node_modules/.bin
 test('newer transitive dep is overridden by newer direct dep', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-bin-links-newer', async config => {
@@ -101,7 +101,7 @@ test('newer transitive dep is overridden by newer direct dep', (): Promise<void>
 });
 
 // Scenario: Transitive dependency having version that is overridden by older version as the direct dependency.
-// Behavior: eslint@3.10.1 is symlinked in node_modeules/.bin
+// Behavior: eslint@3.10.1 is symlinked in node_modules/.bin
 //           and eslint@3.12.2 is symlinked to node_modules/sample-dep-eslint-3.12.2/node_modules/.bin
 test('newer transitive dep is overridden by older direct dep', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-bin-links-older', async config => {
@@ -115,7 +115,7 @@ test('newer transitive dep is overridden by older direct dep', (): Promise<void>
 });
 
 // Scenario: Transitive dependency having version that is conflicting with another transitive dependency version.
-// Behavior: eslint@3.10.1 is symlinked in node_modeules/.bin
+// Behavior: eslint@3.10.1 is symlinked in node_modules/.bin
 //           and eslint@3.12.2 is symlinked to node_modules/sample-dep-eslint-3.12.2/node_modules/.bin.
 //           Here it seems like NPM add the modules in alphabetical order
 //           and transitive deps of first dependency is installed at top level.
@@ -131,7 +131,7 @@ test('first transient dep is installed when same level and reference count', ():
 });
 
 // Scenario: Transitive dependency having version that is conflicting with another dev transitive dependency version.
-// Behavior: eslint@3.10.1 is symlinked in node_modeules/.bin
+// Behavior: eslint@3.10.1 is symlinked in node_modules/.bin
 //           and eslint@3.12.2 is symlinked to node_modules/sample-dep-eslint-3.12.2/node_modules/.bin.
 //           Whether the dependencies are devDependencies or not does not seem to matter to NPM.
 test('first dep is installed when same level and reference count and one is a dev dep', (): Promise<void> => {

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -775,7 +775,7 @@ test.concurrent('install a module with optional dependency should skip incompati
   });
 });
 
-// this tests for a problem occuring due to optional dependency incompatible with os, in this case fsevents
+// this tests for a problem occurring due to optional dependency incompatible with os, in this case fsevents
 // this would fail on os's incompatible with fsevents, which is everything except osx.
 if (process.platform !== 'darwin') {
   test.concurrent(

--- a/__tests__/commands/install/offline-mirror.js
+++ b/__tests__/commands/install/offline-mirror.js
@@ -133,7 +133,7 @@ test('switching platform for installed node_modules should trigger rebuild / usi
     expect(await fs.exists(path.join(config.cwd, 'module-a-build.log'))).toEqual(true);
     expect(tgzFiles.length).toBe(2);
 
-    // runinng install with platform 1 again (no global side effects)
+    // running install with platform 1 again (no global side effects)
     await fs.unlink(path.join(config.cwd, 'node_modules', 'dep-a', 'module-a-build.log'));
     await fs.unlink(path.join(config.cwd, 'module-a-build.log'));
     nameUtils.getSystemParams.mockImplementation(

--- a/__tests__/commands/install/workspaces-install.js
+++ b/__tests__/commands/install/workspaces-install.js
@@ -168,7 +168,7 @@ test.concurrent('install should prioritize non workspace dependency at root over
   });
 });
 
-test.concurrent('install should install subedependencies of workspaces', (): Promise<void> => {
+test.concurrent('install should install subdependencies of workspaces', (): Promise<void> => {
   // the tricky part is that isarray is a subdependency of left-pad that is not referenced in the root
   // but another workspace
   return runInstall({}, 'workspaces-install-subdeps', async (config): Promise<void> => {
@@ -177,7 +177,7 @@ test.concurrent('install should install subedependencies of workspaces', (): Pro
 });
 
 test.concurrent(
-  'install should install subedependencies of workspaces that are not referenced in other workspaces',
+  'install should install subdependencies of workspaces that are not referenced in other workspaces',
   (): Promise<void> => {
     // the tricky part is that left-pad is not a dependency of root
     return runInstall({}, 'workspaces-install-subdeps-2', async (config): Promise<void> => {

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -123,7 +123,7 @@ test.concurrent('pack should exclude all other files if files array is not empty
   });
 });
 
-test.concurrent('pack should exclude all dotflies if not in files and files not empty', (): Promise<void> => {
+test.concurrent('pack should exclude all dotfiles if not in files and files not empty', (): Promise<void> => {
   return runPack([], {}, 'files-exclude-dotfile', async (config): Promise<void> => {
     const {cwd} = config;
     const files = await getFilesFromArchive(

--- a/__tests__/config.js
+++ b/__tests__/config.js
@@ -115,7 +115,7 @@ describe('workspaces config', () => {
     manifest.workspaces = {};
     validateWS(undefined, extractWorkspaces(manifest));
   });
-  test('workspaces is eligibile only for private packages', async () => {
+  test('workspaces is eligible only for private packages', async () => {
     const config = await initConfig({});
     const packages = ['w1', 'w2'];
     const nohoist = ['a'];
@@ -126,7 +126,7 @@ describe('workspaces config', () => {
     manifest.private = false;
     expect(config.getWorkspaces(manifest)).toBeUndefined();
   });
-  test('nohoist is eligibile only for private packages and workspacesNohoistEnabled', async () => {
+  test('nohoist is eligible only for private packages and workspacesNohoistEnabled', async () => {
     const config = await initConfig({});
     const packages = ['w1', 'w2'];
     const nohoist = ['a'];
@@ -171,7 +171,7 @@ describe('workspaces config', () => {
       // ok
     }
 
-    // should not thrown if manifest is eligibile
+    // should not thrown if manifest is eligible
     manifest.private = true;
     expect(config.getWorkspaces(manifest, true)).not.toBeUndefined();
   });

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -312,7 +312,7 @@ test('will hoist packages under subdirectories when they cannot hoist to root', 
   //     -> d@1
   //
   // b,c,d@1 cannot hoist to the root because their @2 versions would be there if not ignored.
-  // However they can still flaten under a@1.
+  // However they can still flatten under a@1.
   const {atPath, ignorePackage, packageHoister} = createTestFixture({
     'a@1.0.0': ['b@1.0.0'],
     'b@1.0.0': ['c@1.0.0'],

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -441,7 +441,7 @@ describe('nohoist', () => {
     expect(result).toContainPackage('c@1.0.0', atPath('a', 'node_modules', 'c'));
     expect(result).toContainPackage('d@1.0.0', atPath('a', 'node_modules', 'd'));
   });
-  test('can dedup and avoid circular reference', () => {
+  test('can dedupe and avoid circular reference', () => {
     const {atPath, packageHoister, packageResolver} = createTestFixture({
       'a@1.0.0': ['c@1.0.0'],
       'b@2.0.0': [],

--- a/__tests__/package-hoister.js
+++ b/__tests__/package-hoister.js
@@ -284,7 +284,7 @@ test('considers ignored packages when determining hoisting', () => {
   // d@1 -> c@2
   //
   // Normally c@2 would hoist to the root, but it cannot because c@5 would be there if it was not ignored.
-  // This preserves deterministic install paths wheter packages are ignored or not.
+  // This preserves deterministic install paths whether packages are ignored or not.
   const {atPath, ignorePackage, packageHoister} = createTestFixture({
     'a@1.0.0': ['d@1.0.0'],
     'b@3.0.0': ['c@5.0.0'],

--- a/__tests__/util/semver.js
+++ b/__tests__/util/semver.js
@@ -1,56 +1,56 @@
 /* @flow */
 
-import {satisfiesWithPreleases} from '../../src/util/semver.js';
+import {satisfiesWithPrereleases} from '../../src/util/semver.js';
 
 const semver = require('semver');
 
-describe('satisfiesWithPreleases', () => {
+describe('satisfiesWithPrereleases', () => {
   it('matches the behavior of node-semver for non-prerelease versions', () => {
     // true
-    expect(satisfiesWithPreleases('2.0.0', '>=1.0.0')).toBe(semver.satisfies('2.0.0', '>=1.0.0'));
-    expect(satisfiesWithPreleases('0.1.1', '^0.1.0')).toBe(semver.satisfies('0.1.1', '^0.1.0'));
-    expect(satisfiesWithPreleases('1.0.1', '~1.0.0')).toBe(semver.satisfies('1.0.1', '~1.0.0'));
+    expect(satisfiesWithPrereleases('2.0.0', '>=1.0.0')).toBe(semver.satisfies('2.0.0', '>=1.0.0'));
+    expect(satisfiesWithPrereleases('0.1.1', '^0.1.0')).toBe(semver.satisfies('0.1.1', '^0.1.0'));
+    expect(satisfiesWithPrereleases('1.0.1', '~1.0.0')).toBe(semver.satisfies('1.0.1', '~1.0.0'));
 
     // false
-    expect(satisfiesWithPreleases('0.2.0', '^0.1.0')).toBe(semver.satisfies('0.2.0', '^0.1.0'));
-    expect(satisfiesWithPreleases('1.1.0', '~1.0.0')).toBe(semver.satisfies('1.1.0', '~1.0.0'));
+    expect(satisfiesWithPrereleases('0.2.0', '^0.1.0')).toBe(semver.satisfies('0.2.0', '^0.1.0'));
+    expect(satisfiesWithPrereleases('1.1.0', '~1.0.0')).toBe(semver.satisfies('1.1.0', '~1.0.0'));
   });
 
   it('matches inexact prerelease versions', () => {
-    expect(satisfiesWithPreleases('1.0.0-beta', '>=1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('2.0.0-alpha', '>=1.0.0-beta')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-beta', '^1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-alpha.2', '^1.0.0-alpha.1')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0', '^1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0', '~1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.1-alpha', '~1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('1.1.0-alpha', '^1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('1.1.0-alpha', '^1.0.0-beta')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-beta', '>=1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('2.0.0-alpha', '>=1.0.0-beta')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-beta', '^1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-alpha.2', '^1.0.0-alpha.1')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0', '^1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0', '~1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.1-alpha', '~1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('1.1.0-alpha', '^1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('1.1.0-alpha', '^1.0.0-beta')).toBe(true);
   });
 
   it('rejects prerelease versions that are too small', () => {
-    expect(satisfiesWithPreleases('1.0.0-alpha', '^1.0.0')).toBe(false);
-    expect(satisfiesWithPreleases('1.0.0-alpha', '>=1.0.0')).toBe(false);
-    expect(satisfiesWithPreleases('1.0.0-alpha', '>=2.0.0-alpha')).toBe(false);
-    expect(satisfiesWithPreleases('0.1.0-alpha', '^0.1.0')).toBe(false);
+    expect(satisfiesWithPrereleases('1.0.0-alpha', '^1.0.0')).toBe(false);
+    expect(satisfiesWithPrereleases('1.0.0-alpha', '>=1.0.0')).toBe(false);
+    expect(satisfiesWithPrereleases('1.0.0-alpha', '>=2.0.0-alpha')).toBe(false);
+    expect(satisfiesWithPrereleases('0.1.0-alpha', '^0.1.0')).toBe(false);
   });
 
   it('rejects prerelease versions that are too big', () => {
-    expect(satisfiesWithPreleases('2.0.0-alpha', '^1.0.0')).toBe(false);
-    expect(satisfiesWithPreleases('3.0.0-alpha', '^1.0.0')).toBe(false);
-    expect(satisfiesWithPreleases('1.1.0-alpha', '~1.0.0')).toBe(false);
-    expect(satisfiesWithPreleases('1.2.0-alpha', '~1.0.0')).toBe(false);
-    expect(satisfiesWithPreleases('1.0.0-alpha.1', '1.0.0-alpha')).toBe(false);
+    expect(satisfiesWithPrereleases('2.0.0-alpha', '^1.0.0')).toBe(false);
+    expect(satisfiesWithPrereleases('3.0.0-alpha', '^1.0.0')).toBe(false);
+    expect(satisfiesWithPrereleases('1.1.0-alpha', '~1.0.0')).toBe(false);
+    expect(satisfiesWithPrereleases('1.2.0-alpha', '~1.0.0')).toBe(false);
+    expect(satisfiesWithPrereleases('1.0.0-alpha.1', '1.0.0-alpha')).toBe(false);
   });
 
   it('follows the semver spec when comparing prerelease versions', () => {
     // Example from http://semver.org/#spec-item-11
-    expect(satisfiesWithPreleases('1.0.0-alpha.1', '>1.0.0-alpha')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-alpha.beta', '>1.0.0-alpha.1')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-beta', '>1.0.0-alpha.beta')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-beta.2', '>1.0.0-beta')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-beta.11', '>1.0.0-beta.2')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0-rc.1', '>1.0.0-beta.11')).toBe(true);
-    expect(satisfiesWithPreleases('1.0.0', '>1.0.0-rc.1')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-alpha.1', '>1.0.0-alpha')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-alpha.beta', '>1.0.0-alpha.1')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-beta', '>1.0.0-alpha.beta')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-beta.2', '>1.0.0-beta')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-beta.11', '>1.0.0-beta.2')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0-rc.1', '>1.0.0-beta.11')).toBe(true);
+    expect(satisfiesWithPrereleases('1.0.0', '>1.0.0-rc.1')).toBe(true);
   });
 });

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -52,8 +52,8 @@ export async function verifyTreeCheck(
     for (const name in rootManifest.dependencies) {
       const version = rootManifest.dependencies[name];
       // skip linked dependencies
-      const isLinkedDepencency = /^link:/i.test(version) || (/^file:/i.test(version) && config.linkFileDependencies);
-      if (isLinkedDepencency) {
+      const isLinkedDependency = /^link:/i.test(version) || (/^file:/i.test(version) && config.linkFileDependencies);
+      if (isLinkedDependency) {
         continue;
       }
       dependenciesToCheckVersion.push({
@@ -68,8 +68,8 @@ export async function verifyTreeCheck(
     for (const name in rootManifest.devDependencies) {
       const version = rootManifest.devDependencies[name];
       // skip linked dependencies
-      const isLinkedDepencency = /^link:/i.test(version) || (/^file:/i.test(version) && config.linkFileDependencies);
-      if (isLinkedDepencency) {
+      const isLinkedDependency = /^link:/i.test(version) || (/^file:/i.test(version) && config.linkFileDependencies);
+      if (isLinkedDependency) {
         continue;
       }
       dependenciesToCheckVersion.push({
@@ -271,9 +271,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     // skip unnecessary checks for linked dependencies
     const remoteType = pkg._reference.remote.type;
-    const isLinkedDepencency =
+    const isLinkedDependency =
       remoteType === 'link' || remoteType === 'workspace' || (remoteType === 'file' && config.linkFileDependencies);
-    if (isLinkedDepencency) {
+    if (isLinkedDependency) {
       continue;
     }
 

--- a/src/cli/commands/team.js
+++ b/src/cli/commands/team.js
@@ -14,7 +14,7 @@ type TeamParts = {
 
 type DeprecationWarning = {
   deprecatedCommand: string,
-  currentComand: string,
+  currentCommand: string,
 };
 
 type CLIFunctionWithParts = (
@@ -49,7 +49,7 @@ function warnDeprecation(reporter: Reporter, deprecationWarning: DeprecationWarn
     reporter.lang(
       'deprecatedCommand',
       `${command} ${deprecationWarning.deprecatedCommand}`,
-      `${command} ${deprecationWarning.currentComand}`,
+      `${command} ${deprecationWarning.currentCommand}`,
     ),
   );
 }
@@ -231,7 +231,7 @@ export const {run, hasWrapper, examples} = buildSubCommands(
       },
       {
         deprecatedCommand: 'rm',
-        currentComand: 'remove',
+        currentCommand: 'remove',
       },
     ),
 
@@ -252,7 +252,7 @@ export const {run, hasWrapper, examples} = buildSubCommands(
       false,
       {
         deprecatedCommand: 'ls',
-        currentComand: 'list',
+        currentCommand: 'list',
       },
     ),
 

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -6,7 +6,7 @@ import {MessageError} from './errors.js';
 import map from './util/map.js';
 import {entries} from './util/misc.js';
 import {version as yarnVersion} from './util/yarn-version.js';
-import {satisfiesWithPreleases} from './util/semver.js';
+import {satisfiesWithPrereleases} from './util/semver.js';
 
 const invariant = require('invariant');
 const semver = require('semver');
@@ -71,7 +71,7 @@ export function testEngine(name: string, range: string, versions: Versions, loos
     return true;
   }
 
-  if (name === 'yarn' && satisfiesWithPreleases(actual, range, looseSemver)) {
+  if (name === 'yarn' && satisfiesWithPrereleases(actual, range, looseSemver)) {
     return true;
   }
 

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -24,7 +24,7 @@ async function fetchOne(ref: PackageReference, config: Config): Promise<FetchedM
   const dest = config.generateHardModulePath(ref);
 
   const remote = ref.remote;
-  // Mock metedata for symlinked dependencies
+  // Mock metadata for symlinked dependencies
   if (remote.type === 'link') {
     const mockPkg: Manifest = {_uid: '', name: '', version: '0.0.0'};
     return Promise.resolve({resolved: null, hash: '', dest, package: mockPkg, cached: false});

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -549,7 +549,7 @@ export default class PackageHoister {
       }
     };
 
-    // add an occuring package to the above data structure
+    // add an occurring package to the above data structure
     const add = (pattern: string, ancestry: Array<Manifest>, ancestryPatterns: Array<string>) => {
       const pkg = this.resolver.getStrictResolvedPattern(pattern);
       if (ancestry.indexOf(pkg) >= 0) {
@@ -632,8 +632,8 @@ export default class PackageHoister {
           mostOccurencePattern = pattern;
         }
       }
-      invariant(mostOccurencePattern, 'expected most occuring pattern');
-      invariant(mostOccurenceCount, 'expected most occuring count');
+      invariant(mostOccurencePattern, 'expected most occurring pattern');
+      invariant(mostOccurenceCount, 'expected most occurring count');
 
       // only hoist this module if it occured more than once
       if (mostOccurenceCount > 1) {

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -213,7 +213,7 @@ export default class PackageInstallScripts {
         }
       }
 
-      // all depedencies are installed
+      // all dependencies are installed
       if (dependenciesFullfilled) {
         return pkg;
       }

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -204,17 +204,17 @@ export default class PackageInstallScripts {
       invariant(ref, 'expected reference');
       const deps = ref.dependencies;
 
-      let dependenciesFullfilled = true;
+      let dependenciesFulfilled = true;
       for (const dep of deps) {
         const pkgDep = this.resolver.getStrictResolvedPattern(dep);
         if (!installed.has(pkgDep)) {
-          dependenciesFullfilled = false;
+          dependenciesFulfilled = false;
           break;
         }
       }
 
       // all dependencies are installed
-      if (dependenciesFullfilled) {
+      if (dependenciesFulfilled) {
         return pkg;
       }
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -13,7 +13,7 @@ import * as promise from './util/promise.js';
 import {entries} from './util/misc.js';
 import * as fs from './util/fs.js';
 import lockMutex from './util/mutex.js';
-import {satisfiesWithPreleases} from './util/semver.js';
+import {satisfiesWithPrereleases} from './util/semver.js';
 import WorkspaceLayout from './workspace-layout.js';
 
 const invariant = require('invariant');
@@ -535,7 +535,7 @@ export default class PackageLinker {
   }
 
   _satisfiesPeerDependency(range: string, version: string): boolean {
-    return range === '*' || satisfiesWithPreleases(version, range, this.config.looseSemver);
+    return range === '*' || satisfiesWithPrereleases(version, range, this.config.looseSemver);
   }
 
   async _warnForMissingBundledDependencies(pkg: Manifest): Promise<void> {

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -214,7 +214,7 @@ export default class PackageResolver {
   }
 
   /**
-   * Get a list of all package names in the depenency graph.
+   * Get a list of all package names in the dependency graph.
    */
 
   getAllDependencyNamesByLevelOrder(seedPatterns: Array<string>): Iterable<string> {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -27,7 +27,7 @@ const REGEX_REGISTRY_SUFFIX = /registry\/?$/;
 export const SCOPE_SEPARATOR = '%2f';
 // All scoped package names are of the format `@scope%2fpkg` from the use of NpmRegistry.escapeName
 // `(?:^|\/)` Match either the start of the string or a `/` but don't capture
-// `[^\/?]+?` Match any character that is not '/' or '?' and capture, up until the first occurance of:
+// `[^\/?]+?` Match any character that is not '/' or '?' and capture, up until the first occurrence of:
 // `(?=%2f|\/)` Match SCOPE_SEPARATOR, the escaped '/', or a raw `/` and don't capture
 // The reason for matching a plain `/` is NPM registry being inconsistent about escaping `/` in
 // scoped package names: when you're fetching a tarball, it is not escaped, when you want info

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -143,7 +143,7 @@ export default class NpmRegistry extends Registry {
 
     const isToRegistry = this.isRequestToRegistry(requestUrl, registry) || this.requestNeedsAuth(requestUrl);
 
-    // this.token must be checked to account for publish requests on non-scopped packages
+    // this.token must be checked to account for publish requests on non-scoped packages
     if (this.token || (isToRegistry && (alwaysAuth || this.isScopedPackage(packageIdent)))) {
       const authorization = this.getAuth(packageIdent);
       if (authorization) {

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -107,7 +107,7 @@ export default class BaseReporter {
   /**
    * `stringifyLangArgs` run `JSON.stringify` on strings too causing
    * them to appear quoted. This marks them as "raw" and prevents
-   * the quiating and escaping
+   * the quoting and escaping
    */
   rawText(str: string): {inspect(): string} {
     return {

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -412,7 +412,7 @@ export default class ConsoleReporter extends BaseReporter {
       };
     }
 
-    // Clear any potentiall old progress bars
+    // Clear any potentially old progress bars
     this.stopProgress();
 
     const bar = (this._progressBar = new Progress(count, this.stderr, (progress: Progress) => {

--- a/src/util/blocking-queue.js
+++ b/src/util/blocking-queue.js
@@ -46,7 +46,7 @@ export default class BlockingQueue {
 
     this.stuckTimer = setTimeout(this.stuckTick, 5000);
 
-    // We need to check the existense of unref because of https://github.com/facebook/jest/issues/4559
+    // We need to check the existence of unref because of https://github.com/facebook/jest/issues/4559
     // $FlowFixMe: Node's setInterval returns a Timeout, not a Number
     this.stuckTimer.unref && this.stuckTimer.unref();
   }

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -197,7 +197,7 @@ async function buildActionsForCopy(
     await Promise.all(items.map(build));
   }
 
-  // simulate the existence of some files to prevent considering them extraenous
+  // simulate the existence of some files to prevent considering them extraneous
   for (const file of artifactFiles) {
     if (possibleExtraneous.has(file)) {
       reporter.verbose(reporter.lang('verboseFilePhantomExtraneous', file));
@@ -405,7 +405,7 @@ async function buildActionsForHardlink(
     await Promise.all(items.map(build));
   }
 
-  // simulate the existence of some files to prevent considering them extraenous
+  // simulate the existence of some files to prevent considering them extraneous
   for (const file of artifactFiles) {
     if (possibleExtraneous.has(file)) {
       reporter.verbose(reporter.lang('verboseFilePhantomExtraneous', file));

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -560,7 +560,7 @@ export function copy(src: string, dest: string, reporter: Reporter): Promise<voi
 
 /**
  * Unlinks the destination to force a recreation. This is needed on case-insensitive file systems
- * to force the correct naming when the filename has changed only in charater-casing. (Jest -> jest).
+ * to force the correct naming when the filename has changed only in character-casing. (Jest -> jest).
  * It also calls a cleanup function once it is done.
  *
  * `data` contains target file attributes like mode, atime and mtime. Built-in copyFile copies these

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -7,7 +7,7 @@ const semver = require('semver');
  * prerelease versions so that "2.0.0-rc.0" satisfies the range ">=1.0.0", for example.
  */
 
-export function satisfiesWithPreleases(version: string, range: string, loose?: boolean = false): boolean {
+export function satisfiesWithPrereleases(version: string, range: string, loose?: boolean = false): boolean {
   let semverRange;
   try {
     // $FlowFixMe: Add a definition for the Range class


### PR DESCRIPTION
**Summary**

Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

**Test plan**

This isn't tested.
I plan to let whatever CI you have tell me about any gaps.

Note: there's at least one API change: `satisfiesWithPrereleases`. It can be split out; a shim for the misspelling can be added...