### PR TITLE
ci(appveyor): Remove old Node builds from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 environment:
   matrix:
     - node_version: "8"
-    - node_version: "6"
-    - node_version: "4"
 
 branches:
   only:


### PR DESCRIPTION
**Summary**

AppVeyor only has one container and runs all different tests sequentially, taking up to 50 minutes
for a full build. Node 4 will become obsolete next month and we don't really want to provide too
much support for Node 6 so this patch removes leaves only Node 8 on AppVeyor builds.

**Test Plan**

CI should pass.