### PR TITLE
fix(resolution): Improve dependency resolution performance

### DIFF
--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -520,8 +520,14 @@ export default class PackageResolver {
 
       request.init();
       await request.find({fresh, frozen: this.frozen});
-    } else if (existingManifest._reference) {
+    } else if (
+      existingManifest._reference &&
+      existingManifest._reference.hint === initialReq.hint &&
+      existingManifest._reference.optional === initialReq.optional
+    ) {
       existingManifest._reference.addRequest(request);
+    } else {
+      await request.find({fresh, frozen: this.frozen});
     }
   }
 


### PR DESCRIPTION
##DO NOT MERGE

**Summary**

Instead of continuing to re-resolve a package in the dependency tree that has already been resolved,
add a request to the existing references requests array. This speeds up very deep/complex dep trees
as seen in workspaces where the workspace modules all depend on each other. Previously the building
of the tree was leading to out of memory errors or just never finishing.

fixes #5726 #5628

**Test plan**

Existing tests still pass. (watch for regressions in peerDep checks, resolutions, nohoist as these features may be affected by changing the way the deps are resolved. i'm making the assumption that these features have sufficient test coverage already.)

For manual testing, see the .zip file in a comment in #5726 for a project that would never finish or eventually out-of-memory error.