### PR TITLE
feat(version): Added semver versioning flags for convenience

### DIFF
--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -133,3 +133,24 @@ test('run version and make sure commit hooks are disabled by config', async (): 
     expect(spawn.mock.calls[2][0]).toEqual(gitArgs);
   });
 });
+
+test('run version with --major flag and make sure major version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, major: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('2.0.0');
+  });
+});
+
+test('run version with --minor flag and make sure minor version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, minor: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.1.0');
+  });
+});
+
+test('run version with --patch flag and make sure patch version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, patch: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1');
+  });
+});

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -21,6 +21,9 @@ function isValidNewVersion(oldVersion: string, newVersion: string, looseSemver: 
 export function setFlags(commander: Object) {
   commander.description('Update the version of your package via the command line.');
   commander.option(NEW_VERSION_FLAG, 'new version');
+  commander.option('--major', 'auto-increment major version number');
+  commander.option('--minor', 'auto-increment minor version number');
+  commander.option('--patch', 'auto-increment patch version number');
   commander.option('--message [message]', 'message');
   commander.option('--no-git-tag-version', 'no git tag version');
   commander.option('--no-commit-hooks', 'bypass git hooks when committing new version');
@@ -75,6 +78,17 @@ export async function setVersion(
   // get new version
   if (newVersion && !isValidNewVersion(oldVersion, newVersion, config.looseSemver)) {
     throw new MessageError(reporter.lang('invalidVersion'));
+  }
+
+  // get new version by bumping old version, if requested
+  if (!newVersion) {
+    if (flags.major) {
+      newVersion = semver.inc(oldVersion, 'major');
+    } else if (flags.minor) {
+      newVersion = semver.inc(oldVersion, 'minor');
+    } else if (flags.patch) {
+      newVersion = semver.inc(oldVersion, 'patch');
+    }
   }
 
   // wasn't passed a version arg so ask interactively


### PR DESCRIPTION
fixes #5670 

**Summary**

Currently, it's possible (although undocumented) to automatically bump the version by running something like `yarn version --loose-semver --new-version minor`. To me, this seems less convenient and less intuitive than something like `yarn version --minor` (closely comparable to `npm version minor`). I've added the ability to automatically increment the version with one of the flags: `--major`, `--minor`, or `--patch`. This will also satisfy feature request #5367.

**Test plan**

I've included Jest test cases for each of the new versioning flags.