### PR TITLE
Fixes how peer dependencies are resolved multiple levels deep

### DIFF
--- a/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl0-1.0.0/index.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl0-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl0-1.0.0/package.json
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl0-1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "peer-deps-lvl0",
+    "version": "1.0.0",
+    "dependencies": {
+        "no-deps": "1.0.0",
+        "peer-deps-lvl1": "1.0.0"
+    }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl1-1.0.0/index.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl1-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl1-1.0.0/package.json
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl1-1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "peer-deps-lvl1",
+    "version": "1.0.0",
+    "dependencies": {
+        "peer-deps-lvl2": "1.0.0"
+    },
+    "peerDependencies": {
+        "no-deps": "*"
+    }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl2-1.0.0/index.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl2-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl2-1.0.0/package.json
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/peer-deps-lvl2-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "peer-deps-lvl2",
+    "version": "1.0.0",
+    "peerDependencies": {
+        "no-deps": "*"
+    }
+}

--- a/packages/pkg-tests/pkg-tests-specs/sources/basic.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/basic.js
@@ -285,6 +285,51 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
     );
 
     test(
+      `it should install in such a way that peer dependencies can be resolved (two levels deep)`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`peer-deps-lvl0`]: `1.0.0`},
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('peer-deps-lvl0')`)).resolves.toMatchObject({
+            name: `peer-deps-lvl0`,
+            version: `1.0.0`,
+            dependencies: {
+              [`peer-deps-lvl1`]: {
+                name: `peer-deps-lvl1`,
+                version: `1.0.0`,
+                dependencies: {
+                  [`peer-deps-lvl2`]: {
+                    name: `peer-deps-lvl2`,
+                    version: `1.0.0`,
+                    peerDependencies: {
+                      [`no-deps`]: {
+                        name: `no-deps`,
+                        version: `1.0.0`,
+                      },
+                    },
+                  },
+                },
+                peerDependencies: {
+                  [`no-deps`]: {
+                    name: `no-deps`,
+                    version: `1.0.0`,
+                  },
+                },
+              },
+              [`no-deps`]: {
+                name: `no-deps`,
+                version: `1.0.0`,
+              },
+            },
+          });
+        },
+      ),
+    );
+
+    test(
       `it should cache the loaded modules`,
       makeTemporaryEnv(
         {


### PR DESCRIPTION
**Summary**

This PR fixes cases where peer dependency across multiple levels of a dependency tree. A practical case is `webpack-dev-server` which has a dependency on`webpack-dev-middleware` and a peer dependency on `webpack`, and `webpack-dev-middleware` which has a peer dependency on `webpack` as well.

Since peer dependencies weren't registered until after the recursion, nested packages weren't able to leverage them. This was hard to spot because of the fallback: if `webpack` was defined as a top-level dependency (as it usually is), everything was working fine. But in the case of `create-react-app`, `webpack` is a dependency of `react-scripts`, which prevented the fallback from kicking in and triggered the bug.

**Test plan**

Added a test.