### PR TITLE
fix(run): Fix script running in paths with special chars

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -354,10 +354,26 @@ test('yarn run <script> <strings that need escaping>', async () => {
 
   const options = {cwd, env: {YARN_SILENT: 1}};
 
-  const trickyStrings = ['$PWD', '%CD%', '^', '!', '\\', '>', '<', '|', '&', "'", '"', '`', '  '];
+  const trickyStrings = ['$PWD', '%CD%', '^', '!', '\\', '>', '<', '|', '&', "'", '"', '`', '  ', '()'];
   const [stdout] = await runYarn(['stringify', ...trickyStrings], options);
 
   expect(stdout.toString().trim()).toEqual(JSON.stringify(trickyStrings));
+});
+
+test('yarn run in path need escaping', async () => {
+  const cwd = await makeTemp('special (chars)');
+
+  await fs.writeFile(path.join(cwd, 'package.json'), '{}');
+  const binDir = path.join(cwd, 'node_modules', '.bin');
+  await fs.mkdirp(binDir);
+  await fs.writeFile(path.join(binDir, 'yolo'), 'echo yolo');
+  await fs.writeFile(path.join(binDir, 'yolo.cmd'), '@ECHO off\necho yolo');
+
+  const options = {cwd, env: {YARN_SILENT: 1}};
+
+  const [stdout] = await runYarn(['yolo'], options);
+
+  expect(stdout.toString().trim()).toEqual('yolo');
 });
 
 test('cache folder fallback', async () => {

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -366,8 +366,11 @@ test('yarn run in path need escaping', async () => {
   await fs.writeFile(path.join(cwd, 'package.json'), '{}');
   const binDir = path.join(cwd, 'node_modules', '.bin');
   await fs.mkdirp(binDir);
-  await fs.writeFile(path.join(binDir, 'yolo'), 'echo yolo');
-  await fs.writeFile(path.join(binDir, 'yolo.cmd'), '@ECHO off\necho yolo');
+  const executablePath = path.join(binDir, 'yolo');
+  await fs.writeFile(executablePath, 'echo yolo');
+  await fs.chmod(executablePath, 0o755);
+  // For Windows
+  await fs.writeFile(`${executablePath}.cmd`, '@ECHO off\necho yolo');
 
   const options = {cwd, env: {YARN_SILENT: 1}};
 

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -392,7 +392,7 @@ test('yarn run <script> <strings that need escaping>', async () => {
 
   const options = {cwd, env: {YARN_SILENT: 1}};
 
-  const trickyStrings = ['$PWD', '%CD%', '^', '!', '\\', '>', '<', '|', '&', "'", '"', '`', '  ', '()'];
+  const trickyStrings = ['$PWD', '%CD%', '^', '!', '\\', '>', '<', '|', '&', "'", '"', '`', '  ', '(', ')'];
   const [stdout] = await runYarn(['stringify', ...trickyStrings], options);
 
   expect(stdout.toString().trim()).toEqual(JSON.stringify(trickyStrings));

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -184,18 +184,7 @@ export async function executeLifecycleScript(
 
   await checkForGypIfNeeded(config, cmd, env[constants.ENV_PATH_KEY].split(path.delimiter));
 
-  // get shell
-  let sh = 'sh';
-  let shFlag = '-c';
-
-  let windowsVerbatimArguments = undefined;
-
-  if (customShell) {
-    sh = customShell;
-  } else if (process.platform === 'win32') {
-    sh = process.env.comspec || 'cmd';
-    shFlag = '/d /s /c';
-    windowsVerbatimArguments = true;
+  if (process.platform === 'win32' && (!customShell || customShell === 'cmd')) {
     // handle windows run scripts starting with a relative path
     cmd = fixCmdWinSlashes(cmd);
   }
@@ -219,7 +208,9 @@ export async function executeLifecycleScript(
       }
     };
   }
-  const stdout = await child.spawn(sh, [shFlag, cmd], {cwd, env, stdio, windowsVerbatimArguments}, updateProgress);
+  const stdout = customShell
+    ? await child.spawn(customShell, [cmd], {cwd, env, stdio, windowsVerbatimArguments: true}, updateProgress)
+    : await child.spawn(cmd, [], {cwd, env, stdio, shell: true}, updateProgress);
 
   return {cwd, command: cmd, stdout};
 }


### PR DESCRIPTION
**Summary**

Fixes #5481.

With #5133, we have stopped passing the command/script name to the shell properly. This patch makes
sure the proper escaping is done when not using the `script-shell` option.

This patch may also fix #5479.

**Test plan**

Added a new integration test.