### PR TITLE
fix(util/fs): use file content instead of mtime to determine equality

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -46,7 +46,7 @@ const messages = {
   verboseFileCopy: 'Copying $0 to $1.',
   verboseFileLink: 'Creating hardlink at $0 to $1.',
   verboseFileSymlink: 'Creating symlink at $0 to $1.',
-  verboseFileSkip: 'Skipping copying of file $0 as the file at $1 is the same size ($2) and mtime ($3).',
+  verboseFileSkip: 'Skipping copying of file $0 as the file at $1 is the same size ($2) and has the same content.',
   verboseFileSkipSymlink: 'Skipping copying of $0 as the file at $1 is the same symlink ($2).',
   verboseFileSkipHardlink: 'Skipping copying of $0 as the file at $1 is the same hardlink ($2).',
   verboseFileRemoveExtraneous: 'Removing extraneous file $0.',

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -13,7 +13,7 @@ import BlockingQueue from './blocking-queue.js';
 import * as promise from './promise.js';
 import {promisify} from './promise.js';
 import map from './map.js';
-import {copyFile, fileDatesEqual, unlink} from './fs-normalized.js';
+import {copyFile, unlink} from './fs-normalized.js';
 
 export const constants =
   typeof fs.constants !== 'undefined'
@@ -222,10 +222,10 @@ async function buildActionsForCopy(
         return;
       }
 
-      if (bothFiles && srcStat.size === destStat.size && fileDatesEqual(srcStat.mtime, destStat.mtime)) {
+      if (bothFiles && srcStat.size === destStat.size && fs.readFileSync(src).equals(fs.readFileSync(dest))) {
         // we can safely assume this is the same file
         onDone();
-        reporter.verbose(reporter.lang('verboseFileSkip', src, dest, srcStat.size, +srcStat.mtime));
+        reporter.verbose(reporter.lang('verboseFileSkip', src, dest, srcStat.size));
         return;
       }
 


### PR DESCRIPTION
**Summary**
npm 6 locks mtime of all files in the published tarball to be October
26th 1985, which means mtime is no longer changed when a package
is published with an npm version above 6.

See: https://npm.community/t/tarball-content-timestamps-locked-to-1985/149

Fixes: #5723
