### PR TITLE
test: Fix `yarn run <failing script>` test on Windows

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -425,7 +425,7 @@ test('yarn run <failing script>', async () => {
     path.join(cwd, 'package.json'),
     JSON.stringify({
       license: 'MIT',
-      scripts: {false: 'false'},
+      scripts: {false: 'exit 1'},
     }),
   );
 


### PR DESCRIPTION
**Summary**

This test was failing on Windows with the following error:
```
'false' is not recognized as an internal or external command,
operable program or batch file.
```

The script used for this test is `false`. This is valid in Bash, but is
not valid in cmd.exe. It has been replaced with `exit 1`, which will
exit with a status of `1` in both Bash and cmd.exe

The reason this test was passing on AppVeyor is that they have Cygwin
installed by default. This includes a binary called `false`.

**Test plan**

N/A