### PR TITLE
Make sure TarballFetcher error messages contain names of problematic files

### DIFF
--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -313,7 +313,10 @@ test('TarballFetcher.fetch throws on truncated tar data', async () => {
     },
     await Config.create({}, reporter),
   );
-  await expect(fetcher.fetch()).rejects.toThrow(new RegExp(reporter.lang('errorExtractingTarball', '.*', '.*')));
+  await expect(fetcher.fetch()).rejects.toThrow(
+    // The "." in ".tgz" should be escaped, but that doesn't work with reporter.lang
+    new RegExp(reporter.lang('errorExtractingTarball', '.*', '.*broken-tar-data.tgz')),
+  );
 });
 
 test('TarballFetcher.fetch throws on truncated tar header', async () => {
@@ -329,5 +332,8 @@ test('TarballFetcher.fetch throws on truncated tar header', async () => {
     },
     await Config.create({}, reporter),
   );
-  await expect(fetcher.fetch()).rejects.toThrow(new RegExp(reporter.lang('errorExtractingTarball', '.*', '.*')));
+  await expect(fetcher.fetch()).rejects.toThrow(
+    // The "." in ".tgz" should be escaped, but that doesn't work with reporter.lang
+    new RegExp(reporter.lang('errorExtractingTarball', '.*', '.*broken-tar-header.tgz')),
+  );
 });

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -823,7 +823,7 @@ export async function readFirstAvailableStream(
     if (tarballPath) {
       try {
         const fd = await open(tarballPath, 'r');
-        stream = fs.createReadStream('', {fd});
+        stream = fs.createReadStream(tarballPath, {fd});
         break;
       } catch (err) {
         // Try the next one


### PR DESCRIPTION
**Summary**

The error messages caused by TarballFetcher are supposed to contain the name of the offending file. The name is taken from the streams `path` attribute, but since a recent change this attribute is empty.

This PR populates the attribute again and tests that the path is actually mentioned in the TarballFetcher error messages.

**Test plan**

Existing tests have been modified to be stricter than before and test for this problem.