### PR TITLE
chore(deps): use an existing babel-preset-stage-0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
-    "babel-preset-stage-0": "^6.0.0",
+    "babel-preset-stage-0": "^6.0.15",
     "babylon": "^6.5.0",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
-    "babel-preset-stage-0": "^6.0.15",
+    "babel-preset-stage-0": "^6.24.1",
     "babylon": "^6.5.0",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,7 +910,7 @@ babel-preset-jest@^21.2.0:
     babel-plugin-jest-hoist "^21.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-preset-stage-0@^6.0.0:
+babel-preset-stage-0@^6.0.15:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz#5642d15042f91384d7e5af8bc88b1db95b039e6a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,7 +910,7 @@ babel-preset-jest@^21.2.0:
     babel-plugin-jest-hoist "^21.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-preset-stage-0@^6.0.15:
+babel-preset-stage-0@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz#5642d15042f91384d7e5af8bc88b1db95b039e6a"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In process of #6225 I found that in `package.json` non existing version of `babel-preset-stage-0` has been provided. 

This PR bumps `babel-preset-stage-0` package to the closest version available to avoid any incompatibilities.

`babel-preset-stage-0` versions published on NPM:
https://www.npmjs.com/package/babel-preset-stage-0?activeTab=versions