### PR TITLE
feat(cli): Change color on console for better accessibility

### DIFF
--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -68,7 +68,7 @@ test.concurrent('works with no arguments', (): Promise<void> => {
     const json: Object = JSON.parse(out);
 
     expect(json.data.body.length).toBe(1);
-    expect(reporter.format.green).toHaveBeenCalledWith('left-pad');
+    expect(reporter.format.blue).toHaveBeenCalledWith('left-pad');
   });
 });
 
@@ -78,7 +78,7 @@ test.concurrent('works with single argument', (): Promise<void> => {
 
     expect(json.data.body.length).toBe(1);
     expect(json.data.body[0][0]).toBe('max-safe-integer');
-    expect(reporter.format.green).toHaveBeenCalledWith('max-safe-integer');
+    expect(reporter.format.blue).toHaveBeenCalledWith('max-safe-integer');
   });
 });
 
@@ -92,7 +92,7 @@ test.concurrent('works with multiple arguments', (): Promise<void> => {
     expect(json.data.body[0][0]).toBe('left-pad');
     expect(json.data.body[1][0]).toBe('max-safe-integer');
     expect(reporter.format.yellow).toHaveBeenCalledWith('left-pad');
-    expect(reporter.format.green).toHaveBeenCalledWith('max-safe-integer');
+    expect(reporter.format.blue).toHaveBeenCalledWith('max-safe-integer');
   });
 });
 
@@ -149,7 +149,7 @@ test.concurrent('displays correct dependency types', (): Promise<void> => {
     expect(reporter.format.yellow).toHaveBeenCalledWith('left-pad');
     expect(body[2][0]).toBe('max-safe-integer');
     expect(body[2][4]).toBe('devDependencies');
-    expect(reporter.format.green).toHaveBeenCalledWith('max-safe-integer');
+    expect(reporter.format.blue).toHaveBeenCalledWith('max-safe-integer');
   });
 });
 

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -53,8 +53,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     const red = reporter.format.red('<red>');
     const yellow = reporter.format.yellow('<yellow>');
-    const green = reporter.format.green('<green>');
-    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
+    const blue = reporter.format.blue('<blue>');
+    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, blue));
 
     const header = ['Package', 'Current', 'Wanted', 'Latest', 'Workspace', 'Package Type', 'URL'];
     if (!usesWorkspaces) {

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -139,8 +139,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   try {
     const red = reporter.format.red('<red>');
     const yellow = reporter.format.yellow('<yellow>');
-    const green = reporter.format.green('<green>');
-    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
+    const blue = reporter.format.blue('<blue>');
+    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, blue));
 
     const answers: Array<Dependency> = await reporter.prompt('Choose which packages to update.', choices, {
       name: 'packages',

--- a/src/constants.js
+++ b/src/constants.js
@@ -116,13 +116,13 @@ export const VERSION_COLOR_SCHEME: {[key: string]: VersionColor} = {
   premajor: 'red',
   minor: 'yellow',
   preminor: 'yellow',
-  patch: 'green',
-  prepatch: 'green',
+  patch: 'blue',
+  prepatch: 'blue',
   prerelease: 'red',
   unchanged: 'white',
   unknown: 'red',
 };
 
-export type VersionColor = 'red' | 'yellow' | 'green' | 'white';
+export type VersionColor = 'red' | 'yellow' | 'blue' | 'white';
 
 export type RequestHint = 'dev' | 'optional' | 'resolution' | 'workspaces';

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -117,7 +117,7 @@ const messages = {
   noGlobalFolder: 'Cannot find a suitable global folder. Tried these: $0',
   allDependenciesUpToDate: 'All of your dependencies are up to date.',
   legendColorsForVersionUpdates:
-    'Color legend : \n $0    : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2  : Patch Update backward-compatible bug fixes',
+    'Color legend : \n $0    : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2   : Patch Update backward-compatible bug fixes',
   frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
   fileWriteError: 'Could not write file $0: $1',
   multiplePackagesCantUnpackInSameDestination:


### PR DESCRIPTION
Hello maintainers. I addressed https://github.com/yarnpkg/yarn/issues/5800.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

For better accessibility.

According to https://github.com/yarnpkg/yarn/issues/5800#issuecomment-387946810, blue is the one with which we should replace green.

> For people like me, red, yellow and blue are much better combinations than red, yellow, and green combinations.

Closes: https://github.com/yarnpkg/yarn/issues/5800

**Test plan**

- [x] `yarn run lint`
- [x] `yarn run test`
- [x] Build with `yarn run build` and use the built to check the change 👇 

before:

![image](https://user-images.githubusercontent.com/1811616/40133331-5a61aebe-597a-11e8-9744-6f75f4ba4e21.png)

![image](https://user-images.githubusercontent.com/1811616/40133935-08ef3dd8-597c-11e8-8a0c-842ba53e4f7a.png)

after:

![image](https://user-images.githubusercontent.com/1811616/40133511-fa0f8828-597a-11e8-96a0-670b8689f964.png)

<img width="962" alt="2018-05-17 2 42 03" src="https://user-images.githubusercontent.com/1811616/40133899-f4532c68-597b-11e8-9d79-e16adc305840.png">

📝 The repository is my own test repository, so please do not take care.
