### PR TITLE
yarn install: respect har flag on tarball fetcher crash

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -520,7 +520,9 @@ export class Install {
     }
 
     let flattenedTopLevelPatterns: Array<string> = [];
-    const steps: Array<(curr: number, total: number) => Promise<{bailout: boolean} | {responseError: ResponseError} | void>> = [];
+    const steps: Array<
+      (curr: number, total: number) => Promise<{bailout: boolean} | {responseError: ResponseError} | void>,
+    > = [];
     const {
       requests: depRequests,
       patterns: rawPatterns,
@@ -561,7 +563,7 @@ export class Install {
       callThroughHook('fetchStep', async () => {
         this.markIgnored(ignorePatterns);
         this.reporter.step(curr, total, this.reporter.lang('fetchingPackages'), emoji.get('truck'));
-        const manifests: Array<Manifest> = [];
+        let manifests: Array<Manifest> = [];
         try {
           manifests = await fetcher.fetch(this.resolver.getManifests(), this.config);
         } catch (err) {
@@ -611,7 +613,7 @@ export class Install {
       }),
     );
 
-    var harStepIndex = -1;
+    let harStepIndex = -1;
     if (this.flags.har) {
       harStepIndex = steps.length;
       steps.push(async (curr: number, total: number) => {

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -9,7 +9,7 @@ import type {RegistryNames} from '../../registries/index.js';
 import type {LockfileObject} from '../../lockfile';
 import {callThroughHook} from '../../util/hooks.js';
 import normalizeManifest from '../../util/normalize-manifest/index.js';
-import {MessageError} from '../../errors.js';
+import {MessageError, ResponseError} from '../../errors.js';
 import InstallationIntegrityChecker from '../../integrity-checker.js';
 import Lockfile from '../../lockfile';
 import {stringify as lockStringify} from '../../lockfile';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

This is a small change to yarn install to allow generating har files when tarball-fetcher runs into repeated server errors (`>=400`).

Before this change, yarn would crash before getting to the har file step.

After this change, yarn still crashes, but it jumps ahead to the har file step and attempts to generate that trace file first.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Why make this change?

I need the har file more for failure cases than success ones. The anonymized logging and high traffic on my package servers means that without the request ids from the response headers I can't trace the problematic server responses. This change will allow me to get those headers from yarn installs that crash during tarball fetching.


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I tested this code by nuking `node_modules` and the auth token for one of the package feeds in my .npmrc file. This caused yarn to crash as soon as it tried to grab a package from said feed.

Yarn output before my change:

```
>> 2018-06-13 19:17:25 ~/code/some-repo   (>'-')> 
>> yarn --har
yarn install v1.3.2
[1/5] 🔍  Resolving packages...
[2/5] 🚚  Fetching packages...
error An unexpected error occurred: "<tarball URI>: Request failed \"401 Unauthorized\"".
info If you think this is a bug, please open a bug report with the information provided in "/Users/sojeri/code/some-repo/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

```

Yarn output after my change:

```
>> 2018-06-13 19:22:16 ~/code/some-repo   ┏(n_n)┓ 
>> ../oss/yarn/bin/yarn --har
yarn install v1.9.0-0
[1/5] 🔍  Resolving packages...
[2/5] 🚚  Fetching packages...
[5/5] ⏺  Saving HAR file: "yarn-install_2018-06-14T02-26-15.951Z.har"...
error An unexpected error occurred: "<tarball URI>: Request failed \"401 Unauthorized\"".
info If you think this is a bug, please open a bug report with the information provided in "/Users/sojeri/code/some-repo/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
