### PR TITLE
fix(create): invoke correct path when using scoped package

### DIFF
--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -60,7 +60,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   await runGlobal(config, reporter, {}, ['add', packageName]);
 
   const binFolder = await getBinFolder(config, {});
-  const command = path.resolve(binFolder, path.basename(commandName));
+  const command = path.resolve(binFolder, commandName);
 
   await child.spawn(command, rest, {stdio: `inherit`, shell: true});
 }

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -56,11 +56,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('invalidPackageName'));
   }
 
-  const {fullName: packageName, scope: packageDir, name: commandName} = coerceCreatePackageName(builderName);
+  const {fullName: packageName, name: commandName} = coerceCreatePackageName(builderName);
   await runGlobal(config, reporter, {}, ['add', packageName]);
 
   const binFolder = await getBinFolder(config, {});
-  const command = path.resolve(binFolder, packageDir, path.basename(commandName));
+  const command = path.resolve(binFolder, path.basename(commandName));
 
   await child.spawn(command, rest, {stdio: `inherit`, shell: true});
 }


### PR DESCRIPTION
**Summary**

When running yarn create, first the package is installed globally,
however after installing create was attempting to invoke the binary from
within a scope folder that did not exists. The corrects the path
resolution to invoke the binary from the actual place it was installed
to.

fixes #6266


**Test plan**

This basically just removes the change introduced in #5983. I'm happy to add tests if needed but I'm unsure how to accomplish that.
