### PR TITLE
fix(console-reporter): Fix issue where tree logger was ignoring --silent/-s flag

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ConsoleReporter._log is silent when isSilent is true 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
 exports[`ConsoleReporter.activity 1`] = `
 Object {
   "stderr": "[1G⠁ [0K[2K[1G",
@@ -122,6 +129,13 @@ Object {
 └─ dep3
    ├─ dep3.1
    └─ dep3.2",
+}
+`;
+
+exports[`ConsoleReporter.tree is silent when isSilent is true 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
 }
 `;
 

--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConsoleReporter._log is silent when isSilent is true 1`] = `
-Object {
-  "stderr": "",
-  "stdout": "",
-}
-`;
-
 exports[`ConsoleReporter.activity 1`] = `
 Object {
   "stderr": "[1G⠁ [0K[2K[1G",
@@ -60,6 +53,13 @@ exports[`ConsoleReporter.log 1`] = `
 Object {
   "stderr": "",
   "stdout": "[2K[1Gfoobar",
+}
+`;
+
+exports[`ConsoleReporter.log is silent when isSilent is true 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
 }
 `;
 

--- a/__tests__/reporters/_mock.js
+++ b/__tests__/reporters/_mock.js
@@ -16,7 +16,7 @@ type MockCallback = (reporter: Reporter, opts: Object) => ?Promise<void>;
 export default function<T>(
   Reporter: Function,
   interceptor: Interceptor<T>,
-  prepare?: (reporter: Reporter) => any,
+  prepare?: ?(reporter: Reporter) => any,
   opts?: Object,
 ): (callback: MockCallback) => Promise<T> {
   return async function(callback: MockCallback): * {

--- a/__tests__/reporters/_mock.js
+++ b/__tests__/reporters/_mock.js
@@ -17,6 +17,7 @@ export default function<T>(
   Reporter: Function,
   interceptor: Interceptor<T>,
   prepare?: (reporter: Reporter) => any,
+  opts?: Object,
 ): (callback: MockCallback) => Promise<T> {
   return async function(callback: MockCallback): * {
     const data: MockData = {
@@ -39,14 +40,15 @@ export default function<T>(
       return stream;
     };
 
-    const opts = {
+    const newOpts = {
       stdin: new Stdin(),
       stdout: buildStream('stdout'),
       stderr: buildStream('stderr'),
       emoji: true,
+      ...(opts || {}),
     };
 
-    const reporter = new Reporter(opts);
+    const reporter = new Reporter(newOpts);
     let prepared;
 
     if (prepare) {
@@ -57,7 +59,7 @@ export default function<T>(
     reporter.isTTY = true;
     reporter.getTotalTime = (): number => 0;
 
-    await callback(reporter, opts);
+    await callback(reporter, newOpts);
     reporter.close();
 
     for (const key in data) {

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -267,11 +267,11 @@ test('close', async () => {
   ).toMatchSnapshot();
 });
 
-test('ConsoleReporter._log is silent when isSilent is true', async () => {
+test('ConsoleReporter.log is silent when isSilent is true', async () => {
   const getConsoleBuff = build(ConsoleReporter, (data): MockData => data, null, {isSilent: true});
   expect(
     await getConsoleBuff(r => {
-      r._log('foobar');
+      r.log('foobar');
     }),
   ).toMatchSnapshot();
 });

--- a/__tests__/reporters/console-reporter.js
+++ b/__tests__/reporters/console-reporter.js
@@ -266,3 +266,41 @@ test('close', async () => {
     }),
   ).toMatchSnapshot();
 });
+
+test('ConsoleReporter._log is silent when isSilent is true', async () => {
+  const getConsoleBuff = build(ConsoleReporter, (data): MockData => data, null, {isSilent: true});
+  expect(
+    await getConsoleBuff(r => {
+      r._log('foobar');
+    }),
+  ).toMatchSnapshot();
+});
+
+test('ConsoleReporter.tree is silent when isSilent is true', async () => {
+  const getConsoleBuff = build(ConsoleReporter, (data): MockData => data, null, {isSilent: true});
+  const trees = [
+    {name: 'dep1'},
+    {
+      name: 'dep2',
+      children: [
+        {
+          name: 'dep2.1',
+          children: [{name: 'dep2.1.1'}, {name: 'dep2.1.2'}],
+        },
+        {
+          name: 'dep2.2',
+          children: [{name: 'dep2.2.1'}, {name: 'dep2.2.2'}],
+        },
+      ],
+    },
+    {
+      name: 'dep3',
+      children: [{name: 'dep3.1'}, {name: 'dep3.2'}],
+    },
+  ];
+  expect(
+    await getConsoleBuff(r => {
+      r.tree('', trees);
+    }),
+  ).toMatchSnapshot();
+});

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -232,6 +232,9 @@ export default class ConsoleReporter extends BaseReporter {
   tree(key: string, trees: Trees) {
     this.stopProgress();
     //
+    if (this.isSilent) {
+      return;
+    }
     const output = ({name, children, hint, color}, titlePrefix, childrenPrefix) => {
       const formatter = this.format;
       const out = getFormattedOutput({


### PR DESCRIPTION
**Summary**

This PR fixes #5721 where `upgrade` was not being silent when the `--silent`/`-s` flags were provided. It still printed the tree.  🖨🌳  

**Test plan**

Added two new test cases.

Manual CLI tests:

Before:
```
> yarn-local upgrade --silent
└─ left-pad@1.3.0
└─ left-pad@1.3.0
```

After:
```
> yarn-local upgrade --silent

```