### PR TITLE
Remove resolving with 401 status code

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -431,7 +431,7 @@ export default class RequestManager {
           return;
         }
 
-        if ([400, 401, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode) !== -1) {
+        if ([400, 404].concat(params.rejectStatusCode || []).indexOf(res.statusCode) !== -1) {
           // So this is actually a rejection ... the hosted git resolver uses this to know whether http is supported
           resolve(false);
         } else if (res.statusCode >= 400) {


### PR DESCRIPTION
**Summary**

When registry returns 401 status code it should be considered as error.
401 means that credentials are invalid, but yarn says that everything is fine.

https://github.com/yarnpkg/yarn/pull/6413 - this PR didn't change handling of 401 errors.

**Test plan**

`yarn publish` with expired/corrupted token in `.npmrc`.