### PR TITLE
fix(pack): higher priority to .npmignore over .gitignore on windows

### DIFF
--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -160,7 +160,7 @@ export function filterOverridenGitignores(files: WalkFiles): WalkFiles {
     } else {
       //don't include .gitignore if .npmignore or .yarnignore are present
       const dir = path.dirname(file.absolute);
-      const higherPriorityIgnoreFilePaths = [`${dir}/${IGNORE_FILENAMES[0]}`, `${dir}/${IGNORE_FILENAMES[1]}`];
+      const higherPriorityIgnoreFilePaths = [path.join(dir, IGNORE_FILENAMES[0]), path.join(dir, IGNORE_FILENAMES[1])];
       const hasHigherPriorityFiles = files.find(file => higherPriorityIgnoreFilePaths.indexOf(file.absolute) > -1);
       if (!hasHigherPriorityFiles) {
         return [...acc, file];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This fixes `yarn pack` not ignoring `.gitignore` when `.npmignore` is avaialable on Windows. Initial fix was done in https://github.com/yarnpkg/yarn/pull/3538, but it used string concatenation to join paths which make it unfortunately fail for Windows which uses different path separator than other systems. It was reported as not fixed in https://github.com/yarnpkg/yarn/issues/685#issuecomment-329895660 (OS: Windows) in initial issue after issue was closed as fixed.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

First I tested if tarball created by `yarn pack` is correct (so it ignores `.gitignore` when I have `.npmignore`). 

To demonstrate here, I added extra console output here https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/pack.js#L89 logging `dotIgnoreFiles` and here's before / after:

**Before:**

```
D:\dev\yarn-test>yarn pack
yarn pack v1.7.0
dotIgnoreFiles [ { relative: '.gitignore',
    basename: '.gitignore',
    absolute: 'D:\\dev\\yarn-test\\.gitignore',
    mtime: 1528836250698 },
  { relative: '.npmignore',
    basename: '.npmignore',
    absolute: 'D:\\dev\\yarn-test\\.npmignore',
    mtime: 1528836254147 } ]
success Wrote tarball to "D:\\dev\\yarn-test\\yarn-test-v1.0.0.tgz".
Done in 0.45s.
```

**After:**

```
D:\dev\yarn-test>yarn pack
yarn pack v1.7.0
dotIgnoreFiles [ { relative: '.npmignore',
    basename: '.npmignore',
    absolute: 'D:\\dev\\yarn-test\\.npmignore',
    mtime: 1528836254147 } ]
success Wrote tarball to "D:\\dev\\yarn-test\\yarn-test-v1.0.0.tgz".
Done in 0.06s.
```

`.gitignore` is correctly omitted if `.npmignore` is present

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
