### PR TITLE
fix: Removes usage of deprecated Buffer constructor. (#5477)

### DIFF
--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -338,8 +338,8 @@ export default class NpmRegistry extends Registry {
       const username = this.getRegistryOrGlobalOption(registry, 'username');
       const password = this.getRegistryOrGlobalOption(registry, '_password');
       if (username && password) {
-        const pw = new Buffer(String(password), 'base64').toString();
-        return 'Basic ' + new Buffer(String(username) + ':' + pw).toString('base64');
+        const pw = Buffer.from(String(password), 'base64').toString();
+        return 'Basic ' + Buffer.from(String(username) + ':' + pw).toString('base64');
       }
     }
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -767,8 +767,8 @@ export function normalizeOS(body: string): string {
   return body.replace(/\r\n/g, '\n');
 }
 
-const cr = new Buffer('\r', 'utf8')[0];
-const lf = new Buffer('\n', 'utf8')[0];
+const cr = '\r'.charCodeAt(0);
+const lf = '\n'.charCodeAt(0);
 
 async function getEolFromFile(path: string): Promise<string | void> {
   if (!await exists(path)) {


### PR DESCRIPTION
**Summary**

Fixes #5477 and #5704.

Remove usager of deprecated `Buffer`constructor to avoid ugly warnings on Node 10.

**Test plan**

Existing test should pass.