### PR TITLE
Fix for pattern not working with upgrade

### DIFF
--- a/__tests__/commands/upgrade.js
+++ b/__tests__/commands/upgrade.js
@@ -112,7 +112,7 @@ test.concurrent('works with multiple arguments', (): Promise<void> => {
   return runUpgrade(['left-pad', 'max-safe-integer'], {}, 'multiple-packages', async (config): ?Promise<void> => {
     await expectInstalledDependency(config, 'left-pad', '^1.0.0', '1.1.3');
     await expectInstalledDependency(config, 'max-safe-integer', '^1.0.0', '1.0.1');
-    await expectInstalledDependency(config, 'is-negative-zero', '^1.0.0', '1.0.0');
+    await expectInstalledDependency(config, 'array-union', '^1.0.1', '1.0.1');
   });
 });
 
@@ -147,8 +147,9 @@ test.concurrent('upgrades from fixed version to latest with workspaces', (): Pro
 
 test.concurrent('works with just a pattern', (): Promise<void> => {
   return runUpgrade([], {pattern: 'max'}, 'multiple-packages', async (config): ?Promise<void> => {
+    await expectInstalledDependency(config, 'left-pad', '^1.0.0', '1.0.0');
     await expectInstalledDependency(config, 'max-safe-integer', '^1.0.0', '1.0.1');
-    await expectInstalledDependency(config, 'is-negative-zero', '^1.0.0', '1.0.0');
+    await expectInstalledDependency(config, 'array-union', '^1.0.1', '1.0.1');
   });
 });
 
@@ -156,7 +157,7 @@ test.concurrent('works with arguments and a pattern', (): Promise<void> => {
   return runUpgrade(['left-pad'], {pattern: 'max'}, 'multiple-packages', async (config): ?Promise<void> => {
     await expectInstalledDependency(config, 'left-pad', '^1.0.0', '1.1.3');
     await expectInstalledDependency(config, 'max-safe-integer', '^1.0.0', '1.0.1');
-    await expectInstalledDependency(config, 'is-negative-zero', '^1.0.0', '1.0.0');
+    await expectInstalledDependency(config, 'array-union', '^1.0.1', '1.0.1');
   });
 });
 

--- a/__tests__/fixtures/upgrade/multiple-packages/package.json
+++ b/__tests__/fixtures/upgrade/multiple-packages/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "is-negative-zero": "^1.0.0",
+    "array-union": "^1.0.1",
     "left-pad": "^1.0.0",
     "max-safe-integer": "^1.0.0"
   }

--- a/__tests__/fixtures/upgrade/multiple-packages/yarn.lock
+++ b/__tests__/fixtures/upgrade/multiple-packages/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-is-negative-zero@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-1.0.0.tgz#1d6854ab92b1eaefeb8164bac0d05efdd532ac85"
+array-union@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.1.tgz#4d410fc8395cb247637124bade9e3f547d5d55f2"
 
 left-pad@^1.0.0:
   version "1.0.0"

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -376,8 +376,11 @@ export default class PackageRequest {
 
     // filter the list down to just the packages requested.
     // prevents us from having to query the metadata for all packages.
-    if (filterByPatterns && filterByPatterns.length) {
-      const filterByNames = filterByPatterns.map(pattern => normalizePattern(pattern).name);
+    if ((filterByPatterns && filterByPatterns.length) || (flags && flags.pattern)) {
+      const filterByNames =
+        filterByPatterns && filterByPatterns.length
+          ? filterByPatterns.map(pattern => normalizePattern(pattern).name)
+          : [];
       depReqPatterns = depReqPatterns.filter(
         dep =>
           filterByNames.indexOf(normalizePattern(dep.pattern).name) >= 0 ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
**Summary**

Fix for #5660

Before it needed to have package argument to enter the block to filter the deps. Now it will do it if either a package is given or a --pattern is given.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Corrected my incorrectly created tests.
Also `is-negative-zero` would not update as there is no new version which would be found in a caret. So changed that to `array-union` which has a version `1.0.2`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
