### PR TITLE
test(info): Fix failing `yarn info <package> readme` tests

### DIFF
--- a/__tests__/commands/__snapshots__/info.js.snap
+++ b/__tests__/commands/__snapshots__/info.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`left-pad readme 1`] = `
+"## left-pad
+
+String left pad
+
+[![Build Status][travis-image]][travis-url]
+
+## Install
+
+\`\`\`bash
+$ npm install left-pad
+\`\`\`
+
+## Usage
+
+\`\`\`js
+const leftPad = require('left-pad')
+
+leftPad('foo', 5)
+// => \\"  foo\\"
+
+leftPad('foobar', 6)
+// => \\"foobar\\"
+
+leftPad(1, 2, '0')
+// => \\"01\\"
+
+leftPad(17, 5, 0)
+// => \\"00017\\"
+\`\`\`
+
+**NOTE:** The third argument should be a single \`char\`. However the module doesn't throw an error if you supply more than one \`char\`s. See [#28](https://github.com/stevemao/left-pad/pull/28).
+
+[travis-image]: https://travis-ci.org/stevemao/left-pad.svg?branch=master
+[travis-url]: https://travis-ci.org/stevemao/left-pad
+
+## Typings
+
+Typings copied from [@types/left-pad](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/left-pad) for convenience.
+"
+`;

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -79,15 +79,15 @@ test.concurrent('with one argument shows info about the package with specified n
 });
 
 test.concurrent('with one argument does not contain readme field', (): Promise<void> => {
-  return runInfo(['yarn'], {}, '', (config, output): ?Promise<void> => {
+  return runInfo(['left-pad'], {}, '', (config, output): ?Promise<void> => {
     expect(output.readme).toBe(undefined);
   });
 });
 
 test.concurrent('with two arguments and second argument "readme" shows readme string', (): Promise<void> => {
-  return runInfo(['yarn', 'readme'], {}, '', (config, output): ?Promise<void> => {
+  return runInfo(['left-pad', 'readme'], {}, '', (config, output): ?Promise<void> => {
     expect(typeof output).toBe('string');
-    expect(output).toMatch(/Installing\sYarn/);
+    expect(output).toMatchSnapshot('left-pad readme');
   });
 });
 


### PR DESCRIPTION
**Summary**

`yarn info` tests were broken due to some registry changes. This patch updates the tests to use an
older package, left-pad to get master green.

**Test plan**

Fixes tests. All builds should pass.