### PR TITLE
fix bin links for link: protocol (fixes #5876)

### DIFF
--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -166,6 +166,15 @@ test('Only top level (after hoisting) bin links should be linked', (): Promise<v
   });
 });
 
+// fixes https://github.com/yarnpkg/yarn/issues/5876
+test('can use link protocol to install a package that would not be found via node module resolution', (): Promise<
+  void,
+> => {
+  return runInstall({binLinks: true}, {source: 'install-link-siblings', cwd: '/bar'}, async config => {
+    expect(await linkAt(config, 'node_modules', '.bin', 'standard')).toEqual('../standard/bin/cmd.js');
+  });
+});
+
 describe('with nohoist', () => {
   // address https://github.com/yarnpkg/yarn/issues/5487
   test('nohoist bin should be linked to its own local module', (): Promise<void> => {

--- a/__tests__/fixtures/install/install-link-siblings/bar/package.json
+++ b/__tests__/fixtures/install/install-link-siblings/bar/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bar",
+  "version": "0.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "foo": "link:../foo"
+  }
+}

--- a/__tests__/fixtures/install/install-link-siblings/foo/package.json
+++ b/__tests__/fixtures/install/install-link-siblings/foo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "standard": "8.4.0"
+  }
+}


### PR DESCRIPTION
**Summary**
Fix #5876 . There was an error in the new bin link calculation logic when the bin folder was a symlink. The code would only look for a target installation of the package to be linked relative to the realpath of the bin folder, when it should also consider targets relative to the symlinked location of the bin folder and choose the closest overall location. Otherwise, it may fail to link.

**Test plan**

Added a new unit test which fails without this change. Based on [this reproduction](https://github.com/spalger/reproduce-issues/tree/master/yarn-reduce-of-empty-array-without-initial-value)