### PR TITLE
Fix #5776: CLI switch "--scripts-prepend-node-path" doesn't work

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -158,6 +158,8 @@ export default class Config {
 
   nonInteractive: boolean;
 
+  scriptsPrependNodePath: boolean;
+
   workspacesEnabled: boolean;
   workspacesNohoistEnabled: boolean;
 
@@ -384,6 +386,8 @@ export default class Config {
 
     // $FlowFixMe$
     this.nonInteractive = !!opts.nonInteractive || isCi || !process.stdout.isTTY;
+
+    this.scriptsPrependNodePath = !!opts.scriptsPrependNodePath;
 
     this.requestManager.setOptions({
       offline: !!opts.offline && !opts.preferOffline,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This is a fix for #5776 where the `--scripts-prepend-node-path` CLI switch is ignored.  The code to wire this flag up in `src/config.js` was missing.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Before: 
```
$ yarn run --scripts-prepend-node-path env | egrep 'NODE|PATH'
  "NODE": "/usr/local/Cellar/node/8.1.0/bin/node",
  "PATH": "/Users/brainfish/code/yarn/node_modules/.bin:...
```

After:
```
$ yarn run --scripts-prepend-node-path env | egrep 'NODE|PATH'
  "NODE": "/usr/local/Cellar/node/8.1.0/bin/node",
  "PATH": "/usr/local/Cellar/node/8.1.0/bin:/Users/brainfish/code/yarn/node_modules/.bin:...
```

