### PR TITLE
Prepend node path only if needed, and only after local directories.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "uuid": "^3.0.1",
     "v8-compile-cache": "^2.0.0",
     "validate-npm-package-license": "^3.0.3",
+    "which": "^1.3.1",
     "yn": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "uuid": "^3.0.1",
     "v8-compile-cache": "^2.0.0",
     "validate-npm-package-license": "^3.0.3",
-    "which": "^1.3.1",
+    "which": "^1.3.0",
     "yn": "^2.0.0"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -47,7 +47,7 @@ export type ConfigOptions = {
   childConcurrency?: number,
   networkTimeout?: number,
   nonInteractive?: boolean,
-  scriptsPrependNodePath?: boolean,
+  scriptsPrependNodePath?: ?boolean,
 
   enableDefaultRc?: boolean,
   extraneousYarnrcFiles?: Array<string>,
@@ -423,7 +423,7 @@ export default class Config {
     // $FlowFixMe$
     this.nonInteractive = !!opts.nonInteractive || isCi || !process.stdout.isTTY;
 
-    this.scriptsPrependNodePath = !!opts.scriptsPrependNodePath;
+    this.scriptsPrependNodePath = opts.scriptsPrependNodePath == undefined ? true : opts.scriptsPrependNodePath;
 
     this.requestManager.setOptions({
       offline: !!opts.offline && !opts.preferOffline,

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -150,10 +150,9 @@ export async function makeEnv(
   // scriptsPrependNodePath=true setting is roughly equivalent to the npm
   // setting scriptsPrependNodePath='auto'.
   if (config.scriptsPrependNodePath) {
-    const execBin = path.dirname(process.execPath);
-    const nodePath = which.sync('node', {path: envPath, nothrow: true});
-    if (!nodePath || path.dirname(nodePath) !== execBin) {
-      pathParts.unshift(execBin);
+    const nodePath = which.sync(path.basename(process.execPath), {path: envPath, nothrow: true});
+    if (!nodePath || nodePath !== process.execPath) {
+      pathParts.unshift(path.dirname(process.execPath));
     }
   }
 


### PR DESCRIPTION
Fixes #5935

#6178 is a partial fix for #5935. This adds the following:

1. Don’t prepend the path *after* the local directories (i.e., delete the lines around line 176 of `yarn/src/util/execute-lifecycle-script.js`)
2. Only prepend the path if the node binary found by searching the environment path is different from our executable path (including if no node is found in the path). This takes care of cases where another node binary precedes our node executable in the path.

I haven't actually tested it (I'm not sure how to build yarn yet), but this should at least be a good start to a full fix for #5935.

If adding `which` as a dependency is a problem, we can revert the logic back to just seeing if `execPath` is in the path, which isn't as good. However, the other parts of this PR I think are needed in master.