### PR TITLE
fix(hosted-git-resolver): ensure prepare script is executed for hosted git repo

### DIFF
--- a/__tests__/fixtures/import/github-package-lock/yarn.lock.import
+++ b/__tests__/fixtures/import/github-package-lock/yarn.lock.import
@@ -4,4 +4,4 @@
 
 beeper@sindresorhus/beeper:
   version "1.1.1"
-  resolved "https://codeload.github.com/sindresorhus/beeper/tar.gz/34f2c73a340f000c9e060f7038362db6782b236e"
+  resolved "https://github.com/sindresorhus/beeper.git#34f2c73a340f000c9e060f7038362db6782b236e"

--- a/__tests__/fixtures/import/github/yarn.lock.import
+++ b/__tests__/fixtures/import/github/yarn.lock.import
@@ -4,4 +4,4 @@
 
 beeper@sindresorhus/beeper:
   version "1.1.1"
-  resolved "https://codeload.github.com/sindresorhus/beeper/tar.gz/34f2c73a340f000c9e060f7038362db6782b236e"
+  resolved "https://github.com/sindresorhus/beeper.git#34f2c73a340f000c9e060f7038362db6782b236e"

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -51,14 +51,14 @@ class ImportResolver extends BaseResolver {
     const exploded = explodeHostedGitFragment(range, this.reporter);
     const hash = (info: any).gitHead;
     invariant(hash, 'expected package gitHead');
-    const url = Resolver.getTarballUrl(exploded, hash);
+    const url = Resolver.getGitHTTPUrl(exploded);
     info._uid = hash;
     info._remote = {
-      resolved: url,
-      type: 'tarball',
+      resolved: `${url}#${hash}`,
+      type: 'git',
       registry: this.registry,
       reference: url,
-      hash: null,
+      hash,
     };
     return info;
   }


### PR DESCRIPTION
**Summary**

Use git-fetcher, not tarball-fetcher to deal with hosted git repo. tarball-fetcher has no knowledge about the difference between normal npm package tarball, and tarball provided by hosted git (which is NOT a proper npm package).

Obviously this fix has performance penalty, but it's necessary to support prepare script.

Another possible solution is to add git-tarball-resolver (extending tarball-resolver), but I don't understand the code base enough to be able to extract hasPrepareScript and fetchFromInstallAndPack out from git-resolver.

closes #5235

**Test plan**

Tested my apps with github public repo, bitbucket public and private repos, all can now trigger prepare scripts.
Tested `yarn import` on my apps.
Tested all above with no yarn cache (`yarn cache clean`) and full yarn cache.