### PR TITLE
Restrict .gitignore to their own subdirectories

### DIFF
--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -109,6 +109,19 @@ test.concurrent('pack should exclude mandatory files from ignored directories', 
   });
 });
 
+test.concurrent('pack should include files only ignored in other directories', (): Promise<void> => {
+  return runPack([], {}, 'include-files-ignored-in-other-directories', async (config): Promise<void> => {
+    const {cwd} = config;
+    const files = await getFilesFromArchive(
+      path.join(cwd, 'include-files-ignored-in-other-directories-v1.0.0.tgz'),
+      path.join(cwd, 'include-files-ignored-in-other-directories-v1.0.0'),
+    );
+    expect(files.indexOf('a.js')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('index.js')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('ignoring/file.js')).toEqual(-1);
+  });
+});
+
 test.concurrent('pack should exclude all other files if files array is not empty', (): Promise<void> => {
   return runPack([], {}, 'files-exclude', async (config): Promise<void> => {
     const {cwd} = config;

--- a/__tests__/fixtures/pack/include-files-ignored-in-other-directories/a.js
+++ b/__tests__/fixtures/pack/include-files-ignored-in-other-directories/a.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/include-files-ignored-in-other-directories/ignoring/.gitignore
+++ b/__tests__/fixtures/pack/include-files-ignored-in-other-directories/ignoring/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/__tests__/fixtures/pack/include-files-ignored-in-other-directories/ignoring/file.js
+++ b/__tests__/fixtures/pack/include-files-ignored-in-other-directories/ignoring/file.js
@@ -1,0 +1,4 @@
+/* @flow */
+console.log('hello world');
+
+// File forcefully added to git

--- a/__tests__/fixtures/pack/include-files-ignored-in-other-directories/index.js
+++ b/__tests__/fixtures/pack/include-files-ignored-in-other-directories/index.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/__tests__/fixtures/pack/include-files-ignored-in-other-directories/package.json
+++ b/__tests__/fixtures/pack/include-files-ignored-in-other-directories/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "include-files-ignored-in-other-directories",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -95,13 +95,20 @@ export function sortFilter(
 }
 
 export function matchesFilter(filter: IgnoreFilter, basename: string, loc: string): boolean {
+  let filterByBasename = true;
   if (filter.base && filter.base !== '.') {
     loc = path.relative(filter.base, loc);
+    filterByBasename = false;
   }
   // the micromatch regex expects unix path separators
   loc = loc.replace('\\', '/');
 
-  return filter.regex.test(loc) || filter.regex.test(`/${loc}`) || mm.isMatch(loc, filter.pattern);
+  return (
+    filter.regex.test(loc) ||
+    filter.regex.test(`/${loc}`) ||
+    (filterByBasename && filter.regex.test(basename)) ||
+    mm.isMatch(loc, filter.pattern)
+  );
 }
 
 export function ignoreLinesToRegex(lines: Array<string>, base: string = '.'): Array<IgnoreFilter> {

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -100,10 +100,10 @@ export function matchesFilter(filter: IgnoreFilter, basename: string, loc: strin
   }
   // the micromatch regex expects unix path separators
   loc = loc.replace('\\', '/');
+
   return (
     filter.regex.test(loc) ||
     filter.regex.test(`/${loc}`) ||
-    filter.regex.test(basename) ||
     mm.isMatch(loc, filter.pattern)
   );
 }

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -101,11 +101,7 @@ export function matchesFilter(filter: IgnoreFilter, basename: string, loc: strin
   // the micromatch regex expects unix path separators
   loc = loc.replace('\\', '/');
 
-  return (
-    filter.regex.test(loc) ||
-    filter.regex.test(`/${loc}`) ||
-    mm.isMatch(loc, filter.pattern)
-  );
+  return filter.regex.test(loc) || filter.regex.test(`/${loc}`) || mm.isMatch(loc, filter.pattern);
 }
 
 export function ignoreLinesToRegex(lines: Array<string>, base: string = '.'): Array<IgnoreFilter> {


### PR DESCRIPTION
**Summary**
Fixed the bug from #5407 and #2603.

The function `matchesFilter` returned `true` if the file's relative path or its basename matched the given regular expression. I adjusted this to only test the basename for a match if the `base` option is not set (or set to `.`).

**Test plan**
I added the test `pack should include files only ignored in other directories`.

Two tests were failing on my local build, but they were also failing before making the changes. All other tests were green.