### PR TITLE
Injects a "process.versions.pnp" variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6449](https://github.com/yarnpkg/yarn/pull/6449) - [**Maël Nison**](https://twitter.com/arcanis)
 
+- Makes the PnP hook inject a `process.versions.pnp` variable when setup (equals to `VERSIONS.std`)
+
+  [#6464](https://github.com/yarnpkg/yarn/pull/6464) - [**Maël Nison**](https://twitter.com/arcanis)
+
 - Fixes the display name of the faulty package when the NPM registry returns corrupted data
 
   [#6455](https://github.com/yarnpkg/yarn/pull/6455) - [**Grey Baker**](https://github.com/greysteil)

--- a/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
@@ -523,7 +523,7 @@ module.exports = makeTemporaryEnv => {
     test(
       `it should export the PnP API through the 'pnpapi' name`,
       makeTemporaryEnv(
-        {dependencies: {[`no-deps`]: `1.0.0`}},
+        {},
         {
           plugNPlay: true,
         },
@@ -533,6 +533,19 @@ module.exports = makeTemporaryEnv => {
           await expect(source(`typeof require('pnpapi').VERSIONS.std`)).resolves.toEqual(`number`);
         },
       ),
+    );
+
+    test(
+      `it should expose the PnP version through 'process.versions.pnp'`,
+      makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
+        await run(`install`);
+
+        const pnpapiVersionsStd = await source(`require('pnpapi').VERSIONS.std`);
+        const processVersionsPnp = await source(`process.versions.pnp`);
+
+        await expect(typeof processVersionsPnp).toEqual(`string`);
+        await expect(processVersionsPnp).toEqual(String(pnpapiVersionsStd));
+      }),
     );
 
     test(

--- a/src/util/generate-pnp-map-api.tpl.js
+++ b/src/util/generate-pnp-map-api.tpl.js
@@ -677,6 +677,8 @@ exports.setup = function setup() {
 
     return false;
   };
+
+  process.versions.pnp = String(exports.VERSIONS.std);
 };
 
 exports.setupCompatibilityLayer = () => {


### PR DESCRIPTION
**Summary**

This PR injects a `process.versions.pnp` variable in the environment when the PnP hook is setup. This is useful for plugins to detect whether they're operating in a PnP environment (where they can require the `pnpapi` module to access the full API) or not without having to rely on try/catch.

**Test plan**

Added a test