### PR TITLE
Write stacktrace in yarn-error.log sooner

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -427,6 +427,8 @@ export function main({
     log.push(`Node version: ${indent(process.versions.node)}`);
     log.push(`Platform: ${indent(process.platform + ' ' + process.arch)}`);
 
+    log.push(`Trace: ${indent(err.stack)}`);
+
     // add manifests
     for (const registryName of registryNames) {
       const possibleLoc = path.join(config.cwd, registries[registryName].filename);
@@ -441,8 +443,6 @@ export function main({
     );
     const lockfile = fs.existsSync(lockLoc) ? fs.readFileSync(lockLoc, 'utf8') : 'No lockfile';
     log.push(`Lockfile: ${indent(lockfile)}`);
-
-    log.push(`Trace: ${indent(err.stack)}`);
 
     const errorReportLoc = writeErrorReport(log);
 


### PR DESCRIPTION
**Summary**

In my opinion lockfile shouldn't be written at all into the error file (#5443) but this should be a simpler solution to that.

The stack trace is more important than the entire contents of the lock file, so I've moved it above it. As it's rather unnecessary to scroll to the end of the file to see the actual error.

**Test plan**

Run any command that produces an error (e.g. non existing command) to produce an error file.