### PR TITLE
Make yarn not to add /usr/bin to PATH if already there

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -144,7 +144,10 @@ export async function makeEnv(
 
   // Include the directory that contains node so that we can guarantee that the scripts
   // will always run with the exact same Node release than the one use to run Yarn
-  pathParts.unshift(path.dirname(process.execPath));
+  const execBin = path.dirname(process.execPath);
+  if (pathParts.indexOf(execBin) === -1) {
+    pathParts.unshift(execBin);
+  }
 
   // Include node-gyp version that was bundled with the current Node.js version,
   // if available.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #5935 

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This one is supposedly going to remain untested:

```diff
commit 3759562d6a4b114723ee7055e7f872153301657b
Author: Yuri Kanivetsky <yuri.kanivetsky@gmail.com>
Date:   Mon Jul 30 12:01:22 2018 +0300

    trying to test...
    
    `yarn test` pollutes PATH with another /usr/bin, and even if
    the child instance of yarn doesn't do that, there are at least two
    /usr/bin's in the PATH

diff --git a/__tests__/fixtures/lifecycle-scripts/usr-bin/package.json b/__tests__/fixtures/lifecycle-scripts/usr-bin/package.json
new file mode 100644
index 00000000..d825e8bd
--- /dev/null
+++ b/__tests__/fixtures/lifecycle-scripts/usr-bin/package.json
@@ -0,0 +1,5 @@
+{
+    "scripts": {
+        "cmd1": "echo $PATH | tr : \\\\n"
+    }
+}
diff --git a/__tests__/lifecycle-scripts.js b/__tests__/lifecycle-scripts.js
index 8f6660ef..aa7369e6 100644
--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -178,6 +178,12 @@ test('should throw error when the script ends with an exit code', async () => {
   await expect(execCommand('test', 'script-fail')).rejects.toBeDefined();
 });
 
+test('should not add /usr/bin to PATH if already there', async () => {
+  const stdout = await execCommand('cmd1', 'usr-bin');
+  const occurences = stdout.split('\n').filter(l => l == path.dirname(process.execPath));
+  expect(occurences.length).toBe(1);
+});
+
 if (process.platform === 'darwin') {
   test('should throw error when the script ends with an exit signal', async () => {
     await expect(execCommand('test', 'script-segfault')).rejects.toBeDefined();
```