### PR TITLE
sort options using flags; Fix #5050

### DIFF
--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -4,7 +4,7 @@ import commands from './index.js';
 import * as constants from '../../constants.js';
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
-import {sortAlpha, hyphenate} from '../../util/misc.js';
+import {sortAlpha, sortOptionsByFlags, hyphenate} from '../../util/misc.js';
 import aliases from '../aliases';
 const chalk = require('chalk');
 
@@ -53,6 +53,8 @@ export function run(config: Config, reporter: Reporter, commander: Object, args:
     reporter.log(reporter.lang('helpCommandsMore', reporter.rawText(chalk.bold('yarn help COMMAND'))));
     reporter.log(reporter.lang('helpLearnMore', reporter.rawText(chalk.bold(constants.YARN_DOCS))));
   });
+
+  commander.options.sort(sortOptionsByFlags);
 
   commander.help();
   return Promise.resolve();

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -15,6 +15,12 @@ export function sortAlpha(a: string, b: string): number {
   return a.length - b.length;
 }
 
+export function sortOptionsByFlags(a: Object, b: Object): number {
+  const aOpt = a.flags.replace(/-/g, '');
+  const bOpt = b.flags.replace(/-/g, '');
+  return sortAlpha(aOpt, bOpt);
+}
+
 export function entries<T>(obj: ?{[key: string]: T}): Array<[string, T]> {
   const entries = [];
   if (obj) {


### PR DESCRIPTION
**Summary**

Fixes #5050. Uses the already defined 'sortAlpha' for the actual sorting.

**Test plan**

Run `yarn help`.

Output,

<img width="1789" alt="screen shot 2018-09-25 at 6 55 11 pm" src="https://user-images.githubusercontent.com/17273984/46017566-6e02d500-c0f5-11e8-85c3-3df32daf74d8.png">


