### PR TITLE
ci(renovate): Disable Renovate Docker support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":preserveSemverRanges"
+    ":preserveSemverRanges",
+    "docker:disable"
   ]
 }


### PR DESCRIPTION
**Summary**

Renovate constantly nags us about pinning Docker image versions which we intentionally don't want to
(see #5622). This PR disables the whole Docker integration since we want our config to stay in this
very specific way for CI.

**Test plan**

Renovate should keep working but PRs like #5622 should not come back.