### PR TITLE
Fix login for `yarn publish` when using publishConfig.registry

### DIFF
--- a/__tests__/commands/publish.js
+++ b/__tests__/commands/publish.js
@@ -22,6 +22,7 @@ const setupMocks = function(config) {
   // $FlowFixMe
   config.registries.npm.getAuth = jest.fn();
   config.registries.npm.getAuth.mockReturnValue('test');
+  // $FlowFixMe
   config.registries.npm.getAuthByRegistry = jest.fn();
   config.registries.npm.getAuthByRegistry.mockReturnValue('test2');
 };

--- a/__tests__/commands/publish.js
+++ b/__tests__/commands/publish.js
@@ -22,6 +22,8 @@ const setupMocks = function(config) {
   // $FlowFixMe
   config.registries.npm.getAuth = jest.fn();
   config.registries.npm.getAuth.mockReturnValue('test');
+  config.registries.npm.getAuthByRegistry = jest.fn();
+  config.registries.npm.getAuthByRegistry.mockReturnValue('test2');
 };
 
 const runPublish = buildRun.bind(
@@ -142,5 +144,34 @@ test.concurrent('can specify a path without `--new-version`', () => {
         }),
       }),
     );
+  });
+});
+
+test.concurrent('publish should respect publishConfig.registry ', () => {
+  const registry = 'https://registry.myorg.com/';
+
+  return runPublish([], {}, 'publish-config-registry', config => {
+    expect(config.registries.npm.request).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        registry,
+      }),
+    );
+    expect(config.registries.npm.getAuthByRegistry).toBeCalledWith(registry);
+  });
+});
+
+test.concurrent('publish with publishConfig.registry and --registry', () => {
+  const registry = 'https://registry.myorg.com/';
+  const registry2 = 'https://registry2.myorg.com/';
+
+  return runPublish([], {registry: registry2}, 'publish-config-registry', config => {
+    expect(config.registries.npm.request).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        registry,
+      }),
+    );
+    expect(config.registries.npm.getAuthByRegistry).toBeCalledWith(registry);
   });
 });

--- a/__tests__/fixtures/publish/publish-config-registry/package.json
+++ b/__tests__/fixtures/publish/publish-config-registry/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "version": "0.0.0",
+  "publishConfig": {
+    "registry": "https://registry.myorg.com/"
+  }
+}

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -41,8 +41,10 @@ export async function getToken(
   reporter: Reporter,
   name: string = '',
   flags: Object = {},
+  registry: string = '',
 ): Promise<() => Promise<void>> {
-  const auth = config.registries.npm.getAuth(name);
+  const auth = registry ? config.registries.npm.getAuthByRegistry(registry) : config.registries.npm.getAuth(name);
+
   if (auth) {
     config.registries.npm.setToken(auth);
     return function revoke(): Promise<void> {

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -149,6 +149,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('noName'));
   }
 
+  if (!flags.registry && pkg && pkg.registry) {
+    flags.registry = pkg.registry;
+  }
+
   //
   reporter.step(1, 4, reporter.lang('bumpingVersion'));
   const commitVersion = await setVersion(config, reporter, flags, [], false);

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -141,6 +141,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   // validate package fields that are required for publishing
+  // $FlowFixMe
   const pkg = await config.readRootManifest();
   if (pkg.private) {
     throw new MessageError(reporter.lang('publishPrivate'));

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -149,7 +149,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('noName'));
   }
 
-  let registry = '';
+  let registry: string = '';
 
   if (pkg && pkg.publishConfig && pkg.publishConfig.registry) {
     registry = pkg.publishConfig.registry;

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -149,17 +149,18 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('noName'));
   }
 
-  if (!flags.registry && pkg && pkg.registry) {
-    flags.registry = pkg.registry;
+  let registry = '';
+
+  if (pkg && pkg.publishConfig && pkg.publishConfig.registry) {
+    registry = pkg.publishConfig.registry;
   }
 
-  //
   reporter.step(1, 4, reporter.lang('bumpingVersion'));
   const commitVersion = await setVersion(config, reporter, flags, [], false);
 
   //
   reporter.step(2, 4, reporter.lang('loggingIn'));
-  const revoke = await getToken(config, reporter, pkg.name, flags);
+  const revoke = await getToken(config, reporter, pkg.name, flags, registry);
 
   //
   reporter.step(3, 4, reporter.lang('publishing'));


### PR DESCRIPTION
**Summary**

Fix https://github.com/yarnpkg/yarn/issues/6258

While getting login token we should use directly publishConfig.registry instead of trying find suitable repo by package's name/scope. 


**Test plan**

```json
// package.json
"publishConfig": {
  "registry": "https://my.registry/"
}
```

```sh
yarn publish
``` 

**Additional thougths**
With this and https://github.com/yarnpkg/yarn/pull/5376 PRs we have a slightly unobvious behavior that `publishConfig.registry` has more priority than flag `--registry`. NPM has the same behavior which reported as bug https://github.com/npm/npm/issues/5522. It has not been fixed yet but I think we could fix that in yarn before npm do it.