### PR TITLE
Adds the directory that contains Node to the PATH

### DIFF
--- a/packages/pkg-tests/pkg-tests-core/sources/utils/fs.js
+++ b/packages/pkg-tests/pkg-tests-core/sources/utils/fs.js
@@ -173,3 +173,15 @@ exports.readJson = async function readJson(source: string): Promise<any> {
     throw new Error(`Invalid json file (${source})`);
   }
 };
+
+exports.chmod = function chmod(target: string, mod: number): Promise<void> {
+  return fs.chmod(target, mod);
+};
+
+exports.makeFakeBinary = async function(
+  target: string,
+  {output = `Fake binary`, exitCode = 1}: {|output: string, exitCode: number|} = {},
+): Promise<void> {
+  await exports.writeFile(target, `#!/bin/sh\necho "${output}"\nexit ${exitCode}\n`);
+  await exports.chmod(target, 0o755);
+};

--- a/packages/pkg-tests/pkg-tests-specs/sources/index.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/index.js
@@ -2,3 +2,4 @@
 
 exports.basic = require('./basic');
 exports.dragon = require('./dragon');
+exports.script = require('./script');

--- a/packages/pkg-tests/pkg-tests-specs/sources/script.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/script.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import type {PackageDriver} from 'pkg-tests-core';
+
+const {fs: {makeFakeBinary}} = require(`pkg-tests-core`);
+
+module.exports = (makeTemporaryEnv: PackageDriver) => {
+  describe(`Scripts tests`, () => {
+    test(
+      `it should run scripts using the same Node than the one used by Yarn`,
+      makeTemporaryEnv({scripts: {myScript: `node --version`}}, async ({path, run, source}) => {
+        await makeFakeBinary(`${path}/bin/node`);
+
+        await expect(run(`run`, `myScript`)).resolves.toMatchObject({
+          stdout: `${process.version}\n`,
+        });
+      }),
+    );
+  });
+};

--- a/packages/pkg-tests/yarn.test.js
+++ b/packages/pkg-tests/yarn.test.js
@@ -5,7 +5,7 @@ const {
   exec: {execFile},
 } = require(`pkg-tests-core`);
 
-const {basic: basicSpecs, dragon: dragonSpecs} = require(`pkg-tests-specs`);
+const {basic: basicSpecs, dragon: dragonSpecs, script: scriptSpecs} = require(`pkg-tests-specs`);
 
 const pkgDriver = generatePkgDriver({
   runDriver: (path, args, {registryUrl}) => {
@@ -24,3 +24,4 @@ beforeEach(async () => {
 
 basicSpecs(pkgDriver);
 dragonSpecs(pkgDriver);
+scriptSpecs(pkgDriver);

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -141,7 +141,11 @@ export async function makeEnv(
   // split up the path
   const envPath = env[constants.ENV_PATH_KEY];
   const pathParts = envPath ? envPath.split(path.delimiter) : [];
-
+  
+  // Include the directory that contains node so that we can guarantee that the scripts
+  // will always run with the exact same Node release than the one use to run Yarn
+  pathParts.unshift(path.dirname(process.execPath));
+  
   // Include node-gyp version that was bundled with the current Node.js version,
   // if available.
   pathParts.unshift(path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'node-gyp-bin'));

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -141,11 +141,11 @@ export async function makeEnv(
   // split up the path
   const envPath = env[constants.ENV_PATH_KEY];
   const pathParts = envPath ? envPath.split(path.delimiter) : [];
-  
+
   // Include the directory that contains node so that we can guarantee that the scripts
   // will always run with the exact same Node release than the one use to run Yarn
   pathParts.unshift(path.dirname(process.execPath));
-  
+
   // Include node-gyp version that was bundled with the current Node.js version,
   // if available.
   pathParts.unshift(path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'node-gyp-bin'));


### PR DESCRIPTION
**Summary**

This diff orders Yarn to run the lifecycle scripts with a PATH configured to offer in priority the same `node` binary used to run Yarn itself. This change makes Yarn more coherent since we were previously doing this for node-gyp.

**Test plan**

Added a test to pkg-tests