### PR TITLE
Add warning when attempting to remove dependency from workspace root

### DIFF
--- a/__tests__/commands/remove.js
+++ b/__tests__/commands/remove.js
@@ -47,6 +47,20 @@ test.concurrent('throws error when package is not found', (): Promise<void> => {
   });
 });
 
+test.concurrent('remove without --ignore-workspace-root-check should fail on the workspace root', async () => {
+  await runInstall({}, 'workspaces-install-basic', async (config, reporter): Promise<void> => {
+    await expect(remove(config, reporter, {}, ['left-pad'])).rejects.toThrow(
+      reporter.lang('workspacesRemoveRootCheck'),
+    );
+  });
+});
+
+test.concurrent("remove with --ignore-workspace-root-check shouldn't fail on the workspace root", async () => {
+  await runInstall({}, 'workspaces-install-basic', async (config, reporter): Promise<void> => {
+    await expect(remove(config, reporter, {ignoreWorkspaceRootCheck: true}, ['left-pad'])).resolves.toBeUndefined();
+  });
+});
+
 test.concurrent('removes package installed from npm registry', (): Promise<void> => {
   return runRemove(['dep-a'], {}, 'npm-registry', async (config): Promise<void> => {
     expect(await fs.exists(path.join(config.cwd, 'node_modules/dep-a'))).toEqual(false);

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -17,6 +17,8 @@ export const requireLockfile = true;
 
 export function setFlags(commander: Object) {
   commander.description('Removes a package from your direct dependencies updating your package.json and yarn.lock.');
+  commander.usage('remove [packages ...] [flags]');
+  commander.option('-W, --ignore-workspace-root-check', 'required to run yarn remove inside a workspace root');
 }
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
@@ -24,8 +26,15 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 }
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  const isWorkspaceRoot = config.workspaceRootFolder && config.cwd === config.workspaceRootFolder;
+
   if (!args.length) {
     throw new MessageError(reporter.lang('tooFewArguments', 1));
+  }
+
+  // running "yarn remove something" in a workspace root is often a mistake
+  if (isWorkspaceRoot && !flags.ignoreWorkspaceRootCheck) {
+    throw new MessageError(reporter.lang('workspacesRemoveRootCheck'));
   }
 
   const totalSteps = args.length + 1;

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -183,7 +183,9 @@ const messages = {
     'Package not found - this is probably an internal error, and should be reported at https://github.com/yarnpkg/yarn/issues.',
 
   workspacesAddRootCheck:
-    'Running this command will add the dependency to the workspace root rather than workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
+    'Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
+  workspacesRemoveRootCheck:
+    'Running this command will remove the dependency from the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
   workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects.',
   workspacesSettingMustBeArray: 'The workspaces field in package.json must be an array.',
   workspacesDisabled:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR addresses issue #5611. 

This PR basically adds a warning when trying to remove a dependency from a workspace root. When specifying the `-W`/`--ignore-workspace-root-check` it will remove the dependency from the workspace root.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Before:
```
❯ yarn remove left-pad
yarn remove v1.6.0
[1/2] Removing module left-pad...
[2/2] Regenerating lockfile and installing missing dependencies...
success Uninstalled packages.
```

After:
```
❯ yarn-local remove left-pad
yarn remove v1.6.0
error Running this command will remove the dependency from the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/remove for documentation about this command.
```

```
❯ yarn-local remove left-pad -W
yarn remove v1.6.0
[1/2] 🗑  Removing module left-pad...
[2/2] 📃  Regenerating lockfile and installing missing dependencies...
success Uninstalled packages.
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
