### PR TITLE
Disables by default the migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6449](https://github.com/yarnpkg/yarn/pull/6449) - [**Maël Nison**](https://twitter.com/arcanis)
 
+- Disables by default (configurable) the automatic migration of the `integrity` field. **It will be re-enabled in 2.0.**
+
+  [#6465](https://github.com/yarnpkg/yarn/pull/6465) - [**Maël Nison**](https://twitter.com/arcanis)
+
 - Fixes the display name of the faulty package when the NPM registry returns corrupted data
 
   [#6455](https://github.com/yarnpkg/yarn/pull/6455) - [**Grey Baker**](https://github.com/greysteil)

--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -65,10 +65,10 @@ test.concurrent('adding to the workspace root should preserve workspace packages
     expect(pkg.dependencies).toEqual({'left-pad': '1.1.3', 'max-safe-integer': '1.0.0'});
 
     const lockfile = explodeLockfile(await fs.readFile(path.join(config.cwd, 'yarn.lock')));
-    expect(lockfile).toHaveLength(20);
+    expect(lockfile).toHaveLength(16);
     expect(lockfile.indexOf('isarray@2.0.1:')).toEqual(0);
-    expect(lockfile.indexOf('left-pad@1.1.3:')).toEqual(4);
-    expect(lockfile.indexOf('max-safe-integer@1.0.0:')).toEqual(8);
+    expect(lockfile.indexOf('left-pad@1.1.3:')).toEqual(3);
+    expect(lockfile.indexOf('max-safe-integer@1.0.0:')).toEqual(6);
   });
 });
 
@@ -432,7 +432,7 @@ test.concurrent('add with new dependency should be deterministic', async () => {
       const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
       const lockFileLines = explodeLockfile(lockFileWritten);
 
-      expect(lockFileLines).toHaveLength(14);
+      expect(lockFileLines).toHaveLength(12);
       expect(lockFileLines.indexOf('mime-db@~1.0.1:')).toBeGreaterThanOrEqual(0);
       expect(lockFileLines.indexOf('mime-db@1.23.0:')).toBeGreaterThanOrEqual(0);
       expect(lockFileLines.indexOf('mime-types@2.0.0:')).toBeGreaterThanOrEqual(0);
@@ -471,7 +471,7 @@ test.concurrent('add with new dependency should be deterministic 2', async () =>
       const lockFileWritten = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
       const lockFileLines = explodeLockfile(lockFileWritten);
       // see why we don't cleanup lockfile https://github.com/yarnpkg/yarn/issues/79
-      expect(lockFileLines).toHaveLength(14);
+      expect(lockFileLines).toHaveLength(12);
 
       const mirror = await fs.walk(path.join(config.cwd, mirrorPath));
       expect(mirror).toHaveLength(3);

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -724,7 +724,7 @@ test('install should fail to authenticate on sha1 integrity mismatch', () =>
     message: expect.stringContaining("computed integrity doesn't match our records"),
   }));
 
-test('install should create integrity field if not present', () =>
+test.skip('install should create integrity field if not present', () =>
   runInstall({}, 'install-update-auth-no-integrity-field', async config => {
     const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileContent);
@@ -736,7 +736,8 @@ test('install should create integrity field if not present', () =>
     ).toEqual(2);
     expect(lockFileLines[2].indexOf('#893312af69b2123def71f57889001671eeb2c853')).toBeGreaterThan(0);
     // backwards-compatibility
-  }));
+  }),
+);
 
 test('install should not create the integrity field if missing and auto-add-integrity is false', () =>
   runInstall({}, 'install-update-auth-no-integrity-field-no-auto-add', async config => {

--- a/__tests__/commands/remove.js
+++ b/__tests__/commands/remove.js
@@ -110,7 +110,7 @@ test.concurrent('removes a single scoped package', (): Promise<void> => {
 
     const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileContent);
-    expect(lockFileLines).toHaveLength(4);
+    expect(lockFileLines).toHaveLength(3);
   });
 });
 
@@ -179,7 +179,7 @@ test.concurrent('removes from workspace packages', async () => {
     const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
     const lockFileLines = explodeLockfile(lockFileContent);
 
-    expect(lockFileLines).toHaveLength(12);
+    expect(lockFileLines).toHaveLength(9);
     expect(lockFileLines[0]).toEqual('left-pad@1.1.3:');
   });
 });

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -454,7 +454,6 @@ export class Install {
       return false;
     }
     const lockfileClean = this.lockfile.parseResultType === 'success';
-    const lockfileIntegrityPresent = !this.lockfile.hasEntriesExistWithoutIntegrity();
     const match = await this.integrityChecker.check(patterns, lockfileCache, this.flags, workspaceLayout);
     if (this.flags.frozenLockfile && (!lockfileClean || match.missingPatterns.length > 0)) {
       throw new MessageError(this.reporter.lang('frozenLockfileError'));
@@ -462,7 +461,10 @@ export class Install {
 
     const haveLockfile = await fs.exists(path.join(this.config.lockfileFolder, constants.LOCKFILE_FILENAME));
 
-    if (match.integrityMatches && haveLockfile && lockfileClean && lockfileIntegrityPresent) {
+    const lockfileIntegrityPresent = !this.lockfile.hasEntriesExistWithoutIntegrity();
+    const integrityBailout = lockfileIntegrityPresent || !this.config.autoAddIntegrity;
+
+    if (match.integrityMatches && haveLockfile && lockfileClean && integrityBailout) {
       this.reporter.success(this.reporter.lang('upToDate'));
       return true;
     }

--- a/src/config.js
+++ b/src/config.js
@@ -423,7 +423,7 @@ export default class Config {
     this.linkFileDependencies = Boolean(this.getOption('yarn-link-file-dependencies'));
     this.packBuiltPackages = Boolean(this.getOption('experimental-pack-script-packages-in-mirror'));
 
-    this.autoAddIntegrity = !boolifyWithDefault(this.getOption('unsafe-disable-integrity-migration'), 'true');
+    this.autoAddIntegrity = !boolifyWithDefault(String(this.getOption('unsafe-disable-integrity-migration')), true);
 
     //init & create cacheFolder, tempFolder
     this.cacheFolder = path.join(this._cacheRootFolder, 'v' + String(constants.CACHE_VERSION));

--- a/src/config.js
+++ b/src/config.js
@@ -408,6 +408,8 @@ export default class Config {
       }
     }
 
+    const toBool = value => value !== 'false' && value !== 'no' && value !== '0';
+
     this.plugnplayShebang = String(this.getOption('plugnplay-shebang') || '') || '/usr/bin/env node';
     this.plugnplayBlacklist = String(this.getOption('plugnplay-blacklist') || '') || null;
 
@@ -422,7 +424,7 @@ export default class Config {
     this.linkFileDependencies = Boolean(this.getOption('yarn-link-file-dependencies'));
     this.packBuiltPackages = Boolean(this.getOption('experimental-pack-script-packages-in-mirror'));
 
-    this.autoAddIntegrity = !this.getOption('unsafe-disable-integrity-migration');
+    this.autoAddIntegrity = !toBool(this.getOption('unsafe-disable-integrity-migration') || 'true');
 
     //init & create cacheFolder, tempFolder
     this.cacheFolder = path.join(this._cacheRootFolder, 'v' + String(constants.CACHE_VERSION));

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ import type {Manifest, PackageRemote, WorkspacesManifestMap, WorkspacesConfig} f
 import type PackageReference from './package-reference.js';
 import {execFromManifest} from './util/execute-lifecycle-script.js';
 import {resolveWithHome} from './util/path.js';
+import {boolifyWithDefault} from './util/conversion.js';
 import normalizeManifest from './util/normalize-manifest/index.js';
 import {MessageError} from './errors.js';
 import * as fs from './util/fs.js';
@@ -408,8 +409,6 @@ export default class Config {
       }
     }
 
-    const toBool = value => value !== 'false' && value !== 'no' && value !== '0';
-
     this.plugnplayShebang = String(this.getOption('plugnplay-shebang') || '') || '/usr/bin/env node';
     this.plugnplayBlacklist = String(this.getOption('plugnplay-blacklist') || '') || null;
 
@@ -424,7 +423,7 @@ export default class Config {
     this.linkFileDependencies = Boolean(this.getOption('yarn-link-file-dependencies'));
     this.packBuiltPackages = Boolean(this.getOption('experimental-pack-script-packages-in-mirror'));
 
-    this.autoAddIntegrity = !toBool(this.getOption('unsafe-disable-integrity-migration') || 'true');
+    this.autoAddIntegrity = !boolifyWithDefault(this.getOption('unsafe-disable-integrity-migration'), 'true');
 
     //init & create cacheFolder, tempFolder
     this.cacheFolder = path.join(this._cacheRootFolder, 'v' + String(constants.CACHE_VERSION));


### PR DESCRIPTION
**Summary**

While not breaking technically speaking, the automatic migration is causing unexpected behaviors to our users. Such a behavior should only happen when bumping the major version.

To prevent that, the `unsafe-disable-integrity-migration` settings will default to `true` for the duration of the 1.X branch. **It will default to `false` again starting with the 2.0.**

In order to migrate your project now, just add the following line into your project-local yarnrc:

```
unsafe-disable-integrity-migration "false"
```

Note that this only affect the lockfile entries already present in your lockfile. Yarn will continue to create the new entries using the `integrity` field. My guess is that by the time the 2.0 lands, enough projects will have been migrated to use the `integrity` field that this will be a painless transition.

**Test plan**

CI
