### PR TITLE
Simplify readFirstAvailableStream()

### DIFF
--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -59,15 +59,15 @@ export default class GitFetcher extends BaseFetcher {
     return path.join(this.dest, constants.TARBALL_FILENAME);
   }
 
-  *getLocalPaths(override: ?string): Generator<?string, void, void> {
-    if (override) {
-      yield path.resolve(this.config.cwd, override);
-    }
-    yield this.getTarballMirrorPath();
-    yield this.getTarballMirrorPath({
-      withCommit: false,
-    });
-    yield this.getTarballCachePath();
+  getLocalPaths(override: ?string): Array<string> {
+    const paths: Array<?string> = [
+      override ? path.resolve(this.config.cwd, override) : null,
+      this.getTarballMirrorPath(),
+      this.getTarballMirrorPath({withCommit: false}),
+      this.getTarballCachePath(),
+    ];
+    // $FlowFixMe: https://github.com/facebook/flow/issues/1414
+    return paths.filter(path => path != null);
   }
 
   async fetchFromLocal(override: ?string): Promise<FetchedOverride> {

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -71,11 +71,12 @@ export default class GitFetcher extends BaseFetcher {
   }
 
   async fetchFromLocal(override: ?string): Promise<FetchedOverride> {
-    const {stream, triedPaths} = await fsUtil.readFirstAvailableStream(this.getLocalPaths(override));
+    const tarPaths = this.getLocalPaths(override);
+    const stream = await fsUtil.readFirstAvailableStream(tarPaths);
 
     return new Promise((resolve, reject) => {
       if (!stream) {
-        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, triedPaths)));
+        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarPaths)));
         return;
       }
       invariant(stream, 'cachedStream should be available at this point');

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -129,11 +129,12 @@ export default class TarballFetcher extends BaseFetcher {
   }
 
   async fetchFromLocal(override: ?string): Promise<FetchedOverride> {
-    const {stream, triedPaths} = await fsUtil.readFirstAvailableStream(this.getLocalPaths(override));
+    const tarPaths = this.getLocalPaths(override);
+    const stream = await fsUtil.readFirstAvailableStream(tarPaths);
 
     return new Promise((resolve, reject) => {
       if (!stream) {
-        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, triedPaths)));
+        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarPaths)));
         return;
       }
       invariant(stream, 'stream should be available at this point');

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -118,12 +118,14 @@ export default class TarballFetcher extends BaseFetcher {
     return {validateStream, extractorStream};
   }
 
-  *getLocalPaths(override: ?string): Generator<?string, void, void> {
-    if (override) {
-      yield path.resolve(this.config.cwd, override);
-    }
-    yield this.getTarballMirrorPath();
-    yield this.getTarballCachePath();
+  getLocalPaths(override: ?string): Array<string> {
+    const paths: Array<?string> = [
+      override ? path.resolve(this.config.cwd, override) : null,
+      this.getTarballMirrorPath(),
+      this.getTarballCachePath(),
+    ];
+    // $FlowFixMe: https://github.com/facebook/flow/issues/1414
+    return paths.filter(path => path != null);
   }
 
   async fetchFromLocal(override: ?string): Promise<FetchedOverride> {

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -816,11 +816,11 @@ export async function makeTempDir(prefix?: string): Promise<string> {
 
 export async function readFirstAvailableStream(paths: Iterable<?string>): Promise<?ReadStream> {
   let stream: ?ReadStream;
-  for (const tarballPath of paths) {
-    if (tarballPath) {
+  for (const path of paths) {
+    if (path) {
       try {
-        const fd = await open(tarballPath, 'r');
-        stream = fs.createReadStream(tarballPath, {fd});
+        const fd = await open(path, 'r');
+        stream = fs.createReadStream(path, {fd});
         break;
       } catch (err) {
         // Try the next one

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -814,17 +814,15 @@ export async function makeTempDir(prefix?: string): Promise<string> {
   return dir;
 }
 
-export async function readFirstAvailableStream(paths: Iterable<?string>): Promise<?ReadStream> {
+export async function readFirstAvailableStream(paths: Iterable<string>): Promise<?ReadStream> {
   let stream: ?ReadStream;
   for (const path of paths) {
-    if (path) {
-      try {
-        const fd = await open(path, 'r');
-        stream = fs.createReadStream(path, {fd});
-        break;
-      } catch (err) {
-        // Try the next one
-      }
+    try {
+      const fd = await open(path, 'r');
+      stream = fs.createReadStream(path, {fd});
+      break;
+    } catch (err) {
+      // Try the next one
     }
   }
   return stream;

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -814,11 +814,8 @@ export async function makeTempDir(prefix?: string): Promise<string> {
   return dir;
 }
 
-export async function readFirstAvailableStream(
-  paths: Iterable<?string>,
-): Promise<{stream: ?ReadStream, triedPaths: Array<string>}> {
+export async function readFirstAvailableStream(paths: Iterable<?string>): Promise<?ReadStream> {
   let stream: ?ReadStream;
-  const triedPaths = [];
   for (const tarballPath of paths) {
     if (tarballPath) {
       try {
@@ -827,11 +824,10 @@ export async function readFirstAvailableStream(
         break;
       } catch (err) {
         // Try the next one
-        triedPaths.push(tarballPath);
       }
     }
   }
-  return {stream, triedPaths};
+  return stream;
 }
 
 export async function getFirstSuitableFolder(

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -815,17 +815,15 @@ export async function makeTempDir(prefix?: string): Promise<string> {
 }
 
 export async function readFirstAvailableStream(paths: Iterable<string>): Promise<?ReadStream> {
-  let stream: ?ReadStream;
   for (const path of paths) {
     try {
       const fd = await open(path, 'r');
-      stream = fs.createReadStream(path, {fd});
-      break;
+      return fs.createReadStream(path, {fd});
     } catch (err) {
       // Try the next one
     }
   }
-  return stream;
+  return null;
 }
 
 export async function getFirstSuitableFolder(


### PR DESCRIPTION
**Summary**

The `readFirstAvailableStream()` function in `util/fs.js` is unnecessarily complicated. By not passing in a generator of nulls and strings but instead using a simple array of stings (with at most 4 elements), the function can be simplified and one of its two return values becomes unnecessary.

The resulting code should be much easier to understand.

**Test plan**

Tests still pass.