### PR TITLE
Fix offline npm cache resolve for scoped packages (rebased)

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -881,6 +881,19 @@ test.concurrent('install with latest tag and --offline flag', async () => {
   });
 });
 
+test.concurrent('install with latest tag and --offline flag scoped', async () => {
+  await runAdd(['@types/node@8.0.0'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {
+    config.offline = true;
+    const add = new Add(['@types/node@latest'], {}, config, reporter, previousAdd.lockfile);
+    await add.init();
+
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    const version = await getPackageVersion(config, '@types/node');
+
+    expect(pkg.dependencies).toEqual({'@types/node': `^${version}`});
+  });
+});
+
 test.concurrent('install with latest tag and --prefer-offline flag', async () => {
   await runAdd(['left-pad@1.1.0'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {
     config.preferOffline = true;
@@ -891,6 +904,20 @@ test.concurrent('install with latest tag and --prefer-offline flag', async () =>
     const version = await getPackageVersion(config, 'left-pad');
 
     expect(pkg.dependencies).toEqual({'left-pad': `^${version}`});
+    expect(version).not.toEqual('1.1.0');
+  });
+});
+
+test.concurrent('install with latest tag and --prefer-offline flag scoped', async () => {
+  await runAdd(['@types/node@8.0.0'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {
+    config.preferOffline = true;
+    const add = new Add(['@types/node@latest'], {}, config, reporter, previousAdd.lockfile);
+    await add.init();
+
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    const version = await getPackageVersion(config, '@types/node');
+
+    expect(pkg.dependencies).toEqual({'@types/node': `^${version}`});
     expect(version).not.toEqual('1.1.0');
   });
 });

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -111,7 +111,17 @@ export default class NpmResolver extends RegistryResolver {
     const cacheFolder = path.join(this.config.cacheFolder, scope ? `${NPM_REGISTRY_ID}-${scope}` : '');
 
     const files = await this.config.getCache('cachedPackages', async (): Promise<Array<string>> => {
-      const files = await fs.readdir(cacheFolder);
+      // Try to read the folder.
+      let files = [];
+      try {
+        files = await fs.readdir(cacheFolder);
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          return [];
+        }
+        throw err;
+      }
+
       const validFiles = [];
 
       for (const name of files) {


### PR DESCRIPTION
This is a rebase of https://github.com/yarnpkg/yarn/pull/4820, which fixes #4818.

cc @arcanis