### PR TITLE
fix(cli): force registryFolders to be unique

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -279,9 +279,11 @@ export default class Config {
       });
 
       this.registries[key] = registry;
-      this.registryFolders.push(registry.folder);
+      if (this.registryFolders.indexOf(registry.folder) === -1) {
+        this.registryFolders.push(registry.folder);
+      }
       const rootModuleFolder = path.join(this.cwd, registry.folder);
-      if (this.rootModuleFolders.indexOf(rootModuleFolder) < 0) {
+      if (this.rootModuleFolders.indexOf(rootModuleFolder) === -1) {
         this.rootModuleFolders.push(rootModuleFolder);
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

It was possible for duplicate registryFolders to be inserted into the array. In code that looped over this array, it could cause additional processing.

fixes #5984

**Test plan**

Put a breakpoint on [this line](https://github.com/yarnpkg/yarn/blob/master/src/config.js#L283) and let the breakpoint hit a few times. It will eventually add duplicates. This fixes that.
