### PR TITLE
Update Debian package to "conflict" with cmdtest

### DIFF
--- a/resources/debian/control.in
+++ b/resources/debian/control.in
@@ -1,7 +1,7 @@
 Package: yarn
 Version: $VERSION-1
 Recommends: nodejs
-Conflicts: nodejs (<< 4.0.0)
+Conflicts: nodejs (<< 4.0.0), cmdtest
 Section: devel
 Priority: optional
 Architecture: all


### PR DESCRIPTION
**Summary**

The `cmdtest` package also installs a `yarn` command, and people often get confused by this (see #2821). If we specify that the Yarn package conflicts with the cmdtest package, installing Yarn will automatically uninstall cmdtest.

**Test plan**

Will test the package built by CircleCI (since I don't have a functional dev environment right now).