### PR TITLE
feat(cli): Add a new --into option to `yarn node` and `yarn run`

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -131,14 +131,14 @@ describe('production', () => {
 });
 
 test('yarn node should start Node', async () => {
-  const [stdoutOutput, _] = await runYarn(['node', '-p', '42']);
+  const [stdoutOutput, _] = await runYarn(['-s', 'node', '-p', '42']);
   expect(stdoutOutput.toString().trim()).toEqual('42');
 });
 
 test('yarn node --into should start Node in a specific directory', async () => {
   const cwd = await makeTemp();
 
-  const [stdoutOutput, _] = await runYarn(['node', '--into', cwd, '-p', 'process.cwd()']);
+  const [stdoutOutput, _] = await runYarn(['-s', 'node', '--into', cwd, '-p', 'process.cwd()']);
   expect(stdoutOutput.toString().trim()).toEqual(await fs.realpath(cwd));
 });
 

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -130,6 +130,18 @@ describe('production', () => {
   });
 });
 
+test('yarn node should start Node', async () => {
+  const [stdoutOutput, _] = await runYarn(['node', '-p', '42']);
+  expect(stdoutOutput.toString().trim()).toEqual('42');
+});
+
+test('yarn node --into should start Node in a specific directory', async () => {
+  const cwd = await makeTemp();
+
+  const [stdoutOutput, _] = await runYarn(['node', '--into', cwd, '-p', 'process.cwd()']);
+  expect(stdoutOutput.toString().trim()).toEqual(await fs.realpath(cwd));
+});
+
 test('--mutex network', async () => {
   const cwd = await makeTemp();
 

--- a/src/cli/commands/node.js
+++ b/src/cli/commands/node.js
@@ -5,7 +5,13 @@ import type {Reporter} from '../../reporters/index.js';
 import * as child from '../../util/child.js';
 import {NODE_BIN_PATH} from '../../constants';
 
-export function setFlags(commander: Object) {}
+export function setFlags(commander: Object) {
+  commander.description(
+    'Runs Node with the same version that the one used by Yarn itself, and by default from the project root',
+  );
+  commander.usage('node [--into PATH] [... args]');
+  commander.option('--into <path>', 'Sets the cwd to the specified location');
+}
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
@@ -15,7 +21,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   try {
     await child.spawn(NODE_BIN_PATH, args, {
       stdio: 'inherit',
-      cwd: config.cwd,
+      cwd: flags.into || config.cwd,
     });
   } catch (err) {
     throw err;

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -14,6 +14,7 @@ const {quoteForShell, sh, unquoted} = require('puka');
 
 export function setFlags(commander: Object) {
   commander.description('Runs a defined package script.');
+  commander.option('--into <path>', 'Sets the cwd to the specified location');
 }
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
@@ -86,7 +87,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
           stage,
           config,
           cmd: cmdWithArgs,
-          cwd: config.cwd,
+          cwd: flags.into || config.cwd,
           isInteractive: true,
           customShell: customShell ? String(customShell) : undefined,
         });

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -168,13 +168,18 @@ export function main({
   const PROXY_COMMANDS = new Set([`run`, `create`, `node`]);
   if (PROXY_COMMANDS.has(commandName)) {
     if (endArgs.length === 0) {
+      let preservedArgs = 0;
       // the "run" and "create" command take one argument that we want to parse as usual (the
       // script/package name), hence the splice(1)
       if (command === commands.run || command === commands.create) {
-        endArgs = ['--', ...args.splice(1)];
-      } else {
-        endArgs = ['--', ...args];
+        preservedArgs += 1;
       }
+      // If the --into option immediately follows the command (or the script name in the "run/create"
+      // case), we parse them as regular options so that we can cd into them
+      if (args[preservedArgs] === `--into`) {
+        preservedArgs += 2;
+      }
+      endArgs = ['--', ...args.splice(preservedArgs)];
     } else {
       warnAboutRunDashDash = true;
     }


### PR DESCRIPTION
**Summary**

This allow them to see their cwd changed to something different from the project directory.

Possible breaking change: Might break scripts running `yarn run something --into foo` if the `something` binary uses an option called `into`. The alternative would be to define `--into` as a global option, and require users to put it before the command name (`yarn --into /tmp node`), which doesn't sound very readable.

**Test plan**

Added an integration test.