### PR TITLE
fix(config): allow .npmrc config to supersede yarn defaults

### DIFF
--- a/__tests__/registries/yarn-registry.js
+++ b/__tests__/registries/yarn-registry.js
@@ -1,0 +1,100 @@
+/* @flow */
+
+import YarnRegistry from '../../src/registries/yarn-registry.js';
+import {BufferReporter} from '../../src/reporters/index.js';
+import {YARN_REGISTRY} from '../../src/constants.js';
+
+function createMocks(): Object {
+  const mockRequestManager = {
+    request: jest.fn(),
+  };
+
+  const mockRegistries = {
+    npm: {
+      getOption(key): mixed {
+        return this.config[key];
+      },
+    },
+    yarn: {},
+  };
+
+  const reporter = new BufferReporter({verbose: true});
+
+  return {
+    mockRequestManager,
+    mockRegistries,
+    reporter,
+  };
+}
+
+describe('yarn registry getOption', () => {
+  test('that getOption falls back to npm if the key is defined as a npm config and also is a yarn default', () => {
+    const {mockRequestManager, mockRegistries, reporter} = createMocks();
+    const yarnRegistry = new YarnRegistry('.', mockRegistries, mockRequestManager, reporter);
+
+    mockRegistries.npm.config = {
+      registry: 'npm:custom-registry',
+    };
+
+    yarnRegistry.config = {
+      registry: YARN_REGISTRY,
+    };
+
+    yarnRegistry.configWithoutDefaults = {};
+
+    expect(yarnRegistry.getOption('registry')).toEqual('npm:custom-registry');
+  });
+
+  test('that getOption will respect custom yarn options over npm', () => {
+    const {mockRequestManager, mockRegistries, reporter} = createMocks();
+    const yarnRegistry = new YarnRegistry('.', mockRegistries, mockRequestManager, reporter);
+
+    mockRegistries.npm.config = {
+      registry: 'npm:custom-registry',
+    };
+
+    yarnRegistry.config = {
+      registry: 'yarn:custom-registry',
+    };
+
+    yarnRegistry.configWithoutDefaults = {
+      registry: 'yarn:custom-registry',
+    };
+
+    expect(yarnRegistry.getOption('registry')).toEqual('yarn:custom-registry');
+  });
+
+  test('that if a option is not defined on either yarn or npm we use yarns default', () => {
+    const {mockRequestManager, mockRegistries, reporter} = createMocks();
+    const yarnRegistry = new YarnRegistry('.', mockRegistries, mockRequestManager, reporter);
+
+    mockRegistries.npm.config = {};
+
+    yarnRegistry.config = {
+      registry: YARN_REGISTRY,
+    };
+
+    yarnRegistry.configWithoutDefaults = {};
+
+    expect(yarnRegistry.getOption('registry')).toEqual(YARN_REGISTRY);
+  });
+
+  test('that if the yarn config value is the same as the default it will be used', () => {
+    const {mockRequestManager, mockRegistries, reporter} = createMocks();
+    const yarnRegistry = new YarnRegistry('.', mockRegistries, mockRequestManager, reporter);
+
+    mockRegistries.npm.config = {
+      registry: 'npm:registry',
+    };
+
+    yarnRegistry.config = {
+      registry: YARN_REGISTRY,
+    };
+
+    yarnRegistry.configWithoutDefaults = {
+      registry: YARN_REGISTRY,
+    };
+
+    expect(yarnRegistry.getOption('registry')).toEqual(YARN_REGISTRY);
+  });
+});

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -51,9 +51,10 @@ export default class YarnRegistry extends NpmRegistry {
 
   homeConfigLoc: string;
   homeConfig: Object;
+  configWithoutDefaults: Object;
 
   getOption(key: string): mixed {
-    let val = this.config[key];
+    let val = this.configWithoutDefaults[key];
 
     // if this isn't set in a yarn config, then use npm
     if (typeof val === 'undefined') {
@@ -66,7 +67,7 @@ export default class YarnRegistry extends NpmRegistry {
 
     // if this isn't set in a yarn config or npm config, then use the default (or undefined)
     if (typeof val === 'undefined') {
-      val = DEFAULTS[key];
+      val = this.config[key];
     }
 
     return val;
@@ -102,6 +103,7 @@ export default class YarnRegistry extends NpmRegistry {
     }
 
     // default yarn config
+    this.configWithoutDefaults = Object.assign({}, this.config);
     this.config = Object.assign({}, DEFAULTS, this.config);
   }
 


### PR DESCRIPTION
**Summary**

Running `yarn config get registry` within a project that contains a .npmrc which overrides the registry config key is not respected and instead the default yarn registry option is returned. Conceptually if you look at the code for `getOption` it first checks to see if the config exists within yarn and if not found it will check for that config within npm's config. However, the problem arises as the config property that is built up gets merged with yarns default values. This means that any config key that exists as a yarn default cannot be overwritten via .npmrc. This change differentiates yarn default configs and configs specified via .yarnrc. This allows the proper config fall back.

**Test plan**

* mkdir /tmp/foobar
* cd /tmp/foobar
* echo 'registry=http://example.com' > .npmrc
* yarn config get registry

Returns `https://registry.yarnpkg.com/`

* yarn-local config get registry

Returns `http://example.com/`