### PR TITLE
fix(run): yarn run should never prompt when non-interactive

### DIFF
--- a/__tests__/commands/__snapshots__/run.js.snap
+++ b/__tests__/commands/__snapshots__/run.js.snap
@@ -3,11 +3,6 @@
 exports[`returns noBinAvailable with no bins 1`] = `
 Array [
   Object {
-    "data": "No command specified.",
-    "error": true,
-    "type": "error",
-  },
-  Object {
     "data": "There are no binary scripts available.",
     "error": true,
     "type": "error",
@@ -44,11 +39,6 @@ Array [
 
 exports[`returns noScriptsAvailable with no scripts 1`] = `
 Array [
-  Object {
-    "data": "No command specified.",
-    "error": true,
-    "type": "error",
-  },
   Object {
     "data": "Commands available from binary scripts: cat-names",
     "error": false,

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -62,11 +62,29 @@ test('lists all available commands with no arguments', (): Promise<void> =>
     const bins = ['cat-names'];
 
     // Emulate run output
-    rprtr.error(rprtr.lang('commandNotSpecified'));
     rprtr.info(`${rprtr.lang('binCommands')}${bins.join(', ')}`);
     rprtr.info(rprtr.lang('possibleCommands'));
     rprtr.list('possibleCommands', scripts, hints);
     rprtr.error(rprtr.lang('commandNotSpecified'));
+
+    expect(reporter.getBuffer()).toEqual(rprtr.getBuffer());
+  }));
+
+test('lists all available commands with no arguments and --non-interactive', (): Promise<void> =>
+  runRun([], {nonInteractive: true}, 'no-args', (config, reporter): ?Promise<void> => {
+    const rprtr = new reporters.BufferReporter({stdout: null, stdin: null});
+    const scripts = ['build', 'prestart', 'start'];
+    const hints = {
+      build: "echo 'building'",
+      prestart: "echo 'prestart'",
+      start: 'node index.js',
+    };
+    const bins = ['cat-names'];
+
+    // Emulate run output
+    rprtr.info(`${rprtr.lang('binCommands')}${bins.join(', ')}`);
+    rprtr.info(rprtr.lang('possibleCommands'));
+    rprtr.list('possibleCommands', scripts, hints);
 
     expect(reporter.getBuffer()).toEqual(rprtr.getBuffer());
   }));

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -113,8 +113,6 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
   // list possible scripts if none specified
   if (args.length === 0) {
-    reporter.error(reporter.lang('commandNotSpecified'));
-
     if (binCommands.length) {
       reporter.info(`${reporter.lang('binCommands') + binCommands.join(', ')}`);
     } else {
@@ -124,12 +122,14 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     if (pkgCommands.length) {
       reporter.info(`${reporter.lang('possibleCommands')}`);
       reporter.list('possibleCommands', pkgCommands, cmdHints);
-      await reporter
-        .question(reporter.lang('commandQuestion'))
-        .then(
-          answer => runCommand(answer.trim().split(' ')),
-          () => reporter.error(reporter.lang('commandNotSpecified')),
-        );
+      if (!flags.nonInteractive) {
+        await reporter
+          .question(reporter.lang('commandQuestion'))
+          .then(
+            answer => runCommand(answer.trim().split(' ')),
+            () => reporter.error(reporter.lang('commandNotSpecified')),
+          );
+      }
     } else {
       reporter.error(reporter.lang('noScriptsAvailable'));
     }


### PR DESCRIPTION
**Summary**

This pr fixes a bug ([#5655](https://github.com/yarnpkg/yarn/issues/5655)) in which `yarn run --non-interactive` prints a `Error: No command specified` message and also suppresses the message `question Which command would you like to run?:` when running non-interactively. 

**Test plan**

```
> yarn-local run --non-interactive
yarn run v1.6.0
info Commands available from binary scripts: acorn, atob, babylon, browserslist, commitizen, detect-libc, errno, escodegen, esgenerate, eslint, esparse, esvalidate, flow, git-cz, git-release-notes, gulp, gunzip-maybe, handlebars, import-local-fixture, jest, jest-runtime, js-yaml, jsesc, jsinspect, json5, loose-envify, miller-rabin, mkdirp, node-pre-gyp, nopt, prettier, rc, regjsparser, rimraf, sane, semver, sha.js, shjs, sshpk-conv, sshpk-sign, sshpk-verify, strip-indent, strip-json-comments, uglifyjs, user-home, uuid, watch, webpack, which
info Project commands
   - build
      gulp build
   - build-bundle
      node ./scripts/build-webpack.js
   - build-chocolatey
      powershell ./scripts/build-chocolatey.ps1
   - build-deb
      ./scripts/build-deb.sh
   - build-dist
      bash ./scripts/build-dist.sh
   - build-win-installer
      scripts\build-windows-installer.bat
   - changelog
      git-release-notes $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..$(git describe --tags --abbrev=0) scripts/changelog.md
   - commit
      git-cz
   - dupe-check
      yarn jsinspect ./src
   - lint
      eslint . && flow check
   - pkg-tests
      yarn --cwd packages/pkg-tests jest yarn.test.js
   - prettier
      eslint src __tests__ --fix
   - release-branch
      ./scripts/release-branch.sh
   - test
      yarn lint && yarn test-only
   - test-coverage
      node --max_old_space_size=4096 node_modules/jest/bin/jest.js --coverage --verbose
   - test-only
      node --max_old_space_size=4096 node_modules/jest/bin/jest.js --verbose
   - watch
      gulp watch
✨  Done in 0.28s.
```
