### PR TITLE
fix for --offline\

### DIFF
--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -110,7 +110,7 @@ export default class NpmResolver extends RegistryResolver {
     invariant(this.config.cacheFolder, 'expected packages root');
     const cacheFolder = path.join(this.config.cacheFolder, scope ? `${NPM_REGISTRY_ID}-${scope}` : '');
 
-    const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
+    const files = await this.config.getCache(`offline-packages-${cacheFolder}`, async (): Promise<Array<string>> => {
       const files = await fs.readdir(cacheFolder);
       const validFiles = [];
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When we read from the offline cache directory, we cache that file listing using `his.config.getCache`, however we had just one static key even though we need to read from different directories for scoped modules.

This means if it looks first in a scoped directory, it won't find the cache of non-scoped modules, or visa versa.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I didn't see a specific test for this. I'm happy to add one if required, just point me to where.

Many thanks!