### PR TITLE
feat: added a `--size` flag to `yarn why`

### DIFF
--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -127,6 +127,55 @@ test('should report when a module is included multiple times including the root'
   });
 });
 
+/**
+ * Tests whether yarn reports size information when --size is passed to `yarn why`
+ */
+describe('size reporting', () => {
+  test('should return sizes when size flag is passed', (): Promise<void> => {
+    return runWhy({size: true}, ['caniuse-lite'], 'dep-included-at-2-levels', (config, reporter) => {
+      const report = reporter.getBuffer();
+      const stepsBanner = report
+        .filter(entry => entry.type === 'step' && entry.data.message)
+        .map(entry => entry.data.message);
+
+      expect(stepsBanner).toContain('Calculating file sizes');
+    });
+  });
+
+  test('should return 4 steps when size flag is passed', (): Promise<void> => {
+    return runWhy({size: true}, ['caniuse-lite'], 'dep-included-at-2-levels', (config, reporter) => {
+      const report = reporter.getBuffer();
+      const totalSteps = report.filter(entry => entry.type === 'step' && entry.data.message).map(entry => entry.data);
+
+      expect(totalSteps.length).toEqual(4);
+      expect(totalSteps[0].total).toEqual(4);
+    });
+  });
+
+  test('should skip sizes info when size flag is not passed', (): Promise<void> => {
+    return runWhy({}, ['caniuse-lite'], 'dep-included-at-2-levels', (config, reporter) => {
+      const report = reporter.getBuffer();
+      const stepsBanner = report
+        .filter(entry => entry.type === 'step' && entry.data.message)
+        .map(entry => entry.data.message);
+
+      stepsBanner.forEach(bannerMessage => {
+        expect(bannerMessage).not.toEqual('Calculating file sizes');
+      });
+    });
+  });
+
+  test('should return 3 steps if size flag is not passed', (): Promise<void> => {
+    return runWhy({}, ['caniuse-lite'], 'dep-included-at-2-levels', (config, reporter) => {
+      const report = reporter.getBuffer();
+      const totalSteps = report.filter(entry => entry.type === 'step' && entry.data.message).map(entry => entry.data);
+
+      expect(totalSteps.length).toEqual(3);
+      expect(totalSteps[0].total).toEqual(3);
+    });
+  });
+});
+
 class MockReporter extends reporters.BufferReporter {
   _lang = jest.fn();
   lang(key: LanguageKeys, ...args: Array<mixed>): string {


### PR DESCRIPTION

**Summary**
Added a flag to `yarn why` that moves the size reporting to opt in by default. While size information is useful, it isn't necessary for most of the time when looking up `why` I have a dependency.

I was motivated to make this change because the information provided by `yarn why` by default is meant to be "why do I have this dependency, where did it come from?". Most of the time, I find I don't care much for the size information. This also will make tools that parse `json` output from `why` have to account for ever so slightly less code.

On larger data sets, I expect this to speed up the execution of `yarn why` because it will avoid doing deep size calculations.

**Test plan**

I have writtent tests for what I could think of. However, I realize they are pretty weak and would love some guidance on making them better. And yes, there is some copy paste in there as this is my first time working with flow so I wanted an easy way to at least get the change working. I expect code review to weed out the duplicate and bad code.
In addition, the contribution guide didn't say the best way to actively test yarn. I assume it is linking it globally? Not sure. To be totally fair, I haven't actually run the command with this flag. All tests and code have been written and run through the test harness. I would also love some guidance (and would be happy to contribute it) on how to actively test the changes made.
