### PR TITLE
fix(util/semver): handle invalid versions in satisfiesWithPrereleases

### DIFF
--- a/__tests__/util/semver.js
+++ b/__tests__/util/semver.js
@@ -42,6 +42,10 @@ describe('satisfiesWithPrereleases', () => {
     expect(satisfiesWithPrereleases('1.0.0-alpha.1', '1.0.0-alpha')).toBe(false);
   });
 
+  it('rejects prerelease versions that are invalid', () => {
+    expect(satisfiesWithPrereleases('1.0.0-alpha.01', '^1.0.0')).toBe(false);
+  });
+
   it('follows the semver spec when comparing prerelease versions', () => {
     // Example from http://semver.org/#spec-item-11
     expect(satisfiesWithPrereleases('1.0.0-alpha.1', '>1.0.0-alpha')).toBe(true);

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -19,7 +19,12 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
   if (!version) {
     return false;
   }
-  const semverVersion = new semver.SemVer(version, semverRange.loose);
+  let semverVersion;
+  try {
+    semverVersion = new semver.SemVer(version, semverRange.loose);
+  } catch (err) {
+    return false;
+  }
 
   // A range has multiple sets of comparators. A version must satisfy all comparators in a set
   // and at least one set to satisfy the range.


### PR DESCRIPTION
**Summary**

Fixes a bug where if invalid SemVer versions were present on a registry, Yarn wouldn't be able to update that dependency.

It's (very) rare for invalid SemVer versions to be present on npm registries, but it's possible, particularly for private registries which may or may not have checks present when versions are pushed.

Before this patch, the presence of any such versions would causes a resolution-ending `TypeError: Invalid Version` when determining which version to update that dependency to. After this patch, invalid versions on the registry will be quietly ignored.

**Test plan**

I've added a test which fails if the code change here isn't applied.