### PR TITLE
fix: Show essential output for list commands when using --silent option

### DIFF
--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -115,7 +115,7 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
       });
     });
 
-    reporter.tree('licenses', trees);
+    reporter.tree('licenses', trees, {force: true});
   }
 }
 export function setFlags(commander: Object) {

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -223,5 +223,5 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     trees = trees.filter(tree => filterTree(tree, args, flags.pattern));
   }
 
-  reporter.tree('list', trees);
+  reporter.tree('list', trees, {force: true});
 }

--- a/src/reporters/base-reporter.js
+++ b/src/reporters/base-reporter.js
@@ -189,7 +189,7 @@ export default class BaseReporter {
   list(key: string, items: Array<string>, hints?: Object) {}
 
   // Outputs basic tree structure to console
-  tree(key: string, obj: Trees) {}
+  tree(key: string, obj: Trees, {force = false}: {force?: boolean} = {}) {}
 
   // called whenever we begin a step in the CLI.
   step(current: number, total: number, message: string, emoji?: string) {}

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -229,10 +229,10 @@ export default class ConsoleReporter extends BaseReporter {
     });
   }
   // handles basic tree output to console
-  tree(key: string, trees: Trees) {
+  tree(key: string, trees: Trees, {force = false}: {force?: boolean} = {}) {
     this.stopProgress();
     //
-    if (this.isSilent) {
+    if (this.isSilent && !force) {
       return;
     }
     const output = ({name, children, hint, color}, titlePrefix, childrenPrefix) => {


### PR DESCRIPTION
**Summary**

When running a list command, ensure `--silent` option doesn't suppress the  essential output, only supplementary information like how long it took and which version of yarn was used.

Fixes #6127

**Test plan**

The following commands should both produce output - previously they did not:

```
yarn --silent list
yarn --silent licenses list
```