### PR TITLE
test(init): Fix flaky init test which used snapshots w/ concurrent

### DIFF
--- a/__tests__/commands/__snapshots__/init.js.snap
+++ b/__tests__/commands/__snapshots__/init.js.snap
@@ -10,20 +10,20 @@ Object {
 }
 `;
 
+exports[`init --yes should create package.json with defaults: init-yes 1`] = `
+Object {
+  "license": "MIT",
+  "main": "index.js",
+  "name": "init-yes",
+  "version": "1.0.0",
+}
+`;
+
 exports[`init and give private empty: init-private-empty 1`] = `
 Object {
   "license": "MIT",
   "main": "index.js",
   "name": "private-empty",
-  "version": "1.0.0",
-}
-`;
-
-exports[`init should create package.json on current cwd: init-yes 1`] = `
-Object {
-  "license": "MIT",
-  "main": "index.js",
-  "name": "init-yes",
   "version": "1.0.0",
 }
 `;

--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -36,8 +36,8 @@ test.concurrent('init should create package.json on current cwd', (): Promise<vo
   );
 });
 
-test.concurrent('init --yes should create package.json with defaults', (): Promise<void> => {
-  return buildRun(
+test('init --yes should create package.json with defaults', (): Promise<void> =>
+  buildRun(
     ConsoleReporter,
     fixturesLoc,
     (args, flags, config, reporter, lockfile): Promise<void> => {
@@ -57,8 +57,7 @@ test.concurrent('init --yes should create package.json with defaults', (): Promi
       expect(manifest.private).toEqual(undefined);
       expect({...manifest, name: 'init-yes'}).toMatchSnapshot('init-yes');
     },
-  );
-});
+  ));
 
 test('init --yes --private should create package.json with defaults and private true', (): Promise<void> =>
   buildRun(


### PR DESCRIPTION
**Summary**

Snapshots should not be used with `test.concurrent`. This PR fixes a
flaky test which was doing exactly this.

**Test plan**

CI should pass.