### PR TITLE
feat: allows yarn config set to override package.json config keys

### DIFF
--- a/__tests__/util/execute-lifecycle-script.js
+++ b/__tests__/util/execute-lifecycle-script.js
@@ -1,0 +1,100 @@
+/* @flow */
+import path from 'path';
+import {makeEnv} from '../../src/util/execute-lifecycle-script';
+import Config from '../../src/config';
+import {NoopReporter} from '../../src/reporters';
+
+const cwd = path.resolve(__dirname);
+
+const initConfig = async cfg => {
+  const reporter = new NoopReporter();
+  const config = new Config(reporter);
+  await config.init(cfg);
+  return config;
+};
+
+const withManifest = async (stage, value, keys = {}) => {
+  const config = await initConfig({});
+  config.maybeReadManifest = dir => {
+    expect(dir).toEqual(cwd);
+    return Promise.resolve({
+      scripts: {[stage]: value},
+      ...keys,
+    });
+  };
+  return config;
+};
+
+describe('makeEnv', () => {
+  it('assigns npm_lifecycle_event to env', async () => {
+    const stage = 'my-script';
+    const config = await initConfig({});
+    const env = await makeEnv(stage, cwd, config);
+    expect(env.npm_lifecycle_event).toEqual(stage);
+  });
+
+  it('assigns NODE_ENV production', async () => {
+    const config = await initConfig({production: true});
+    const env = await makeEnv('test-script', cwd, config);
+    expect(env.NODE_ENV).toEqual('production');
+  });
+
+  describe('npm_package_*', () => {
+    it('assigns npm_lifecycle_script if manifest has a matching script', async () => {
+      const stage = 'test-script';
+      const value = 'run this script';
+      const config = await withManifest(stage, value);
+      const env = await makeEnv(stage, cwd, config);
+      expect(env.npm_lifecycle_script).toEqual(value);
+    });
+
+    it('does not overwrite npm_lifecycle_script if manifest does not have a matching script', async () => {
+      const stage = 'test-script';
+      const config = await withManifest('wrong-stage', 'new value');
+      const env = await makeEnv(stage, cwd, config);
+      expect(env.npm_lifecycle_script).toEqual(process.env.npm_lifecycle_script);
+    });
+
+    it('recursively adds keys separated by _', async () => {
+      const config = await withManifest('', '', {
+        top: 'first',
+        recursive: {
+          key: 'value',
+          more: {another: 'what'},
+        },
+      });
+      const env = await makeEnv('', cwd, config);
+      expect(env['npm_package_top']).toEqual('first');
+      expect(env['npm_package_recursive_key']).toEqual('value');
+      expect(env['npm_package_recursive_more_another']).toEqual('what');
+    });
+
+    it('replaces invalid chars with _', async () => {
+      const config = await withManifest('', '', {'in^va!d_key': 'test'});
+      const env = await makeEnv('', cwd, config);
+      expect(env['npm_package_in_va_d_key']).toEqual('test');
+    });
+  });
+
+  describe('npm_package_config_*', () => {
+    it('overwrites npm_package_config_* keys from yarn config or npm config', async () => {
+      const name = 'manifest-name';
+      const config = await withManifest('', '', {name, config: {key: 'value', keytwo: 'valuetwo'}});
+      config.registries.yarn.config = {[`${name}:key`]: 'replaced'};
+      config.registries.npm.config = {[`${name}:keytwo`]: 'also replaced'};
+      const env = await makeEnv('', cwd, config);
+      expect(env['npm_package_config_key']).toEqual('replaced');
+      expect(env['npm_package_config_keytwo']).toEqual('also replaced');
+    });
+
+    it('does not overwrite if the name does not match the manifest', async () => {
+      const name = 'manifest-name';
+      const config = await withManifest('', '', {name, config: {key: 'value', keytwo: 'valuetwo'}});
+      config.registries.yarn.config = {'wrong-name:key': 'replaced'};
+      config.registries.npm.config = {'another-name:keytwo': 'also replaced'};
+      const env = await makeEnv('', cwd, config);
+      expect(env['npm_package_config_key']).toEqual('value');
+      expect(env['npm_package_config_keytwo']).toEqual('valuetwo');
+    });
+  });
+});

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -105,21 +105,23 @@ export async function makeEnv(
     ...Object.keys(config.registries.yarn.config),
     ...Object.keys(config.registries.npm.config),
   ]);
-  const cleaned = Array.from(keys).filter(key => !key.match(/:_/) && IGNORE_CONFIG_KEYS.indexOf(key) < 0).map(key => {
-    let val = config.getOption(key);
-    if (!val) {
-      val = '';
-    } else if (typeof val === 'number') {
-      val = '' + val;
-    } else if (typeof val !== 'string') {
-      val = JSON.stringify(val);
-    }
+  const cleaned = Array.from(keys)
+    .filter(key => !key.match(/:_/) && IGNORE_CONFIG_KEYS.indexOf(key) === -1)
+    .map(key => {
+      let val = config.getOption(key);
+      if (!val) {
+        val = '';
+      } else if (typeof val === 'number') {
+        val = '' + val;
+      } else if (typeof val !== 'string') {
+        val = JSON.stringify(val);
+      }
 
-    if (val.indexOf('\n') >= 0) {
-      val = JSON.stringify(val);
-    }
-    return [key, val];
-  });
+      if (val.indexOf('\n') >= 0) {
+        val = JSON.stringify(val);
+      }
+      return [key, val];
+    });
   // add npm_config_*
   for (const [key, val] of cleaned) {
     const cleanKey = key.replace(/^_+/, '');
@@ -130,7 +132,7 @@ export async function makeEnv(
   if (manifest && manifest.name) {
     const packageConfigPrefix = `${manifest.name}:`;
     for (const [key, val] of cleaned) {
-      if (!key.startsWith(packageConfigPrefix)) {
+      if (key.indexOf(packageConfigPrefix) !== 0) {
         continue;
       }
       const cleanKey = key.replace(/^_+/, '').replace(packageConfigPrefix, '');

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -8,7 +8,7 @@ import * as child from './child.js';
 import {exists} from './fs.js';
 import {registries} from '../resolvers/index.js';
 import {fixCmdWinSlashes} from './fix-cmd-win-slashes.js';
-import {run as globalRun, getBinFolder as getGlobalBinFolder} from '../cli/commands/global.js';
+import {getBinFolder as getGlobalBinFolder, run as globalRun} from '../cli/commands/global.js';
 
 const invariant = require('invariant');
 const path = require('path');
@@ -25,6 +25,8 @@ const IGNORE_MANIFEST_KEYS = ['readme'];
 // This helps us avoid some gyp issues when building native modules.
 // See https://github.com/yarnpkg/yarn/issues/2286.
 const IGNORE_CONFIG_KEYS = ['lastUpdateCheck'];
+
+const INVALID_CHAR_REGEX = /[^a-zA-Z0-9_]/g;
 
 export async function makeEnv(
   stage: string,
@@ -91,25 +93,20 @@ export async function makeEnv(
         }
 
         //replacing invalid chars with underscore
-        const cleanKey = key.replace(/[^a-zA-Z0-9_]/g, '_');
+        const cleanKey = key.replace(INVALID_CHAR_REGEX, '_');
 
         env[`npm_package_${cleanKey}`] = cleanVal;
       }
     }
   }
 
-  // add npm_config_*
+  // add npm_config_* and npm_package_config_* from yarn config
   const keys: Set<string> = new Set([
     ...Object.keys(config.registries.yarn.config),
     ...Object.keys(config.registries.npm.config),
   ]);
-  for (const key of keys) {
-    if (key.match(/:_/) || IGNORE_CONFIG_KEYS.indexOf(key) >= 0) {
-      continue;
-    }
-
+  const cleaned = Array.from(keys).filter(key => !key.match(/:_/) && IGNORE_CONFIG_KEYS.indexOf(key) < 0).map(key => {
     let val = config.getOption(key);
-
     if (!val) {
       val = '';
     } else if (typeof val === 'number') {
@@ -121,10 +118,25 @@ export async function makeEnv(
     if (val.indexOf('\n') >= 0) {
       val = JSON.stringify(val);
     }
-
+    return [key, val];
+  });
+  // add npm_config_*
+  for (const [key, val] of cleaned) {
     const cleanKey = key.replace(/^_+/, '');
-    const envKey = `npm_config_${cleanKey}`.replace(/[^a-zA-Z0-9_]/g, '_');
+    const envKey = `npm_config_${cleanKey}`.replace(INVALID_CHAR_REGEX, '_');
     env[envKey] = val;
+  }
+  // add npm_package_config_*
+  if (manifest && manifest.name) {
+    const packageConfigPrefix = `${manifest.name}:`;
+    for (const [key, val] of cleaned) {
+      if (!key.startsWith(packageConfigPrefix)) {
+        continue;
+      }
+      const cleanKey = key.replace(/^_+/, '').replace(packageConfigPrefix, '');
+      const envKey = `npm_package_config_${cleanKey}`.replace(INVALID_CHAR_REGEX, '_');
+      env[envKey] = val;
+    }
   }
 
   // split up the path


### PR DESCRIPTION
This is #5409, but on a different branch because I fucked up.

> feature in npm: https://docs.npmjs.com/files/package.json#config
> 
> issue: https://github.com/yarnpkg/yarn/issues/2989
> 
> **Summary**
> 
> The goal of this PR is to allow the same feature as found in npm:
> 
> package.json
> 
> ```json
> "name": "yarn",
> "config": {
>     "whatever": "test"
> }
> ```
> 
> `yarn config set yarn:whatever production`
> 
> should make the environment variable
> 
> `npm_package_config_whatever === 'production'`
> 
> **Test plan**
> 
> Automated tests are incoming. Tested manually with `yarn env`.
> 
> Are these changes too much or is there a better way of accomplishing this?
