### PR TITLE
Enable Renovate master issue approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "config:base",
     ":preserveSemverRanges",
     ":semanticCommitsDisabled",
+    ":masterIssueApproval",
     "docker:disable"
   ]
 }


### PR DESCRIPTION
**Summary**

After enabling this setting, Renovate will:
- Create a "master" issue containing a list of all outdated dependencies
- No longer automatically create Pull Requests once updates are available
- Provide "checkboxes" in the master issue to allow maintainers to selectively approve PRs for creation

Note: existing PRs will remain open and approvals will be needed only for future/subsequent PRs after this merge.

As suggested by @arcanis, example issue dogfooding this issue is here: https://github.com/renovatebot/renovate/issues/2599

**Test plan**

None necessary
