### PR TITLE
Remove yarn-e2e from Jenkins

### DIFF
--- a/jenkins_jobs.groovy
+++ b/jenkins_jobs.groovy
@@ -49,32 +49,6 @@ job('yarn-version') {
   }
 }
 
-matrixJob('yarn-e2e') {
-  displayName 'Yarn End To End'
-  description 'Nightly end-to-end tests for Yarn'
-  scm {
-    github 'yarnpkg/yarn', 'master'
-  }
-  triggers {
-    cron '@midnight'
-  }
-  axes {
-    text 'os', 'ubuntu-16.04', 'ubuntu-14.04', 'ubuntu-12.04'
-    label 'label', 'docker' // Only run on build hosts that have Docker
-  }
-  steps {
-    // 192.168.122.1:3142 is apt-cacher-ng on the Docker host
-    shell '''
-      cd end_to_end_tests
-      APT_PROXY=192.168.122.1:3142 ./test-$os.sh
-    '''
-  }
-  publishers {
-    gitHubIssueNotifier {
-    }
-  }
-}
-
 job('yarn-chocolatey') {
   displayName 'Yarn Chocolatey'
   description 'Ensures the Chocolatey package for Yarn is up-to-date'


### PR DESCRIPTION
These tests are now being ran directly in CircleCI.
