### PR TITLE
Fetch tags for cached git repo

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -319,6 +319,7 @@ export default class Git implements GitRefResolvingInterface {
 
     return fs.lockQueue.push(gitUrl.repository, async () => {
       if (await fs.exists(cwd)) {
+        await spawnGit(['fetch', '--tags'], {cwd});
         await spawnGit(['pull'], {cwd});
       } else {
         await spawnGit(['clone', gitUrl.repository, cwd]);


### PR DESCRIPTION
**Summary**

Fixes #6256

This change fixes an issue where the cached git repo was not updated with the latest tags.
As a result yarn would exit with the `git archive` command -> `fatal: not a tree object`.
