### PR TITLE
test: Fail early if the local yarn build is missing

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {existsSync} from 'fs';
+
 import NoopReporter from '../src/reporters/base-reporter.js';
 import makeTemp from './_temp';
 import * as fs from '../src/util/fs.js';
@@ -15,6 +17,10 @@ let ver = process.versions.node;
 ver = ver.split('-')[0];
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+
+if (!existsSync(path.resolve(__dirname, '../lib'))) {
+  throw new Error('These tests require `yarn build` to have been run first.');
+}
 
 async function execCommand(
   cmd: string,

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -2,6 +2,7 @@
 /* eslint max-len: 0 */
 
 import http from 'http';
+import {existsSync} from 'fs';
 
 import invariant from 'invariant';
 import execa from 'execa';
@@ -15,6 +16,10 @@ import en from '../src/reporters/lang/en.js';
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
 const path = require('path');
+
+if (!existsSync(path.resolve(__dirname, '../lib'))) {
+  throw new Error('These tests require `yarn build` to have been run first.');
+}
 
 function addTest(pattern, {strictPeers} = {strictPeers: false}, yarnArgs: Array<string> = []) {
   test.concurrent(`yarn add ${pattern}`, async () => {

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {existsSync} from 'fs';
+
 import NoopReporter from '../src/reporters/base-reporter.js';
 import makeTemp from './_temp';
 import * as fs from '../src/util/fs.js';
@@ -11,6 +13,10 @@ const fixturesLoc = path.join(__dirname, './fixtures/lifecycle-scripts');
 const yarnBin = path.join(__dirname, '../bin/yarn.js');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+
+if (!existsSync(path.resolve(__dirname, '../lib'))) {
+  throw new Error('These tests require `yarn build` to have been run first.');
+}
 
 async function execCommand(cmd: string, packageName: string, env = process.env): Promise<string> {
   const srcPackageDir = path.join(fixturesLoc, packageName);


### PR DESCRIPTION
**Summary**

Previously if `yarn test` was run without first having run `yarn build`, these three test suites would fail with over 1000 lines of unclear console output. Now, later tests are stopped from running to reduce verbosity, and a more contributor-friendly error message displayed instead.

Note: We unfortunately can't handle this case in `beforeAll()`, since even if it throws, later tests in the same file are still run:
https://github.com/facebook/jest/issues/2713

**Test plan**

Output of `yarn test` previously:

<details>

<summary>Click to expand</summary>

```
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 3)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 75)
(node:11068) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 FAIL  __tests__\integration.js
  × yarn add scrollin (348ms)
  × yarn add https://git@github.com/stevemao/left-pad.git (7ms)
  × yarn add https://github.com/bestander/chrome-app-livereload.git
  × yarn add bestander/chrome-app-livereload (24ms)
  × --mutex network (361ms)
  × --mutex network with busy port (76ms)
  × --cwd option (2ms)
  × default rc (11ms)
  × --no-default-rc (18ms)
  × --use-yarnrc (35ms)
  × yarnrc arguments (75ms)
  × yarn run <script> --opt (3ms)
  × yarn run <script> -- --opt
  × yarn run <script> <strings that need escaping> (163ms)
  × yarn run <failing script> (1ms)
  × yarn run in path need escaping (144ms)
  × cache folder fallback (84ms)
  × relative cache folder (30ms)
  × yarn create (66ms)
  × yarn init -y (51ms)
  production
    × it should be true when NODE_ENV=production (139ms)
    × it should default to false (132ms)
    × it should prefer CLI over NODE_ENV (132ms)
    × it should prefer YARN_PRODUCTION over NODE_ENV (132ms)
    × it should prefer CLI over YARN_PRODUCTION (130ms)
  --registry option
    × --registry option with npm registry (1ms)
    × --registry option with yarn registry (2ms)
    × --registry option with non-exiting registry and show an error (1ms)
    × registry option from yarnrc (38ms)
  yarnrc path
    × js file (163ms)
    × executable file (19ms)
    × js file exit code (1ms)
    × sh file exit code (61ms)

  ● yarn add scrollin

    Error
      Error: Command failed: C:\Users\Ed\src\yarn\bin\yarn add scrollin --cache-folder C:\msys64\tmp\d-11883-11068-zzhphr.css6\cache
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn add https://git@github.com/stevemao/left-pad.git

    Error
      Error: Command failed: C:\Users\Ed\src\yarn\bin\yarn add https://github.com/bestander/chrome-app-livereload.git --cache-folder C:\msys64\tmp\d-11883-11068-ei7mmw.8nssk\cache
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn add https://github.com/bestander/chrome-app-livereload.git

    Error
      Error: Command failed: C:\Users\Ed\src\yarn\bin\yarn add https://github.com/bestander/chrome-app-livereload.git --cache-folder C:\msys64\tmp\d-11883-11068-ei7mmw.8nssk\cache
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn add bestander/chrome-app-livereload

    Error
      Error: Command failed: C:\Users\Ed\src\yarn\bin\yarn add https://git@github.com/stevemao/left-pad.git --cache-folder C:\msys64\tmp\d-11883-11068-1y9egp.aovbdi\cache
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn add bestander/chrome-app-livereload

    Error
      Error: Command failed: C:\Users\Ed\src\yarn\bin\yarn add bestander/chrome-app-livereload --cache-folder C:\msys64\tmp\d-11883-11068-7afug2.6oxp\cache
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● production › it should be true when NODE_ENV=production

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn config current"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● production › it should default to false

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn config current"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● production › it should prefer CLI over NODE_ENV

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn --prod false config current"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● production › it should prefer YARN_PRODUCTION over NODE_ENV

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn config current"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● production › it should prefer CLI over YARN_PRODUCTION

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn --prod 1 config current"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --mutex network

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --mutex network with busy port

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --registry option › --registry option with npm registry

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --registry option › --registry option with yarn registry

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --registry option › --registry option with non-exiting registry and show an error

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --registry option › registry option from yarnrc

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --cwd option

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● default rc

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --no-default-rc

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● --use-yarnrc

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarnrc arguments

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarnrc path › js file

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarnrc path › executable file

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarnrc path › js file exit code

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarnrc path › sh file exit code

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run <script> --opt

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run <script> -- --opt

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run <script> <strings that need escaping>

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn cache dir"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run <script> <strings that need escaping>

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run <failing script>

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run in path need escaping

    Error

      190 |   expect(mutexError).toBeDefined();
      191 |   invariant(mutexError != null, 'mutexError should be defined at this point otherwise Jest will throw above');
    > 192 |   expect(mutexError.message).toMatch(new RegExp(en.mutexPortBusy.replace(/\$\d/g, '\\d+')));
      193 | });
      194 |
      195 | describe('--registry option', () => {
      Error: expect(received).toMatch(expected)

      Expected value to match:
        /Cannot use the network mutex on port \d+. It is probably used by another app./
      Received:
        "Command failed: C:\\WINDOWS\\system32\\cmd.exe /q /s /c \"C:\\Users\\Ed\\src\\\yarn\\bin\\yarn --mutex network:62092 run test 100\"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\\Users\\Ed\\src\\\yarn\\bin/../lib/cli'
          at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
          at Function.Module._load (internal/modules/cjs/loader.js:507:25)
          at Module.require (internal/modules/cjs/loader.js:637:17)
          at require (internal/modules/cjs/helpers.js:20:18)
          at Object.<anonymous> (C:\\Users\\Ed\\src\\\yarn\\bin\\yarn.js:24:13)
          at Module._compile (internal/modules/cjs/loader.js:689:30)
          at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
          at Module.load (internal/modules/cjs/loader.js:599:32)
          at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
          at Function.Module._load (internal/modules/cjs/loader.js:530:3)

      "
      at Object.<anonymous> (__tests__/integration.js:192:30)
          at Generator.throw (<anonymous>)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:30:13

  ● yarn run in path need escaping

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn cache dir --no-default-rc"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run in path need escaping

    Error

      236 |     } catch (err) {
      237 |       const stdoutOutput = err.message;
    > 238 |       expect(stdoutOutput.toString()).toMatch(/getaddrinfo ENOTFOUND example-registry-doesnt-exist\.com/g);
      239 |     }
      240 |   });
      241 |
      Error: expect(received).toMatch(expected)

      Expected value to match:
        /getaddrinfo ENOTFOUND example-registry-doesnt-exist\.com/g
      Received:
        "Command failed: C:\\WINDOWS\\system32\\cmd.exe /q /s /c \"C:\\Users\\Ed\\src\\\yarn\\bin\\yarn add is-array --registry https://example-registry-doesnt-exist.com\"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\\Users\\Ed\\src\\\yarn\\bin/../lib/cli'
          at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
          at Function.Module._load (internal/modules/cjs/loader.js:507:25)
          at Module.require (internal/modules/cjs/loader.js:637:17)
          at require (internal/modules/cjs/helpers.js:20:18)
          at Object.<anonymous> (C:\\Users\\Ed\\src\\\yarn\\bin\\yarn.js:24:13)
          at Module._compile (internal/modules/cjs/loader.js:689:30)
          at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
          at Module.load (internal/modules/cjs/loader.js:599:32)
          at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
          at Function.Module._load (internal/modules/cjs/loader.js:530:3)

      "
      at Object.<anonymous> (__tests__/integration.js:238:39)
          at Generator.throw (<anonymous>)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:30:13

  ● yarn run in path need escaping

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn cache dir --use-yarnrc ./custom-yarnrc"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn run in path need escaping

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn add left-pad --registry https://registry.npmjs.org"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn add left-pad@1.1.3"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn add left-pad"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn add is-array --registry https://registry.yarnpkg.com"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run echo --opt"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● cache folder fallback

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● relative cache folder

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● relative cache folder

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn add left-pad"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● relative cache folder

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn create

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run echo -- --opt"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn create

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

  ● yarn init -y

    expect(received).toEqual(expected)

    Expected value to equal:
      123
    Received:
      1

      375 |     }
      376 |
    > 377 |     expect(error).toEqual(123);
      378 |   });
      379 | });
      380 |

      at Object.<anonymous> (__tests__/integration.js:377:19)
          at Generator.throw (<anonymous>)
      at step (node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at node_modules/babel-runtime/helpers/asyncToGenerator.js:30:13

  ● yarn init -y

    Error
      Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
      internal/modules/cjs/loader.js:583
          throw err;
          ^

      Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
      at Function.Module._load (internal/modules/cjs/loader.js:507:25)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Object.<anonymous> (bin/yarn.js:24:13)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)


      at makeError (node_modules/execa/index.js:172:9)
      at Promise.all.then.arr (node_modules/execa/index.js:277:16)

 › 1 obsolete snapshot found.
  - yarnrc arguments: yarnrc-args 1
Snapshot Summary
 › 1 obsolete snapshot found, re-run jest with `-u` to remove them.

Test Suites: 1 failed, 1 total
Tests:       33 failed, 33 total
Snapshots:   0 total
Time:        4.256s
Ran all test suites matching /__tests__\\integration.js/i.
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 77)
(node:11068) UnhandledPromiseRejectionWarning: Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\Ed\src\yarn\bin\yarn.js:24:13)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)


(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 79)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 81)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 83)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 85)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 87)
(node:11068) UnhandledPromiseRejectionWarning: Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\Ed\src\yarn\bin\yarn.js:24:13)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)


(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 89)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 91)
(node:11068) UnhandledPromiseRejectionWarning: Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\Ed\src\yarn\bin\yarn.js:24:13)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)


(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 93)
(node:11068) UnhandledPromiseRejectionWarning: Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\Ed\src\yarn\bin\yarn.js:24:13)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)


(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 95)
(node:11068) UnhandledPromiseRejectionWarning: Error: Command failed: C:\WINDOWS\system32\cmd.exe /q /s /c "C:\Users\Ed\src\yarn\bin\yarn run test 100"
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'C:\Users\Ed\src\yarn\bin/../lib/cli'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\Ed\src\yarn\bin\yarn.js:24:13)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)


(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 97)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 99)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 12)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 16)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 18)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 14)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 22)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 26)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 20)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 24)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 34)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 32)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 30)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 28)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 36)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 49)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 38)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 42)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 44)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 40)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 47)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 55)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 67)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 70)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 63)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 73)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 79)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 97)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 89)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 93)
(node:11068) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 95)
(node:11068) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addExpectationResult' of undefined
(node:11068) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 100)
```

</details>

<br/>

Output of `yarn test` with this PR:

<details>

<summary>Click to expand</summary>

```
 FAIL  __tests__\lifecycle-scripts.js
  ● Test suite failed to run

    These tests require `yarn build` to have been run first.

      81 |   async () => {
      82 |     const env = Object.assign({}, process.env);
    > 83 |     delete env.npm_config_argv;
      84 |
      85 |     const stdouts = await Promise.all([
      86 |       execCommand('install', 'npm_config_argv_env_vars', env),

      at Object.<anonymous> (__tests__/lifecycle-scripts.js:83:9)

 FAIL  __tests__\index.js
  ● Test suite failed to run

    These tests require `yarn build` to have been run first.

       97 |       throw new Error('the command did not fail');
       98 |     })
    >  99 |     .catch(error => expect(error.message.replace(/\\/g, '')).toContain(expectedMessage));
      100 | }
      101 |
      102 | function expectAnInfoMessageAfterError(command: Promise<Array<?string>>, expectedInfo: string): Promise<void> {

      at Object.<anonymous> (__tests__/index.js:99:9)

 FAIL  __tests__\integration.js
  ● Test suite failed to run

    These tests require `yarn build` to have been run first.

      107 |     const options = {cwd, env: {YARN_SILENT: 1, NODE_ENV: ''}};
      108 |
    > 109 |     const [stdoutOutput, _] = await runYarn(['config', 'current'], options);
      110 |
      111 |     expect(JSON.parse(stdoutOutput.toString())).toHaveProperty('production', false);
      112 |   });

      at Object.<anonymous> (__tests__/integration.js:109:9)
```

</details>