### PR TITLE
ci(brew): Pass access token to Homebrew job

### DIFF
--- a/jenkins_jobs.groovy
+++ b/jenkins_jobs.groovy
@@ -76,6 +76,11 @@ job('yarn-homebrew') {
   scm {
     github 'yarnpkg/yarn', 'master'
   }
+  wrappers {
+    credentialsBinding {
+      string 'HOMEBREW_GITHUB_API_TOKEN', 'YARN_GITHUB_TOKEN'
+    }
+  }
   parameters {
     // Passed from yarn-version job
     stringParam 'YARN_VERSION'


### PR DESCRIPTION
**Summary**

Homebrew changed how their `brew bump-formula-pr` script works, and it now requires a GitHub access token to be set as an environment variable instead of reusing the access token configured for "Hub" (https://hub.github.com/)

This updates the Jenkins job to pass a credential (the access token) to the script as an environment variable.

Closes #5861

**Test plan**

Make sure we can update formulas on Homebrew after the change.