### PR TITLE
fix(run): Fix custom shell execution

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -220,9 +220,8 @@ export async function executeLifecycleScript({
     detached = false;
   }
 
-  const stdout = customShell
-    ? await child.spawn(customShell, [cmd], {cwd, env, stdio, detached, windowsVerbatimArguments: true}, onProgress)
-    : await child.spawn(cmd, [], {cwd, env, stdio, detached, shell: true}, onProgress);
+  const shell = customShell || true;
+  const stdout = await child.spawn(cmd, [], {cwd, env, stdio, detached, shell}, onProgress);
 
   return {cwd, command: cmd, stdout};
 }


### PR DESCRIPTION
**Summary**

A previous change removed the -c option that was passed to the shell, causing script like "echo foo"
to fail if script-shell was set to bash. This change cleans up the way custom shell is specified,
passing the shell to node's child process spawner instead of trying to make it part of our command
string. Doing it this way seems to account for the previously required -c flag.

fixes #5699 

**Test plan**

No test was added because our tests for the `yarn run` command use a mocked `execute-lifecycle-script`. Plus these tests would get run on windows too, so making a test that specified a config of `script-shell bash` would fail if it was unmocked.

Can be tested manually by creating a `.yarnrc` that contains:

```
script-shell bash
```

and adding a script like:

```
  "scripts": {
    "foo": "echo foo; echo bar; echo $SHELL"
  }
```

which should produce the output

```
$ yarn run foo
yarn run v1.6.0
$ echo foo; echo bar; echo $SHELL
foo
bar
/bin/bash
✨  Done in 0.15s.
```