### PR TITLE
test(warning): Jest: Ignore build directory modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
     "testEnvironment": "node",
     "modulePathIgnorePatterns": [
       "__tests__/fixtures/",
-      "packages/pkg-tests/pkg-tests-fixtures"
+      "packages/pkg-tests/pkg-tests-fixtures",
+      "dist/"
     ],
     "testPathIgnorePatterns": [
       "__tests__/(fixtures|__mocks__)/",


### PR DESCRIPTION
**Summary**

The test suite displays the following warning message when run:
```
jest-haste-map: @providesModule naming collision:
  Duplicate module name: yarn
  Paths: <repo directory>\dist\package.json collides with
    <repo directory>\package.json
```

This is because the Jest module system finds two copies of Yarn; the
primary package and the build output. This causes ambiguity when loading
`yarn` from a test, or a module that depends upon yarn.

Adding the build directory to `modulePathIgnorePatterns` prevents this
message. This means that if `yarn` is imported from within a test (which
it is not currently), the version found will be the primary package, not
the built version.

This seems acceptable. Currently, components of `yarn` are referenced by
filename rather than by package name, and they are all from the `src`
directory. The many cases where the built `yarn` is run in tests are all
done through a child process, where this change would not be applicable
anyway.

**Test plan**

This should have no functional difference on the outcome of the test suite, aside from the absence of that warning message. This can be demonstrated by CI.