### PR TITLE
fix workspace packages ignore-pattern

### DIFF
--- a/__tests__/commands/install/workspaces-install.js
+++ b/__tests__/commands/install/workspaces-install.js
@@ -243,6 +243,29 @@ test.concurrent('install should ignore node_modules in workspaces when used with
   });
 });
 
+describe('install should ignore deep node_modules in workspaces', () => {
+  test('without nohoist', (): Promise<void> => {
+    return runInstall(
+      {workspacesNohoistEnabled: false},
+      'workspaces-install-already-exists-deep',
+      async (config): Promise<void> => {
+        expect(await fs.exists(path.join(config.cwd, 'node_modules', 'a'))).toBe(true);
+        expect(await fs.exists(path.join(config.cwd, 'node_modules', 'b'))).toBe(true);
+      },
+    );
+  });
+  test('with nohoist', (): Promise<void> => {
+    return runInstall(
+      {workspacesNohoistEnabled: true},
+      'workspaces-install-already-exists-deep',
+      async (config): Promise<void> => {
+        expect(await fs.exists(path.join(config.cwd, 'node_modules', 'a'))).toBe(true);
+        expect(await fs.exists(path.join(config.cwd, 'node_modules', 'b'))).toBe(true);
+      },
+    );
+  });
+});
+
 test.concurrent('install should link binaries properly when run from child workspace', async () => {
   await runInstall({binLinks: true}, 'workspaces-install-bin', async (config, reporter): Promise<void> => {
     // initial install

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "workspaces-install-already-exists",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true,
+  "workspaces": {
+    "packages": ["packages/**/*"],
+    "nohoist": ["**/**"]
+  }
+}

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/a/node_modules/lol/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/a/node_modules/lol/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lol",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/a/node_modules/lol/x/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/a/node_modules/lol/x/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "x",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/a/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/b/node_modules/lol/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/b/node_modules/lol/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lol",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/b/node_modules/lol/x/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/b/node_modules/lol/x/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "x",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/b/package.json
+++ b/__tests__/fixtures/install/workspaces-install-already-exists-deep/packages/b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -660,7 +660,8 @@ export default class Config {
       .map(registryName => this.registries[registryName].constructor.filename)
       .join('|');
     const trailingPattern = `/+(${registryFilenames})`;
-    const ignorePatterns = this.registryFolders.map(folder => `/${folder}/*/+(${registryFilenames})`);
+    // anything under folder (node_modules) should be ignored, thus use the '**' instead of shallow match "*"
+    const ignorePatterns = this.registryFolders.map(folder => `/${folder}/**/+(${registryFilenames})`);
 
     const files = await Promise.all(
       patterns.map(pattern =>

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -51,7 +51,7 @@ export async function makeEnv(
 
   env.npm_lifecycle_event = stage;
   env.npm_node_execpath = env.NODE;
-  env.npm_execpath = env.npm_execpath || process.mainModule.filename;
+  env.npm_execpath = env.npm_execpath || (process.mainModule && process.mainModule.filename);
 
   // Set the env to production for npm compat if production mode.
   // https://github.com/npm/npm/blob/30d75e738b9cb7a6a3f9b50e971adcbe63458ed3/lib/utils/lifecycle.js#L336


### PR DESCRIPTION

**Summary**

address #5579 related to #3986/#3996: 
in order to prevent greedy workspaces.packages patterns to match unnecessary packages, #3996 added the `node_modules/*/package.json` pattern to exclude packages under the workspace package's node_modules folder. While sufficient for most use cases, it does not work for "deep" path such as "node_modules/X/Y/package.json". This PR replaced the shallow wildcard with globstar "**" so it will ignore **all** packages under the workspace package's node_modules folder.

- Config.js: replace the shallow ignore pattern with a deep pattern.
- execute-lifecycle-script: address when process.mainModule is undefined
- tests: the rest are all tests.

**Test plan**

both new and old tests should pass
