### PR TITLE
feat(request): add noProxy setting for configuration (#5048)

### DIFF
--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -9,6 +9,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 const net = require('net');
 const https = require('https');
+const http = require('http');
 const path = require('path');
 
 test('RequestManager.request with cafile', async () => {
@@ -119,6 +120,167 @@ test('RequestManager.request with mutual TLS', async () => {
   expect(body).toBe('ok');
 });
 
+const setupServer = async () => {
+  const options = {
+    key: await fs.readFile(path.join(__dirname, '..', 'fixtures', 'certificates', 'server-key.pem')),
+    cert: await fs.readFile(path.join(__dirname, '..', 'fixtures', 'certificates', 'server-cert.pem')),
+  };
+  const httpsServer = https.createServer(options, (req, res) => {
+    res.end('ok');
+  });
+  const httpServer = http.createServer((req, res) => {
+    res.end('ok');
+  });
+
+  httpsServer.listen(0);
+  httpServer.listen(0);
+
+  const httpsPort = httpsServer.address().port;
+  const httpPort = httpServer.address().port;
+
+  return {
+    caFilePath: path.join(__dirname, '..', 'fixtures', 'certificates', 'cacerts.pem'),
+    httpPort: httpPort,
+    httpUrl: `http://localhost:${httpPort}/?nocache`,
+    httpsPort: httpsPort,
+    httpsUrl: `https://localhost:${httpsPort}/?nocache`,
+    close: () => {
+      httpsServer.close();
+      httpServer.close();
+    }
+  }
+};
+
+const setProxyEnvVars = () => {
+  process.env.HTTP_PROXY = 'http://example-proxy.com';
+  process.env.HTTPS_PROXY = 'http://example-proxy.com';
+  delete process.env.NO_PROXY;
+};
+
+const deleteProxyEnvVars = () => {
+  delete process.env.HTTP_PROXY;
+  delete process.env.HTTPS_PROXY;
+  delete process.env.NO_PROXY;
+};
+
+test('RequestManager.request with env vars proxy options and only no-proxy option in config', async () => {
+  const server = await setupServer();
+
+  try {
+    setProxyEnvVars();
+
+    const configWithoutProxyExclusion = await Config.create({
+      cafile: server.caFilePath
+    });
+
+    let error;
+    try {
+      await configWithoutProxyExclusion.requestManager.request({
+        url: server.httpsUrl,
+        headers: {Connection: 'close'},
+      });
+    } catch(e) {
+      error = e;
+    }
+    expect(error).toBeTruthy();
+
+    error = undefined;
+    try {
+      await configWithoutProxyExclusion.requestManager.request({
+        url: server.httpUrl,
+        headers: {Connection: 'close'},
+      });
+    } catch(e) {
+      error = e;
+    }
+    expect(error).toBeTruthy();
+
+    const configWithProxyExclusion = await Config.create({
+      cafile: server.caFilePath,
+      noProxy: 'localhost',
+    });
+
+    let successfulRequestBody = await configWithProxyExclusion.requestManager.request({
+      url: server.httpsUrl,
+      headers: {Connection: 'close'},
+    });
+    expect(successfulRequestBody).toBe('ok');
+
+    successfulRequestBody = await configWithProxyExclusion.requestManager.request({
+      url: server.httpUrl,
+      headers: {Connection: 'close'},
+    });
+    expect(successfulRequestBody).toBe('ok');
+  } finally {
+    server.close();
+  }
+});
+
+const testProxyOptionsInConfigFile = async () => {
+  const server = await setupServer();
+
+  try {
+    const configWithoutProxyExclusion = await Config.create({
+      cafile: server.caFilePath,
+      httpProxy: 'http://example-proxy.com',
+      httpsProxy: 'http://example-proxy.com',
+    });
+
+    let error;
+    try {
+      await configWithoutProxyExclusion.requestManager.request({
+        url: server.httpsUrl,
+        headers: {Connection: 'close'},
+      });
+    } catch(e) {
+      error = e;
+    }
+    expect(error).toBeTruthy();
+
+    error = undefined;
+    try {
+      await configWithoutProxyExclusion.requestManager.request({
+        url: server.httpUrl,
+        headers: {Connection: 'close'},
+      });
+    } catch(e) {
+      error = e;
+    }
+    expect(error).toBeTruthy();
+
+    const configWithProxyExclusion = await Config.create({
+      cafile: server.caFilePath,
+      noProxy: 'localhost',
+      httpProxy: 'http://example-proxy.com',
+      httpsProxy: 'http://example-proxy.com',
+    });
+
+    let successfulRequestBody = await configWithProxyExclusion.requestManager.request({
+      url: server.httpsUrl,
+      headers: {Connection: 'close'},
+    });
+    expect(successfulRequestBody).toBe('ok');
+
+    successfulRequestBody = await configWithProxyExclusion.requestManager.request({
+      url: server.httpUrl,
+      headers: {Connection: 'close'},
+    });
+    expect(successfulRequestBody).toBe('ok');
+  } finally {
+    server.close();
+  }
+};
+
+test('RequestManager.request with proxy and no-proxy options only in config without env vars', async () => {
+  deleteProxyEnvVars();
+  testProxyOptionsInConfigFile();
+});
+
+test('RequestManager.request with both proxy options in env vars and config and no-proxy options in config', async () => {
+  setProxyEnvVars();
+  testProxyOptionsInConfigFile();
+});
+
 test('RequestManager.execute timeout error with maxRetryAttempts=1', async () => {
   jest.useFakeTimers();
 
@@ -196,14 +358,12 @@ test('RequestManager.execute Request 403 error', async () => {
   });
   await config.requestManager.execute({
     params: {
-      url: `https://localhost:port/?nocache`,
+      url: `https://localhost:80/?nocache`,
       headers: {Connection: 'close'},
     },
     resolve: body => {},
     reject: err => {
-      expect(err.message).toBe(
-        'https://localhost:port/?nocache: Request "https://localhost:port/?nocache" returned a 403',
-      );
+      expect(err.message).toBe('https://localhost:80/?nocache: Request "https://localhost:80/?nocache" returned a 403');
     },
   });
 });
@@ -212,11 +372,11 @@ test('RequestManager.request with offlineNoRequests', async () => {
   const config = await Config.create({offline: true}, new Reporter());
   try {
     await config.requestManager.request({
-      url: `https://localhost:port/?nocache`,
+      url: `https://localhost:80/?nocache`,
       headers: {Connection: 'close'},
     });
   } catch (err) {
-    expect(err.message).toBe('Can\'t make a request in offline mode ("https://localhost:port/?nocache")');
+    expect(err.message).toBe('Can\'t make a request in offline mode ("https://localhost:80/?nocache")');
   }
 });
 

--- a/src/config.js
+++ b/src/config.js
@@ -54,6 +54,7 @@ export type ConfigOptions = {
 
   httpProxy?: ?string,
   httpsProxy?: ?string,
+  noProxy?: ?string,
 
   commandName?: ?string,
   registry?: ?string,
@@ -282,10 +283,12 @@ export default class Config {
 
     const httpProxy = opts.httpProxy || this.getOption('proxy');
     const httpsProxy = opts.httpsProxy || this.getOption('https-proxy');
+    const noProxy = opts.noProxy || this.getOption('no-proxy');
     this.requestManager.setOptions({
       userAgent: String(this.getOption('user-agent')),
       httpProxy: httpProxy === false ? false : String(httpProxy || ''),
       httpsProxy: httpsProxy === false ? false : String(httpsProxy || ''),
+      noProxy: String(noProxy || ''),
       strictSSL: Boolean(this.getOption('strict-ssl')),
       ca: Array.prototype.concat(opts.ca || this.getOption('ca') || []).map(String),
       cafile: String(opts.cafile || this.getOption('cafile', true) || ''),

--- a/src/util/proxy-exclusion.js
+++ b/src/util/proxy-exclusion.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+import {URL} from 'url';
+
+type Zone = {
+  hostname: string,
+  port: number,
+  hasPort: boolean,
+};
+
+function formatHostname(hostname: string): string {
+  // canonicalize the hostname, so that 'oogle.com' won't match 'google.com'
+  return hostname.replace(/^\.*/, '.').toLowerCase();
+}
+
+function parseNoProxyZone(zone: string): Zone {
+  zone = zone.trim().toLowerCase();
+
+  const zoneParts = zone.split(':', 2);
+  const hostname = formatHostname(zoneParts[0]);
+  const port: number = (zoneParts[1]: any);
+  const hasPort = zone.indexOf(':') > -1;
+
+  return {
+    hostname,
+    port,
+    hasPort,
+  };
+}
+
+export default function isExcludedFromProxy(url: string, noProxy: string): boolean {
+  if (!noProxy) {
+    return false;
+  }
+
+  if (noProxy === '*') {
+    return true;
+  }
+
+  const uri = new URL(url);
+
+  const port = uri.port || (uri.protocol === 'https:' ? '443' : '80');
+  const hostname = formatHostname(uri.hostname);
+  const noProxyList = noProxy.split(',');
+
+  // iterate through the noProxyList until it finds a match.
+  return noProxyList.map(parseNoProxyZone).some(noProxyZone => {
+    const isMatchedAt = hostname.indexOf(noProxyZone.hostname);
+    const hostnameMatched = isMatchedAt > -1 && isMatchedAt === hostname.length - noProxyZone.hostname.length;
+
+    if (noProxyZone.hasPort) {
+      return port === noProxyZone.port && hostnameMatched;
+    }
+
+    return hostnameMatched;
+  });
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->
No

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Proxy exclusion is currently not possible in configuration file. If proxy is defined in configuration file, no proxy exclusion can therefore be specified at the moment, because environment variable is not taken into account in this case.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added test 'RequestManager.request with no_proxy option' to check both http and https behavior with proxy exclusion.
Tested with corporate proxy by calling yarn install with local repository.
I had to adapt the test 'RequestManager.execute timeout error with maxRetryAttempts=1' because the string port is not a valid port for a url.