### PR TITLE
 fix(resolution): Handle git urls that have a hash in the branch name.

### DIFF
--- a/__tests__/util/version.js
+++ b/__tests__/util/version.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+import {explodeHashedUrl} from '../../src/util/version';
+
+describe('getDataDir', () => {
+  test('correctly separates a url with a hash', () => {
+    const expectedUrl = 'git+ssh://git@github.com:org/proj.git';
+    const expectedHash = 'branch'
+    const {url, hash} = explodeHashedUrl(`${expectedUrl}#${expectedHash}`);
+    expect(url).toBe(expectedUrl);
+    expect(hash).toBe(expectedHash);
+  });
+
+  test('returns an empty string as the hash for a url with no hash', () => {
+    const expectedUrl = 'git+ssh://git@github.com:org/proj.git';
+    const expectedHash = ''
+    const {url, hash} = explodeHashedUrl(expectedUrl);
+    expect(url).toBe(expectedUrl);
+    expect(hash).toBe(expectedHash);
+  });
+
+  test('correctly separates a url with a hash in the hash', () => {
+    const expectedUrl = 'git+ssh://git@github.com:org/proj.git';
+    const expectedHash = 'branch#123'
+    const {url, hash} = explodeHashedUrl(`${expectedUrl}#${expectedHash}`);
+    expect(url).toBe(expectedUrl);
+    expect(hash).toBe(expectedHash);
+  });
+});

--- a/__tests__/util/version.js
+++ b/__tests__/util/version.js
@@ -5,7 +5,7 @@ import {explodeHashedUrl} from '../../src/util/version';
 describe('getDataDir', () => {
   test('correctly separates a url with a hash', () => {
     const expectedUrl = 'git+ssh://git@github.com:org/proj.git';
-    const expectedHash = 'branch'
+    const expectedHash = 'branch';
     const {url, hash} = explodeHashedUrl(`${expectedUrl}#${expectedHash}`);
     expect(url).toBe(expectedUrl);
     expect(hash).toBe(expectedHash);
@@ -13,7 +13,7 @@ describe('getDataDir', () => {
 
   test('returns an empty string as the hash for a url with no hash', () => {
     const expectedUrl = 'git+ssh://git@github.com:org/proj.git';
-    const expectedHash = ''
+    const expectedHash = '';
     const {url, hash} = explodeHashedUrl(expectedUrl);
     expect(url).toBe(expectedUrl);
     expect(hash).toBe(expectedHash);
@@ -21,7 +21,7 @@ describe('getDataDir', () => {
 
   test('correctly separates a url with a hash in the hash', () => {
     const expectedUrl = 'git+ssh://git@github.com:org/proj.git';
-    const expectedHash = 'branch#123'
+    const expectedHash = 'branch#123';
     const {url, hash} = explodeHashedUrl(`${expectedUrl}#${expectedHash}`);
     expect(url).toBe(expectedUrl);
     expect(hash).toBe(expectedHash);

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 export function explodeHashedUrl(url: string): {url: string, hash: string} {
-  const parts = url.split('#');
+  const [server, ...hashes] = url.split('#');
 
   return {
-    hash: parts[1] || '',
-    url: parts[0],
+    hash: hashes.length ? hashes.join('#') : '',
+    url: server,
   };
 }


### PR DESCRIPTION
**Summary**

Previously yarn was using a string split('#') to separate the URL from the branch name. If a branch
also had a hash in it, then the rest of the split chunks were ignored, meaning only the chunk before
the first '#' was used as the branch name. This change handles those URLs correctly, preserving the
'#'s in URL hashes.

fixes #5954

**Test plan**

Added `__tests__/utils/version.js`
