### PR TITLE
feat(bin): Implement an optional parameter support to `yarn bin`

### DIFF
--- a/__tests__/commands/bin.js
+++ b/__tests__/commands/bin.js
@@ -11,13 +11,13 @@ const runBin = buildRun.bind(null, BufferReporter, fixturesLoc, (args, flags, co
   return run(config, reporter, flags, args);
 });
 
-test('run bin with no arguments should return the folder where are stored the binaries', (): Promise<void> => {
+test('running bin without arguments should return the folder where the binaries are stored', (): Promise<void> => {
   return runBin([], {}, '../install/install-production-bin', (config, reporter): ?Promise<void> => {
     expect(reporter.getBufferText()).toMatch(/[\\\/]node_modules[\\\/]\.bin[\\\/]?$/);
   });
 });
 
-test('run bin with an arguments should return the location of the binary', (): Promise<void> => {
+test('running bin with a binary name as the argument should return its full path', (): Promise<void> => {
   return runBin(['rimraf'], {}, '../install/install-production-bin', (config, reporter): ?Promise<void> => {
     expect(reporter.getBufferText()).toMatch(/[\\\/]node_modules[\\\/]\.bin[\\\/]rimraf$/);
   });

--- a/__tests__/commands/bin.js
+++ b/__tests__/commands/bin.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import {run as buildRun} from './_helpers.js';
+import {BufferReporter} from '../../src/reporters/index.js';
+import {run} from '../../src/cli/commands/bin.js';
+
+const path = require('path');
+
+const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'bin');
+const runBin = buildRun.bind(null, BufferReporter, fixturesLoc, (args, flags, config, reporter): Promise<void> => {
+  return run(config, reporter, flags, args);
+});
+
+test('run bin with no arguments should return the folder where are stored the binaries', (): Promise<void> => {
+  return runBin([], {}, '../install/install-production-bin', (config, reporter): ?Promise<void> => {
+    expect(reporter.getBufferText()).toMatch(/[\\\/]node_modules[\\\/]\.bin[\\\/]?$/);
+  });
+});
+
+test('run bin with an arguments should return the location of the binary', (): Promise<void> => {
+  return runBin(['rimraf'], {}, '../install/install-production-bin', (config, reporter): ?Promise<void> => {
+    expect(reporter.getBufferText()).toMatch(/[\\\/]node_modules[\\\/]\.bin[\\\/]rimraf$/);
+  });
+});

--- a/__tests__/commands/bin.js
+++ b/__tests__/commands/bin.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {run as buildRun} from './_helpers.js';
+import {run as buildRun, runInstall} from './_helpers.js';
 import {BufferReporter} from '../../src/reporters/index.js';
 import {run} from '../../src/cli/commands/bin.js';
 
@@ -18,7 +18,9 @@ test('running bin without arguments should return the folder where the binaries 
 });
 
 test('running bin with a binary name as the argument should return its full path', (): Promise<void> => {
-  return runBin(['rimraf'], {}, '../install/install-production-bin', (config, reporter): ?Promise<void> => {
+  return runInstall({binLinks: true}, 'install-production-bin', async (config): ?Promise<void> => {
+    const reporter = new BufferReporter();
+    await run(config, reporter, {}, ['rimraf']);
     expect(reporter.getBufferText()).toMatch(/[\\\/]node_modules[\\\/]\.bin[\\\/]rimraf$/);
   });
 });

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -16,6 +16,12 @@ export function setFlags(commander: Object) {
 
 export function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const binFolder = path.join(config.cwd, config.registries[RegistryYarn.registry].folder, '.bin');
-  reporter.log(binFolder, {force: true});
+  if (args.length === 0) {
+    reporter.log(binFolder, {force: true});
+  } else {
+    for (const arg of args) {
+      reporter.log(`${binFolder}/${arg}`, {force: true});
+    }
+  }
   return Promise.resolve();
 }

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -4,6 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import RegistryYarn from '../../resolvers/registries/yarn-resolver.js';
 
+const fs = require('fs');
 const path = require('path');
 
 export function hasWrapper(commander: Object): boolean {
@@ -19,8 +20,12 @@ export function run(config: Config, reporter: Reporter, flags: Object, args: Arr
   if (args.length === 0) {
     reporter.log(binFolder, {force: true});
   } else {
-    for (const arg of args) {
-      reporter.log(`${binFolder}/${arg}`, {force: true});
+    const binName = args[0];
+    const finalPath = path.normalize(`${binFolder}/${binName}`);
+    if (fs.existsSync(finalPath)) {
+      reporter.log(finalPath, {force: true});
+    } else {
+      reporter.error(reporter.lang('packageBinaryNotFound', binName));
     }
   }
   return Promise.resolve();

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -354,6 +354,7 @@ const messages = {
   packageInstalledWithBinaries: 'Installed $0 with binaries:',
   packageHasBinaries: '$0 has binaries:',
   packageHasNoBinaries: '$0 has no binaries',
+  packageBinaryNotFound: "Couldn't find a binary named $0",
 
   couldBeDeduped: '$0 could be deduped from $1 to $2',
   lockfileNotContainPattern: 'Lockfile does not contain pattern: $0',


### PR DESCRIPTION
**Summary**

This allows to get the path to a binary without making assumptions regarding the layout of the
`node_modules` folder.

**Test plan**

Added a test.