### PR TITLE
chore: fix incomplete sanitization

### DIFF
--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -101,7 +101,7 @@ export function matchesFilter(filter: IgnoreFilter, basename: string, loc: strin
     filterByBasename = false;
   }
   // the micromatch regex expects unix path separators
-  loc = loc.replace('\\', '/');
+  loc = loc.replace(/\\/g, '/');
 
   return (
     filter.regex.test(loc) ||


### PR DESCRIPTION
**Summary**

This PR fixes an alert that was found on LGTM: https://lgtm.com/projects/g/yarnpkg/yarn/alerts/?mode=tree&ruleFocus=1506222917439

https://github.com/yarnpkg/yarn/blob/8cbbc6df34d5ff050bed507224f42abd1b104904/src/util/filter.js#L103-L104

This replacement was incomplete, and would only replace the first backslash which is not what was intended.

**Test plan**

Output from node:

```js
> 'fooo\\bar\\baz'.replace('\\', '/')
'fooo/bar\\baz'
> 'fooo\\bar\\baz'.replace(/\\/g, '/')
'fooo/bar/baz'
```

I'm not sure how to otherwise test this part of the code, or introduce a test case that proves that the previous version fails and the fix fixes it.