### PR TITLE
Proposal: Add `ignore-workspace-root-check` option to `.yarnrc`

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -170,8 +170,10 @@ export class Add extends Install {
   async init(): Promise<Array<string>> {
     const isWorkspaceRoot = this.config.workspaceRootFolder && this.config.cwd === this.config.workspaceRootFolder;
 
+    const ignoreWorkspaceRootCheck =
+      this.flags.ignoreWorkspaceRootCheck || this.config.getOption('ignore-workspace-root-check');
     // running "yarn add something" in a workspace root is often a mistake
-    if (isWorkspaceRoot && !this.flags.ignoreWorkspaceRootCheck) {
+    if (isWorkspaceRoot && !ignoreWorkspaceRootCheck) {
       throw new MessageError(this.reporter.lang('workspacesAddRootCheck'));
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Yarn already has flag `--ignore-workspace-root-check|-W` https://github.com/yarnpkg/yarn/pull/4630. It can be used to install dependencies in workspace root directory. If you want to use workspaces without removing root package, it can be super annoying to add `-W` each time you run `yarn add <...>`. Since yarn already has flag for ignoring this check, I think it might be handy to able set this option in `.yarnrc`.

Not sure that this feature is a  _substantial feature request_, ignoring https://github.com/yarnpkg/rfcs.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Happy to write unit tests for that, but `jest __tests__/commands/add.js` from `master` on my local setup fails with this output:

```
    TypeError: /var/folders/vx/f7cd9hkn3j75d9pgf6xlnjb80000gp/T/yarn-integrity-pure-lockfile-1522108786768-0.5606388068711743/node_modules/package-a: Cannot read property 'filename' of undefined

      52 |   env.npm_lifecycle_event = stage;
      53 |   env.npm_node_execpath = env.NODE;
    > 54 |   env.npm_execpath = env.npm_execpath || process.mainModule.filename;
      55 |
      56 |   // Set the env to production for npm compat if production mode.
      57 |   // https://github.com/npm/npm/blob/30d75e738b9cb7a6a3f9b50e971adcbe63458ed3/lib/utils/lifecycle.js#L336

...

Test Suites: 1 failed, 1 total
Tests:       7 failed, 2 skipped, 48 passed, 57 total
Snapshots:   0 total
Time:        29.408s
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
