### PR TITLE
Add ability to publish non-interactively without version bumping

### DIFF
--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -61,14 +61,12 @@ test('run version with --non-interactive and --new-version should succeed', (): 
   });
 });
 
-test('run version with --non-interactive and without --new-version should fail', async (): Promise<void> => {
-  let thrown = false;
-  try {
-    await runRun([], {nonInteractive: true}, 'no-args');
-  } catch (e) {
-    thrown = true;
-  }
-  expect(thrown).toEqual(true);
+test('run version with --non-interactive and without --new-version should succeed', (): Promise<void> => {
+  return runRun([], {nonInteractive: true}, 'no-args', async (config, reporter): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+
+    expect(pkg.version).toEqual(oldVersion);
+  });
 });
 
 test('run version and make sure all lifecycle steps are executed', (): Promise<void> => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -196,10 +196,8 @@ test.concurrent('should show version of yarn with -v', async () => {
 });
 
 test.concurrent('should run version command', async () => {
-  await expectAnErrorMessage(
-    execCommand('version', [], 'run-version'),
-    'You must specify a new version with --new-version when running with --non-interactive.',
-  );
+  const stdout = await execCommand('version', [], 'run-version');
+  expect(stdout[0]).toEqual(`yarn version v${pkg.version}`);
 });
 
 test.concurrent('should run --version command', async () => {

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -95,7 +95,9 @@ export async function setVersion(
   while (!newVersion) {
     // make sure we're not running in non-interactive mode before asking for new version
     if (flags.nonInteractive || config.nonInteractive) {
-      throw new MessageError(reporter.lang('nonInteractiveNoVersionSpecified'));
+      // if no version is specified, use current version in package.json
+      newVersion = oldVersion;
+      break;
     }
 
     newVersion = await reporter.question(reporter.lang('newVersion'));


### PR DESCRIPTION
**Summary**

This PR adds a new feature to make it possible to publish non-interactively without specifying a new version. The current version in `package.json` will be used if no new version is specified.  

**Test plan**

```
> yarn publish --non-interactive
yarn publish v1.6.0
[1/4] Bumping version...
info Current version: 1.6.0
[2/4] Logging in...
[3/4] Publishing...
```
