### PR TITLE
Fix yarn behaviour when scripts are failing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,7 +19,8 @@
      "plugins": [
        ["array-includes"],
        ["transform-inline-imports-commonjs"],
-       ["transform-runtime", { "polyfill": true, "regenerator": false }]
+       ["transform-runtime", { "polyfill": true, "regenerator": false }],
+       ["transform-builtin-extend", { "globals": ["Error"] }]
      ]
    },
    "test": {

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -398,6 +398,30 @@ test('yarn run <script> <strings that need escaping>', async () => {
   expect(stdout.toString().trim()).toEqual(JSON.stringify(trickyStrings));
 });
 
+test('yarn run <failing script>', async () => {
+  const cwd = await makeTemp();
+
+  await fs.writeFile(
+    path.join(cwd, 'package.json'),
+    JSON.stringify({
+      license: 'MIT',
+      scripts: {false: 'false'},
+    }),
+  );
+
+  let stderr = null;
+  let err = null;
+  try {
+    await runYarn(['run', 'false'], {cwd, env: {YARN_SILENT: 1}});
+  } catch (e) {
+    stderr = e.stderr.trim();
+    err = e.code;
+  }
+
+  expect(err).toEqual(1);
+  expect(stderr).toEqual('error Command failed with exit code 1.');
+});
+
 test('yarn run in path need escaping', async () => {
   const cwd = await makeTemp('special (chars)');
 

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -412,7 +412,7 @@ test('yarn run <failing script>', async () => {
   let stderr = null;
   let err = null;
   try {
-    await runYarn(['run', 'false'], {cwd, env: {YARN_SILENT: 1}});
+    await runYarn(['run', 'false'], {cwd});
   } catch (e) {
     stderr = e.stderr.trim();
     err = e.code;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-eslint": "^7.2.3",
     "babel-loader": "^6.2.5",
     "babel-plugin-array-includes": "^2.0.3",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-inline-imports-commonjs": "^1.0.0",
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-env": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,6 +629,13 @@ babel-plugin-transform-async-to-generator@^6.22.0, babel-plugin-transform-async-
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-builtin-extend@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz#5e96fecf58b8fa1ed74efcad88475b2af3c9116e"
+  dependencies:
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
+
 babel-plugin-transform-class-constructor-call@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"
@@ -988,7 +995,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1012,7 +1019,7 @@ babel-template@^6.16.0, babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-template@^6.26.0:
+babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:


### PR DESCRIPTION
**Summary**
Fix for #5451, #5457.

The test case in the first commit fails for pre-node5 builds, in the way described in the links issues. The problem are classes deriving from `Error`, which are problematic in ES5 ([babel][babel-Error]). Adding `babel-plugin-transform-builtin-extend` fixes the issue in this case.

**Why now?**
The error surfaced because the [current yarn build published on npm][v1.5.1] is a pre-node5 build while for example [v1.3.1][v1.3.1] seems to have been created by the more modern build configuration. This can be seen by checking if code like "class A extends B" got compiled to ES5 or not.

 [babel-Error]: https://babeljs.io/docs/usage/caveats/#classes
 [v1.3.1]: https://registry.npmjs.org/yarn/-/yarn-1.3.1.tgz
 [v1.5.1]: https://registry.npmjs.org/yarn/-/yarn-1.5.1.tgz