### PR TITLE
Replace Chocolatey nodejs dependency with nodejs-lts.

### DIFF
--- a/resources/win-chocolatey/yarn.nuspec
+++ b/resources/win-chocolatey/yarn.nuspec
@@ -36,7 +36,7 @@ utilization.
 		<bugTrackerUrl>https://github.com/yarnpkg/yarn/issues</bugTrackerUrl>
 		<releaseNotes>https://github.com/yarnpkg/yarn/releases/tag/v$version$</releaseNotes>
 		<dependencies>
-			<dependency id="nodejs.install" version="6.0" />
+			<dependency id="nodejs-lts" version="6.0" />
 		</dependencies>
 	</metadata>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR replaces the Chocolatey package's [nodejs.install](https://chocolatey.org/packages/nodejs.install) dependency with [nodejs-lts](https://chocolatey.org/packages/nodejs-lts). Since Yarn doesn't require the latest version of NodeJS depending on the LTS release should cause less situations where a user's other tools are not compatible with the NodeJS version installed via Chocolatey.

The nodejs.install package's documentation recommends depending on nodejs-lts, and some people have requested this change on the Chocolatey discussion page.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I verified that the Chocolatey package is buildable and installs, I don't expect this to cause issues since the change is quite trivial.
