### PR TITLE
feat(workspaces): nested workspaces

### DIFF
--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -29,6 +29,11 @@ async function runWorkspaces(
 test('workspaces info should list the workspaces', (): Promise<void> => {
   return runWorkspaces({}, ['info'], 'run-basic', (config, reporter) => {
     expect(reporter.getBufferJson()).toEqual({
+      'nested-workspace-1': {
+        location: 'packages/nested-workspace/packages/nested-workspace-child-1',
+        workspaceDependencies: ['workspace-1'],
+        mismatchedWorkspaceDependencies: [],
+      },
       'workspace-1': {
         location: 'packages/workspace-child-1',
         workspaceDependencies: [],
@@ -37,6 +42,47 @@ test('workspaces info should list the workspaces', (): Promise<void> => {
       'workspace-2': {
         location: 'packages/workspace-child-2',
         workspaceDependencies: ['workspace-1'],
+        mismatchedWorkspaceDependencies: [],
+      },
+    });
+  });
+});
+
+test('workspaces info for nested workspace should list the global workspaces', (): Promise<void> => {
+  const name = path.join('run-basic', 'packages', 'nested-workspace', 'packages', 'nested-workspace-child-1');
+  return runWorkspaces({}, ['info'], name, (config, reporter) => {
+    expect(reporter.getBufferJson()).toEqual({
+      'nested-workspace-1': {
+        location: 'packages/nested-workspace/packages/nested-workspace-child-1',
+        workspaceDependencies: ['workspace-1'],
+        mismatchedWorkspaceDependencies: [],
+      },
+      'workspace-1': {
+        location: 'packages/workspace-child-1',
+        workspaceDependencies: [],
+        mismatchedWorkspaceDependencies: [],
+      },
+      'workspace-2': {
+        location: 'packages/workspace-child-2',
+        workspaceDependencies: ['workspace-1'],
+        mismatchedWorkspaceDependencies: [],
+      },
+    });
+  });
+});
+
+test('workspaces info should list the local workspaces if nested is unspecified in the global', (): Promise<void> => {
+  const name = path.join('run-basic', 'packages', 'nested-workspace', 'packages', 'nested-workspace-child-2');
+  return runWorkspaces({}, ['info'], name, (config, reporter) => {
+    expect(reporter.getBufferJson()).toEqual({
+      'nested-workspace-1': {
+        location: 'packages/nested-workspace-child-1',
+        workspaceDependencies: [],
+        mismatchedWorkspaceDependencies: [],
+      },
+      'nested-workspace-2': {
+        location: 'packages/nested-workspace-child-2',
+        workspaceDependencies: [],
         mismatchedWorkspaceDependencies: [],
       },
     });

--- a/__tests__/fixtures/workspace/run-basic/package.json
+++ b/__tests__/fixtures/workspace/run-basic/package.json
@@ -2,6 +2,7 @@
   "name": "my-project",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/workspace-child-*",
+    "packages/nested-workspace/packages/nested-workspace-child-1"
   ]
 }

--- a/__tests__/fixtures/workspace/run-basic/packages/nested-workspace/package.json
+++ b/__tests__/fixtures/workspace/run-basic/packages/nested-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "another-project-with-worspaces",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__tests__/fixtures/workspace/run-basic/packages/nested-workspace/packages/nested-workspace-child-1/package.json
+++ b/__tests__/fixtures/workspace/run-basic/packages/nested-workspace/packages/nested-workspace-child-1/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nested-workspace-1",
+  "version": "1.0.0",
+  "license": "BSD-2-Clause",
+  "scripts": {
+    "prescript": "echo nested-workspace-1 prescript",
+    "script": "echo nested-workspace-1 script",
+    "postscript": "echo nested-workspace-1 postscript"
+  },
+  "dependencies": {
+    "workspace-1": "1.0.0"
+  }
+}

--- a/__tests__/fixtures/workspace/run-basic/packages/nested-workspace/packages/nested-workspace-child-2/package.json
+++ b/__tests__/fixtures/workspace/run-basic/packages/nested-workspace/packages/nested-workspace-child-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nested-workspace-2",
+  "version": "1.0.0",
+  "license": "BSD-2-Clause",
+  "scripts": {
+    "prescript": "echo nested-workspace-2 prescript",
+    "script": "echo nested-workspace-2 script",
+    "postscript": "echo nested-workspace-2 postscript"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -657,6 +657,7 @@ export default class Config {
   }
 
   async findWorkspaceRoot(initial: string): Promise<?string> {
+    let lastFound = null;
     let previous = null;
     let current = path.normalize(initial);
     if (!await fs.exists(current)) {
@@ -669,9 +670,7 @@ export default class Config {
       if (ws && ws.packages) {
         const relativePath = path.relative(current, initial);
         if (relativePath === '' || micromatch([relativePath], ws.packages).length > 0) {
-          return current;
-        } else {
-          return null;
+          lastFound = current;
         }
       }
 
@@ -679,7 +678,7 @@ export default class Config {
       current = path.dirname(current);
     } while (current !== previous);
 
-    return null;
+    return lastFound;
   }
 
   async resolveWorkspaces(root: string, rootManifest: Manifest): Promise<WorkspacesManifestMap> {


### PR DESCRIPTION
**motivation**
yarn finds the closest manifest with `workspaces`. It's ok in almost all cases, but it fails if a package in workspace already has his own workspaces. In this case will be better to use global workspaces settings.

**Test plan**
```
Package
|-- package.json # has workspaces
|-- packages
|   |-- a
|   |   |-- package.json # also has workspaces
|   |   |-- more_packages
|   |   |   |-- aa # `yarn workspaces info` here should return workspaces from the root package.json
|   |   |   |-- ab
|   |-- b
…
```