### PR TITLE
ConsoleReporter: do not color if !isTTY

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -10,7 +10,7 @@ Object {
 exports[`ConsoleReporter.command 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G$ foobar",
+  "stdout": "[2K[1G[2m$ foobar[22m",
 }
 `;
 
@@ -38,14 +38,14 @@ Object {
 exports[`ConsoleReporter.header 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1Gyarn foobar v0.0.0",
+  "stdout": "[2K[1G[1myarn foobar v0.0.0[22m",
 }
 `;
 
 exports[`ConsoleReporter.info 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1Ginfo foobar",
+  "stdout": "[2K[1G[34minfo[39m foobar",
 }
 `;
 
@@ -94,9 +94,9 @@ Object {
 exports[`ConsoleReporter.select 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1Ginfo Ayo?
-[2K[1G  1) foo
-[2K[1G  2) bar
+  "stdout": "[2K[1G[34minfo[39m Ayo?
+[2K[1G  [2m1)[22m foo
+[2K[1G  [2m2)[22m bar
 [1G[0JSelect one: [13G1",
 }
 `;
@@ -104,14 +104,14 @@ Object {
 exports[`ConsoleReporter.step 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[1/5] foboar...",
+  "stdout": "[2K[1G[2m[1/5][22m foboar...",
 }
 `;
 
 exports[`ConsoleReporter.success 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1Gsuccess foobar",
+  "stdout": "[2K[1G[32msuccess[39m foobar",
 }
 `;
 

--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -10,7 +10,7 @@ Object {
 exports[`ConsoleReporter.command 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[2m$ foobar[22m",
+  "stdout": "[2K[1G$ foobar",
 }
 `;
 
@@ -38,14 +38,14 @@ Object {
 exports[`ConsoleReporter.header 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[1myarn foobar v0.0.0[22m",
+  "stdout": "[2K[1Gyarn foobar v0.0.0",
 }
 `;
 
 exports[`ConsoleReporter.info 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[34minfo[39m foobar",
+  "stdout": "[2K[1Ginfo foobar",
 }
 `;
 
@@ -94,9 +94,9 @@ Object {
 exports[`ConsoleReporter.select 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[34minfo[39m Ayo?
-[2K[1G  [2m1)[22m foo
-[2K[1G  [2m2)[22m bar
+  "stdout": "[2K[1Ginfo Ayo?
+[2K[1G  1) foo
+[2K[1G  2) bar
 [1G[0JSelect one: [13G1",
 }
 `;
@@ -104,14 +104,14 @@ Object {
 exports[`ConsoleReporter.step 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[2m[1/5][22m foboar...",
+  "stdout": "[2K[1G[1/5] foboar...",
 }
 `;
 
 exports[`ConsoleReporter.success 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G[32msuccess[39m foobar",
+  "stdout": "[2K[1Gsuccess foobar",
 }
 `;
 

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -122,7 +122,7 @@ export default class ConsoleReporter extends BaseReporter {
     if (typeof value !== 'number' && typeof value !== 'string') {
       value = inspect(value, {
         breakLength: 0,
-        colors: true,
+        colors: this.isTTY,
         depth: null,
         maxArrayLength: null,
       });
@@ -168,9 +168,6 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   _log(msg: string, {force = false}: {force?: boolean} = {}) {
-    if (!process.stdout.isTTY) {
-      msg = this.format.stripColor(msg);
-    }
     if (this.isSilent && !force) {
       return;
     }

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -168,6 +168,9 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   _log(msg: string, {force = false}: {force?: boolean} = {}) {
+    if (!process.stdout.isTTY) {
+      msg = this.format.stripColor(msg);
+    }
     if (this.isSilent && !force) {
       return;
     }


### PR DESCRIPTION
**Summary**

Given the general problem of yarn emitting console color codes at inappropriate times, this PR tackles one particular case that's been annoying me.

Before:
```
jrr@jrrmbp ~> yarn versions |more
yarn versions v1.9.4
{ yarn: ESC[32m'1.9.4'ESC[39m,
  http_parser: ESC[32m'2.8.0'ESC[39m,
  node: ESC[32m'8.11.3'ESC[39m,
  v8: ESC[32m'6.2.414.54'ESC[39m,
  uv: ESC[32m'1.19.1'ESC[39m,
  zlib: ESC[32m'1.2.11'ESC[39m,
  ares: ESC[32m'1.10.1-DEV'ESC[39m,
  modules: ESC[32m'57'ESC[39m,
  nghttp2: ESC[32m'1.32.0'ESC[39m,
  napi: ESC[32m'3'ESC[39m,
  openssl: ESC[32m'1.0.2o'ESC[39m,
  icu: ESC[32m'60.1'ESC[39m,
  unicode: ESC[32m'10.0'ESC[39m,
  cldr: ESC[32m'32.0'ESC[39m,
  tz: ESC[32m'2017c'ESC[39m }
Done in 0.02s.
```

After:

```
jrr@jrrmbp ~/r/yarn (fix/console-reporter-colors)> ./bin/yarn versions |more
yarn versions v1.10.0-0
{ yarn: '1.10.0-0',
  http_parser: '2.8.0',
  node: '8.11.3',
  v8: '6.2.414.54',
  uv: '1.19.1',
  zlib: '1.2.11',
  ares: '1.10.1-DEV',
  modules: '57',
  nghttp2: '1.32.0',
  napi: '3',
  openssl: '1.0.2o',
  icu: '60.1',
  unicode: '10.0',
  cldr: '32.0',
  tz: '2017c' }
Done in 0.13s.
```

See issue here: https://github.com/yarnpkg/yarn/issues/728#

-----

This band-aids one particular symptom that has been annoying me in my CI output, but perhaps in the future a larger refactor could:
- reduce the number of special cases (there's a surprising number of `isTTY` checks in a few different files)
- rely on Chalk's built-in terminal detection. (shouldn't we get this for free? "Color support is automatically detected", https://github.com/chalk/chalk#chalklevel)