### PR TITLE
Disable semantic commit prefixes for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     ":preserveSemverRanges",
+    ":semanticCommitsDisabled",
     "docker:disable"
   ]
 }


### PR DESCRIPTION
**Summary**

As suggested by @edmorley here: https://github.com/yarnpkg/yarn/pull/6463#issuecomment-426240070

This will prevent Renovate from autodetecting semantic commits have been added to master and switching them on automatically, and instead just keep them permanently off.

**Test plan**

No tests required or changelog update as this is bot config internal to this repo only.
