### PR TITLE
Show error message to user when publishing fails

### DIFF
--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -114,7 +114,7 @@ async function publish(config: Config, pkg: any, flags: Object, dir: string): Pr
       body: root,
     });
   } catch (error) {
-    throw new MessageError(config.reporter.lang('publishFail'));
+    throw new MessageError(config.reporter.lang('publishFail', error.message));
   }
 
   await config.executeLifecycleScript('publish');

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -321,7 +321,7 @@ const messages = {
   incorrectCredentials: 'Incorrect username or password.',
   clearedCredentials: 'Cleared login credentials.',
 
-  publishFail: "Couldn't publish package.",
+  publishFail: "Couldn't publish package: $0",
   publishPrivate: 'Package marked as private, not publishing.',
   published: 'Published.',
   publishing: 'Publishing',


### PR DESCRIPTION
**Summary**

When publishing a package with `yarn publish` fails, yarn catches the error and shows "Couldn't publish package.". That's not very useful to diagnose the problem.

With this change, it additionally shows the message of the caught error, for example for a truncated `.tgz` file:

> error Couldn't publish package: "https://registry.yarnpkg.com/somepackage: unexpected end of file"

**Test plan**

No actual functionality changed, only the error message got expanded. The tests still pass.