### PR TITLE
fix(resolution): Allow github dependency refs of type "#pull/1/head"

### DIFF
--- a/__tests__/util/git/git-ref-resolver.js
+++ b/__tests__/util/git/git-ref-resolver.js
@@ -75,6 +75,10 @@ test('resolveVersion', async () => {
     sha: '6e97e0159f10c275f227d0f067d99f2a97331cef',
     ref: 'refs/pull/100/head',
   });
+  expect(await resolve('pull/100/head')).toEqual({
+    sha: '6e97e0159f10c275f227d0f067d99f2a97331cef',
+    ref: 'refs/pull/100/head',
+  });
   // not-existing sha
   expect(await resolve('0123456')).toEqual(null);
 

--- a/src/util/git/git-ref-resolver.js
+++ b/src/util/git/git-ref-resolver.js
@@ -19,6 +19,7 @@ export type ResolveVersionOptions = {
 };
 type Names = {tags: Array<string>, heads: Array<string>};
 
+const REF_PREFIX = 'refs/';
 const REF_TAG_PREFIX = 'refs/tags/';
 const REF_BRANCH_PREFIX = 'refs/heads/';
 const REF_PR_PREFIX = 'refs/pull/';
@@ -68,6 +69,9 @@ const tryVersionAsPullRequestNo = ({version, refs}: ResolveVersionOptions): ?Res
 
 const tryVersionAsBranchName = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
   tryRef(refs, `${REF_BRANCH_PREFIX}${version}`);
+
+const tryVersionAsDirectRef = ({version, refs}: ResolveVersionOptions): ?ResolvedSha =>
+  tryRef(refs, `${REF_PREFIX}${version}`);
 
 const computeSemverNames = ({config, refs}: ResolveVersionOptions): Names => {
   const names = {
@@ -120,6 +124,7 @@ const VERSION_RESOLUTION_STEPS: Array<(ResolveVersionOptions) => ?ResolvedSha | 
   tryVersionAsBranchName,
   tryVersionAsSemverRange,
   tryWildcardVersionAsDefaultBranch,
+  tryVersionAsDirectRef,
 ];
 
 /**


### PR DESCRIPTION
**Summary**

Fixes #1610. Previously yarn would allow a dependency on a GitHub pull request with "#1/head" where 1 is the PR number. npm allows the format "#pull/1/head" as well. For compatibility, allowing Yarn to fall back to this format.

**Test plan**

Added a test to `git-ref-resolver` to test the case `"pull/10/head"`