### PR TITLE
Read config from ~/.yarnrc

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -658,7 +658,6 @@ describe('request', () => {
     };
     const registry = createRegistry({});
     registry.registries.yarn = createRegistry(testCase.config, 'yarn');
-    registry.registries.yarn.registries.npm = registry;
     testCase.requests.forEach(req => {
       const desc =
         `with request url ${req.url}${req.pkg ? ` in context of package ${req.pkg}` : ''} ` +

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -2,6 +2,8 @@
 
 import {resolve, join as pathJoin} from 'path';
 
+import type {RegistryNames} from '../../src/registries/index.js';
+import {registries} from '../../src/registries/index.js';
 import NpmRegistry from '../../src/registries/npm-registry.js';
 import {BufferReporter} from '../../src/reporters/index.js';
 import homeDir, {home} from '../../src/util/user-home-dir.js';
@@ -74,19 +76,20 @@ function createMocks(): Object {
 describe('request', () => {
   // a helper function for creating an instance of npm registry,
   // making requests and inspecting request parameters
-  function createRegistry(config: Object): Object {
+  function createRegistry(config: Object, registry: RegistryNames = 'npm'): Object {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
-    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter);
+    const npmRegistry = new registries[registry](testCwd, mockRegistries, mockRequestManager, mockReporter);
     npmRegistry.config = config;
-    return {
-      request(url: string, options: Object, packageName: string): Object {
-        npmRegistry.request(url, options, packageName);
-        const lastIndex = mockRequestManager.request.mock.calls.length - 1;
-        const requestParams = mockRequestManager.request.mock.calls[lastIndex][0];
-        return requestParams;
-      },
+    const request = npmRegistry.request.bind(npmRegistry);
+    npmRegistry.request = (url: string, options: Object, packageName: string): Object => {
+      request(url, options, packageName);
+      const lastIndex = mockRequestManager.request.mock.calls.length - 1;
+      const requestParams = mockRequestManager.request.mock.calls[lastIndex][0];
+      return requestParams;
     };
+
+    return npmRegistry;
   }
 
   test('should call requestManager.request with url', () => {
@@ -568,6 +571,104 @@ describe('request', () => {
           expect(requestParams.url.substr(0, req.expect.root.length)).toBe(req.expect.root);
           expect(requestParams.headers.authorization).toBe(req.expect.auth ? `Bearer ${req.expect.auth}` : undefined);
         });
+      });
+    });
+  });
+
+  describe('Private scoped registries with authentication details in YarnRegistry', () => {
+    const testCase = {
+      config: {
+        '//registry.myorg.com/:_authToken': 'scopedPrivateAuthToken',
+        '@private:registry': 'https://registry.myorg.com/',
+        '//registry.npmjs.org/:_authToken': 'scopedNPMAuthToken',
+        '@scoped:registry': 'https://registry.npmjs.org/',
+      },
+      requests: [
+        {
+          url: 'yarn',
+          pkg: 'yarn',
+          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+        },
+        {
+          url: '@yarn%2fcore',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNPMAuthToken'},
+        },
+        {
+          url: '-/package/yarn/dist-tags',
+          pkg: 'yarn',
+          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+        },
+        {
+          url: '-/package/@yarn%2fcore/dist-tags',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNPMAuthToken'},
+        },
+        {
+          url: '-/user/token/abcdef',
+          pkg: null,
+          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+        },
+        {
+          url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNPMAuthToken'},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNPMAuthToken'},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: null,
+          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+        },
+        {
+          url: 'https://some.cdn.com/@yarn/core.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+        {
+          url: 'https://some.cdn.com/@yarn/core.tgz',
+          pkg: null,
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+        {
+          url: '@private/pkg',
+          pkg: '@private/pkg',
+          expect: {root: 'https://registry.myorg.com', auth: 'scopedPrivateAuthToken'},
+        },
+        {
+          url: 'https://some.cdn.com/some-hash/@private-pkg-1.0.0.tar.gz',
+          pkg: '@private/pkg',
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+        {
+          url: 'https://some.cdn.com/@private/pkg',
+          pkg: null,
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+        {
+          url: '@scoped/pkg',
+          pkg: '@scoped/pkg',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNPMAuthToken'},
+        },
+      ],
+    };
+    const registry = createRegistry(testCase.config, 'yarn');
+    registry.registries.npm = createRegistry({});
+    test('NpmRegistry config to be empty', () => {
+      expect(registry.registries.npm.config).toEqual({});
+    });
+    testCase.requests.forEach(req => {
+      const desc =
+        `with request url ${req.url}${req.pkg ? ` in context of package ${req.pkg}` : ''} ` +
+        `auth is ${req.expect.auth ? req.expect.auth : 'not sent'}`;
+      (req.skip ? it.skip : req.only ? it.only : it)(desc, () => {
+        const requestParams = registry.request(req.url, {}, req.pkg);
+        expect(requestParams.url.substr(0, req.expect.root.length)).toBe(req.expect.root);
+        expect(requestParams.headers.authorization).toBe(req.expect.auth ? `Bearer ${req.expect.auth}` : undefined);
       });
     });
   });

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -587,32 +587,32 @@ describe('request', () => {
         {
           url: 'yarn',
           pkg: 'yarn',
-          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+          expect: {root: 'https://registry.npmjs.org', auth: false},
         },
         {
           url: '@yarn%2fcore',
           pkg: '@yarn/core',
-          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNPMAuthToken'},
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNPMAuthToken'},
         },
         {
           url: '-/package/yarn/dist-tags',
           pkg: 'yarn',
-          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+          expect: {root: 'https://registry.npmjs.org', auth: false},
         },
         {
           url: '-/package/@yarn%2fcore/dist-tags',
           pkg: '@yarn/core',
-          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNPMAuthToken'},
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNPMAuthToken'},
         },
         {
           url: '-/user/token/abcdef',
           pkg: null,
-          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+          expect: {root: 'https://registry.npmjs.org', auth: false},
         },
         {
           url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
           pkg: '@yarn/core',
-          expect: {root: 'https://registry.npmjs.org', auth: false},
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNPMAuthToken'},
         },
         {
           url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -612,7 +612,7 @@ describe('request', () => {
         {
           url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
           pkg: '@yarn/core',
-          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNPMAuthToken'},
+          expect: {root: 'https://registry.npmjs.org', auth: false},
         },
         {
           url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
@@ -656,11 +656,9 @@ describe('request', () => {
         },
       ],
     };
-    const registry = createRegistry(testCase.config, 'yarn');
-    registry.registries.npm = createRegistry({});
-    test('NpmRegistry config to be empty', () => {
-      expect(registry.registries.npm.config).toEqual({});
-    });
+    const registry = createRegistry({});
+    registry.registries.yarn = createRegistry(testCase.config, 'yarn');
+    registry.registries.yarn.registries.npm = registry;
     testCase.requests.forEach(req => {
       const desc =
         `with request url ${req.url}${req.pkg ? ` in context of package ${req.pkg}` : ''} ` +

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -76,21 +76,23 @@ export default class BaseRegistry {
     this.token = token;
   }
 
-  getOption(key: string, searchRegistries: boolean = true): mixed {
+  getOption(key: string): mixed {
     let val = this.config[key];
 
-    if (typeof val === 'undefined' && searchRegistries) {
+    if (typeof val === 'undefined') {
       for (const registryName of Object.keys(this.registries)) {
         const registry = this.registries[registryName];
 
-        if (!registry.getOption || registry.constructor.name === this.constructor.name) {
+        if (registry.constructor.name === this.constructor.name) {
           continue;
         }
 
-        val = registry.getOption(key);
+        if (registry.config && registry.config[key]) {
+          val = registry.config[key];
 
-        if (typeof val !== 'undefined') {
-          break;
+          if (typeof val !== 'undefined') {
+            break;
+          }
         }
       }
     }

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -298,8 +298,7 @@ export default class NpmRegistry extends Registry {
     }
 
     for (const scope of [this.getScope(packageIdent), '']) {
-      const registry =
-        this.getScopedOption(scope, 'registry') || this.registries.yarn.getScopedOption(scope, 'registry');
+      const registry = this.getScopedOption(scope, 'registry');
       if (registry) {
         return String(registry);
       }
@@ -347,7 +346,8 @@ export default class NpmRegistry extends Registry {
   }
 
   getScopedOption(scope: string, option: string): mixed {
-    return this.getOption(scope + (scope ? ':' : '') + option);
+    const key = scope + (scope ? ':' : '') + option;
+    return this.getOption(key) || this.registries.yarn.getOption(key);
   }
 
   getRegistryOption(registry: string, option: string): mixed {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -346,24 +346,7 @@ export default class NpmRegistry extends Registry {
   }
 
   getScopedOption(scope: string, option: string): mixed {
-    const key = scope + (scope ? ':' : '') + option;
-
-    let val = this.getOption(key);
-
-    if (typeof val === 'undefined') {
-      const registries = Object.keys(this.registries);
-      for (const registryName of registries) {
-        if (this.registries[registryName].getOption) {
-          val = this.registries[registryName].getOption(key);
-        }
-
-        if (typeof val !== 'undefined') {
-          break;
-        }
-      }
-    }
-
-    return val;
+    return this.getOption(scope + (scope ? ':' : '') + option);
   }
 
   getRegistryOption(registry: string, option: string): mixed {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -347,7 +347,23 @@ export default class NpmRegistry extends Registry {
 
   getScopedOption(scope: string, option: string): mixed {
     const key = scope + (scope ? ':' : '') + option;
-    return this.getOption(key) || this.registries.yarn.getOption(key);
+
+    let val = this.getOption(key);
+
+    if (typeof val === 'undefined') {
+      const registries = Object.keys(this.registries);
+      for (const registryName of registries) {
+        if (this.registries[registryName].getOption) {
+          val = this.registries[registryName].getOption(key);
+        }
+
+        if (typeof val !== 'undefined') {
+          break;
+        }
+      }
+    }
+
+    return val;
   }
 
   getRegistryOption(registry: string, option: string): mixed {

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -31,14 +31,6 @@ export const DEFAULTS = {
   'user-agent': [`yarn/${version}`, 'npm/?', `node/${process.version}`, process.platform, process.arch].join(' '),
 };
 
-const npmMap = {
-  'version-git-sign': 'sign-git-tag',
-  'version-tag-prefix': 'tag-version-prefix',
-  'version-git-tag': 'git-tag-version',
-  'version-commit-hooks': 'commit-hooks',
-  'version-git-message': 'message',
-};
-
 export default class YarnRegistry extends NpmRegistry {
   constructor(cwd: string, registries: ConfigRegistries, requestManager: RequestManager, reporter: Reporter) {
     super(cwd, registries, requestManager, reporter);
@@ -55,13 +47,9 @@ export default class YarnRegistry extends NpmRegistry {
   getOption(key: string): mixed {
     let val = this.config[key];
 
-    // if this isn't set in a yarn config, then use npm
+    // if this isn't set in a yarn config, look elsewhere
     if (typeof val === 'undefined') {
-      val = this.registries.npm.getOption(npmMap[key]);
-    }
-
-    if (typeof val === 'undefined') {
-      val = this.registries.npm.getOption(key);
+      val = super.getOption(key, false);
     }
 
     // if this isn't set in a yarn config or npm config, then use the default (or undefined)

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -49,7 +49,7 @@ export default class YarnRegistry extends NpmRegistry {
 
     // if this isn't set in a yarn config, look elsewhere
     if (typeof val === 'undefined') {
-      val = super.getOption(key, false);
+      val = super.getOption(key);
     }
 
     // if this isn't set in a yarn config or npm config, then use the default (or undefined)


### PR DESCRIPTION
Given the following:
```
yarn config set @scope:registry https://registry.npmjs.org/
yarn config set //registry.npmjs.org/:_authToken xxxx-xxxx-xxxx-xxxx-xxxxxxxxx
```
I expect to be able to be able to access the private packages on the registry.

I believe this relates to #3932 as well as a few others.

**Explanation**: `YarnRegistry` extends `NpmRegistry` however `NpmRegistry.getScopedOption` does not try to read from `YarnRegistry.config` so it is unable to find `//registry.npmjs.org/:_authToken` resulting in errors.
