### PR TITLE
feat(version): Ability to disable commit hooks on versioning

### DIFF
--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -18,7 +18,10 @@ spawn.mockReturnValue(Promise.resolve(''));
 
 const path = require('path');
 
-beforeEach(() => execCommand.mockClear());
+beforeEach(() => {
+  execCommand.mockClear();
+  spawn.mockClear();
+});
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'version');
 const runRun = buildRun.bind(null, BufferReporter, fixturesLoc, (args, flags, config, reporter): Promise<void> => {
@@ -95,5 +98,38 @@ test('run version and make sure only the defined lifecycle steps are executed', 
 
     expect(execCommand.mock.calls[0]).toEqual(preversionLifecycle);
     expect(execCommand.mock.calls[1]).toEqual(postversionLifecycle);
+  });
+});
+
+test('run version and make sure git commit hooks are enabled by default', async (): Promise<void> => {
+  const fixture = 'no-args';
+  await fs.mkdirp(path.join(fixturesLoc, fixture, '.git'));
+
+  return runRun([], {newVersion, gitTagVersion}, fixture, (): ?Promise<void> => {
+    const gitArgs = ['commit', '-m', 'v2.0.0'];
+    expect(spawn.mock.calls.length).toBe(4);
+    expect(spawn.mock.calls[2][0]).toEqual(gitArgs);
+  });
+});
+
+test('run version with --no-commit-hooks and make sure git commit hooks are disabled', async (): Promise<void> => {
+  const fixture = 'no-args';
+  await fs.mkdirp(path.join(fixturesLoc, fixture, '.git'));
+
+  return runRun([], {newVersion, gitTagVersion, commitHooks: false}, fixture, (): ?Promise<void> => {
+    const gitArgs = ['commit', '-m', 'v2.0.0', '-n'];
+    expect(spawn.mock.calls.length).toBe(4);
+    expect(spawn.mock.calls[2][0]).toEqual(gitArgs);
+  });
+});
+
+test('run version and make sure commit hooks are disabled by config', async (): Promise<void> => {
+  const fixture = 'no-args-no-git-hooks';
+  await fs.mkdirp(path.join(fixturesLoc, fixture, '.git'));
+
+  return runRun([], {newVersion, gitTagVersion}, fixture, (): ?Promise<void> => {
+    const gitArgs = ['commit', '-m', 'v2.0.0', '-n'];
+    expect(spawn.mock.calls.length).toBe(4);
+    expect(spawn.mock.calls[2][0]).toEqual(gitArgs);
   });
 });

--- a/__tests__/fixtures/version/no-args-no-git-hooks/.yarnrc
+++ b/__tests__/fixtures/version/no-args-no-git-hooks/.yarnrc
@@ -1,0 +1,1 @@
+version-commit-hooks false

--- a/__tests__/fixtures/version/no-args-no-git-hooks/package.json
+++ b/__tests__/fixtures/version/no-args-no-git-hooks/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "license": "BSD-2-Clause",
+  "scripts": {
+    "preversion": "echo preversion",
+    "version": "echo version",
+    "postversion": "echo postversion"
+  }
+}

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -15,6 +15,7 @@ const path = require('path');
 export const DEFAULTS = {
   'version-tag-prefix': 'v',
   'version-git-tag': true,
+  'version-commit-hooks': true,
   'version-git-sign': false,
   'version-git-message': 'v%s',
 
@@ -33,6 +34,7 @@ const npmMap = {
   'version-git-sign': 'sign-git-tag',
   'version-tag-prefix': 'tag-version-prefix',
   'version-git-tag': 'git-tag-version',
+  'version-commit-hooks': 'commit-hooks',
   'version-git-message': 'message',
 };
 


### PR DESCRIPTION
**Summary**

Last year I contributed the ability to disable commit hooks when versioning with npm (See [this commit](https://github.com/npm/npm/commit/2dec601c6d5a576751d50efbcf76eaef4deff31e#diff-2992be03e25e9f38300b7ce175e4f4e1)). It makes sense to add the same functionality to yarn.

The original motivation for this feature is based on a pre-commit hook that included linting and testing a large code base, taking ~20 seconds to run. When that hook is run on the preceding commits, it's unnecessary and time-taking to do so on versioning. Because of that, it's nice to have the option to disable that git hook.

**Test plan**

Added lower level integration tests.