### PR TITLE
ci(appveyor): Fix AppVeyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   - yarn run build-dist
   - yarn run build-win-installer
 test_script:
-  - yarn test-only --maxWorkers 3
+  - ps: yarn test-only --maxWorkers 3
 artifacts:
   - path: artifacts/*.msi
     name: Installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,9 @@ build_script:
   - yarn run build-dist
   - yarn run build-win-installer
 test_script:
-  - ps: yarn test-only --maxWorkers 3
+  - ps: >-
+      $env:npm_execpath = (Get-Command yarn).Path; node
+      ./node_modules/jest/bin/jest.js --verbose --maxWorkers=3
 artifacts:
   - path: artifacts/*.msi
     name: Installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   - yarn run build-dist
   - yarn run build-win-installer
 test_script:
-  - node ./node_modules/jest/bin/jest.js --verbose
+  - yarn test-only --maxWorkers 3
 artifacts:
   - path: artifacts/*.msi
     name: Installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build_script:
   - yarn run build-win-installer
 test_script:
   - cmd: |-
-      FOR /F "tokens=*" %g IN ('where yarn') do (SET npm_execpath=%g)
+      SET npm_execpath=%APPVEYOR_BUILD_FOLDER%\bin\yarn.js
       node ./node_modules/jest/bin/jest.js --verbose --maxWorkers=3
 artifacts:
   - path: artifacts/*.msi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,9 @@ build_script:
   - yarn run build-dist
   - yarn run build-win-installer
 test_script:
-  - ps: >-
-      $env:npm_execpath = (Get-Command yarn).Path; node
-      ./node_modules/jest/bin/jest.js --verbose --maxWorkers=3
+  - cmd: |-
+      FOR /F "tokens=*" %g IN ('where yarn') do (SET npm_execpath=%g)
+      node ./node_modules/jest/bin/jest.js --verbose --maxWorkers=3
 artifacts:
   - path: artifacts/*.msi
     name: Installer


### PR DESCRIPTION
**Summary**

Follow up to #5569. Jest 22.4.x mocks the process object without a proper stub for `process.mainModule`. In our lifecycle code, we try to set `env.npm_execpath` when it is not defined by
using `process.mainModule.filename`. When running tests on AppVeyor, we run Jest directly, thus we
don't have `env.npm_execpath` set, triggering the `process.mainModule` code path which is also not set,
causing tests to fail.

**Test plan**

AppVeyor builds should pass.
