### PR TITLE
Remove leading spaces of `yarn run`'s answer

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -123,7 +123,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       reporter.list('possibleCommands', pkgCommands, cmdHints);
       await reporter
         .question(reporter.lang('commandQuestion'))
-        .then(answer => runCommand(answer.trim().split(' ')), () => reporter.error(reporter.lang('commandNotSpecified')));
+        .then(
+          answer => runCommand(answer.trim().split(' ')),
+          () => reporter.error(reporter.lang('commandNotSpecified')),
+        );
     } else {
       reporter.error(reporter.lang('noScriptsAvailable'));
     }

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -123,7 +123,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       reporter.list('possibleCommands', pkgCommands, cmdHints);
       await reporter
         .question(reporter.lang('commandQuestion'))
-        .then(answer => runCommand(answer.split(' ')), () => reporter.error(reporter.lang('commandNotSpecified')));
+        .then(answer => runCommand(answer.trim().split(' ')), () => reporter.error(reporter.lang('commandNotSpecified')));
     } else {
       reporter.error(reporter.lang('noScriptsAvailable'));
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

If user's answer contains leading spaces, the command will fail. Like:

```sh
> yarn run
...
question Which command would you like to run?:  start
error An unexpected error occurred: "Command \"\" not found.".
```

This PR add a `trim` operation to remove leading spaces

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
