### PR TITLE
Fix #5816: Trailing slash breaks workspace features when yarn run inside workspace folder

### DIFF
--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -11,10 +11,10 @@ const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'workspace');
 async function runWorkspaces(
   flags: Object,
   args: Array<string>,
-  name: string,
+  cwdSubfolders: string[],
   checkSteps?: ?(config: Config, reporter: BufferReporter) => ?Promise<void>,
 ): Promise<void> {
-  const cwd = path.join(fixturesLoc, name);
+  const cwd = path.join(fixturesLoc, ...cwdSubfolders);
   const reporter = new reporters.BufferReporter({stdout: null, stdin: null, isSilent: true});
 
   const config = await Config.create({cwd}, reporter);
@@ -27,7 +27,7 @@ async function runWorkspaces(
 }
 
 test('workspaces info should list the workspaces', (): Promise<void> => {
-  return runWorkspaces({}, ['info'], 'run-basic', (config, reporter) => {
+  return runWorkspaces({}, ['info'], ['run-basic'], (config, reporter) => {
     expect(reporter.getBufferJson()).toEqual({
       'workspace-1': {
         location: 'packages/workspace-child-1',
@@ -37,6 +37,18 @@ test('workspaces info should list the workspaces', (): Promise<void> => {
       'workspace-2': {
         location: 'packages/workspace-child-2',
         workspaceDependencies: ['workspace-1'],
+        mismatchedWorkspaceDependencies: [],
+      },
+    });
+  });
+});
+
+test('workspaces info should list the workspaces inside workspace folder', (): Promise<void> => {
+  return runWorkspaces({}, ['info'], ['run-variations', 'trailing-slash'], (config, reporter) => {
+    expect(reporter.getBufferJson()).toEqual({
+      'trailing-slash': {
+        location: 'trailing-slash',
+        workspaceDependencies: [],
         mismatchedWorkspaceDependencies: [],
       },
     });

--- a/__tests__/fixtures/workspace/run-variations/package.json
+++ b/__tests__/fixtures/workspace/run-variations/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-project",
+  "private": true,
+  "workspaces": [
+    "trailing-slash/"
+  ]
+}

--- a/__tests__/fixtures/workspace/run-variations/trailing-slash/package.json
+++ b/__tests__/fixtures/workspace/run-variations/trailing-slash/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "trailing-slash",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "prescript": "echo trailing-slash prescript",
+    "script": "echo trailing-slash script",
+    "postscript": "echo trailing-slash postscript"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -633,7 +633,15 @@ export default class Config {
       const ws = extractWorkspaces(manifest);
       if (ws && ws.packages) {
         const relativePath = path.relative(current, initial);
-        if (relativePath === '' || micromatch([relativePath], ws.packages).length > 0) {
+        // Make packages trailing-slash-agnostic
+        const sanitizedPackages = ws.packages.map(packageGlob => {
+          if (packageGlob.endsWith('/')) {
+            packageGlob = packageGlob.slice(0, -1);
+          }
+          return packageGlob + '{,/}';
+        });
+
+        if (relativePath === '' || micromatch.any(relativePath, sanitizedPackages)) {
           return current;
         } else {
           return null;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Attempt to fix #5816.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I've added the use case from #5816 as a test case.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Feedback needed
I'm very unsure about this solution. The test case is too general, it does not directly test the root problem, just one of its symptoms. Also, the replacement of the trailing slash does not seem very robust.

Can I improve this?
