### PR TITLE
Fixes relative cache paths

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -468,6 +468,19 @@ test('cache folder fallback', async () => {
   expect(stderrOutput2.toString()).toMatch(/Skipping preferred cache folder/);
 });
 
+test('relative cache folder', async () => {
+  const base = await makeTemp();
+
+  await fs.writeFile(`${base}/.yarnrc`, 'cache-folder "./foo"\n');
+
+  await fs.mkdirp(`${base}/sub`);
+  await fs.mkdirp(`${base}/foo`);
+
+  const [stdoutOutput, _] = await runYarn(['cache', 'dir'], {cwd: `${base}/sub`});
+
+  expect(await fs.realpath(path.dirname(stdoutOutput.toString()))).toEqual(await fs.realpath(`${base}/foo`));
+});
+
 test('yarn create', async () => {
   const cwd = await makeTemp();
   const options = {cwd, env: {YARN_SILENT: 1}};

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -31,6 +31,8 @@ export const DEFAULTS = {
   'user-agent': [`yarn/${version}`, 'npm/?', `node/${process.version}`, process.platform, process.arch].join(' '),
 };
 
+const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder'];
+
 const npmMap = {
   'version-git-sign': 'sign-git-tag',
   'version-tag-prefix': 'tag-version-prefix',
@@ -80,13 +82,13 @@ export default class YarnRegistry extends NpmRegistry {
         this.homeConfig = config;
       }
 
-      // normalize offline mirror path relative to the current yarnrc
-      const offlineLoc = config['yarn-offline-mirror'];
+      for (const key of RELATIVE_KEYS) {
+        const valueLoc = config[key];
 
-      // don't normalize if we already have a mirror path
-      if (!this.config['yarn-offline-mirror'] && offlineLoc) {
-        const mirrorLoc = (config['yarn-offline-mirror'] = path.resolve(path.dirname(loc), offlineLoc));
-        await fs.mkdirp(mirrorLoc);
+        if (!this.config[key] && valueLoc) {
+          const resolvedLoc = (config[key] = path.resolve(path.dirname(loc), valueLoc));
+          await fs.mkdirp(resolvedLoc);
+        }
       }
 
       // merge with any existing environment variables


### PR DESCRIPTION
**Summary**

Relative cache paths set in the yarnrc file are currently resolved relative to the cwd (even worse - the actual cwd, not the typical `cwd` from our codebase, which equals the project path). They should instead be resolved relative to the `.yarnrc` they originate from, so that they keep a consistent value everytime.

**Test plan**

Added a test.