### PR TITLE
fix(workspaces): Allow patterns with non-semver ranges to match workspace packages

### DIFF
--- a/__tests__/workspace-layout.js
+++ b/__tests__/workspace-layout.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+import WorkspaceLayout from '../src/workspace-layout.js';
+import Config from '../src/config.js';
+import NoopReporter from '../src/reporters/noop-reporter';
+import type {WorkspacesManifestMap} from '../src/types';
+
+const workspaceMap: WorkspacesManifestMap = Object.freeze({
+  pkgA: {
+    loc: './pkgA',
+    manifest: {
+      _uid: '1',
+      name: 'pkgA',
+      version: '1.2.3',
+    },
+  },
+  '@yarn/pkgB': {
+    loc: './pkgB',
+    manifest: {
+      _uid: '1',
+      name: '@yarn/pkgB',
+      version: '1.2.3',
+    },
+  },
+});
+
+describe('WorkspaceLayout.getManifestByPattern()', () => {
+  test('returns null when workspace does not contain a package with requested name', () => {
+    const layout = new WorkspaceLayout(workspaceMap, new Config(new NoopReporter()));
+    const result = layout.getManifestByPattern('does-not-exist');
+    expect(result).toBe(null);
+  });
+
+  test('returns null when workspace contains a package with requested name but version does not match', () => {
+    const layout = new WorkspaceLayout(workspaceMap, new Config(new NoopReporter()));
+    const result = layout.getManifestByPattern('pkgA@^9.0.0');
+    expect(result).toBe(null);
+  });
+
+  test('returns manifest when workspace contains a package with requested name and version matches', () => {
+    const layout = new WorkspaceLayout(workspaceMap, new Config(new NoopReporter()));
+    const result = layout.getManifestByPattern('pkgA@^1.0.0');
+    expect(result).toBe(workspaceMap.pkgA);
+  });
+
+  test('returns null when workspace contains a package with requested name and version is not a semver range', () => {
+    const layout = new WorkspaceLayout(workspaceMap, new Config(new NoopReporter()));
+    const result = layout.getManifestByPattern('pkgA@git+https://git@github.com/yarnpkg/test-package.git');
+    expect(result).toBe(workspaceMap.pkgA);
+  });
+
+  test('returns manifest when workspace contains a scoped package with requested name and version matches', () => {
+    const layout = new WorkspaceLayout(workspaceMap, new Config(new NoopReporter()));
+    const result = layout.getManifestByPattern('@yarn/pkgB@^1.0.0');
+    expect(result).toBe(workspaceMap['@yarn/pkgB']);
+  });
+});

--- a/src/workspace-layout.js
+++ b/src/workspace-layout.js
@@ -23,9 +23,25 @@ export default class WorkspaceLayout {
   getManifestByPattern(pattern: string): ?{loc: string, manifest: Manifest} {
     const {name, range} = normalizePattern(pattern);
     const workspace = this.getWorkspaceManifest(name);
-    if (!workspace || !semver.satisfies(workspace.manifest.version, range, this.config.looseSemver)) {
+    if (!workspace) {
+      // the dependency specifies a package name that does not exist in this workspace.
       return null;
     }
-    return workspace;
+    if (!semver.validRange(range)) {
+      // if the dependency specifies a range that isn't valid semver.
+      // It is probably an "exotic" pattern like a github url,
+      // or has no range at all as in the case of running the command
+      //   yarn workspace @yarnpkg/pkgB add @yarnpkg/pkgA
+      // For these, we just match on the package name and allow the workspace package to be used.
+      return workspace;
+    }
+    if (semver.satisfies(workspace.manifest.version, range, this.config.looseSemver)) {
+      // the dependency specifies a package name that exists in this workspace
+      // and the workspace package's version matches the requested range. Use the workspace package.
+      return workspace;
+    }
+    // the dependency specifies a package name that exists in this workspace,
+    // but the workspace package is a version that does not match the requeted range.
+    return null;
   }
 }


### PR DESCRIPTION
**Summary**

Previously for a requested dependency pattern to match a package in a workspace, it's name had to
match and so did the semver range. If a request specified a non-semver range (like a github url)
then it would not match, causing the resolver to attempt to resolve the package on the registry
instead of use the workspace package. This change will match a workspace package just on it's name
if no valid semver range was found on the requested pattern.

This also fixes the command `yarn workspace @scope/foo add @scope/bar` where `@scope/bar` is a workspace package. The semver range of the request is empty (no version was specified in the command), so it used to not match the package and instead try to find it on the registry. Now it will properly match the workspace package name.

fixes #4878
fixes #3973
affects #5726

**Test plan**

Added new test file for `workspace-layout`.
