### PR TITLE
Send local fetch error to verbose reporter before falling back to external fetch

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -221,6 +221,7 @@ export default class TarballFetcher extends BaseFetcher {
   }
 
   _fetch(): Promise<FetchedOverride> {
+
     const isFilePath = this.reference.startsWith('file:');
     this.reference = removePrefix(this.reference, 'file:');
     const urlParse = url.parse(this.reference);
@@ -234,7 +235,11 @@ export default class TarballFetcher extends BaseFetcher {
       return this.fetchFromLocal(this.reference);
     }
 
-    return this.fetchFromLocal().catch(err => this.fetchFromExternal());
+    return this.fetchFromLocal().catch(err => {
+      this.reporter.verbose(this.reporter.lang("errorFetchingFromLocal", err.message));
+      this.reporter.verbose(err.message);
+      return this.fetchFromExternal();
+    });
   }
 }
 

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -221,7 +221,6 @@ export default class TarballFetcher extends BaseFetcher {
   }
 
   _fetch(): Promise<FetchedOverride> {
-
     const isFilePath = this.reference.startsWith('file:');
     this.reference = removePrefix(this.reference, 'file:');
     const urlParse = url.parse(this.reference);
@@ -236,7 +235,7 @@ export default class TarballFetcher extends BaseFetcher {
     }
 
     return this.fetchFromLocal().catch(err => {
-      this.reporter.verbose(this.reporter.lang("errorFetchingFromLocal", err.message));
+      this.reporter.verbose(this.reporter.lang('errorFetchingFromLocal', err.message));
       this.reporter.verbose(err.message);
       return this.fetchFromExternal();
     });

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -7,6 +7,7 @@ const messages = {
   nothingToInstall: 'Nothing to install.',
   resolvingPackages: 'Resolving packages',
   checkingManifest: 'Validating package.json',
+  errorFetchingFromLocal: 'Error fetching package from local disk cache:',
   fetchingPackages: 'Fetching packages',
   linkingDependencies: 'Linking dependencies',
   rebuildingPackages: 'Rebuilding all packages',


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**


<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Finally got a chance to put together a PR for the offline install enhancement (#5695) I submitted a few months ago.

Today, if Yarn is unable to install a package locally (local cache or offline mirror), it falls back to installing from an external source. However, if you've configured Yarn with `--offline`, the external fetch immediately fails with an exception.

What's tricky is the exception from `fetchFromLocal` is swallowed, so the reason for the failure is lost. This makes it much harder to debug corrupted archives etc.

This change updates the fallback to log the `fetchFromLocal` exception to the `verbose` reporter, so that it can be viewed if the `--verbose` CLI flag was provided. I opted to print the error in 2 lines because formatting the actual error message directly into the `errorFetchingFromLocal` message caused the final output to have `\` escapes for all the quotes, which reduced readability.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I first tested this with a missing package archive, which resulted in this output:

```
verbose 3.761 Error fetching package from local disk cache: "\"https://registry.yarnpkg.com/react/-/react-16.4.1.tgz\": Tarball is not in network and can not be located in cache ([\"/Users/andersonw/client/virtual_env/yarn_packages/react-16.4.1.tgz\",\"/Users/andersonw/Library/Caches/Yarn/v1/npm-react-16.4.1-de51ba5764b5dbcd1f9079037b862bd26b82fe32/.yarn-tarball.tgz\"])"
verbose 3.79 Error: Can't make a request in offline mode ("https://registry.yarnpkg.com/react/-/react-16.4.1.tgz")
    at RequestManager.request (/Users/andersonw/sandbox/yarn/lib/util/request-manager.js:194:29)
    at NpmRegistry.request (/Users/andersonw/sandbox/yarn/lib/registries/npm-registry.js:227:32)
    at /Users/andersonw/sandbox/yarn/lib/fetchers/tarball-fetcher.js:208:33
    at Generator.next (<anonymous>)
    at step (/Users/andersonw/sandbox/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/andersonw/sandbox/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at new Promise (<anonymous>)
    at new F (/Users/andersonw/sandbox/yarn/node_modules/core-js/library/modules/_export.js:35:28)
    at /Users/andersonw/sandbox/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
    at TarballFetcher.fetchFromExternal (/Users/andersonw/sandbox/yarn/lib/fetchers/tarball-fetcher.js:268:7)
error Can't make a request in offline mode ("https://registry.yarnpkg.com/react/-/react-16.4.1.tgz")
```

Then I tested with an intentionally corrupted archive, which produced this:

```
verbose 1.993 Error fetching package from local disk cache:
verbose 1.993 Extracting tar content of "/Users/andersonw/client/virtual_env/yarn_packages/react-16.4.1.tgz" failed, the file appears to be corrupt: "Unexpected end of data"
verbose 2.02 Error: Can't make a request in offline mode ("https://registry.yarnpkg.com/react/-/react-16.4.1.tgz")
    at RequestManager.request (/Users/andersonw/sandbox/yarn/lib/util/request-manager.js:194:29)
    at NpmRegistry.request (/Users/andersonw/sandbox/yarn/lib/registries/npm-registry.js:227:32)
    at /Users/andersonw/sandbox/yarn/lib/fetchers/tarball-fetcher.js:208:33
    at Generator.next (<anonymous>)
    at step (/Users/andersonw/sandbox/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/andersonw/sandbox/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at new Promise (<anonymous>)
    at new F (/Users/andersonw/sandbox/yarn/node_modules/core-js/library/modules/_export.js:35:28)
    at /Users/andersonw/sandbox/yarn/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
    at TarballFetcher.fetchFromExternal (/Users/andersonw/sandbox/yarn/lib/fetchers/tarball-fetcher.js:268:7)
error Can't make a request in offline mode ("https://registry.yarnpkg.com/react/-/react-16.4.1.tgz")
```

Since this diff is only adding verbose logging, it didn't make a ton of sense to add new tests, but if more tests are desired here, let me know!