### PR TITLE
Makes CircleCI run the pkg-tests testsuite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,25 @@ test_steps: &test_steps
     - *test_build
     - *test_run
 
+pkg_tests_install: &pkg_tests_install
+  run:
+    name: Install the dependencies for the pkg-tests testsuite
+    command: |
+        ./bin/yarn --cwd packages/pkg-tests
+
+pkg_tests_run: &pkg_tests_run
+  run:
+    name: Tests (pkg-tests testsuite)
+    command: |
+        ./bin/yarn --cwd packages/pkg-tests jest yarn.test.js
+
+pkg_tests: &pkg_tests
+  steps:
+    - *attach_workspace
+    - *test_build
+    - *pkg_tests_install
+    - *pkg_tests_run
+
 default_filters: &default_filters
   tags:
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
@@ -96,6 +115,9 @@ jobs:
           root: ~/project
           paths:
             - yarn
+  test-pkg-tests-linux-node8:
+    <<: *docker_defaults
+    <<: *pkg_tests
   test-linux-node8:
     <<: *docker_defaults
     <<: *test_steps
@@ -163,6 +185,10 @@ workflows:
           filters: *default_filters
           requires:
             - install
+      - test-pkg-tests-linux-node8:
+          filters: *default_filters
+          requires:
+            - install
       - test-linux-node8:
           filters: *default_filters
           requires:
@@ -193,6 +219,7 @@ workflows:
             branches:
               ignore: /.*/
           requires:
+            - test-pkg-tests-linux-node8
             - test-linux-node8
             - test-linux-node6
             - test-linux-node4

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "build-win-installer": "scripts\\build-windows-installer.bat",
     "dupe-check": "yarn jsinspect ./src",
     "lint": "eslint . && flow check",
+    "pkg-tests": "yarn --cwd packages/pkg-tests jest yarn.test.js",
     "prettier": "eslint src __tests__ --fix",
     "release-branch": "./scripts/release-branch.sh",
     "test": "yarn lint && yarn test-only",

--- a/packages/pkg-tests/yarn.test.js
+++ b/packages/pkg-tests/yarn.test.js
@@ -10,7 +10,7 @@ const {basic: basicSpecs, dragon: dragonSpecs} = require(`pkg-tests-specs`);
 const pkgDriver = generatePkgDriver({
   runDriver: (path, args, {registryUrl}) => {
     const extraArgs = [`--cache-folder`, `${path}/.cache`];
-    return execFile(process.execPath, [`${process.cwd()}/../../dist/bin/yarn.js`, ...extraArgs, ...args], {
+    return execFile(process.execPath, [`${process.cwd()}/../../bin/yarn.js`, ...extraArgs, ...args], {
       env: {[`NPM_CONFIG_REGISTRY`]: registryUrl, [`YARN_SILENT`]: `1`},
       cwd: path,
     });


### PR DESCRIPTION
**Summary**

This PR makes CircleCI run a test instance for the pkg-tests testsuite. It's currently only run on a Node 8 instance, but this can be improved later on.

**Test plan**

CircleCI