### PR TITLE
fix(cli): adjust colors for unstable version updates

### DIFF
--- a/__tests__/util/semver.js
+++ b/__tests__/util/semver.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-import {satisfiesWithPrereleases} from '../../src/util/semver.js';
-
-const semver = require('semver');
+import semver from 'semver';
+import {satisfiesWithPrereleases, diffWithUnstable} from '../../src/util/semver.js';
 
 describe('satisfiesWithPrereleases', () => {
   it('matches the behavior of node-semver for non-prerelease versions', () => {
@@ -52,5 +51,46 @@ describe('satisfiesWithPrereleases', () => {
     expect(satisfiesWithPrereleases('1.0.0-beta.11', '>1.0.0-beta.2')).toBe(true);
     expect(satisfiesWithPrereleases('1.0.0-rc.1', '>1.0.0-beta.11')).toBe(true);
     expect(satisfiesWithPrereleases('1.0.0', '>1.0.0-rc.1')).toBe(true);
+  });
+});
+
+describe('diffWithUnstable', () => {
+  it('matches the behavior of node-semver for stable versions', () => {
+    expect(diffWithUnstable('2.0.0', '1.0.0')).toBe(semver.diff('2.0.0', '1.0.0'));
+    expect(diffWithUnstable('2.1.0', '2.0.0')).toBe(semver.diff('2.1.0', '2.0.0'));
+    expect(diffWithUnstable('2.1.1', '2.1.0')).toBe(semver.diff('2.1.1', '2.1.0'));
+    expect(diffWithUnstable('2.1.1-beta', '2.1.0')).toBe(semver.diff('2.1.1-beta', '2.1.0'));
+    expect(diffWithUnstable('2.1.1-alpha', '2.1.1')).toBe(semver.diff('2.1.1-alpha', '2.1.1'));
+    expect(diffWithUnstable('2.1.1', '2.1.1')).toBe(semver.diff('2.1.1', '2.1.1'));
+    expect(diffWithUnstable('2.1.1-rc', '2.1.1-rc')).toBe(semver.diff('2.1.1-rc', '2.1.1-rc'));
+  });
+
+  it('treats patch and minor releases for pre-major versions as minor & major respectively', () => {
+    expect(diffWithUnstable('0.2.0', '0.2.1')).toBe('minor');
+    expect(diffWithUnstable('0.2.0', '0.2.1-rc')).toBe('preminor');
+    expect(diffWithUnstable('0.1.0', '0.2.0')).toBe('major');
+    expect(diffWithUnstable('0.1.0', '0.2.0-alpha')).toBe('premajor');
+    expect(diffWithUnstable('0.2.1', '1.0.0')).toBe('major');
+    expect(diffWithUnstable('0.2.1-rc', '1.0.0-beta')).toBe('premajor');
+    expect(diffWithUnstable('0.2.2-rc.0', '0.2.2-rc.1')).toBe('prerelease');
+  });
+
+  it('treats patch and minor releases for pre-minor versions as major', () => {
+    expect(diffWithUnstable('0.0.1', '0.0.2')).toBe('major');
+    expect(diffWithUnstable('0.0.1', '0.0.2-rc')).toBe('premajor');
+    expect(diffWithUnstable('0.0.2', '0.1.0')).toBe('major');
+    expect(diffWithUnstable('0.0.2', '0.1.0-alpha')).toBe('premajor');
+    expect(diffWithUnstable('0.0.2', '1.0.0')).toBe('major');
+    expect(diffWithUnstable('0.0.2-rc', '1.0.0-beta')).toBe('premajor');
+    expect(diffWithUnstable('0.0.2-rc.1', '0.0.2-rc.2')).toBe('prerelease');
+  });
+
+  it('returns null for equal versions', () => {
+    expect(diffWithUnstable('1.0.0', '1.0.0')).toBeNull();
+    expect(diffWithUnstable('2.0.1-beta.0', '2.0.1-beta.0')).toBeNull();
+    expect(diffWithUnstable('0.2.1', '0.2.1')).toBeNull();
+    expect(diffWithUnstable('0.2.3-alpha', '0.2.3-alpha')).toBeNull();
+    expect(diffWithUnstable('0.0.11', '0.0.11')).toBeNull();
+    expect(diffWithUnstable('0.0.100-beta.2', '0.0.100-beta.2')).toBeNull();
   });
 });

--- a/src/util/color-for-versions.js
+++ b/src/util/color-for-versions.js
@@ -1,5 +1,6 @@
 /* @flow */
 import semver from 'semver';
+import {diffWithUnstable} from './semver.js';
 import {VERSION_COLOR_SCHEME} from '../constants.js';
 import type {VersionColor} from '../constants.js';
 
@@ -8,7 +9,7 @@ export default function(from: string, to: string): VersionColor {
   const validTo = semver.valid(to);
   let versionBump = 'unknown';
   if (validFrom && validTo) {
-    versionBump = semver.diff(validFrom, validTo) || 'unchanged';
+    versionBump = diffWithUnstable(validFrom, validTo) || 'unchanged';
   }
   return VERSION_COLOR_SCHEME[versionBump];
 }

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const semver = require('semver');
+import semver, {type Release} from 'semver';
 
 /**
  * Returns whether the given semver version satisfies the given range. Notably this supports
@@ -44,4 +44,67 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
 
     return !comparatorSet.some(comparator => !comparator.test(semverVersion));
   });
+}
+
+const PRE_RELEASES = {
+  major: 'premajor',
+  minor: 'preminor',
+  patch: 'prepatch',
+};
+
+/**
+ * Returns the difference between two versions as a semantic string representation.
+ * Similar to the `diff` method in node-semver, but it also accounts for unstable versions,
+ * like 0.x.x or 0.0.x.
+ */
+
+export function diffWithUnstable(version1: string, version2: string): Release | null {
+  if (semver.eq(version1, version2) === false) {
+    const v1 = semver.parse(version1);
+    const v2 = semver.parse(version2);
+
+    if (v1 != null && v2 != null) {
+      const isPreRelease = v1.prerelease.length > 0 || v2.prerelease.length > 0;
+      const preMajor = v1.major === 0 || v2.major === 0;
+      const preMinor = preMajor && (v1.minor === 0 || v2.minor === 0);
+
+      let diff = null;
+
+      if (v1.major !== v2.major) {
+        diff = 'major';
+      } else if (v1.minor !== v2.minor) {
+        if (preMajor) {
+          // If the major version number is zero (0.x.x), treat a change
+          // of the minor version number as a major change.
+          diff = 'major';
+        } else {
+          diff = 'minor';
+        }
+      } else if (v1.patch !== v2.patch) {
+        if (preMinor) {
+          // If the major & minor version numbers are zero (0.0.x), treat a change
+          // of the patch version number as a major change.
+          diff = 'major';
+        } else if (preMajor) {
+          // If the major version number is zero (0.x.x), treat a change
+          // of the patch version number as a minor change.
+          diff = 'minor';
+        } else {
+          diff = 'patch';
+        }
+      }
+
+      if (isPreRelease) {
+        if (diff != null) {
+          diff = PRE_RELEASES[diff];
+        } else {
+          diff = 'prerelease';
+        }
+      }
+
+      return diff;
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
**Summary**

Fixes #4942.

The yarn CLI uses colors to indicate backwards compatibility for version updates in the `yarn outdated` and `yarn upgrade-interactive` commands. These can be confusing and also misleading for updates to unstable package versions (0.x.y & 0.0.x), as it doesn't match either the semver spec nor how both yarn and npm handle updates to these versions using caret-ranges. 

This change special-cases the diff calculation, along with the color representation, for updates to *unstable* package versions, to more accurately indicate the level of backwards compatibility.

For `0.x.y` versions, increments to the *minor* version number (`y`) will be considered a *major* version change, and increments to the *patch* version number (`x`), will be considered a *minor* version change.

For `0.0.x` versions, increments to *any* version number will be considered a *major* version change.

This matches the behavior of how both yarn & npm[1] treats updates to packages defined with a caret-range, and anecdotally how most package authors treat updates in these version ranges. The semver *spec* is less specific regarding this, and states[2] that *any* version change to "Major version zero" versions could be breaking.

References:
[1] https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004
[2] https://semver.org/#spec-item-4

**Test plan**

Added unit tests.

**Example output for `yarn outdated`**

Before:
![screenshot from 2018-03-10 18-37-55](https://user-images.githubusercontent.com/173085/37245047-ab32df10-2492-11e8-8dff-e1051d0721b0.png)

After:
![screenshot from 2018-03-10 18-38-18](https://user-images.githubusercontent.com/173085/37245048-b19abdf0-2492-11e8-8267-816510107c16.png)
