### PR TITLE
fix(cli): reword manifest

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -69,7 +69,7 @@ const messages = {
     "Couldn't find any versions for $0 that matches $1 in our cache (possible versions are $2). This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.",
   couldntFindVersionThatMatchesRange: "Couldn't find any versions for $0 that matches $1",
   chooseVersionFromList: 'Please choose a version of $0 from this list:',
-  moduleNotInManifest: "This module isn't specified in a manifest.",
+  moduleNotInManifest: "This module isn't specified in a package.json file.",
   moduleAlreadyInManifest: '$0 is already in $1. Please remove existing entry first before adding it to $2.',
   unknownFolderOrTarball: "Passed folder/tarball doesn't exist,",
   unknownPackage: "Couldn't find package $0.",


### PR DESCRIPTION
Hello maintainers.

**Summary**

This PR is trying to close https://github.com/yarnpkg/yarn/issues/6111.

Although I'm aware of that there are still many the term "manifest" in this repository, changing just the error message which is pointed out in the issue is even worth for users.


**Test plan**

I've run `yarn remove` command on local and checked the error message has changed.


```
$ node ./lib/cli/index.js remove invalid-package-name                                                                                                  reword-manifest-to-package-json
yarn remove v1.10.0-0
(node:83703) ExperimentalWarning: The fs.promises API is experimental
[1/2] 🗑  Removing module invalid-package-name...
error This module isn't specified in a package.json file.
info Visit https://yarnpkg.com/en/docs/cli/remove for documentation about this command.
```

```
# before
error This module isn't specified in a manifest.

# after
error This module isn't specified in a package.json file.
```