### PR TITLE
chore(deps): update deprecated deps for node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tar-fs": "^1.16.0",
     "tar-stream": "^1.6.0",
     "uuid": "^3.0.1",
-    "v8-compile-cache": "^1.1.0",
+    "v8-compile-cache": "^2.0.0",
     "validate-npm-package-license": "^3.0.3",
     "yn": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,10 +2058,10 @@ duplexer2@0.0.2:
     readable-stream "~1.1.9"
 
 duplexify@^3.1.2, duplexify@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.0.tgz#1aa773002e1578457e9d9d4a50b0ccaaebcbd604"
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.4.tgz#4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4"
   dependencies:
-    end-of-stream "1.0.0"
+    end-of-stream "^1.0.0"
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
@@ -2099,12 +2099,6 @@ emoji-regex@^6.1.0:
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
-
-end-of-stream@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
-  dependencies:
-    once "~1.3.0"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.0"
@@ -4654,8 +4648,8 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 natives@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6407,9 +6401,9 @@ uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
-v8-compile-cache@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.0.tgz#1dc2a340fb8e5f800a32bcdbfb8c23cd747021b9"
+v8-compile-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz#526492e35fc616864284700b7043e01baee09f0a"
 
 v8flags@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
**Summary**
These are a few upgrades of dependencies in order to address issues on node 10 (in relation to: https://github.com/yarnpkg/yarn/issues/5477)

*duplexify* *3.5.0* => *3.5.4* (https://github.com/mafintosh/duplexify/commit/00d08fa3f223e1c7d1c05e0350c236d1c4e32d09)
*v8-compile-cache* *^1.1.0* => *^2.0.0* (https://github.com/zertosh/v8-compile-cache/pull/7)
*natives* *1.1.0* => *1.1.3* (https://github.com/gulpjs/gulp/issues/2162)

The last did not have to do with `new Buffer` but was something I personally encountered when using `gulp` for building in `node 10`. I don't know how common this is, but the fix is easy and within scope, so decided to include it.


**Test plan**

CI should be green.
