### PR TITLE
Disables jest-haste-map for the fixtures

### DIFF
--- a/packages/pkg-tests/package.json
+++ b/packages/pkg-tests/package.json
@@ -22,5 +22,10 @@
         "bracketSpacing": false,
         "printWidth": 120,
         "parser": "flow"
+    },
+    "jest": {
+        "modulePathIgnorePatterns": [
+            "<rootDir>[/\\\\]pkg-tests-fixtures[/\\\\]packages[/\\\\]"
+        ]
     }
 }


### PR DESCRIPTION
**Summary**

Remove this from the output of running the pkg-tests testsuite:

<img width="1494" alt="screen shot 2018-03-01 at 3 45 33 pm" src="https://user-images.githubusercontent.com/1037931/36853941-a92bee78-1d67-11e8-817d-560e86a3e58c.png">

**Test plan**

Manual check + CircleCI