### PR TITLE
feat(run): Set `INIT_CWD` in environment

### DIFF
--- a/__tests__/util/execute-lifecycle-script.js
+++ b/__tests__/util/execute-lifecycle-script.js
@@ -39,6 +39,12 @@ describe('makeEnv', () => {
     expect(env.NODE_ENV).toEqual('production');
   });
 
+  it('assigns INIT_CWD to env', async () => {
+    const config = await initConfig();
+    const env = await makeEnv('test-script', cwd, config);
+    expect(env.INIT_CWD).toEqual(process.cwd());
+  });
+
   describe('npm_package_*', () => {
     it('assigns npm_lifecycle_script if manifest has a matching script', async () => {
       const stage = 'test-script';

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -37,6 +37,7 @@ export async function makeEnv(
 } {
   const env = {
     NODE: process.execPath,
+    INIT_CWD: process.cwd(),
     // This lets `process.env.NODE` to override our `process.execPath`.
     // This is a bit confusing but it is how `npm` was designed so we
     // try to be compatible with that.


### PR DESCRIPTION
**Summary**
`INIT_CWD` environment variable holds the full path you were in when you ran `yarn run`

Motivation: https://twitter.com/housecor/status/983773854530260992

**Test plan**

1. Create a script called `testscript.js`
2. In the file type `console.log(process.env.INIT_CWD);`
3. In `package.json` add a script with a key `testscript` and value `node testscript.js`
4. Build yarn
5. Call `../bin/yarn testscript` from the command line in a subfolder
6. The script should log the folder you're running the script from

Video: https://www.youtube.com/watch?v=XY_w8GVtuCY

**Test plan**

Added a new test.