### PR TITLE
`--registry` should have higher priority over `publishConfig.registry`

### DIFF
--- a/__tests__/commands/publish.js
+++ b/__tests__/commands/publish.js
@@ -162,11 +162,10 @@ test.concurrent('publish should respect publishConfig.registry ', () => {
   });
 });
 
-test.concurrent('publish with publishConfig.registry and --registry', () => {
-  const registry = 'https://registry.myorg.com/';
-  const registry2 = 'https://registry2.myorg.com/';
+test.concurrent('publish should allow `--registry` to override publishConfig.registry', () => {
+  const registry = 'https://registry2.myorg.com/';
 
-  return runPublish([], {registry: registry2}, 'publish-config-registry', config => {
+  return runPublish([], {registry}, 'publish-config-registry', config => {
     expect(config.registries.npm.request).toBeCalledWith(
       expect.any(String),
       expect.objectContaining({

--- a/src/types.js
+++ b/src/types.js
@@ -147,6 +147,11 @@ export type Manifest = {
   fresh?: boolean,
 
   prebuiltVariants?: {[filename: string]: string},
+
+  publishConfig?: {
+    access?: string,
+    registry?: string,
+  },
 };
 
 //


### PR DESCRIPTION
**Summary**

Flag `--registry` should have higher priority over `publishConfig.registry` like `--access` has higher priority over `publishConfig.access`. This makes usage of `publish` more explicit.


**Test plan**

```json
// package.json
"publishConfig": {
  "registry": "https://my.registry/"
}
```
```sh
yarn test --registry http://my.another.registry/
```