### PR TITLE
Updated contributing urls so they're not pointing to 404.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see https://yarnpkg.com/org/contributing/
+Please see https://yarnpkg.com/lang/en/org/contributing/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](https://yarnpkg.com/lang/en/org/contributing/).
 
 ## Prior art
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The changes doesn't affect the code anyhow so I don't think the mandatory fields here need to be filled, it's just a change fixing 404 urls in readme and contributing files.


