### PR TITLE
Ensure malformedRegistryResponse errors always have a dependency name

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -866,4 +866,23 @@ describe('checkOutdated functional test', () => {
 
     expect(message).toEqual(expect.stringContaining('No valid versions'));
   });
+
+  test('package with an empty response', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+
+    mockRequestManager.request = () => {
+      return {};
+    };
+
+    let message;
+    try {
+      await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0');
+    } catch (err) {
+      message = err.message;
+    }
+
+    expect(message).toEqual(expect.stringContaining('malformed response from registry for "left-pad"'));
+  });
 });

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -190,14 +190,15 @@ export default class NpmRegistry extends Registry {
   }
 
   async checkOutdated(config: Config, name: string, range: string): CheckOutdatedReturn {
-    const req = await this.request(NpmRegistry.escapeName(name), {unfiltered: true});
+    const escapedName = NpmRegistry.escapeName(name);
+    const req = await this.request(escapedName, {unfiltered: true});
     if (!req) {
       throw new Error('couldnt find ' + name);
     }
 
     // By default use top level 'repository' and 'homepage' values
     let {repository, homepage} = req;
-    const wantedPkg = await NpmResolver.findVersionInRegistryResponse(config, range, req);
+    const wantedPkg = await NpmResolver.findVersionInRegistryResponse(config, escapedName, range, req);
 
     // But some local repositories like Verdaccio do not return 'repository' nor 'homepage'
     // in top level data structure, so we fallback to wanted package manifest

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -31,6 +31,7 @@ export default class NpmResolver extends RegistryResolver {
 
   static async findVersionInRegistryResponse(
     config: Config,
+    name: string,
     range: string,
     body: RegistryResponse,
     request: ?PackageRequest,
@@ -40,7 +41,7 @@ export default class NpmResolver extends RegistryResolver {
     }
 
     if (!body['dist-tags'] || !body.versions) {
-      throw new MessageError(config.reporter.lang('malformedRegistryResponse', body.name));
+      throw new MessageError(config.reporter.lang('malformedRegistryResponse', name));
     }
 
     if (range in body['dist-tags']) {
@@ -91,10 +92,12 @@ export default class NpmResolver extends RegistryResolver {
       }
     }
 
-    const body = await this.config.registries.npm.request(NpmRegistry.escapeName(this.name));
+    const escapedName = NpmRegistry.escapeName(this.name);
+    const desiredRange = desiredVersion || this.range;
+    const body = await this.config.registries.npm.request(escapedName);
 
     if (body) {
-      return NpmResolver.findVersionInRegistryResponse(this.config, desiredVersion || this.range, body, this.request);
+      return NpmResolver.findVersionInRegistryResponse(this.config, escapedName, desiredRange, body, this.request);
     } else {
       return null;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

It's relatively common to see `Received malformed response from registry for undefined` errors, where the `undefined` is coming from the fast that the returned body was totally invalid JSON, and therefore the package name couldn't be parsed from it.

This PR ensures that a package name will always be show in such errors.

**Test plan**

A new test checks that the dependency name is included in the error message for malformed responses, even if it was not returned by the registry.