### PR TITLE
fix(config): relative cafile path works correctly

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -526,3 +526,16 @@ test('yarn init -y', async () => {
   const manifestFile = await fs.readFile(path.join(cwd, 'package.json'));
   expect(manifestFile).toEqual(initialManifestFile);
 });
+
+test('relative cafile', async () => {
+  const base = await makeTemp();
+
+  await fs.writeFile(`${base}/.yarnrc`, 'cafile "./foo/server.cer"\n');
+
+  await fs.mkdirp(`${base}/sub`);
+  await fs.mkdirp(`${base}/foo`);
+
+  const [stdoutOutput, _] = await runYarn(['config', 'get', 'cafile'], {cwd: `${base}/sub`});
+
+  expect(await fs.realpath(stdoutOutput.toString())).toEqual(await fs.realpath(`${base}/foo/server.cer`));
+});

--- a/src/rc.js
+++ b/src/rc.js
@@ -9,7 +9,7 @@ import {parse} from './lockfile';
 import * as rcUtil from './util/rc.js';
 
 // Keys that will get resolved relative to the path of the rc file they belong to
-const PATH_KEYS = new Set(['yarn-path', 'cache-folder', 'global-folder', 'modules-folder', 'cwd']);
+const PATH_KEYS = new Set(['yarn-path', 'cache-folder', 'global-folder', 'modules-folder', 'cwd', 'cafile']);
 
 // given a cwd, load all .yarnrc files relative to it
 export function getRcConfigForCwd(cwd: string, args: Array<string>): {[key: string]: string} {

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -97,7 +97,7 @@ export default class YarnRegistry extends NpmRegistry {
 
         if (!this.config[key] && valueLoc) {
           config[key] = path.resolve(path.dirname(loc), valueLoc);
-          if (RELATIVE_KEYS_MAKE_DIR.includes(key)) {
+          if (RELATIVE_KEYS_MAKE_DIR.indexOf(key) >= 0) {
             const resolvedLoc = config[key];
             await fs.mkdirp(resolvedLoc);
           }

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -32,6 +32,7 @@ export const DEFAULTS = {
 };
 
 const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder', 'cafile'];
+const RELATIVE_KEYS_MAKE_DIR = ['yarn-offline-mirror', 'cache-folder'];
 
 const npmMap = {
   'version-git-sign': 'sign-git-tag',
@@ -95,14 +96,10 @@ export default class YarnRegistry extends NpmRegistry {
         const valueLoc = config[key];
 
         if (!this.config[key] && valueLoc) {
-          const resolvedLoc = (config[key] = path.resolve(path.dirname(loc), valueLoc));
-          try {
+          config[key] = path.resolve(path.dirname(loc), valueLoc);
+          if (RELATIVE_KEYS_MAKE_DIR.includes(key)) {
+            const resolvedLoc = config[key];
             await fs.mkdirp(resolvedLoc);
-          } catch (err) {
-            // ignore EEXIST error. this only occurs when resolvedLoc is a file path
-            if (err.code !== 'EEXIST') {
-              throw err;
-            }
           }
         }
       }

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -98,9 +98,10 @@ export default class YarnRegistry extends NpmRegistry {
           const resolvedLoc = (config[key] = path.resolve(path.dirname(loc), valueLoc));
           try {
             await fs.mkdirp(resolvedLoc);
-          } catch (ex) {
-            if (ex.code !== 'EEXIST') {
-              throw ex;
+          } catch (err) {
+            // ignore EEXIST error. this only occurs when resolvedLoc is a file path
+            if (err.code !== 'EEXIST') {
+              throw err;
             }
           }
         }

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -31,7 +31,7 @@ export const DEFAULTS = {
   'user-agent': [`yarn/${version}`, 'npm/?', `node/${process.version}`, process.platform, process.arch].join(' '),
 };
 
-const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder'];
+const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder', 'cafile'];
 
 const npmMap = {
   'version-git-sign': 'sign-git-tag',
@@ -96,7 +96,13 @@ export default class YarnRegistry extends NpmRegistry {
 
         if (!this.config[key] && valueLoc) {
           const resolvedLoc = (config[key] = path.resolve(path.dirname(loc), valueLoc));
-          await fs.mkdirp(resolvedLoc);
+          try {
+            await fs.mkdirp(resolvedLoc);
+          } catch (ex) {
+            if (ex.code !== 'EEXIST') {
+              throw ex;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
**Summary**

When the cafile variable in the .yarnrc file is relative, the path to
file was resolved relative to current working directory not to the path
of the .yarnrc file.

Fixes: #6057

**Test plan**

Tests are added.
