### PR TITLE
fix(deps): change cmd-shim to @zkochan/cmd-shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",
   "dependencies": {
+    "@zkochan/cmd-shim": "^2.2.4",
     "babel-runtime": "^6.26.0",
     "bytes": "^3.0.0",
     "camelcase": "^4.0.0",
     "chalk": "^2.1.0",
-    "cmd-shim": "^2.0.1",
     "commander": "^2.9.0",
     "death": "^1.0.0",
     "debug": "^3.0.0",

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -8,7 +8,7 @@ import * as fs from '../../util/fs.js';
 import {getBinFolder as getGlobalBinFolder} from './global';
 
 const invariant = require('invariant');
-const cmdShim = promise.promisify(require('cmd-shim'));
+const cmdShim = promise.promisify(require('@zkochan/cmd-shim'));
 const path = require('path');
 
 export async function getRegistryFolder(config: Config, name: string): Promise<string> {

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -17,7 +17,7 @@ import {satisfiesWithPrereleases} from './util/semver.js';
 import WorkspaceLayout from './workspace-layout.js';
 
 const invariant = require('invariant');
-const cmdShim = promise.promisify(require('cmd-shim'));
+const cmdShim = promise.promisify(require('@zkochan/cmd-shim'));
 const path = require('path');
 // Concurrency for creating bin links disabled because of the issue #1961
 const linkBinConcurrency = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,14 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@zkochan/cmd-shim@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-2.2.4.tgz#5730a936491219d88487e92d12c6c3bdb16c3c6e"
+  dependencies:
+    is-windows "^1.0.0"
+    mkdirp-promise "^5.0.1"
+    mz "^2.5.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -147,6 +155,10 @@ ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
 anymatch@^1.3.0:
   version "1.3.0"
@@ -1593,13 +1605,6 @@ cloneable-readable@^1.0.0:
     inherits "^2.0.1"
     process-nextick-args "^1.0.6"
     through2 "^2.0.1"
-
-cmd-shim@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
-  dependencies:
-    graceful-fs "^4.1.2"
-    mkdirp "~0.5.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -3658,7 +3663,7 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -4592,7 +4597,13 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp-promise@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz#e9b8f68e552c68a9c1713b84883f7a1dd039b8a1"
+  dependencies:
+    mkdirp "*"
+
+mkdirp@*, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -4619,6 +4630,14 @@ mute-stream@0.0.6:
 mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mz@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nan@^2.3.0:
   version "2.6.2"
@@ -6157,6 +6176,18 @@ test-exclude@^4.1.1:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Update devDependency `cmd-shim` with issues to a patched version

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

As described in [its PR#29](https://github.com/npm/cmd-shim/pull/29), it contains [a piece of code](https://github.com/npm/cmd-shim/blob/master/index.js#L166) that can cause error in strict mode.
```javascript
function chmodShim (to, cb) {
  var then = times(2, cb, cb)
  fs.chmod(to, 0755, then) // SyntaxError: Invalid number
  fs.chmod(to + ".cmd", 0755, then)
}
```
There was actually NO octal number literal syntax before ES2015 adding support with `0o` prefix, and `0` prefix always throw errors in strict mode.
[Refer to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Converting_mistakes_into_errors) for more details.

`cmd-shim` has been [out of maintenance for 2 years](https://github.com/npm/cmd-shim/commits/master), and it's [only been tested out on early Node (<= 0.10)](https://github.com/npm/cmd-shim/blob/master/.travis.yml). So I update `yarn`'s dependency on it to [a fork version](https://github.com/npm/cmd-shim) in which this issue is fixed.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->