### PR TITLE
[WIP] dedupe hoister levelQueue items for performance gains

### DIFF
--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -243,11 +243,11 @@ export default class PackageHoister {
     this.taintKey(key, info);
 
     //
-    const pushed = {};
+    const pushed = new Set();
     for (const depPattern of ref.dependencies) {
-      if (!pushed[depPattern]) {
+      if (!set.has(depPattern)) {
         this.levelQueue.push([depPattern, info]);
-        pushed[depPattern] = true;
+        set.add(depPattern);
       }
     }
 

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -245,9 +245,9 @@ export default class PackageHoister {
     //
     const pushed = new Set();
     for (const depPattern of ref.dependencies) {
-      if (!set.has(depPattern)) {
+      if (!pushed.has(depPattern)) {
         this.levelQueue.push([depPattern, info]);
-        set.add(depPattern);
+        pushed.add(depPattern);
       }
     }
 

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -243,8 +243,12 @@ export default class PackageHoister {
     this.taintKey(key, info);
 
     //
+    const pushed = {};
     for (const depPattern of ref.dependencies) {
-      this.levelQueue.push([depPattern, info]);
+      if (!pushed[depPattern]) {
+        this.levelQueue.push([depPattern, info]);
+        pushed[depPattern] = true;
+      }
     }
 
     return info;


### PR DESCRIPTION
**Summary**

I'm submitting this PR early so I can get as much feedback as possible. I am not at all familiar with the yarn codebase, so I'm not sure if I'm even making this change in the right place.

I have a rather large monorepo (~150 packages) and when running `yarn install` from yarn>=1.4.0, it just hangs during the "Linking Dependencies" step. For example, today I let it run for 3.5 hours before I finally gave in and killed it. For the past several months I've just used v1.3.2 as a temporary workaround. Today I spent several hours in the yarn code adding `console.log` statements all over the place and I think I've determined that `this.levelQueue` is growing exponentially at [package-hoister.js:247](https://github.com/yarnpkg/yarn/blob/master/src/package-hoister.js#L247). The same dependencies are being added to the levelQueue hundreds of times (if not thousands). My levelQueue had nearly three million items in it, and it takes a long time to iterate over all those dependencies, which made it look like yarn had just crashed.

I added a few lines of code to de-dupe the items being pushed onto the queue and that seems to solve my issue.

Because I'm not familiar with the codebase, I don't know what unintended effect this might have, but it seemed to solve all my issues and the node modules appear to have installed correctly (and rather quickly too!).

Please let me know if you have any concerns. I'll gladly finish out this pull request with tests, etc. but I want to make sure I'm going in the right direction first.

**Test plan**

I'll write some unit tests for this if it is an acceptable change.