### PR TITLE
fix(perf): Filter queue in PackageHoister.seed instead of splicing

### DIFF
--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -163,8 +163,11 @@ export default class PackageHoister {
       while (queue.length > 0 && hasChanged) {
         hasChanged = false;
 
-        for (let t = 0; t < queue.length; ++t) {
-          const pattern = queue[t][0];
+        const queueCopy = queue;
+        queue = [];
+        for (let t = 0; t < queueCopy.length; ++t) {
+          const queueItem = queueCopy[t];
+          const pattern = queueItem[0];
           const pkg = this.resolver.getStrictResolvedPattern(pattern);
 
           const peerDependencies = Object.keys(pkg.peerDependencies || {});
@@ -172,14 +175,15 @@ export default class PackageHoister {
 
           if (areDependenciesFulfilled) {
             // Move the package inside our sorted queue
-            sortedQueue.push(queue[t]);
-            queue.splice(t--, 1);
+            sortedQueue.push(queueItem);
 
             // Add it to our set, so that we know it is available
             availableSet.add(pattern);
 
             // Schedule a next pass, in case other packages had peer dependencies on this one
             hasChanged = true;
+          } else {
+            queue.push(queueItem);
           }
         }
       }


### PR DESCRIPTION
**Summary**

For big repositories with thousands of packages splicing the queue array can take upwards of 60s to complete. Changing the algorithm to filter the queue only once solves this.

Our monorepo contains more than 2k packages at the top level, with a workspace of more than 200 packages. Yarn got very slow lately, with `install --force` taking more than 4 minutes easily - mostly hanging at "Linking dependencies" with no progress updates.
I profiled yarn with `ndb` and found the culprit to be native `Array.splice`. After this change, it's still the biggest offender but I couldn't find any more obvious call sites to fix.
With the fix we went down from 240s to 50s for `yarn install --force` on Node 10.1.  After upgrading to 10.8 we went down even further to 24s.

**Test plan**

This is a minor change and the touched code is already tested.
