### PR TITLE
Remove unused constants

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -23,8 +23,6 @@ export const YARN_INSTALLER_SH = 'https://yarnpkg.com/install.sh';
 export const YARN_INSTALLER_MSI = 'https://yarnpkg.com/latest.msi';
 
 export const SELF_UPDATE_VERSION_URL = 'https://yarnpkg.com/latest-version';
-export const SELF_UPDATE_TARBALL_URL = 'https://yarnpkg.com/latest.tar.gz';
-export const SELF_UPDATE_DOWNLOAD_FOLDER = 'updates';
 
 // cache version, bump whenever we make backwards incompatible changes
 export const CACHE_VERSION = 1;
@@ -86,7 +84,6 @@ export const LOCKFILE_FILENAME = 'yarn.lock';
 export const METADATA_FILENAME = '.yarn-metadata.json';
 export const TARBALL_FILENAME = '.yarn-tarball.tgz';
 export const CLEAN_FILENAME = '.yarnclean';
-export const ACCESS_FILENAME = '.yarn-access';
 
 export const DEFAULT_INDENT = '  ';
 export const SINGLE_INSTANCE_PORT = 31997;


### PR DESCRIPTION
**Summary**

I just found that those constants are not used anywhere, then just removed them.

- `SELF_UPDATE_TARBALL_URL` : it may be remain when removing `self-update`
- `SELF_UPDATE_DOWNLOAD_FOLDER` : it may be remain when removing `self-update`
- `ACCESS_FILENAME` : this seems to have never been used

Please feel free to close this if you won't need this kind of nitpicking pull request. :P

**Test plan**

Let me put search results.

```shell
~/.g/g/o/yarn ❯❯❯ ag (SELF_UPDATE_TARBALL_URL|SELF_UPDATE_DOWNLOAD_FOLDER|ACCESS_FILENAME) .                                                        ⏎ remove-unused-constants ✱
src/constants.js
26:export const SELF_UPDATE_TARBALL_URL = 'https://yarnpkg.com/latest.tar.gz';
27:export const SELF_UPDATE_DOWNLOAD_FOLDER = 'updates';
89:export const ACCESS_FILENAME = '.yarn-access';
~/.g/g/o/yarn ❯❯❯
```