### PR TITLE
fix(install): Skip version resolution prompt if flat and non-interactive is set

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -677,6 +677,11 @@ export class Install {
         continue;
       }
 
+      if (infos.length > 1 && this.config.nonInteractive) {
+        flattenedPatterns.push(this.resolver.patternsByPackage[name][0]);
+        continue;
+      }
+
       const options = infos.map((info): ReporterSelectOption => {
         const ref = info._reference;
         invariant(ref, 'expected reference');


### PR DESCRIPTION
**Summary**
When using the `--non-interactive` flag together with `--flat` the user will be asked to manually select a version of a package with conflicts.

This can be very problematic for CI systems and annoying with projects that have many of those conflicts.

The behaviour described [here](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-non-interactive) would be not to show interactive prompts and instead autoselect a version.

This PR fixes this by selecting the first suggested version.