### PR TITLE
Bugfix #5614: When offline pruning, don't unlink prebuilt packages.

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -767,7 +767,9 @@ export class Install {
     const mirrorFiles = await fs.walk(mirror);
     for (const file of mirrorFiles) {
       const isTarball = path.extname(file.basename) === '.tgz';
-      if (isTarball && !requiredTarballs.has(file.basename)) {
+      // if using experimental-pack-script-packages-in-mirror flag, don't unlink prebuilt packages
+      const hasPrebuiltPackage = file.relative.startsWith('prebuilt/');
+      if (isTarball && !hasPrebuiltPackage && !requiredTarballs.has(file.basename)) {
         await fs.unlink(file.absolute);
       }
     }


### PR DESCRIPTION
**Summary**
When ```experimental-pack-script-packages-in-mirror``` is set in conjunction with ```yarn-offline-mirror-pruning true```, prebuilt packages in /yarn-offline-mirror-dir/prebuilt/* are deleted.

Fixes #5614 from @bestander PR #5314.

**Test plan**
Should pass tests created for #5314 🤓
