### PR TITLE
Set the default value of enableDefaultRc to true

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -404,7 +404,7 @@ export default class Config {
 
     this.commandName = opts.commandName || '';
 
-    this.enableDefaultRc = !!opts.enableDefaultRc;
+    this.enableDefaultRc = opts.enableDefaultRc == undefined ? true : !!opts.enableDefaultRc;
     this.extraneousYarnrcFiles = opts.extraneousYarnrcFiles || [];
 
     this.preferOffline = !!opts.preferOffline;


### PR DESCRIPTION
**Summary**

~~Bug fix for #-6174.~~ Previously, the default value for `enableDefaultRc` was false, but that's unexpected, and caused an issue when a Config instance was created in `global.js` without passing the expected default.

The same approach as here is taken for `looseSemver` on line 403.

**Test plan**

This is just setting a default value, so I don't think needs tests.