### PR TITLE
fix(cli-create): fix scoped creation

### DIFF
--- a/__tests__/commands/create.js
+++ b/__tests__/commands/create.js
@@ -1,0 +1,101 @@
+// @flow
+
+import {parsePackageName, coerceCreatePackageName} from '../../src/cli/commands/create';
+
+describe(`parsePackageName`, () => {
+  test('invalid', () => {
+    expect(() => {
+      parsePackageName('@/name');
+    }).toThrowError(`Scope should not be empty, got "@/name"`);
+    expect(() => {
+      parsePackageName('/name');
+    }).toThrowError(`Name should not start with "/", got "/name"`);
+    expect(() => {
+      parsePackageName('./name');
+    }).toThrowError(`Name should not start with ".", got "./name"`);
+  });
+
+  test('basic', () => {
+    expect(parsePackageName('name')).toEqual({
+      fullName: 'name',
+      name: 'name',
+      scope: '',
+      path: '',
+      full: 'name',
+    });
+    expect(parsePackageName('@scope/name')).toEqual({
+      fullName: '@scope/name',
+      name: 'name',
+      scope: '@scope',
+      path: '',
+      full: '@scope/name',
+    });
+    expect(parsePackageName('@scope/name/path/to/file.js')).toEqual({
+      fullName: '@scope/name',
+      name: 'name',
+      scope: '@scope',
+      path: 'path/to/file.js',
+      full: '@scope/name/path/to/file.js',
+    });
+  });
+
+  test('without name', () => {
+    expect(parsePackageName('@scope/')).toEqual({
+      fullName: '@scope',
+      name: '',
+      scope: '@scope',
+      path: '',
+      full: '@scope',
+    });
+    expect(parsePackageName('@scope')).toEqual({
+      fullName: '@scope',
+      name: '',
+      scope: '@scope',
+      path: '',
+      full: '@scope',
+    });
+  });
+});
+
+describe(`coerceCreatePackageName`, () => {
+  test('invalid', () => {
+    expect(() => {
+      coerceCreatePackageName('@/name');
+    }).toThrow();
+    expect(() => {
+      coerceCreatePackageName('/name');
+    }).toThrow();
+    expect(() => {
+      coerceCreatePackageName('./name');
+    }).toThrow();
+  });
+
+  test('basic', () => {
+    expect(coerceCreatePackageName('name')).toEqual({
+      fullName: 'create-name',
+      name: 'create-name',
+      scope: '',
+      path: '',
+      full: 'create-name',
+    });
+    expect(coerceCreatePackageName('@scope/name')).toEqual({
+      fullName: '@scope/create-name',
+      name: 'create-name',
+      scope: '@scope',
+      path: '',
+      full: '@scope/create-name',
+    });
+    expect(coerceCreatePackageName('@scope/name/path/to/file.js')).toEqual({
+      fullName: '@scope/create-name',
+      name: 'create-name',
+      scope: '@scope',
+      path: 'path/to/file.js',
+      full: '@scope/create-name/path/to/file.js',
+    });
+  });
+
+  test('not postfixing with "-" if name is emptu', () => {
+    expect(coerceCreatePackageName('@scope/').fullName).toEqual('@scope/create');
+    expect(coerceCreatePackageName('@scope').fullName).toEqual('@scope/create');
+  });
+});

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -16,6 +16,42 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 
+const coerceName = (name = '') => (name === '' ? 'create' : `create-${name}`);
+const coerceScope = (scope = '') => (scope === '@' ? '' : scope);
+const coerceFullName = (scope, name) => [coerceScope(scope), coerceName(name)].filter(Boolean).join('/');
+
+/**
+ * # Tests
+ *
+ * ## basic
+ * parseBuilderName('name').packageName === 'create-name'
+ * parseBuilderName('@scope/name').packageName === '@scope/create-name'
+ *
+ * ## not adding "-" if name is empty
+ * parseBuilderName('@scope/').packageName === '@scope/create'
+ * parseBuilderName('@scope').packageName === '@scope/create'
+ *
+ * ## edge cases
+ * parseBuilderName('@/name').packageName === 'create-name'
+ * parseBuilderName('/name').packageName === 'create-name'
+ * parseBuilderName('@/').packageName === 'create'
+ */
+const parseBuilderName = str => {
+  const parts = str.split('/');
+  if (parts.length === 1 && !str.includes('@')) {
+    return {
+      packageName: coerceName(str),
+      packageDir: '',
+      commandName: coerceName(str),
+    };
+  }
+  return {
+    packageName: coerceFullName(parts[0], parts[1]),
+    packageDir: coerceScope(parts[0]),
+    commandName: coerceName(parts[1]),
+  };
+};
+
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const [builderName, ...rest] = args;
 
@@ -23,10 +59,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('invalidPackageName'));
   }
 
-  const packageName = builderName.replace(/^(@[^\/]+\/)?/, '$1create-');
-  const packageDir = packageName.replace(/^(?:(@[^\/]+)\/)?.*/, '$1');
-  const commandName = packageName.replace(/^@[^\/]+\//, '');
-
+  const {packageName, packageDir, commandName} = parseBuilderName(builderName);
   await runGlobal(config, reporter, {}, ['add', packageName]);
 
   const binFolder = await getBinFolder(config, {});

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -16,7 +16,7 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
   return true;
 }
 
-export const parsePackageName = (str = '') => {
+export function parsePackageName(str: string): Object {
   if (str.charAt(0) === '/') {
     throw new Error(`Name should not start with "/", got "${str}"`);
   }
@@ -35,9 +35,9 @@ export const parsePackageName = (str = '') => {
   const full = [scope, name, path].filter(Boolean).join('/');
 
   return {fullName, name, scope, path, full};
-};
+}
 
-export const coerceCreatePackageName = (str = '') => {
+export function coerceCreatePackageName(str: string): Object {
   const pkgNameObj = parsePackageName(str);
   const coercedName = pkgNameObj.name !== '' ? `create-${pkgNameObj.name}` : `create`;
   const coercedPkgNameObj = {
@@ -47,7 +47,7 @@ export const coerceCreatePackageName = (str = '') => {
     full: [pkgNameObj.scope, coercedName, pkgNameObj.path].filter(Boolean).join('/'),
   };
   return coercedPkgNameObj;
-};
+}
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const [builderName, ...rest] = args;


### PR DESCRIPTION
This one works as it should:
yarn create @scope/name => @scope/create-name

There were problems when name was omitted:

Before:
yarn create @scope => create-
yarn create @scope/ => @scope/create-

After:
yarn create @scope => @scope/create
yarn create @scope/ => @scope/create

Fixes #6233

**Summary**

it Is not substantial feature request.

Existing behaviour is a bit odd and not aligned with npm. This PR aims to fix it.

**Test plan**

```
~/projects/oss/yarn fix/scoped-create
☯ ./bin/yarn create name
{ packageName: 'create-name',
  packageDir: '',
  commandName: 'create-name' }

~/projects/oss/yarn fix/scoped-create
☯ ./bin/yarn create @scope/name
{ packageName: '@scope/create-name',
  packageDir: '@scope',
  commandName: 'create-name' }

~/projects/oss/yarn fix/scoped-create
☯ ./bin/yarn create @scope/
{ packageName: '@scope/create',
  packageDir: '@scope',
  commandName: 'create' }

~/projects/oss/yarn fix/scoped-create
☯ ./bin/yarn create @scope
{ packageName: '@scope/create',
  packageDir: '@scope',
  commandName: 'create' }
```

Disclaimer:
* I didnt manage to adjust existing RegExps to fix bug: whenever I fixed one use case another one was breaking.
* Due to difficulties with RegExps I streamlined package's scope and name extraction with few helpers.
* ~Couldn't find a place to add test for helper, so I inlined working test assertions.~
* Also I couldn't find documentation in a repository, thus couldn't update it and sadly contribution guide doesnt describe how to update docs.

If tests or documentation are required to be added/updated in the same PR please let me know how to do it.