### PR TITLE
Bugfix #3724

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -306,6 +306,10 @@ export default class Config {
       }
     }
 
+    if (this.modulesFolder) {
+      this.registryFolders.push(this.modulesFolder);
+    }
+
     this.networkConcurrency =
       opts.networkConcurrency || Number(this.getOption('network-concurrency')) || constants.NETWORK_CONCURRENCY;
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -313,7 +313,7 @@ export default class PackageLinker {
 
     const findExtraneousFiles = async basePath => {
       for (const folder of this.config.registryFolders) {
-        const loc = path.join(basePath, folder);
+        const loc = path.resolve(basePath, folder);
 
         if (await fs.exists(loc)) {
           const files = await fs.readdir(loc);

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -491,7 +491,12 @@ export default class PackageLinker {
         topLevelDependencies,
         async ([dest, {pkg}]) => {
           if (pkg._reference && pkg._reference.locations.length && pkg.bin && Object.keys(pkg.bin).length) {
-            const binLoc = path.join(this.config.lockfileFolder, this.config.getFolder(pkg));
+            let binLoc;
+            if (this.config.modulesFolder) {
+              binLoc = path.join(this.config.modulesFolder);
+            } else {
+              binLoc = path.join(this.config.lockfileFolder, this.config.getFolder(pkg));
+            }
             await this.linkSelfDependencies(pkg, dest, binLoc);
             tickBin();
           }

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -175,6 +175,9 @@ export async function makeEnv(
     }
     pathParts.unshift(path.join(config.linkFolder, binFolder));
     pathParts.unshift(path.join(cwd, binFolder));
+    if (config.modulesFolder) {
+      pathParts.unshift(path.join(config.modulesFolder, '.bin'));
+    }
   }
 
   if (config.scriptsPrependNodePath) {


### PR DESCRIPTION
**Summary**

Fix #3724 

When running `yarn install` with a customized `--modules-folder`, binaries are still linked under the default `node_modules/.bin`.

This PR fixes that behavior.

From now on:
1. `install` and `add` commands will link binaries under `custom/.bin`.
1. `run` command will prepend the custom folder path to `PATH` env.
1. `remove` command will remove the specified package from the custom folder. The same way `install --force` will prune extraneous from custom folder.

**Test plan**

All the following were tested with local `.yarnrc` too.

**_Add_**
```bash
$ yarn --modules-folder custom add acorn
$ tree -a --noreport custom/.bin/
custom/.bin/
└── acorn -> ../acorn/bin/acorn
```

**_Install_**
```bash
$ cat package.json 
{
  "dependencies": {
    "acorn": "^5.7.1"
  }
}
$ yarn --modules-folder custom install
$ tree -a --noreport custom/.bin/
custom/.bin/
└── acorn -> ../acorn/bin/acorn
```
**_Run_**
```bash
$ cat package.json 
{
  "scripts": {
    "start": "acorn --help"
  },
  "dependencies": {
    "acorn": "^5.7.1"
  }
}
$ yarn --modules-folder custom start
$ acorn --help
usage: acorn [--ecma3|--ecma5|--ecma6|--ecma7|--ecma8|--ecma9|...|--ecma2015|--ecma2016|--ecma2017|--ecma2018|...]
        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] [infile]
Done in 0.26s.
```

**_Remove_**
```bash
$ yarn remove acorn
$ tree -a --noreport custom
custom
└── .yarn-integrity
```