### PR TITLE
(WIP) yarn exits with an error when a dependency has no latest tag

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -440,7 +440,7 @@ export default class PackageRequest {
 
     // Make sure to always output `exotic` versions to be compatible with npm
     const isDepOld = ({current, latest, wanted}) =>
-      latest === 'exotic' || (semver.lt(current, wanted) || semver.lt(current, latest));
+      latest === undefined || latest === 'exotic' || (semver.lt(current, wanted) || semver.lt(current, latest));
     const orderByName = (depA, depB) => depA.name.localeCompare(depB.name);
     return deps.filter(isDepOld).sort(orderByName);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When a dependency package has no latest tag the commands **yarn upgrade** and **yarn upgrade-interactive** will throw the following error:
An unexpected error occurred: "Invalid Version: undefined".

This is because in method **getOutdatedPackages** of the class **PackageRequest** latest is undefined when no latest tag is found and the call to semver.lt(current, latest) throws an error.

I simply checked if latest is undefined before the call to semver.lt(current, latest) .

fixes #5955 

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I did not know how to write a test for this because i have found no public package that did not has a latest tag. Any advice would be great.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
