### PR TITLE
Fix #5517: Backlashes in output fail for escape sequences in Windows

### DIFF
--- a/__tests__/reporters/base-reporter.js
+++ b/__tests__/reporters/base-reporter.js
@@ -1,7 +1,8 @@
 /* @flow */
 /* eslint yarn-internal/warn-language: 0 */
 
-import BaseReporter from '../../src/reporters/base-reporter.js';
+import BaseReporter, {stringifyLangArgs} from '../../src/reporters/base-reporter.js';
+import {EOL} from 'os';
 
 test('BaseReporter.getTotalTime', () => {
   const reporter = new BaseReporter();
@@ -124,4 +125,17 @@ test('BaseReporter.prompt', async () => {
   }
   expect(error).not.toBeUndefined();
   reporter.close();
+});
+
+test('stringifyLangArgs should replace \\n and \\r\\n with new line', () => {
+  const input = '\r\nUnexpected token 123\r\nat position\n.Try again';
+  const expected = `"${EOL}Unexpected token 123${EOL}at position${EOL}.Try again"`;
+  expect(stringifyLangArgs([input])).toEqual([expected]);
+});
+
+test('stringifyLangArgs should not replace \\\\n with new line', () => {
+  const input = 'Directory not found: C:\\Users\\An\\Documents\\Projects\\newProject';
+  const expected = '"Directory not found: C:\\\\Users\\\\An\\\\Documents\\\\Projects\\\\newProject"';
+
+  expect(stringifyLangArgs([input])).toEqual([expected]);
 });

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -46,7 +46,9 @@ export function stringifyLangArgs(args: Array<any>): Array<string> {
         // should match all literal line breaks and
         // "u001b" that follow an odd number of backslashes and convert them to ESC
         // we do this because the JSON.stringify process has escaped these characters
-        return str.replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b').replace(/[\\]r[\\]n|[\\]n/g, os.EOL);
+        return str
+          .replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b')
+          .replace(/[\\]r[\\]n|[\\]?[\\]n/g, ($0, $1) => ($1 ? $0 : os.EOL));
       } catch (e) {
         return util.inspect(val);
       }

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -48,7 +48,11 @@ export function stringifyLangArgs(args: Array<any>): Array<string> {
         // we do this because the JSON.stringify process has escaped these characters
         return str
           .replace(/((?:^|[^\\])(?:\\{2})*)\\u001[bB]/g, '$1\u001b')
-          .replace(/[\\]r[\\]n|[\\]?[\\]n/g, ($0, $1) => ($1 ? $0 : os.EOL));
+          .replace(/[\\]r[\\]n|([\\])?[\\]n/g, (match, precededBacklash) => {
+            // precededBacklash not null when "\n" is preceded by a backlash ("\\n")
+            // match will be "\\n" and we don't replace it with os.EOL
+            return precededBacklash ? match : os.EOL;
+          });
       } catch (e) {
         return util.inspect(val);
       }


### PR DESCRIPTION
This is my very first PR. So if there's any suggestions or if I'm missing anything, please advise 😀

**Summary**
This is the fix for [#5517](https://github.com/yarnpkg/yarn/issues/5517) where backlashes in the output in Windows are broken if the directory path contains "\n". The **stringifyLangArgs** method has been modified so that "\n" will only be replaced by EOL if it is not preceded by a "\\". 

**Test plan**
The test project path is C:\\Users\\An\\Documents\\Projects\\oss\\name\
Before
```
error An unexpected error occurred: "C:\\Users\\An\\Documents\\Projects\\oss\ 
ame\\package.json: Unexpected token U in JSON at position 139". 
```

After 
```
error An unexpected error occurred: "C:\\Users\\An\\Documents\\Projects\\oss\\name\\package.json: Unexpected token U in JSON at position 139". 
```

Also added automated tests.