### PR TITLE
Added ability to run script on all workspaces

### DIFF
--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -1,12 +1,17 @@
 // @flow
+jest.mock('../../src/util/child');
 
 import {BufferReporter} from '../../src/reporters/index.js';
 import {run as workspace} from '../../src/cli/commands/workspaces.js';
 import * as reporters from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
 import path from 'path';
+import {NODE_BIN_PATH, YARN_BIN_PATH} from '../../src/constants';
 
 const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'workspace');
+const spawn: $FlowFixMe = require('../../src/util/child').spawn;
+
+beforeEach(() => spawn.mockClear());
 
 async function runWorkspaces(
   flags: Object,
@@ -39,6 +44,20 @@ test('workspaces info should list the workspaces', (): Promise<void> => {
         workspaceDependencies: ['workspace-1'],
         mismatchedWorkspaceDependencies: [],
       },
+    });
+  });
+});
+
+test('workspaces run should spawn command for each workspace', (): Promise<void> => {
+  const originalArgs = ['run', 'script', 'arg1', '--flag1'];
+  return runWorkspaces({originalArgs}, ['run', 'script', 'arg1', '--flag1'], 'run-basic', config => {
+    expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'script', 'arg1', '--flag1'], {
+      stdio: 'inherit',
+      cwd: path.join(fixturesLoc, 'run-basic', 'packages', 'workspace-child-1'),
+    });
+    expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'script', 'arg1', '--flag1'], {
+      stdio: 'inherit',
+      cwd: path.join(fixturesLoc, 'run-basic', 'packages', 'workspace-child-2'),
     });
   });
 });

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -5,6 +5,8 @@ import {MessageError} from '../../errors.js';
 import type {Reporter} from '../../reporters/index.js';
 import buildSubCommands from './_build-sub-commands.js';
 import {DEPENDENCY_TYPES} from '../../constants.js';
+import * as child from '../../util/child.js';
+import {NODE_BIN_PATH, YARN_BIN_PATH} from '../../constants';
 
 const invariant = require('invariant');
 const path = require('path');
@@ -60,9 +62,44 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
   reporter.log(JSON.stringify(publicData, null, 2), {force: true});
 }
 
+export async function runScript(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  const {workspaceRootFolder} = config;
+
+  if (!workspaceRootFolder) {
+    throw new MessageError(reporter.lang('workspaceRootNotFound', config.cwd));
+  }
+
+  const manifest = await config.findManifest(workspaceRootFolder, false);
+  invariant(manifest && manifest.workspaces, 'We must find a manifest with a "workspaces" property');
+
+  const workspaces = await config.resolveWorkspaces(workspaceRootFolder, manifest);
+
+  try {
+    const [_, ...rest] = flags.originalArgs || [];
+    const childProcesses = [];
+
+    for (const workspaceName of Object.keys(workspaces)) {
+      const {loc} = workspaces[workspaceName];
+      childProcesses.push(
+        child.spawn(NODE_BIN_PATH, [YARN_BIN_PATH, ...rest], {
+          stdio: 'inherit',
+          cwd: loc,
+        }),
+      );
+    }
+
+    await Promise.all(childProcesses);
+  } catch (err) {
+    throw err;
+  }
+}
+
 const {run, setFlags, examples} = buildSubCommands('workspaces', {
   async info(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
     await info(config, reporter, flags, args);
+  },
+  async run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    await runScript(config, reporter, flags, args);
   },
 });
 

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -76,19 +76,15 @@ export async function runScript(config: Config, reporter: Reporter, flags: Objec
 
   try {
     const [_, ...rest] = flags.originalArgs || [];
-    const childProcesses = [];
 
     for (const workspaceName of Object.keys(workspaces)) {
       const {loc} = workspaces[workspaceName];
-      childProcesses.push(
-        child.spawn(NODE_BIN_PATH, [YARN_BIN_PATH, ...rest], {
-          stdio: 'inherit',
-          cwd: loc,
-        }),
-      );
-    }
 
-    await Promise.all(childProcesses);
+      await child.spawn(NODE_BIN_PATH, [YARN_BIN_PATH, ...rest], {
+        stdio: 'inherit',
+        cwd: loc,
+      });
+    }
   } catch (err) {
     throw err;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Added the ability to run a script on every workspace in a project. 
`yarn workspaces run script`

Motivation was to be able to run build or test across an entire monorepo during a CI process. While it was possible to run a script on a workspace individually by name `yarn workspace workspace-1 script`. This required you to know and list all workspaces. 
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I added more tests that ensure that the commands are being spawned properly. Since most of the code was copied from functioning parts of the project, I felt this was sufficient. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

*Update*
Based on feedback I validated that arguments can be passed. 

Here were the commands I ran. 
- `cd __tests__/fixtures/workspace/run-basic`
- `yarn workspace workspace-1 add jest`
- `yarn workspace workspace-2 add jest`
- `yarn workspace workspace-1 run jest --all` --> sanity check
- `yarn workspaces run jest --all`

While jest doesn't pass because there are no tests, you can see from the output the arguments are passed properly. 
Here are the spawned child commands
```
$ /Users/kwelch/_git/yarn/__tests__/fixtures/workspace/run-basic/packages/workspace-child-2/node_modules/.bin/jest --all
$ /Users/kwelch/_git/yarn/__tests__/fixtures/workspace/run-basic/packages/workspace-child-1/node_modules/.bin/jest --all
```
