### PR TITLE
Check registry status code for 500 errors

### DIFF
--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -205,6 +205,32 @@ test('RequestManager.execute Request 403 error', async () => {
   });
 });
 
+// Cloudflare will occasionally return an html response with a 500 status code on some calls
+test('RequestManager.execute fails on 500 error', async () => {
+  jest.resetModules();
+  const config = await Config.create({}, new Reporter());
+  jest.mock('request', factory => options => {
+    options.callback(
+      '',
+      {statusCode: 500},
+      `<!DOCTYPE html><title>Rendering error | registry.yarnpkg.com | Cloudflare</title>...`,
+    );
+    return {
+      on: () => {},
+    };
+  });
+  await config.requestManager.execute({
+    params: {
+      url: `https://localhost:port/?nocache`,
+      headers: {Connection: 'close'},
+    },
+    resolve: body => {},
+    reject: err => {
+      expect(err.message).toBe('https://localhost:port/?nocache: Registry error');
+    },
+  });
+});
+
 test('RequestManager.request with offlineNoRequests', async () => {
   const config = await Config.create({offline: true}, new Reporter());
   try {

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -226,7 +226,9 @@ test('RequestManager.execute fails on 500 error', async () => {
     },
     resolve: body => {},
     reject: err => {
-      expect(err.message).toBe('https://localhost:port/?nocache: Request "https://localhost:port/?nocache" returned a 500');
+      expect(err.message).toBe(
+        'https://localhost:port/?nocache: Request "https://localhost:port/?nocache" returned a 500',
+      );
     },
   });
 });

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -226,7 +226,7 @@ test('RequestManager.execute fails on 500 error', async () => {
     },
     resolve: body => {},
     reject: err => {
-      expect(err.message).toBe('https://localhost:port/?nocache: Registry error');
+      expect(err.message).toBe('https://localhost:port/?nocache: Request "https://localhost:port/?nocache" returned a 500');
     },
   });
 });

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -397,6 +397,9 @@ export default class RequestManager {
         if (res.statusCode === 403) {
           const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
           reject(new Error(errMsg));
+        } else if (res.statusCode >= 500) {
+          const errMsg = 'Registry error';
+          reject(new Error(errMsg));
         } else {
           if ([400, 401, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode) !== -1) {
             body = false;

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -394,11 +394,8 @@ export default class RequestManager {
           return;
         }
 
-        if (res.statusCode === 403) {
+        if (res.statusCode === 403 || res.statusCode >= 500) {
           const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
-          reject(new Error(errMsg));
-        } else if (res.statusCode >= 500) {
-          const errMsg = 'Registry error';
           reject(new Error(errMsg));
         } else {
           if ([400, 401, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode) !== -1) {


### PR DESCRIPTION
**Summary**

Over the last week I received several reports from Heroku users using Yarn to install dependency where the installation would fail. Generally the errors would be one of these two:

```
Error: Received malformed response from registry for undefined. The registry may be down.
```

```
Error: https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz: Integrity check failed for "tmpl" (computed integrity doesn't match our records, got "sha1-JRR4x9Dq/iPzyx1+yQY+TRa9x6c=")
```

The next build would generally succeed, but then a different module would fail an integrity check. I deployed a modified version of Yarn that would console log the response when one of these errors would occur and found that in these cases, CloudFlare was returning a 500 response with an HTML error message as the `body`. This is not common, but I was able to recreate it by curling a particular tarball in the registry in a loop.

Looking at [the malformed response code](https://github.com/yarnpkg/yarn/blob/master/src/resolvers/registries/npm-resolver.js#L42), it would receive the HTML error page, check for parameters, and then fail with the error above.

This PR adds an explicit check for the case that the returned status code is 500 or greater without relying on a JSON response with an `error` field.

**Test plan**

```
yarn test
```