### PR TITLE
fix(build): Apply bundle fix to legacy build

### DIFF
--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -28,11 +28,11 @@ const compiler = webpack({
     'packages/lockfile/index.js': path.join(basedir, 'src/lockfile/index.js'),
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
+        use: 'babel-loader',
       },
       {
         test: /rx\.lite\.aggregates\.js/,
@@ -70,12 +70,20 @@ const compilerLegacy = webpack({
   // devtool: 'inline-source-map',
   entry: path.join(basedir, 'src/cli/index.js'),
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: babelRc.env['pre-node5'],
+        use: [
+          {
+            loader:'babel-loader',
+            options: babelRc.env['pre-node5'],
+          }
+        ],
+      },
+      {
+        test: /rx\.lite\.aggregates\.js/,
+        use: 'imports-loader?define=>false'
       },
     ],
   },


### PR DESCRIPTION
**Summary**

The Webpack config for the modern build was [adjusted recently to add a loader](https://github.com/yarnpkg/yarn/pull/6274),
which is used as a workaround for a bug introduced by a [recent dependency
update](#6208 ). The legacy config needed the same update.

The Webpack config was also updated in superficial ways to follow
recommendations made for migrating from Webpack v1 to v2 (e.g. using
`module.rules` instead of `module.loaders`). These changes should have no
functional impact, and should make migrating to future versions of Webpack
easier.

fix #6269

**Test plan**

I have tested building and running both the modern and legacy builds. Before this change, the artifact from the modern build worked, but the one from the legacy build did not. Now they both work.

I also compared the stdout from running the `build-bundle` command, before and after this change (it prints the list of files included in the bundle). The output matched exactly.