### PR TITLE
Fix: undefined@undefined requires a flat dependency graph (#4245)

### DIFF
--- a/src/package-request.js
+++ b/src/package-request.js
@@ -261,7 +261,7 @@ export default class PackageRequest {
     }
 
     if (info.flat && !this.resolver.flat) {
-      throw new MessageError(this.reporter.lang('flatGlobalError'));
+      throw new MessageError(this.reporter.lang('flatGlobalError', `${info.name}@${info.version}`));
     }
 
     // validate version info

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -107,7 +107,7 @@ const messages = {
   networkWarning:
     "You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.",
   flatGlobalError:
-    'The package $0@$1 requires a flat dependency graph. Add `"flat": true` to your package.json and try again.',
+    'The package $0 requires a flat dependency graph. Add `"flat": true` to your package.json and try again.',
   noName: `Package doesn't have a name.`,
   noVersion: `Package doesn't have a version.`,
   answerRequired: 'An answer is required.',


### PR DESCRIPTION
When `install`ing in a repo with a dependency that specifies `"flat": true`, but without the `--flat` flag or `"flat": true` in your own package.json, you get an error: `The package undefined@undefined requires a flat dependency graph. Add \`"flat": true\` to your package.json and try again.`

This was occuring because the relevant error message, `flatGlobalError` was expecting two variables for interpolation: the package name and the package version.

This fix changes that to one variable (to be consistent with other uses) and passes the appropriate values in to the message.

**Summary**

Previously, Yarn was detecting upon install that a dependency of the current project specified `flat` installation (by way of the `"flat": true` flag in `package.json`), and showed the user an error if the current installation was not flat - either by CLI flag (`--flat`) or package configuration (`"flat": true`).

Unfortunately, this error was less helpful that it should have been because instead of informing the user of what dependency was requiring flat installation, it said only `undefined@undefined`.

This change fixes that omission by specifying the package name and version of the dependency with the flat requirement, helping the user track down what was triggering this error.

**Test plan**

Before:
![yarn undefined fix before](https://user-images.githubusercontent.com/939801/45226563-24109700-b28d-11e8-9e25-f4e36f7d1efe.PNG)

After:
![yarn undefined fix after](https://user-images.githubusercontent.com/939801/45226571-2b37a500-b28d-11e8-9e0d-cf728fd10380.PNG)

