### PR TITLE
Use UV_FS_COPYFILE_FICLONE flag in fs.copyFile when available

### DIFF
--- a/src/util/fs-normalized.js
+++ b/src/util/fs-normalized.js
@@ -38,7 +38,7 @@ export const unlink: (path: string) => Promise<void> = promisify(require('rimraf
 export const copyFile = async function(data: CopyFileAction, cleanup: () => mixed): Promise<void> {
   try {
     await unlink(data.dest);
-    await copyFilePoly(data.src, data.dest, 0, data);
+    await copyFilePoly(data.src, data.dest, fs.constants.COPYFILE_FICLONE || 0, data);
   } finally {
     if (cleanup) {
       cleanup();

--- a/src/util/fs-normalized.js
+++ b/src/util/fs-normalized.js
@@ -38,7 +38,7 @@ export const unlink: (path: string) => Promise<void> = promisify(require('rimraf
 export const copyFile = async function(data: CopyFileAction, cleanup: () => mixed): Promise<void> {
   try {
     await unlink(data.dest);
-    await copyFilePoly(data.src, data.dest, fs.constants.COPYFILE_FICLONE || 0, data);
+    await copyFilePoly(data.src, data.dest, (fs.constants: any).COPYFILE_FICLONE || 0, data);
   } finally {
     if (cleanup) {
       cleanup();

--- a/src/util/fs-normalized.js
+++ b/src/util/fs-normalized.js
@@ -36,9 +36,11 @@ export const unlink: (path: string) => Promise<void> = promisify(require('rimraf
  * to force the correct naming when the filename has changed only in character-casing. (Jest -> jest).
  */
 export const copyFile = async function(data: CopyFileAction, cleanup: () => mixed): Promise<void> {
+  // $FlowFixMe: Flow doesn't currently support COPYFILE_FICLONE
+  const ficloneFlag = fs.constants.COPYFILE_FICLONE || 0;
   try {
     await unlink(data.dest);
-    await copyFilePoly(data.src, data.dest, (fs.constants: any).COPYFILE_FICLONE || 0, data);
+    await copyFilePoly(data.src, data.dest, ficloneFlag, data);
   } finally {
     if (cleanup) {
       cleanup();


### PR DESCRIPTION
**Summary**

Fixes #5456.

This flag increases performance and saves disk space on COW filesystems that support this flag (APFS, btrfs). On my machine running High Sierra, this decreases `yarn install --offline` time from 9.24s to 6.89s for a project with a lot of dependencies.

**Test plan**

- `yarn run test` passes
