### PR TITLE
fix(info): report empty npm response with `infoFail` again

### DIFF
--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -5,7 +5,6 @@ import type Config from '../../config.js';
 import NpmRegistry from '../../registries/npm-registry.js';
 import parsePackageName from '../../util/parse-package-name.js';
 const semver = require('semver');
-const invariant = require('invariant');
 
 function clean(object: any): any {
   if (Array.isArray(object)) {

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -68,7 +68,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     reporter.error(reporter.lang('infoFail'));
     return;
   }
-  invariant(result, 'result must not be empty');
+  if (!result) {
+    reporter.error(reporter.lang('infoFail'));
+    return;
+  }
 
   result = clean(result);
 


### PR DESCRIPTION
**Summary**

#5903 added support for exceptions thrown by the npm request, but changed handling of empty responses. They are now an invariant violation instead of an expected error reported as `infoFail`.

But empty responses [can still happen][1]. I assume they should continue to be handled like they were before #5903. This pull request makes this change.

**Test plan**

Tests should still pass and hopefully more reliably than before.

 [1]: https://circleci.com/gh/yarnpkg/yarn/16689