### PR TITLE
remove .vscode settings from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test/fixtures/**/.fbkpm
 .idea
 .yarn-meta
 /packages/lockfile/index.js
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "javascript.validate.enable": false
-}


### PR DESCRIPTION
**Summary**

looks like a .vscode/settings file has been accidentally checked in a few days ago (#5572). This file is only related to vscode and most vscode dev would probably prefer their own settings ;-). We should not need to keep it in the repo.

- removed settings.json 
- added `.vscode/` to .gitignore to prevent accidental checkin in the future.

**Test plan**

there is no code change.
