### PR TITLE
Fix: Correctly load v8-compile-cache

### DIFF
--- a/bin/yarn.js
+++ b/bin/yarn.js
@@ -11,18 +11,17 @@ if (majorVer < 4) {
   console.error('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.');
   process.exit(1); // eslint-disable-line no-process-exit
 } else {
-  var dirPath = '../lib/';
-  var v8CompileCachePath = dirPath + 'v8-compile-cache';
-  var fs = require('fs');
-  // We don't have/need this on legacy builds and dev builds
-  if (fs.existsSync(v8CompileCachePath)) {
-    require(v8CompileCachePath);
+  try {
+    require(__dirname + '/../lib/v8-compile-cache.js');
+  } catch (err) {
+    // We don't have/need this on legacy builds and dev builds
   }
 
   // Just requiring this package will trigger a yarn run since the
   // `require.main === module` check inside `cli/index.js` will always
   // be truthy when built with webpack :(
-  var cli = require(dirPath + 'cli');
+  // `lib/cli` may be `lib/cli/index.js` or `lib/cli.js` depending on the build.
+  var cli = require(__dirname + '/../lib/cli');
   if (!cli.autoRun) {
     cli.default().catch(function(error) {
       console.error(error.stack || error.message || error);


### PR DESCRIPTION
`v8-compile-cache` is not loading because `fs.existsSync` is checking for a file that doesn't exist. `fs.existsSync` resolves relative to the cwd, not the current module (like `require`), and `v8CompileCachePath`'s filename is missing `.js`.

Instead of checking for the existence of `v8-compile-cache.js`, just try to `require` it in a `try`/`catch`, using a full path. Also switched the `require` of `cli.js` to use the same pattern for consistency (plus it's a module resolution micro-optimization).

```
# before
$ time ./dist/bin/yarn -v
1.10.0-0
./dist/bin/yarn -v  0.28s user 0.06s system 98% cpu 0.344 total

# after
$ time ./dist/bin/yarn -v
1.10.0-0
./dist/bin/yarn -v  0.16s user 0.05s system 97% cpu 0.213 total
```