### PR TITLE
fix(info): handle 404 with non-empty body

### DIFF
--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -64,11 +64,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   let result;
   try {
     result = await config.registries.npm.request(name, {unfiltered: true});
-    invariant(result, 'result must not be empty');
   } catch (e) {
     reporter.error(reporter.lang('infoFail'));
     return;
   }
+  invariant(result, 'result must not be empty');
 
   result = clean(result);
 

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -5,6 +5,7 @@ import type Config from '../../config.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 import parsePackageName from '../../util/parse-package-name.js';
 const semver = require('semver');
+const invariant = require('invariant');
 
 function clean(object: any): any {
   if (Array.isArray(object)) {
@@ -60,8 +61,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const packageInput = NpmRegistry.escapeName(packageName);
   const {name, version} = parsePackageName(packageInput);
 
-  let result = await config.registries.npm.request(name, {unfiltered: true});
-  if (!result) {
+  let result;
+  try {
+    result = await config.registries.npm.request(name, {unfiltered: true});
+    invariant(result, 'result must not be empty');
+  } catch (e) {
     reporter.error(reporter.lang('infoFail'));
     return;
   }


### PR DESCRIPTION
**Summary**
Right now tests are failing on master. 

The test that's failing: https://github.com/yarnpkg/yarn/blob/643deaa9673bcfe3afb41413572c0df2aa308e03/__tests__/commands/info.js#L135-L140

It fails here: https://github.com/yarnpkg/yarn/blob/643deaa9673bcfe3afb41413572c0df2aa308e03/src/util/request-manager.js#L392-L395

When this is rejected: https://github.com/yarnpkg/yarn/blob/643deaa9673bcfe3afb41413572c0df2aa308e03/src/cli/commands/info.js#L63

Checking out a commit from 1 month ago on master still fails at the same point. 
My guess is that this happens because in the past, the npm registry returned an empty body on 404, and now it returns a JSON with an error. I cannot confirm this however. Since this is a pretty simple fix, I thought there's no need to go deeper.

**Test plan**

CI should be green.
