### PR TITLE
fix(cli/publish): allow to publish directory without `--new-version`

### DIFF
--- a/__tests__/commands/publish.js
+++ b/__tests__/commands/publish.js
@@ -131,3 +131,16 @@ test.concurrent('can specify a path', () => {
     );
   });
 });
+
+test.concurrent('can specify a path without `--new-version`', () => {
+  return runPublish(['mypkg'], {}, 'subdir', config => {
+    expect(config.registries.npm.request).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          access: undefined,
+        }),
+      }),
+    );
+  });
+});

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -151,7 +151,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
   //
   reporter.step(1, 4, reporter.lang('bumpingVersion'));
-  const commitVersion = await setVersion(config, reporter, flags, args, false);
+  const commitVersion = await setVersion(config, reporter, flags, [], false);
 
   //
   reporter.step(2, 4, reporter.lang('loggingIn'));


### PR DESCRIPTION
**Summary**

Fix https://github.com/yarnpkg/yarn/issues/2430

This PR fix `yarn publish [tarball]` and `yarn publish [folder]` commands: flag `--new-version` should not be required, like when using just `yarn publish`.

Current bugged behavior:
```sh
$ yarn publish build
yarn publish v1.9.4
[1/4] Bumping version...
error Use the "--new-version [version]" flag to create a new version.
info Visit https://yarnpkg.com/en/docs/cli/publish for documentation about this command.
```

**Test plan**

```sh
yarn publish build
```

or

```sh
yarn publish some-package.tgz
```