### PR TITLE
Categorize dependencies based on outdated level

### DIFF
--- a/src/util/categorizeDependencies.js
+++ b/src/util/categorizeDependencies.js
@@ -1,0 +1,36 @@
+// @flow
+import {diffWithUnstable} from './semver';
+
+export const categorizeDependencies = function(dependencies: Array<Object>): Object {
+  const major = [];
+  const minor = [];
+  const patch = [];
+  const other = [];
+
+  dependencies.map(dependency => {
+    if (dependency.name !== 'eslint-plugin-yarn-internal') {
+      const outdatedLevel = diffWithUnstable(dependency.current, dependency.latest);
+
+      switch (outdatedLevel) {
+        case 'major':
+          major.push(dependency);
+          break;
+        case 'minor':
+          minor.push(dependency);
+          break;
+        case 'patch':
+          patch.push(dependency);
+          break;
+        default:
+          other.push(dependency);
+      }
+    }
+  });
+
+  return {
+    major,
+    minor,
+    patch,
+    other,
+  };
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When running `yarn outdated`, categorize dependencies based on their 'outdated level' as proposed in https://github.com/yarnpkg/yarn/issues/5990.

This PR is not done yet. Any feedback is appreciated, but there are some specific things I'd like to know:
- Is the general direction of my approach is something that you'd consider merging?
- When I remove line 11 in `src/util/categorizeDependencies.js`, I get the following error: `error An unexpected error occurred: "Invalid Version: exotic".` If I follow the stack trace, I end up in `semver.js`, but I can't find what exactly triggers this error or how to fix this. Could you give me some pointers?
- Do you have any suggestions for the header names?
- If I'm using header names, should I remove the 'old' Color legend?

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
Run `yarn outdated`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Old:
<img width="786" alt="schermafbeelding 2018-10-04 om 18 08 25" src="https://user-images.githubusercontent.com/17744553/46487545-929b3300-c800-11e8-8a0b-f25564f0ffaa.png">

New:
<img width="887" alt="schermafbeelding 2018-10-04 om 17 58 14" src="https://user-images.githubusercontent.com/17744553/46487475-55cf3c00-c800-11e8-8998-e3933f9763a3.png">

Fixes #5990