### PR TITLE
fix(run): Remove notice and licenseText fields from npm_package_*

### DIFF
--- a/__tests__/util/execute-lifecycle-script.js
+++ b/__tests__/util/execute-lifecycle-script.js
@@ -80,6 +80,20 @@ describe('makeEnv', () => {
       const env = await makeEnv('', cwd, config);
       expect(env['npm_package_in_va_d_key']).toEqual('test');
     });
+
+    it('it omits certain fields which tend to be too large', async () => {
+      const config = await withManifest('', '', {
+        readme: 'I shall be infinitely long',
+        notice: 'I am the very long legalese that nobody but lawyers care about',
+        licenseText: 'I am important but tend to be long',
+        hello: 'I shall stay',
+      });
+      const env = await makeEnv('', cwd, config);
+      expect(env).not.toHaveProperty('npm_package_readme');
+      expect(env).not.toHaveProperty('npm_package_notice');
+      expect(env).not.toHaveProperty('npm_package_licenseText');
+      expect(env).toHaveProperty('npm_package_hello', 'I shall stay');
+    });
   });
 
   describe('npm_package_config_*', () => {

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -19,14 +19,14 @@ export type LifecycleReturn = Promise<{
   stdout: string,
 }>;
 
-const IGNORE_MANIFEST_KEYS = ['readme'];
+const IGNORE_MANIFEST_KEYS = new Set(['readme', 'notice', 'licenseText']);
 
 // We treat these configs as internal, thus not expose them to process.env.
 // This helps us avoid some gyp issues when building native modules.
 // See https://github.com/yarnpkg/yarn/issues/2286.
 const IGNORE_CONFIG_KEYS = ['lastUpdateCheck'];
 
-const INVALID_CHAR_REGEX = /[^a-zA-Z0-9_]/g;
+const INVALID_CHAR_REGEX = /\W/g;
 
 export async function makeEnv(
   stage: string,
@@ -78,16 +78,14 @@ export async function makeEnv(
     const queue = [['', manifest]];
     while (queue.length) {
       const [key, val] = queue.pop();
-      if (key[0] === '_') {
-        continue;
-      }
-
       if (typeof val === 'object') {
         for (const subKey in val) {
-          const completeKey = [key, subKey].filter((part: ?string): boolean => !!part).join('_');
-          queue.push([completeKey, val[subKey]]);
+          const fullKey = [key, subKey].filter(Boolean).join('_');
+          if (fullKey && fullKey[0] !== '_' && !IGNORE_MANIFEST_KEYS.has(fullKey)) {
+            queue.push([fullKey, val[subKey]]);
+          }
         }
-      } else if (IGNORE_MANIFEST_KEYS.indexOf(key) < 0) {
+      } else {
         let cleanVal = String(val);
         if (cleanVal.indexOf('\n') >= 0) {
           cleanVal = JSON.stringify(cleanVal);


### PR DESCRIPTION
**Summary**

Fixes #5420. NOTICE and licenseText for packages can be quite long which
can cause E2BIG errors when trying to put it into environment variables
when running scripts. Since these fields are not useful for scripts
anyway, add them to the current blacklist which already has a similar
field in it, `readme`.

**Test plan**

Added an automated test to ensure the env doesn't have these fields but
keeps any other keys.