### PR TITLE
Enforce usage of TLS 1.2 when building Chocolatey package

### DIFF
--- a/scripts/build-chocolatey.ps1
+++ b/scripts/build-chocolatey.ps1
@@ -7,6 +7,10 @@ param(
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
+# Enforce usage of TLS 1.2, as GitHub requires it. PowerShell uses TLS 1.0 by 
+# default, which causes "Could not create SSL/TLS secure channel" errors
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+
 if ($Env:YARN_RC -eq 'true') {
   Write-Output 'This is an RC release; Chocolatey will not be updated'
   Exit


### PR DESCRIPTION
**Summary**
Currently, the Chocolatey build is failing: https://github.com/yarnpkg/yarn/issues/5416

```
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Jenkins\workspace\yarn-chocolatey\scripts\build-chocolatey.ps1:44 char:1
+ Invoke-WebRequest -Uri $url -OutFile $installer_file
```

Github appears to have started enforcing TLS 1.2 at some point: https://www.ssllabs.com/ssltest/analyze.html?d=github.com
![](https://d.sb/2018/02/firefox_27-13.51.59.png)

However, PowerShell uses TLS 1.0 by default. This causes an error when loading from GitHub via `Invoke-WebRequest`:
```
PS C:\Users\danlo> Invoke-WebRequest -Uri https://github.com/
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
At line:1 char:1
+ Invoke-WebRequest -Uri https://github.com/
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

We need to enforce TLS 1.2 to make it work:
```
[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
```

**Test plan**
Downloading Yarn installer via Invoke-WebRequest was failing:
```
Invoke-WebRequest -Uri "https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-1.5.1.msi" -OutFile "c:\temp\yarn.msi"
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
At line:1 char:1
+ Invoke-WebRequest -Uri "https://github.com/yarnpkg/yarn/releases/down ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebExcept
   ion
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

Now it works!