### PR TITLE
Add yarn.ps1, fixes #6092 (bad Ctrl C behavior)

### DIFF
--- a/bin/yarn.ps1
+++ b/bin/yarn.ps1
@@ -1,0 +1,6 @@
+function Get-ScriptDirectory {
+	$Invocation = (Get-Variable MyInvocation -Scope 1).Value
+	Split-Path $Invocation.MyCommand.Path
+}
+
+node "$(Get-ScriptDirectory)/yarn.js" $args


### PR DESCRIPTION
… #6092

**Summary**

Not a substantial pull request. `cmd` is unmaintained, according to its authors at Microsoft. One of the issues is that the termination behavior (Ctrl C) for `cmd` scripts cannot be modifed, but there are likely other issues with `cmd` being unmaintained. 

**Test plan**

All Windows `yarn` commands still work, with no effect on speed and output. 