### PR TITLE
Comprehensive reorganization of localization file

### DIFF
--- a/__tests__/commands/__snapshots__/run.js.snap
+++ b/__tests__/commands/__snapshots__/run.js.snap
@@ -24,7 +24,7 @@ Array [
         "prestart",
         "start",
       ],
-      "type": "possibleCommands",
+      "type": "runPossibleCommands",
     },
     "error": false,
     "type": "list",

--- a/__tests__/commands/autoclean.js
+++ b/__tests__/commands/autoclean.js
@@ -32,19 +32,19 @@ async function runAutoclean(
 
 test.concurrent('tells user to run with --init when .yarnclean does not exist', (): Promise<void> => {
   return runAutoclean({}, 'not-initialized', (config, reporter, output): ?Promise<void> => {
-    expect(output).toContain(reporter.lang('cleanDoesNotExist', CLEAN_FILENAME));
+    expect(output).toContain(reporter.lang('autoCleanDoesNotExist', CLEAN_FILENAME));
   });
 });
 
 test.concurrent('tells user to run with --init when .yarnclean does not exist and --force', (): Promise<void> => {
   return runAutoclean({force: true}, 'not-initialized', (config, reporter, output): ?Promise<void> => {
-    expect(output).toContain(reporter.lang('cleanDoesNotExist', CLEAN_FILENAME));
+    expect(output).toContain(reporter.lang('autoCleanDoesNotExist', CLEAN_FILENAME));
   });
 });
 
 test.concurrent('tells user to edit .yarnclean after init', (): Promise<void> => {
   return runAutoclean({init: true}, 'not-initialized', (config, reporter, output): ?Promise<void> => {
-    expect(output).toContain(reporter.lang('cleanCreatedFile', CLEAN_FILENAME));
+    expect(output).toContain(reporter.lang('autoCleanCreatedFile', CLEAN_FILENAME));
   });
 });
 
@@ -56,13 +56,13 @@ test.concurrent('creates .yarnclean when --init passed', async () => {
 
 test.concurrent('tells user to run with --force when .yarnclean exists', (): Promise<void> => {
   return runAutoclean({}, 'initialized', (config, reporter, output): ?Promise<void> => {
-    expect(output).toContain(reporter.lang('cleanRequiresForce', CLEAN_FILENAME));
+    expect(output).toContain(reporter.lang('autoCleanRequiresForce', CLEAN_FILENAME));
   });
 });
 
 test.concurrent('tells user file exists already when --init and .yarnclean exists', (): Promise<void> => {
   return runAutoclean({init: true}, 'initialized', (config, reporter, output): ?Promise<void> => {
-    expect(output).toContain(reporter.lang('cleanAlreadyExists', CLEAN_FILENAME));
+    expect(output).toContain(reporter.lang('autoCleanAlreadyExists', CLEAN_FILENAME));
   });
 });
 

--- a/__tests__/commands/check.js
+++ b/__tests__/commands/check.js
@@ -160,7 +160,7 @@ test.concurrent('--integrity should fail if yarn.lock has new pattern', async ()
         thrown = true;
       }
       expect(thrown).toEqual(true);
-      expect(getStdout()).toContain("Integrity check: Lock files don't match");
+      expect(getStdout()).toContain('Integrity check: Lock files do not match');
     },
   );
 });
@@ -184,7 +184,7 @@ test.concurrent('--integrity should fail if yarn.lock has resolved changed', asy
         thrown = true;
       }
       expect(thrown).toEqual(true);
-      expect(getStdout()).toContain("Integrity check: Lock files don't match");
+      expect(getStdout()).toContain('Integrity check: Lock files do not match');
     },
   );
 });
@@ -220,7 +220,7 @@ test.concurrent('--integrity should fail if --ignore-scripts is changed', async 
         thrown = true;
       }
       expect(thrown).toEqual(true);
-      expect(getStdout()).toContain("Integrity check: Flags don't match");
+      expect(getStdout()).toContain('Integrity check: Flags do not match');
     },
   );
 });
@@ -284,7 +284,7 @@ test.concurrent('--integrity should fail if integrity file have different linked
         thrown = true;
       }
       expect(thrown).toEqual(true);
-      expect(getStdout()).toContain("Integrity check: Linked modules don't match");
+      expect(getStdout()).toContain('Integrity check: Linked modules do not match');
     },
   );
 });
@@ -306,7 +306,7 @@ test.concurrent('--integrity should fail if integrity file has different systemP
         thrown = true;
       }
       expect(thrown).toEqual(true);
-      expect(getStdout()).toContain(reporter.lang('integritySystemParamsDontMatch'));
+      expect(getStdout()).toContain(reporter.lang('integrityCheckerSystemParamsDontMatch'));
     },
   );
 });

--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -47,7 +47,7 @@ const expectedKeys = [
 const unexpectedKeys = ['dependencies', 'devDependencies', 'scripts'];
 
 beforeEach(() => {
-  // the mocked requests have stripped metadata, don't use it in the following tests
+  // the mocked requests have stripped metadata, do not use it in the following tests
   jest.unmock('request');
 });
 
@@ -142,6 +142,6 @@ test.concurrent('reports error on invalid package names', (): Promise<void> => {
 test.concurrent('reports error with too many arguments', (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
   return runInfo(['yarn', 'version', 'extra.invalid.arg'], {}, '', (config, output): ?Promise<void> => {
-    expect(output).toContain(reporter.lang('tooManyArguments', 2));
+    expect(output).toContain(reporter.lang('commonTooManyArguments', 2));
   });
 });

--- a/__tests__/commands/install/focus.js
+++ b/__tests__/commands/install/focus.js
@@ -18,7 +18,7 @@ test.concurrent('focus does not work from a non-workspaces project', async (): P
   } catch (e) {
     error = e.message;
   }
-  expect(error).toContain(reporter.lang('workspacesFocusRootCheck'));
+  expect(error).toContain(reporter.lang('configWorkspacesFocusRootCheck'));
 });
 
 test.concurrent('focus does not work from the root of a workspaces project', async (): Promise<void> => {
@@ -29,7 +29,7 @@ test.concurrent('focus does not work from the root of a workspaces project', asy
   } catch (e) {
     error = e.message;
   }
-  expect(error).toContain(reporter.lang('workspacesFocusRootCheck'));
+  expect(error).toContain(reporter.lang('configWorkspacesFocusRootCheck'));
 });
 
 test.concurrent('focus does a normal workspace installation', (): Promise<void> => {

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -436,17 +436,17 @@ test('install with file: protocol as default', () =>
   runInstall({}, 'install-file-as-default', async (config, reporter, install, getOutput) => {
     expect(await fs.readFile(path.join(config.cwd, 'node_modules', 'foo', 'index.js'))).toEqual('foobar;\n');
 
-    expect(getOutput()).toContain(reporter.lang('implicitFileDeprecated', 'bar'));
+    expect(getOutput()).toContain(reporter.lang('packageRequestImplicitFileDeprecated', 'bar'));
   }));
 
 test("don't install with file: protocol as default if target is a file", () =>
   expect(runInstall({lockfile: false}, 'install-file-as-default-no-file')).rejects.toMatchObject({
-    message: expect.stringContaining('Couldn\'t find any versions for "foo" that matches "bar"'),
+    message: expect.stringContaining('Could not find any versions for "foo" that matches "bar"'),
   }));
 
 test("don't install with implicit file: protocol if target does not have package.json", () =>
   expect(runInstall({lockfile: false}, 'install-file-as-default-no-package')).rejects.toMatchObject({
-    message: expect.stringContaining('Couldn\'t find any versions for "foo" that matches "bar"'),
+    message: expect.stringContaining('Could not find any versions for "foo" that matches "bar"'),
   }));
 
 test('install with explicit file: protocol if target does not have package.json', () =>
@@ -493,7 +493,7 @@ test('install file: dedupe dependencies 3', () =>
     const stdout = getStdout();
     // Need to check if message is logged, but don't need to check for any specific parameters
     // so splitting on undefined and testing if all message parts are in stdout
-    const messageParts = reporter.lang('multiplePackagesCantUnpackInSameDestination').split('undefined');
+    const messageParts = reporter.lang('packageFetcherMultiplePackagesSameDestination').split('undefined');
     const warningMessage = messageParts.every(part => stdout.includes(part));
     expect(warningMessage).toBe(false);
   }));
@@ -573,7 +573,7 @@ test('install with comments in manifest resolutions does not result in warning',
 
       expect(
         warnings.some(warning => {
-          return warning.data.toString().indexOf(reporter.lang('invalidResolutionName', '//')) > -1;
+          return warning.data.toString().indexOf(reporter.lang('resolutionMapInvalidResolutionName', '//')) > -1;
         }),
       ).toEqual(false);
     },
@@ -711,17 +711,17 @@ test('install should authenticate integrity with wrong sha1 and right sha512 che
 
 test('install should fail to authenticate integrity with correct sha1 and incorrect sha512', () =>
   expect(runInstall({}, 'install-update-auth-right-sha1-wrong-sha512')).rejects.toMatchObject({
-    message: expect.stringContaining("computed integrity doesn't match our records"),
+    message: expect.stringContaining('computed integrity does not match our records'),
   }));
 
 test('install should fail to authenticate on sha512 integrity mismatch', () =>
   expect(runInstall({}, 'install-update-auth-wrong-sha512')).rejects.toMatchObject({
-    message: expect.stringContaining("computed integrity doesn't match our records"),
+    message: expect.stringContaining('computed integrity does not match our records'),
   }));
 
 test('install should fail to authenticate on sha1 integrity mismatch', () =>
   expect(runInstall({}, 'install-update-auth-wrong-sha1')).rejects.toMatchObject({
-    message: expect.stringContaining("computed integrity doesn't match our records"),
+    message: expect.stringContaining('computed integrity does not match our records'),
   }));
 
 test('install should create integrity field if not present', () =>
@@ -754,7 +754,7 @@ test('install should not create integrity field if not present and in offline mo
 
 test('install should ignore existing hash if integrity is present even if it fails to authenticate it', () =>
   expect(runInstall({}, 'install-update-auth-bad-sha512-good-hash')).rejects.toMatchObject({
-    message: expect.stringContaining("computed integrity doesn't match our records"),
+    message: expect.stringContaining('computed integrity does not match our records'),
   }));
 
 test('install should ignore unknown integrity algorithms if it has other options in the sri', () =>
@@ -1031,7 +1031,9 @@ test('warns for missing bundledDependencies', () =>
       expect(
         warnings.some(warning => {
           return (
-            warning.data.toString().indexOf(reporter.lang('missingBundledDependency', 'tap@0.3.1', 'tap-consumer')) > -1
+            warning.data
+              .toString()
+              .indexOf(reporter.lang('packageLinkerMissingBundledDependency', 'tap@0.3.1', 'tap-consumer')) > -1
           );
         }),
       ).toEqual(true);
@@ -1109,7 +1111,7 @@ test('file: dependency ending with `.git` should work', () =>
 test('install will not warn for missing peerDep when both shallower and deeper', () =>
   runInstall({}, 'peer-dep-included-at-2-levels', (config, reporter, install, getStdout) => {
     const stdout = getStdout();
-    const messageParts = reporter.lang('unmetPeer').split('undefined');
+    const messageParts = reporter.lang('packageLinkerUnmetPeer').split('undefined');
     const warningMessage = messageParts.every(part => stdout.includes(part));
     expect(warningMessage).toBe(false);
   }));

--- a/__tests__/commands/install/lockfiles.js
+++ b/__tests__/commands/install/lockfiles.js
@@ -65,7 +65,7 @@ test.concurrent("throws an error if existing lockfile isn't satisfied with --fro
     await runInstall({frozenLockfile: true}, 'install-throws-error-if-not-satisfied-and-frozen-lockfile', () => {});
   } catch (err) {
     thrown = true;
-    expect(err.message).toContain(reporter.lang('frozenLockfileError'));
+    expect(err.message).toContain(reporter.lang('installFrozenLockfileError'));
   }
   expect(thrown).toEqual(true);
 });

--- a/__tests__/commands/install/resolutions.js
+++ b/__tests__/commands/install/resolutions.js
@@ -42,7 +42,7 @@ test.concurrent('install with --frozen-lockfile with resolutions', async (): Pro
       expect(await getPackageVersion(config, 'left-pad')).toEqual('1.1.3');
     });
   } catch (err) {
-    expect(err.message).not.toContain(reporter.lang('frozenLockfileError'));
+    expect(err.message).not.toContain(reporter.lang('installFrozenLockfileError'));
   }
 });
 

--- a/__tests__/commands/install/workspaces-install.js
+++ b/__tests__/commands/install/workspaces-install.js
@@ -19,7 +19,7 @@ test.concurrent("workspaces don't work with disabled configuration in .yarnrc", 
   } catch (e) {
     error = e.message;
   }
-  expect(error).toContain(reporter.lang('workspacesDisabled'));
+  expect(error).toContain(reporter.lang('configWorkspacesDisabled'));
 });
 
 test.concurrent("workspaces don't work on non private projects", async (): Promise<void> => {
@@ -30,7 +30,7 @@ test.concurrent("workspaces don't work on non private projects", async (): Promi
   } catch (e) {
     error = e.message;
   }
-  expect(error).toContain(reporter.lang('workspacesRequirePrivateProjects'));
+  expect(error).toContain(reporter.lang('configWorkspacesRequirePrivateProjects'));
 });
 
 test.concurrent("workspaces don't work with duplicate names", async (): Promise<void> => {
@@ -41,7 +41,7 @@ test.concurrent("workspaces don't work with duplicate names", async (): Promise<
   } catch (e) {
     error = e.message;
   }
-  expect(error).toContain(reporter.lang('workspaceNameDuplicate', 'workspace-1'));
+  expect(error).toContain(reporter.lang('configWorkspaceNameDuplicate', 'workspace-1'));
 });
 
 test.concurrent("workspaces warn and get ignored if they don't have a name and a version", (): Promise<void> => {

--- a/__tests__/commands/link.js
+++ b/__tests__/commands/link.js
@@ -22,7 +22,7 @@ test.concurrent('throws error if package.json does not have name', async (): Pro
   try {
     await runLink([], {linkFolder}, 'package-no-name', () => {});
   } catch (err) {
-    expect(err.message).toContain(reporter.lang('unknownPackageName'));
+    expect(err.message).toContain(reporter.lang('commonUnknownPackageName'));
   }
 });
 

--- a/__tests__/commands/list.js
+++ b/__tests__/commands/list.js
@@ -33,7 +33,7 @@ describe('list', () => {
       try {
         await runList([], {}, 'lockfile-outdated');
       } catch (err) {
-        expect(err.message).toContain(reporter.lang('lockfileOutdated'));
+        expect(err.message).toContain(reporter.lang('packageRequestLockfileOutdated'));
       } finally {
         resolve();
       }
@@ -124,7 +124,7 @@ describe('list', () => {
       const tree = reporter.getBuffer().slice(-1);
       const trees = [makeTree('gulp@3.9.1', {color: 'bold'})];
 
-      const messageParts = reporter.lang('deprecatedListArgs').split('undefined');
+      const messageParts = reporter.lang('listDeprecatedArgs').split('undefined');
       const output = reporter.getBuffer();
       const hasWarningMessage = output.some(messages => messageParts.indexOf(String(messages.data)) > -1);
       expect(hasWarningMessage).toBe(true);

--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -50,7 +50,7 @@ test.concurrent('throws if lockfile is out of date', (): Promise<void> => {
     try {
       await runOutdated([], {}, 'lockfile-outdated');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('lockfileOutdated'));
+      expect(err.message).toContain(reporter.lang('packageRequestLockfileOutdated'));
     } finally {
       resolve();
     }

--- a/__tests__/commands/remove.js
+++ b/__tests__/commands/remove.js
@@ -26,7 +26,7 @@ test.concurrent('throws error with no arguments', (): Promise<void> => {
     try {
       await runRemove([], {}, '');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('tooFewArguments', 1));
+      expect(err.message).toContain(reporter.lang('commonTooFewArguments', 1));
     } finally {
       resolve();
     }
@@ -40,7 +40,7 @@ test.concurrent('throws error when package is not found', (): Promise<void> => {
     try {
       await runRemove(['dep-b'], {}, 'npm-registry');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('moduleNotInManifest'));
+      expect(err.message).toContain(reporter.lang('removeModuleNotInManifest'));
     } finally {
       resolve();
     }
@@ -50,7 +50,7 @@ test.concurrent('throws error when package is not found', (): Promise<void> => {
 test.concurrent('remove without --ignore-workspace-root-check should fail on the workspace root', async () => {
   await runInstall({}, 'workspaces-install-basic', async (config, reporter): Promise<void> => {
     await expect(remove(config, reporter, {}, ['left-pad'])).rejects.toThrow(
-      reporter.lang('workspacesRemoveRootCheck'),
+      reporter.lang('removeWorkspacesRemoveRootCheck'),
     );
   });
 });

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -62,10 +62,10 @@ test('lists all available commands with no arguments', (): Promise<void> =>
     const bins = ['cat-names'];
 
     // Emulate run output
-    rprtr.info(`${rprtr.lang('binCommands')}${bins.join(', ')}`);
-    rprtr.info(rprtr.lang('possibleCommands'));
-    rprtr.list('possibleCommands', scripts, hints);
-    rprtr.error(rprtr.lang('commandNotSpecified'));
+    rprtr.info(`${rprtr.lang('runBinCommands')}${bins.join(', ')}`);
+    rprtr.info(rprtr.lang('runPossibleCommands'));
+    rprtr.list('runPossibleCommands', scripts, hints);
+    rprtr.error(rprtr.lang('runCommandNotSpecified'));
 
     expect(reporter.getBuffer()).toEqual(rprtr.getBuffer());
   }));
@@ -82,9 +82,9 @@ test('lists all available commands with no arguments and --non-interactive', ():
     const bins = ['cat-names'];
 
     // Emulate run output
-    rprtr.info(`${rprtr.lang('binCommands')}${bins.join(', ')}`);
-    rprtr.info(rprtr.lang('possibleCommands'));
-    rprtr.list('possibleCommands', scripts, hints);
+    rprtr.info(`${rprtr.lang('runBinCommands')}${bins.join(', ')}`);
+    rprtr.info(rprtr.lang('runPossibleCommands'));
+    rprtr.list('runPossibleCommands', scripts, hints);
 
     expect(reporter.getBuffer()).toEqual(rprtr.getBuffer());
   }));

--- a/__tests__/commands/unlink.js
+++ b/__tests__/commands/unlink.js
@@ -53,7 +53,7 @@ test.concurrent('throws error if package.json does not have name', async (): Pro
   try {
     await runUnlink([], {linkFolder}, 'package-no-name', () => {});
   } catch (err) {
-    expect(err.message).toContain(reporter.lang('unknownPackageName'));
+    expect(err.message).toContain(reporter.lang('commonUnknownPackageName'));
   }
 });
 

--- a/__tests__/commands/upgrade-interactive.js
+++ b/__tests__/commands/upgrade-interactive.js
@@ -21,7 +21,7 @@ test.concurrent('throws if lockfile is out of date', (): Promise<void> => {
     try {
       await runUpgrade([], {}, 'lockfile-outdated');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('lockfileOutdated'));
+      expect(err.message).toContain(reporter.lang('packageRequestLockfileOutdated'));
     } finally {
       resolve();
     }
@@ -31,6 +31,6 @@ test.concurrent('throws if lockfile is out of date', (): Promise<void> => {
 test.concurrent('exits with success if no upgrades', (): Promise<void> => {
   const reporter = new reporters.ConsoleReporter({});
   return runUpgrade([], {}, 'up-to-date', (config, rep, install, output): ?Promise<void> => {
-    expect(output()).toContain(reporter.lang('allDependenciesUpToDate'));
+    expect(output()).toContain(reporter.lang('upgradeInteractiveUpToDate'));
   });
 });

--- a/__tests__/commands/upgrade.js
+++ b/__tests__/commands/upgrade.js
@@ -62,7 +62,7 @@ test.concurrent('throws if lockfile is out of date', (): Promise<void> => {
     try {
       await runUpgrade([], {}, 'lockfile-outdated');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('lockfileOutdated'));
+      expect(err.message).toContain(reporter.lang('packageRequestLockfileOutdated'));
     } finally {
       resolve();
     }

--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -38,8 +38,8 @@ test('run version with no arguments and --new-version flag', (): Promise<void> =
     const rprtr = new reporters.BufferReporter({stdout: null, stdin: null});
 
     // Emulate run output
-    rprtr.info(`${rprtr.lang('currentVersion')}: ${oldVersion}`);
-    rprtr.info(`${rprtr.lang('newVersion')}: ${newVersion}`);
+    rprtr.info(`${rprtr.lang('versionCurrentVersion')}: ${oldVersion}`);
+    rprtr.info(`${rprtr.lang('versionNewVersion')}: ${newVersion}`);
 
     expect(reporter.getBuffer()).toEqual(rprtr.getBuffer());
   });

--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -43,7 +43,7 @@ test.concurrent('throws error with no arguments', (): Promise<void> => {
     try {
       await runWhy({}, [], 'basic');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('missingWhyDependency'));
+      expect(err.message).toContain(reporter.lang('whyMissingDependency'));
     } finally {
       resolve();
     }
@@ -57,7 +57,7 @@ test.concurrent('throws error with too many arguments', (): Promise<void> => {
     try {
       await runWhy({}, ['one', 'two'], 'basic');
     } catch (err) {
-      expect(err.message).toContain(reporter.lang('tooManyArguments', 1));
+      expect(err.message).toContain(reporter.lang('commonTooManyArguments', 1));
     } finally {
       resolve();
     }

--- a/__tests__/config.js
+++ b/__tests__/config.js
@@ -194,7 +194,7 @@ describe('workspaces config', () => {
     config.workspacesNohoistEnabled = false;
     expect(getNohoist(config.getWorkspaces(manifest, false))).toBeUndefined();
     expect(mockReporter.numberOfCalls()).toEqual(1);
-    expect(mockReporter.findCalls('workspacesNohoistDisabled').length).toEqual(1);
+    expect(mockReporter.findCalls('configWorkspacesNoHoistDisabled').length).toEqual(1);
 
     mockReporter.reset();
 
@@ -202,7 +202,7 @@ describe('workspaces config', () => {
     manifest.private = false;
     expect(getNohoist(config.getWorkspaces(manifest, false))).toBeUndefined();
     expect(mockReporter.numberOfCalls()).toEqual(1);
-    expect(mockReporter.findCalls('workspacesNohoistRequirePrivatePackages').length).toEqual(1);
+    expect(mockReporter.findCalls('configWorkspacesNoHoistRequirePrivatePackages').length).toEqual(1);
   });
 });
 

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -163,7 +163,7 @@ test('TarballFetcher.fetch throws on invalid hash', async () => {
   );
 
   expect(fetcher.fetch()).rejects.toMatchObject({
-    message: expect.stringContaining("computed integrity doesn't match our records"),
+    message: expect.stringContaining('computed integrity does not match our records'),
   });
   expect(readdirSync(path.join(offlineMirrorDir))).toEqual([]);
 });
@@ -210,7 +210,7 @@ test('TarballFetcher.fetch throws on invalid integrity', async () => {
   );
 
   expect(fetcher.fetch()).rejects.toMatchObject({
-    message: expect.stringContaining("computed integrity doesn't match our records"),
+    message: expect.stringContaining('computed integrity does not match our records'),
   });
   expect(readdirSync(path.join(offlineMirrorDir))).toEqual([]);
 });
@@ -336,8 +336,8 @@ test('TarballFetcher.fetch throws on truncated tar data', async () => {
     await Config.create({}, reporter),
   );
   await expect(fetcher.fetch()).rejects.toThrow(
-    // The "." in ".tgz" should be escaped, but that doesn't work with reporter.lang
-    new RegExp(reporter.lang('errorExtractingTarball', '.*', '.*broken-tar-data.tgz')),
+    // The "." in ".tgz" should be escaped, but that does not work with reporter.lang
+    new RegExp(reporter.lang('tarballFetcherErrorExtractingTarball', '.*', '.*broken-tar-data.tgz')),
   );
 });
 
@@ -355,7 +355,7 @@ test('TarballFetcher.fetch throws on truncated tar header', async () => {
     await Config.create({}, reporter),
   );
   await expect(fetcher.fetch()).rejects.toThrow(
-    // The "." in ".tgz" should be escaped, but that doesn't work with reporter.lang
-    new RegExp(reporter.lang('errorExtractingTarball', '.*', '.*broken-tar-header.tgz')),
+    // The "." in ".tgz" should be escaped, but that does not work with reporter.lang
+    new RegExp(reporter.lang('tarballFetcherErrorExtractingTarball', '.*', '.*broken-tar-header.tgz')),
   );
 });

--- a/__tests__/fixtures/normalize-manifest/throw name start dot/expected.json
+++ b/__tests__/fixtures/normalize-manifest/throw name start dot/expected.json
@@ -1,3 +1,3 @@
 {
-  "_error": ".foobar: Name can't start with a dot"
+  "_error": ".foobar: Name cannot start with a dot"
 }

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -168,7 +168,7 @@ test('--mutex network with busy port', async () => {
 
   const server = http.createServer((request, response) => {
     response.writeHead(200);
-    response.end("I'm a broken JSON string to crash Yarn network mutex.");
+    response.end('I am a broken JSON string to crash Yarn network mutex.');
   });
   server.listen({
     port,
@@ -194,7 +194,7 @@ test('--mutex network with busy port', async () => {
 
   expect(mutexError).toBeDefined();
   invariant(mutexError != null, 'mutexError should be defined at this point otherwise Jest will throw above');
-  expect(mutexError.message).toMatch(new RegExp(en.mutexPortBusy.replace(/\$\d/g, '\\d+')));
+  expect(mutexError.message).toMatch(new RegExp(en.coreMutexPortBusy.replace(/\$\d/g, '\\d+')));
 });
 
 describe('--registry option', () => {
@@ -402,9 +402,7 @@ for (const withDoubleDash of [false, true]) {
     );
 
     expect(stdoutOutput.toString().trim()).toEqual('--opt');
-    (exp => (withDoubleDash ? exp : exp.not))(expect(stderrOutput.toString())).toMatch(
-      /From Yarn 1\.0 onwards, scripts don't require "--" for options to be forwarded/,
-    );
+    (exp => (withDoubleDash ? exp : exp.not))(expect(stderrOutput.toString())).toBe(en.coreDoubleDashDeprecation);
   });
 }
 

--- a/__tests__/reporters/base-reporter.js
+++ b/__tests__/reporters/base-reporter.js
@@ -112,7 +112,7 @@ test('BaseReporter.disableProgress', () => {
 test('BaseReporter.termstrings', () => {
   const reporter = new BaseReporter();
   const expected = '"\u001b[2mjsprim#\u001b[22mjson-schema" not installed';
-  expect(reporter.lang('packageNotInstalled', '\u001b[2mjsprim#\u001b[22mjson-schema')).toEqual(expected);
+  expect(reporter.lang('checkPackageNotInstalled', '\u001b[2mjsprim#\u001b[22mjson-schema')).toEqual(expected);
 });
 
 test('BaseReporter.prompt', async () => {

--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -147,7 +147,10 @@ describe('secureGitUrl()', function() {
         {
           type: 'warning',
           error: true,
-          data: reporter.lang(protocol == 'git:' ? 'downloadGitWithoutCommit' : 'downloadHTTPWithoutCommit', inputurl),
+          data: reporter.lang(
+            protocol == 'git:' ? 'getDownloadGitWithoutCommit' : 'getDownloadHttpWithoutCommit',
+            inputurl,
+          ),
         },
       ]);
     }

--- a/__tests__/util/promise.js
+++ b/__tests__/util/promise.js
@@ -50,7 +50,7 @@ test('queue', async function(): Promise<void> {
   }
 
   await promise.queue([], function() {
-    throw new Error("Shouldn't be called");
+    throw new Error('Should not be called');
   });
 
   await promise.queue(Array(10), create, 5);

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -253,7 +253,7 @@ test('RequestManager.request with offlineNoRequests', async () => {
       headers: {Connection: 'close'},
     });
   } catch (err) {
-    expect(err.message).toBe('Can\'t make a request in offline mode ("https://localhost:port/?nocache")');
+    expect(err.message).toBe('Cannot make a request in offline mode ("https://localhost:port/?nocache")');
   }
 });
 

--- a/src/cli/commands/_build-sub-commands.js
+++ b/src/cli/commands/_build-sub-commands.js
@@ -37,12 +37,14 @@ export default function(rootCommandName: string, subCommands: SubCommands, usage
     }
 
     if (usage && usage.length) {
-      reporter.error(`${reporter.lang('usage')}:`);
+      reporter.error(`${reporter.lang('buildSubCommandsUsage')}:`);
       for (const msg of usage) {
         reporter.error(`yarn ${rootCommandName} ${msg}`);
       }
     }
-    return Promise.reject(new MessageError(reporter.lang('invalidCommand', subCommandNames.join(', '))));
+    return Promise.reject(
+      new MessageError(reporter.lang('buildSubCommandsInvalidCommand', subCommandNames.join(', '))),
+    );
   }
 
   function hasWrapper(commander: Object, args: Array<string>): boolean {

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -120,7 +120,7 @@ export class Add extends Install {
     try {
       manifest = this.resolver.getStrictResolvedPattern(cwdPackage);
     } catch (e) {
-      this.reporter.warn(this.reporter.lang('unknownPackage', cwdPackage));
+      this.reporter.warn(this.reporter.lang('commonUnknownPackage', cwdPackage));
       return patterns;
     }
 
@@ -175,7 +175,7 @@ export class Add extends Install {
 
     // running "yarn add something" in a workspace root is often a mistake
     if (isWorkspaceRoot && !this.flags.ignoreWorkspaceRootCheck) {
-      throw new MessageError(this.reporter.lang('workspacesAddRootCheck'));
+      throw new MessageError(this.reporter.lang('addWorkspacesAddRootCheck'));
     }
 
     this.addedPatterns = [];
@@ -200,7 +200,9 @@ export class Add extends Install {
         SILENCE_DEPENDENCY_TYPE_WARNINGS.indexOf(this.config.commandName) === -1 &&
         dependencyType !== this.flagToOrigin
       ) {
-        this.reporter.warn(this.reporter.lang('moduleAlreadyInManifest', pkgName, dependencyType, this.flagToOrigin));
+        this.reporter.warn(
+          this.reporter.lang('addModuleAlreadyInManifest', pkgName, dependencyType, this.flagToOrigin),
+        );
       }
     });
 
@@ -231,9 +233,9 @@ export class Add extends Install {
     const {trees, count} = await buildTree(this.resolver, this.linker, merged, opts, true, true);
 
     if (count === 1) {
-      this.reporter.success(this.reporter.lang('savedNewDependency'));
+      this.reporter.success(this.reporter.lang('addSavedNewDependency'));
     } else {
-      this.reporter.success(this.reporter.lang('savedNewDependencies', count));
+      this.reporter.success(this.reporter.lang('addSavedNewDependencies', count));
     }
 
     if (!count) {
@@ -247,9 +249,9 @@ export class Add extends Install {
     }
     const directRequireDependencies = trees.filter(({name}) => resolverPatterns.has(name));
 
-    this.reporter.info(this.reporter.lang('directDependencies'));
+    this.reporter.info(this.reporter.lang('addDirectDependencies'));
     this.reporter.tree('newDirectDependencies', directRequireDependencies);
-    this.reporter.info(this.reporter.lang('allDependencies'));
+    this.reporter.info(this.reporter.lang('addAllDependencies'));
     this.reporter.tree('newAllDependencies', trees);
   }
 
@@ -304,7 +306,7 @@ export function setFlags(commander: Object) {
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   if (!args.length) {
-    throw new MessageError(reporter.lang('missingAddDependencies'));
+    throw new MessageError(reporter.lang('addMissingAddDependencies'));
   }
 
   const lockfile = await Lockfile.fromDirectory(config.lockfileFolder, reporter);

--- a/src/cli/commands/autoclean.js
+++ b/src/cli/commands/autoclean.js
@@ -132,17 +132,17 @@ export async function clean(
 }
 
 async function runInit(cwd: string, reporter: Reporter): Promise<void> {
-  reporter.step(1, 1, reporter.lang('cleanCreatingFile', CLEAN_FILENAME));
+  reporter.step(1, 1, reporter.lang('autoCleanCreatingFile', CLEAN_FILENAME));
   const cleanLoc = path.join(cwd, CLEAN_FILENAME);
   await fs.writeFile(cleanLoc, `${DEFAULT_FILTER}\n`, {flag: 'wx'});
-  reporter.info(reporter.lang('cleanCreatedFile', CLEAN_FILENAME));
+  reporter.info(reporter.lang('autoCleanCreatedFile', CLEAN_FILENAME));
 }
 
 async function runAutoClean(config: Config, reporter: Reporter): Promise<void> {
-  reporter.step(1, 1, reporter.lang('cleaning'));
+  reporter.step(1, 1, reporter.lang('autoCleanCleaning'));
   const {removedFiles, removedSize} = await clean(config, reporter);
-  reporter.info(reporter.lang('cleanRemovedFiles', removedFiles));
-  reporter.info(reporter.lang('cleanSavedSize', Number((removedSize / 1024 / 1024).toFixed(2))));
+  reporter.info(reporter.lang('autoCleanRemovedFiles', removedFiles));
+  reporter.info(reporter.lang('autoCleanSavedSize', Number((removedSize / 1024 / 1024).toFixed(2))));
 }
 
 async function checkForCleanFile(cwd: string): Promise<boolean> {
@@ -155,15 +155,15 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const cleanFileExists = await checkForCleanFile(config.cwd);
 
   if (flags.init && cleanFileExists) {
-    reporter.info(reporter.lang('cleanAlreadyExists', CLEAN_FILENAME));
+    reporter.info(reporter.lang('autoCleanAlreadyExists', CLEAN_FILENAME));
   } else if (flags.init) {
     await runInit(config.cwd, reporter);
   } else if (flags.force && cleanFileExists) {
     await runAutoClean(config, reporter);
   } else if (cleanFileExists) {
-    reporter.info(reporter.lang('cleanRequiresForce', CLEAN_FILENAME));
+    reporter.info(reporter.lang('autoCleanRequiresForce', CLEAN_FILENAME));
   } else {
-    reporter.info(reporter.lang('cleanDoesNotExist', CLEAN_FILENAME));
+    reporter.info(reporter.lang('autoCleanDoesNotExist', CLEAN_FILENAME));
   }
 }
 

--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -28,7 +28,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     if (binPath) {
       reporter.log(binPath, {force: true});
     } else {
-      reporter.error(reporter.lang('packageBinaryNotFound', binName));
+      reporter.error(reporter.lang('binPackageBinaryNotFound', binName));
     }
   }
 }

--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -115,13 +115,13 @@ async function clean(config: Config, reporter: Reporter, flags: Object, args: Ar
       }
 
       activity.end();
-      reporter.success(reporter.lang('clearedPackageFromCache', args[0]));
+      reporter.success(reporter.lang('cacheClearedPackageFromCache', args[0]));
     } else {
       // Clear all cache
       await fs.unlink(config._cacheRootFolder);
       await fs.mkdirp(config.cacheFolder);
       activity.end();
-      reporter.success(reporter.lang('clearedCache'));
+      reporter.success(reporter.lang('cacheClearedCache'));
     }
   }
 }

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -97,7 +97,7 @@ export async function verifyTreeCheck(
       continue;
     }
     if (!await fs.exists(manifestLoc)) {
-      reportError('packageNotInstalled', `${dep.originalKey}`);
+      reportError('checkPackageNotInstalled', `${dep.originalKey}`);
       continue;
     }
     if (!await fs.exists(path.join(manifestLoc, 'package.json'))) {
@@ -108,7 +108,7 @@ export async function verifyTreeCheck(
       semver.validRange(dep.version, config.looseSemver) &&
       !semver.satisfies(pkg.version, dep.version, config.looseSemver)
     ) {
-      reportError('packageWrongVersion', dep.originalKey, dep.version, pkg.version);
+      reportError('checkPackageWrongVersion', dep.originalKey, dep.version, pkg.version);
       continue;
     }
     const dependencies = pkg.dependencies;
@@ -142,16 +142,16 @@ export async function verifyTreeCheck(
           locations.pop();
         }
         if (!found) {
-          reportError('packageNotInstalled', `${dep.originalKey}#${subdep}`);
+          reportError('checkPackageNotInstalled', `${dep.originalKey}#${subdep}`);
         }
       }
     }
   }
 
   if (errCount > 0) {
-    throw new MessageError(reporter.lang('foundErrors', errCount));
+    throw new MessageError(reporter.lang('checkFoundErrors', errCount));
   } else {
-    reporter.success(reporter.lang('folderInSync'));
+    reporter.success(reporter.lang('checkFolderInSync'));
   }
 }
 
@@ -176,20 +176,20 @@ async function integrityHashCheck(
 
   const match = await integrityChecker.check(patterns, lockfile.cache, flags, workspaceLayout);
   for (const pattern of match.missingPatterns) {
-    reportError('lockfileNotContainPattern', pattern);
+    reportError('checkLockfileNotContainPattern', pattern);
   }
   if (match.integrityFileMissing) {
-    reportError('noIntegrityFile');
+    reportError('checkNoIntegrityFile');
   }
   if (match.integrityMatches === false) {
     reporter.warn(reporter.lang(integrityErrors[match.integrityError]));
-    reportError('integrityCheckFailed');
+    reportError('checkIntegrityCheckFailed');
   }
 
   if (errCount > 0) {
-    throw new MessageError(reporter.lang('foundErrors', errCount));
+    throw new MessageError(reporter.lang('checkFoundErrors', errCount));
   } else {
-    reporter.success(reporter.lang('folderInSync'));
+    reporter.success(reporter.lang('checkFolderInSync'));
   }
 }
 
@@ -233,7 +233,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   // check if patterns exist in lockfile
   for (const pattern of patterns) {
     if (!lockfile.getLocked(pattern) && (!workspaceLayout || !workspaceLayout.getManifestByPattern(pattern))) {
-      reportError('lockfileNotContainPattern', pattern);
+      reportError('checkLockfileNotContainPattern', pattern);
     }
   }
 
@@ -281,9 +281,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     if (!await fs.exists(loc)) {
       if (pkg._reference.optional) {
-        reporter.warn(reporter.lang('optionalDepNotInstalled', human));
+        reporter.warn(reporter.lang('checkOptionalDepNotInstalled', human));
       } else {
-        reportError('packageNotInstalled', human);
+        reportError('checkPackageNotInstalled', human);
       }
       continue;
     }
@@ -296,7 +296,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
       if (pkg.version !== packageJson.version) {
         // node_modules contains wrong version
-        reportError('packageWrongVersion', human, pkg.version, packageJson.version);
+        reportError('checkPackageWrongVersion', human, pkg.version, packageJson.version);
       }
 
       const deps = Object.assign({}, packageJson.dependencies, packageJson.peerDependencies);
@@ -346,13 +346,13 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
               const {range: resRange} = normalizePattern(resPattern);
 
               if (semver.satisfies(depPkg.version, resRange, config.looseSemver)) {
-                reporter.warn(reporter.lang('incompatibleResolutionVersion', foundHuman, subHuman));
+                reporter.warn(reporter.lang('resolutionMapIncompatibleResolutionVersion', foundHuman, subHuman));
                 warningCount++;
               } else {
-                reportError('packageDontSatisfy', resHuman, foundHuman);
+                reportError('checkPackageDoesntSatisfy', resHuman, foundHuman);
               }
             } else {
-              reportError('packageDontSatisfy', subHuman, foundHuman);
+              reportError('checkPackageDoesntSatisfy', subHuman, foundHuman);
             }
 
             continue;
@@ -380,7 +380,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
             ) {
               reporter.warn(
                 reporter.lang(
-                  'couldBeDeduped',
+                  'checkCouldBeDeduped',
                   subHuman,
                   packageJson.version,
                   `${humaniseLocation(path.dirname(locPkg)).join('#')}@${packageJson.version}`,
@@ -396,12 +396,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   if (warningCount > 1) {
-    reporter.info(reporter.lang('foundWarnings', warningCount));
+    reporter.info(reporter.lang('checkFoundWarnings', warningCount));
   }
 
   if (errCount > 0) {
-    throw new MessageError(reporter.lang('foundErrors', errCount));
+    throw new MessageError(reporter.lang('checkFoundErrors', errCount));
   } else {
-    reporter.success(reporter.lang('folderInSync'));
+    reporter.success(reporter.lang('checkFolderInSync'));
   }
 }

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -53,7 +53,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const [builderName, ...rest] = args;
 
   if (!builderName) {
-    throw new MessageError(reporter.lang('invalidPackageName'));
+    throw new MessageError(reporter.lang('commonInvalidPackageName'));
   }
 
   const {fullName: packageName, name: commandName} = coerceCreatePackageName(builderName);

--- a/src/cli/commands/generate-lock-entry.js
+++ b/src/cli/commands/generate-lock-entry.js
@@ -17,10 +17,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     manifest = await config.readRootManifest();
   }
   if (!manifest.name) {
-    throw new MessageError(reporter.lang('noName'));
+    throw new MessageError(reporter.lang('commonNoPackageName'));
   }
   if (!manifest.version) {
-    throw new MessageError(reporter.lang('noVersion'));
+    throw new MessageError(reporter.lang('commonNoPackageVersion'));
   }
 
   const entry = {

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -106,7 +106,7 @@ async function getGlobalPrefix(config: Config, flags: Object): Promise<string> {
   if (!prefix) {
     config.reporter.warn(
       config.reporter.lang(
-        'noGlobalFolder',
+        'globalNoFolder',
         prefixFolderQueryResult.skipped.map(item => path.dirname(item.folder)).join(', '),
       ),
     );
@@ -128,7 +128,7 @@ async function initUpdateBins(config: Config, reporter: Reporter, flags: Object)
 
   function throwPermError(err: Error & {[code: string]: string}, dest: string) {
     if (err.code === 'EACCES') {
-      throw new MessageError(reporter.lang('noPermission', dest));
+      throw new MessageError(reporter.lang('globalNoPermission', dest));
     } else {
       throw err;
     }
@@ -181,13 +181,13 @@ function ls(manifest: Manifest, reporter: Reporter, saved: boolean) {
   const human = `${manifest.name}@${manifest.version}`;
   if (bins.length) {
     if (saved) {
-      reporter.success(reporter.lang('packageInstalledWithBinaries', human));
+      reporter.success(reporter.lang('globalPackageInstalledWithBinaries', human));
     } else {
-      reporter.info(reporter.lang('packageHasBinaries', human));
+      reporter.info(reporter.lang('globalPackageHasBinaries', human));
     }
     reporter.list(`bins-${manifest.name}`, bins);
   } else if (saved) {
-    reporter.warn(reporter.lang('packageHasNoBinaries', human));
+    reporter.warn(reporter.lang('globalPackageHasNoBinaries', human));
   }
 }
 
@@ -212,7 +212,7 @@ const {run, setFlags: _setFlags} = buildSubCommands('global', {
 
     const updateBins = await initUpdateBins(config, reporter, flags);
     if (args.indexOf('yarn') !== -1) {
-      reporter.warn(reporter.lang('packageContainsYarnAsGlobal'));
+      reporter.warn(reporter.lang('globalPackageContainsYarnAsGlobal'));
     }
 
     // install module

--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -267,7 +267,7 @@ class ImportPackageRequest extends PackageRequest {
 
   findVersionInfo(): Promise<Manifest> {
     if (!this.import) {
-      this.reporter.verbose(this.reporter.lang('skippingImport', this.pattern, this.getParentHumanName()));
+      this.reporter.verbose(this.reporter.lang('importSkipping', this.pattern, this.getParentHumanName()));
       return super.findVersionInfo();
     }
     const resolver = new ImportResolver(this, this.pattern);
@@ -369,7 +369,7 @@ export class Import extends Install {
   }
   async init(): Promise<Array<string>> {
     if (await fs.exists(path.join(this.config.cwd, LOCKFILE_FILENAME))) {
-      throw new MessageError(this.reporter.lang('lockfileExists'));
+      throw new MessageError(this.reporter.lang('importLockfileExists'));
     }
     const {packageJson, packageLock} = await this.getExternalLockfileContents();
     const importSource =

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -46,7 +46,7 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   if (args.length > 2) {
-    reporter.error(reporter.lang('tooManyArguments', 2));
+    reporter.error(reporter.lang('commonTooManyArguments', 2));
     return;
   }
 

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -62,7 +62,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       question: 'name',
       default: path.basename(config.cwd),
       validation: validate.isValidPackageName,
-      validationError: 'invalidPackageName',
+      validationError: 'commonInvalidPackageName',
     },
     {
       key: 'version',
@@ -147,7 +147,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
           if (entry.validation(String(answer))) {
             validAnswer = true;
           } else {
-            reporter.error(reporter.lang('invalidPackageName'));
+            reporter.error(reporter.lang('commonInvalidPackageName'));
           }
         }
       } else {

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -53,7 +53,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const manifest = await config.readRootManifest();
     const name = manifest.name;
     if (!name) {
-      throw new MessageError(reporter.lang('unknownPackageName'));
+      throw new MessageError(reporter.lang('commonUnknownPackageName'));
     }
 
     const linkLoc = path.join(config.linkFolder, name);
@@ -72,7 +72,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
           const binSrcLoc = path.join(linkLoc, binSrc);
           const binDestLoc = path.join(globalBinFolder, binName);
           if (await fs.exists(binDestLoc)) {
-            reporter.warn(reporter.lang('binLinkCollision', binName));
+            reporter.warn(reporter.lang('linkBinCollision', binName));
           } else {
             if (process.platform === 'win32') {
               await cmdShim(binSrcLoc, binDestLoc);

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -217,7 +217,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   let {trees}: {trees: Trees} = await buildTree(install.resolver, install.linker, activePatterns, opts);
 
   if (args.length) {
-    reporter.warn(reporter.lang('deprecatedListArgs'));
+    reporter.warn(reporter.lang('listDeprecatedArgs'));
   }
   if (args.length || flags.pattern) {
     trees = trees.filter(tree => filterTree(tree, args, flags.pattern));

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -14,18 +14,18 @@ async function getCredentials(
   let {username, email} = config.registries.yarn.config;
 
   if (username) {
-    reporter.info(`${reporter.lang('npmUsername')}: ${username}`);
+    reporter.info(`${reporter.lang('loginNpmUsername')}: ${username}`);
   } else {
-    username = await reporter.question(reporter.lang('npmUsername'));
+    username = await reporter.question(reporter.lang('loginNpmUsername'));
     if (!username) {
       return null;
     }
   }
 
   if (email) {
-    reporter.info(`${reporter.lang('npmEmail')}: ${email}`);
+    reporter.info(`${reporter.lang('loginNpmEmail')}: ${email}`);
   } else {
-    email = await reporter.question(reporter.lang('npmEmail'));
+    email = await reporter.question(reporter.lang('loginNpmEmail'));
     if (!email) {
       return null;
     }
@@ -48,7 +48,7 @@ export async function getToken(
   if (auth) {
     config.registries.npm.setToken(auth);
     return function revoke(): Promise<void> {
-      reporter.info(reporter.lang('notRevokingConfigToken'));
+      reporter.info(reporter.lang('loginNotRevokingConfigToken'));
       return Promise.resolve();
     };
   }
@@ -57,14 +57,14 @@ export async function getToken(
   if (env) {
     config.registries.npm.setToken(`Bearer ${env}`);
     return function revoke(): Promise<void> {
-      reporter.info(reporter.lang('notRevokingEnvToken'));
+      reporter.info(reporter.lang('loginNotRevokingEnvToken'));
       return Promise.resolve();
     };
   }
 
   // make sure we're not running in non-interactive mode before asking for login
   if (flags.nonInteractive || config.nonInteractive) {
-    throw new MessageError(reporter.lang('nonInteractiveNoToken'));
+    throw new MessageError(reporter.lang('loginNonInteractiveNoToken'));
   }
 
   //
@@ -72,13 +72,13 @@ export async function getToken(
   if (!creds) {
     reporter.warn(reporter.lang('loginAsPublic'));
     return function revoke(): Promise<void> {
-      reporter.info(reporter.lang('noTokenToRevoke'));
+      reporter.info(reporter.lang('loginNoTokenToRevoke'));
       return Promise.resolve();
     };
   }
 
   const {username, email} = creds;
-  const password = await reporter.question(reporter.lang('npmPassword'), {
+  const password = await reporter.question(reporter.lang('loginNpmPassword'), {
     password: true,
     required: true,
   });
@@ -102,19 +102,19 @@ export async function getToken(
   });
 
   if (res && res.ok) {
-    reporter.success(reporter.lang('loggedIn'));
+    reporter.success(reporter.lang('loginLoggedIn'));
 
     const token = res.token;
     config.registries.npm.setToken(`Bearer ${token}`);
 
     return async function revoke(): Promise<void> {
-      reporter.success(reporter.lang('revokedToken'));
+      reporter.success(reporter.lang('loginRevokedToken'));
       await config.registries.npm.request(`-/user/token/${token}`, {
         method: 'DELETE',
       });
     };
   } else {
-    throw new MessageError(reporter.lang('incorrectCredentials'));
+    throw new MessageError(reporter.lang('loginIncorrectCredentials'));
   }
 }
 

--- a/src/cli/commands/logout.js
+++ b/src/cli/commands/logout.js
@@ -17,5 +17,5 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     email: undefined,
   });
 
-  reporter.success(reporter.lang('clearedCredentials'));
+  reporter.success(reporter.lang('logoutClearedCredentials'));
 }

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -54,7 +54,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const red = reporter.format.red('<red>');
     const yellow = reporter.format.yellow('<yellow>');
     const green = reporter.format.green('<green>');
-    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
+    reporter.info(reporter.lang('commonLegendColorsForVersionUpdates', red, yellow, green));
 
     const header = ['Package', 'Current', 'Wanted', 'Latest', 'Workspace', 'Package Type', 'URL'];
     if (!usesWorkspaces) {

--- a/src/cli/commands/owner.js
+++ b/src/cli/commands/owner.js
@@ -29,11 +29,11 @@ export async function mutate(
   const username = args.shift();
   const name = await getName(args, config);
   if (!isValidPackageName(name)) {
-    throw new MessageError(reporter.lang('invalidPackageName'));
+    throw new MessageError(reporter.lang('commonInvalidPackageName'));
   }
 
   const msgs = buildMessages(username, name);
-  reporter.step(1, 3, reporter.lang('loggingIn'));
+  reporter.step(1, 3, reporter.lang('commonLoggingIn'));
   const revoke = await getToken(config, reporter, name);
 
   reporter.step(2, 3, msgs.info);
@@ -47,7 +47,7 @@ export async function mutate(
       error = mutator({name: user.name, email: user.email}, pkg);
     } else {
       error = true;
-      reporter.error(reporter.lang('unknownPackage', name));
+      reporter.error(reporter.lang('commonUnknownPackage', name));
     }
 
     // update package
@@ -70,10 +70,10 @@ export async function mutate(
     }
   } else {
     error = true;
-    reporter.error(reporter.lang('unknownUser', username));
+    reporter.error(reporter.lang('ownerUnknownUser', username));
   }
 
-  reporter.step(3, 3, reporter.lang('revokingToken'));
+  reporter.step(3, 3, reporter.lang('commonRevokingToken'));
   await revoke();
 
   if (error) {
@@ -130,7 +130,7 @@ function remove(config: Config, reporter: Reporter, flags: Object, args: Array<s
       });
 
       if (!found) {
-        reporter.error(reporter.lang('userNotAnOwner', user.name));
+        reporter.error(reporter.lang('ownerUserNotAnOwner', user.name));
       }
 
       return found;

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -180,10 +180,10 @@ export async function run(
 ): Promise<void> {
   const pkg = await config.readRootManifest();
   if (!pkg.name) {
-    throw new MessageError(reporter.lang('noName'));
+    throw new MessageError(reporter.lang('commonNoPackageName'));
   }
   if (!pkg.version) {
-    throw new MessageError(reporter.lang('noVersion'));
+    throw new MessageError(reporter.lang('commonNoPackageVersion'));
   }
 
   const normaliseScope = name => (name[0] === '@' ? name.substr(1).replace('/', '-') : name);

--- a/src/cli/commands/publish.js
+++ b/src/cli/commands/publish.js
@@ -39,7 +39,7 @@ async function publish(config: Config, pkg: any, flags: Object, dir: string): Pr
 
   // validate access argument
   if (access && access !== 'public' && access !== 'restricted') {
-    throw new MessageError(config.reporter.lang('invalidAccess'));
+    throw new MessageError(config.reporter.lang('publishInvalidAccess'));
   }
 
   // TODO this might modify package.json, do we need to reload it?
@@ -127,10 +127,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   // validate arguments
   const dir = args[0] ? path.resolve(config.cwd, args[0]) : config.cwd;
   if (args.length > 1) {
-    throw new MessageError(reporter.lang('tooManyArguments', 1));
+    throw new MessageError(reporter.lang('commonTooManyArguments', 1));
   }
   if (!await fs.exists(dir)) {
-    throw new MessageError(reporter.lang('unknownFolderOrTarball'));
+    throw new MessageError(reporter.lang('publishUnknownFolderOrTarball'));
   }
 
   const stat = await fs.lstat(dir);
@@ -147,7 +147,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('publishPrivate'));
   }
   if (!pkg.name) {
-    throw new MessageError(reporter.lang('noName'));
+    throw new MessageError(reporter.lang('commonNoPackageName'));
   }
 
   let registry: string = '';
@@ -156,20 +156,20 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     registry = pkg.publishConfig.registry;
   }
 
-  reporter.step(1, 4, reporter.lang('bumpingVersion'));
+  reporter.step(1, 4, reporter.lang('publishBumpingVersion'));
   const commitVersion = await setVersion(config, reporter, flags, [], false);
 
   //
-  reporter.step(2, 4, reporter.lang('loggingIn'));
+  reporter.step(2, 4, reporter.lang('commonLoggingIn'));
   const revoke = await getToken(config, reporter, pkg.name, flags, registry);
 
   //
-  reporter.step(3, 4, reporter.lang('publishing'));
+  reporter.step(3, 4, reporter.lang('publishPending'));
   await publish(config, pkg, flags, publishPath);
   await commitVersion();
-  reporter.success(reporter.lang('published'));
+  reporter.success(reporter.lang('publishSuccess'));
 
   //
-  reporter.step(4, 4, reporter.lang('revokingToken'));
+  reporter.step(4, 4, reporter.lang('commonRevokingToken'));
   await revoke();
 }

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -29,12 +29,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const isWorkspaceRoot = config.workspaceRootFolder && config.cwd === config.workspaceRootFolder;
 
   if (!args.length) {
-    throw new MessageError(reporter.lang('tooFewArguments', 1));
+    throw new MessageError(reporter.lang('commonTooFewArguments', 1));
   }
 
   // running "yarn remove something" in a workspace root is often a mistake
   if (isWorkspaceRoot && !flags.ignoreWorkspaceRootCheck) {
-    throw new MessageError(reporter.lang('workspacesRemoveRootCheck'));
+    throw new MessageError(reporter.lang('removeWorkspacesRemoveRootCheck'));
   }
 
   const totalSteps = args.length + 1;
@@ -72,7 +72,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     }
 
     if (!found) {
-      throw new MessageError(reporter.lang('moduleNotInManifest'));
+      throw new MessageError(reporter.lang('removeModuleNotInManifest'));
     }
   }
 
@@ -87,11 +87,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   // reinstall so we can get the updated lockfile
-  reporter.step(++step, totalSteps, reporter.lang('uninstallRegenerate'), emoji.get('page_with_curl'));
+  reporter.step(++step, totalSteps, reporter.lang('removeUninstallRegenerate'), emoji.get('page_with_curl'));
   const installFlags = {force: true, workspaceRootIsCwd: true, ...flags};
   const reinstall = new Install(installFlags, config, new NoopReporter(), lockfile);
   await reinstall.init();
 
   //
-  reporter.success(reporter.lang('uninstalledPackages'));
+  reporter.success(reporter.lang('removeUninstalledPackages'));
 }

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -156,9 +156,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   // list possible scripts if none specified
   if (args.length === 0) {
     if (binCommands.size > 0) {
-      reporter.info(`${reporter.lang('binCommands') + Array.from(binCommands).join(', ')}`);
+      reporter.info(`${reporter.lang('runBinCommands') + Array.from(binCommands).join(', ')}`);
     } else {
-      reporter.error(reporter.lang('noBinAvailable'));
+      reporter.error(reporter.lang('runNoBinAvailable'));
     }
 
     const printedCommands: Map<string, string> = new Map();
@@ -170,18 +170,18 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     }
 
     if (pkgCommands.size > 0) {
-      reporter.info(`${reporter.lang('possibleCommands')}`);
-      reporter.list('possibleCommands', Array.from(pkgCommands), toObject(printedCommands));
+      reporter.info(`${reporter.lang('runPossibleCommands')}`);
+      reporter.list('runPossibleCommands', Array.from(pkgCommands), toObject(printedCommands));
       if (!flags.nonInteractive) {
         await reporter
-          .question(reporter.lang('commandQuestion'))
+          .question(reporter.lang('runCommandQuestion'))
           .then(
             answer => runCommand(answer.trim().split(' ')),
-            () => reporter.error(reporter.lang('commandNotSpecified')),
+            () => reporter.error(reporter.lang('runCommandNotSpecified')),
           );
       }
     } else {
-      reporter.error(reporter.lang('noScriptsAvailable'));
+      reporter.error(reporter.lang('runNoScriptsAvailable'));
     }
     return Promise.resolve();
   } else {

--- a/src/cli/commands/tag.js
+++ b/src/cli/commands/tag.js
@@ -19,19 +19,19 @@ export async function getName(args: Array<string>, config: Config): Promise<stri
 
   if (name) {
     if (!isValidPackageName(name)) {
-      throw new MessageError(config.reporter.lang('invalidPackageName'));
+      throw new MessageError(config.reporter.lang('commonInvalidPackageName'));
     }
 
     return NpmRegistry.escapeName(name);
   } else {
-    throw new MessageError(config.reporter.lang('unknownPackageName'));
+    throw new MessageError(config.reporter.lang('commonUnknownPackageName'));
   }
 }
 
 async function list(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   const name = await getName(args, config);
 
-  reporter.step(1, 1, reporter.lang('gettingTags'));
+  reporter.step(1, 1, reporter.lang('tagGettingTags'));
   const tags = await config.registries.npm.request(`-/package/${name}/dist-tags`);
 
   if (tags) {
@@ -42,7 +42,7 @@ async function list(config: Config, reporter: Reporter, flags: Object, args: Arr
   }
 
   if (!tags) {
-    throw new MessageError(reporter.lang('packageNotFoundRegistry', name, 'npm'));
+    throw new MessageError(reporter.lang('commonPackageNotFoundRegistry', name, 'npm'));
   }
 }
 
@@ -54,21 +54,21 @@ async function remove(config: Config, reporter: Reporter, flags: Object, args: A
   const name = await getName(args, config);
   const tag = args.shift();
 
-  reporter.step(1, 3, reporter.lang('loggingIn'));
+  reporter.step(1, 3, reporter.lang('commonLoggingIn'));
   const revoke = await getToken(config, reporter, name);
 
-  reporter.step(2, 3, reporter.lang('deletingTags'));
+  reporter.step(2, 3, reporter.lang('tagDeletingTags'));
   const result = await config.registries.npm.request(`-/package/${name}/dist-tags/${encodeURI(tag)}`, {
     method: 'DELETE',
   });
 
   if (result === false) {
-    reporter.error(reporter.lang('deletedTagFail'));
+    reporter.error(reporter.lang('tagDeletedTagFail'));
   } else {
-    reporter.success(reporter.lang('deletedTag'));
+    reporter.success(reporter.lang('tagDeletedTag'));
   }
 
-  reporter.step(3, 3, reporter.lang('revokingToken'));
+  reporter.step(3, 3, reporter.lang('commonRevokingToken'));
   await revoke();
 
   if (result === false) {
@@ -92,18 +92,18 @@ export const {run, hasWrapper, examples} = buildSubCommands(
 
       const {name, range, hasVersion} = normalizePattern(args.shift());
       if (!hasVersion) {
-        throw new MessageError(reporter.lang('requiredVersionInRange'));
+        throw new MessageError(reporter.lang('tagRequiredVersionInRange'));
       }
       if (!isValidPackageName(name)) {
-        throw new MessageError(reporter.lang('invalidPackageName'));
+        throw new MessageError(reporter.lang('commonInvalidPackageName'));
       }
 
       const tag = args.shift();
 
-      reporter.step(1, 3, reporter.lang('loggingIn'));
+      reporter.step(1, 3, reporter.lang('commonLoggingIn'));
       const revoke = await getToken(config, reporter, name);
 
-      reporter.step(2, 3, reporter.lang('creatingTag', tag, range));
+      reporter.step(2, 3, reporter.lang('tagCreatingTag', tag, range));
       const result = await config.registries.npm.request(
         `-/package/${NpmRegistry.escapeName(name)}/dist-tags/${encodeURI(tag)}`,
         {
@@ -113,12 +113,12 @@ export const {run, hasWrapper, examples} = buildSubCommands(
       );
 
       if (result != null && result.ok) {
-        reporter.success(reporter.lang('createdTag'));
+        reporter.success(reporter.lang('tagCreatedTag'));
       } else {
-        reporter.error(reporter.lang('createdTagFail'));
+        reporter.error(reporter.lang('tagCreatedTagFail'));
       }
 
-      reporter.step(3, 3, reporter.lang('revokingToken'));
+      reporter.step(3, 3, reporter.lang('commonRevokingToken'));
       await revoke();
 
       if (result != null && result.ok) {

--- a/src/cli/commands/team.js
+++ b/src/cli/commands/team.js
@@ -47,7 +47,7 @@ function warnDeprecation(reporter: Reporter, deprecationWarning: DeprecationWarn
   const command = 'yarn team';
   reporter.warn(
     reporter.lang(
-      'deprecatedCommand',
+      'teamDeprecatedCommand',
       `${command} ${deprecationWarning.deprecatedCommand}`,
       `${command} ${deprecationWarning.currentCommand}`,
     ),
@@ -73,7 +73,7 @@ function wrapRequired(
       return false;
     }
 
-    reporter.step(1, 3, reporter.lang('loggingIn'));
+    reporter.step(1, 3, reporter.lang('commonLoggingIn'));
     const revoke = await getToken(config, reporter);
 
     const res = await callback(parts, config, reporter, flags, args);
@@ -81,7 +81,7 @@ function wrapRequired(
       return res;
     }
 
-    reporter.step(3, 3, reporter.lang('revokingToken'));
+    reporter.step(3, 3, reporter.lang('commonRevokingToken'));
     await revoke();
     return true;
   };

--- a/src/cli/commands/unlink.js
+++ b/src/cli/commands/unlink.js
@@ -34,7 +34,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const manifest = await config.readRootManifest();
     const name = manifest.name;
     if (!name) {
-      throw new MessageError(reporter.lang('unknownPackageName'));
+      throw new MessageError(reporter.lang('commonUnknownPackageName'));
     }
 
     const linkLoc = path.join(config.linkFolder, name);

--- a/src/cli/commands/unplug.js
+++ b/src/cli/commands/unplug.js
@@ -27,10 +27,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('unplugDisabled'));
   }
   if (!args.length && flags.clear) {
-    throw new MessageError(reporter.lang('tooFewArguments', 1));
+    throw new MessageError(reporter.lang('commonTooFewArguments', 1));
   }
   if (args.length && flags.clearAll) {
-    throw new MessageError(reporter.lang('noArguments'));
+    throw new MessageError(reporter.lang('commonNoArguments'));
   }
 
   if (flags.clearAll) {

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -42,7 +42,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const deps = await getOutdated(config, reporter, {...flags, includeWorkspaceDeps: true}, lockfile, args);
 
   if (deps.length === 0) {
-    reporter.success(reporter.lang('allDependenciesUpToDate'));
+    reporter.success(reporter.lang('upgradeInteractiveUpToDate'));
     return;
   }
 
@@ -140,7 +140,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const red = reporter.format.red('<red>');
     const yellow = reporter.format.yellow('<yellow>');
     const green = reporter.format.green('<green>');
-    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
+    reporter.info(reporter.lang('commonLegendColorsForVersionUpdates', red, yellow, green));
 
     const answers: Array<Dependency> = await reporter.prompt('Choose which packages to update.', choices, {
       name: 'packages',
@@ -173,7 +173,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         for (const loc of Object.keys(depsByWorkspace)) {
           const patterns = depsByWorkspace[loc].map(getPattern);
           cleanLockfile(lockfile, deps, packagePatterns, reporter);
-          reporter.info(reporter.lang('updateInstalling', getNameFromHint(hint)));
+          reporter.info(reporter.lang('upgradeInteractiveUpdateInstalling', getNameFromHint(hint)));
           if (loc !== '') {
             config.cwd = path.resolve(path.dirname(loc));
           }

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -49,7 +49,7 @@ function setUserRequestedPackageVersions(
       if (normalized.hasVersion && dep.name === normalized.name) {
         found = true;
         dep.upgradeTo = newPattern;
-        reporter.verbose(reporter.lang('verboseUpgradeBecauseRequested', requestedPattern, newPattern));
+        reporter.verbose(reporter.lang('upgradeBecauseRequested', requestedPattern, newPattern));
       }
     });
 
@@ -68,7 +68,7 @@ function setUserRequestedPackageVersions(
         workspaceName: '',
         workspaceLoc: '',
       });
-      reporter.verbose(reporter.lang('verboseUpgradeBecauseRequested', requestedPattern, newPattern));
+      reporter.verbose(reporter.lang('upgradeBecauseRequested', requestedPattern, newPattern));
     }
   });
 }
@@ -128,13 +128,13 @@ export function cleanLockfile(
   function cleanDepFromLockfile(pattern: string, depth: number) {
     const lockManifest = lockfile.getLocked(pattern);
     if (!lockManifest || (depth > 1 && packagePatterns.some(packagePattern => packagePattern.pattern === pattern))) {
-      reporter.verbose(reporter.lang('verboseUpgradeNotUnlocking', pattern));
+      reporter.verbose(reporter.lang('upgradeNotUnlocking', pattern));
       return;
     }
 
     const dependencies = Object.assign({}, lockManifest.dependencies || {}, lockManifest.optionalDependencies || {});
     const depPatterns = Object.keys(dependencies).map(key => `${key}@${dependencies[key]}`);
-    reporter.verbose(reporter.lang('verboseUpgradeUnlocking', pattern));
+    reporter.verbose(reporter.lang('upgradeUnlocking', pattern));
     lockfile.removePattern(pattern);
     depPatterns.forEach(pattern => cleanDepFromLockfile(pattern, depth + 1));
   }
@@ -232,7 +232,7 @@ export async function getOutdated(
     .filter(scopeFilter.bind(this, flags));
   deps.forEach(dep => {
     dep.upgradeTo = buildPatternToUpgradeTo(dep, flags);
-    reporter.verbose(reporter.lang('verboseUpgradeBecauseOutdated', dep.name, dep.upgradeTo));
+    reporter.verbose(reporter.lang('upgradeBecauseOutdated', dep.name, dep.upgradeTo));
   });
 
   return deps;

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -47,7 +47,7 @@ export async function setVersion(
   invariant(pkgLoc, 'expected package location');
 
   if (args.length && !newVersion) {
-    throw new MessageError(reporter.lang('invalidVersionArgument', NEW_VERSION_FLAG));
+    throw new MessageError(reporter.lang('versionInvalidVersionArgument', NEW_VERSION_FLAG));
   }
 
   function runLifecycle(lifecycle: string): Promise<void> {
@@ -70,14 +70,14 @@ export async function setVersion(
   // get old version
   let oldVersion = pkg.version;
   if (oldVersion) {
-    reporter.info(`${reporter.lang('currentVersion')}: ${oldVersion}`);
+    reporter.info(`${reporter.lang('versionCurrentVersion')}: ${oldVersion}`);
   } else {
     oldVersion = '0.0.0';
   }
 
   // get new version
   if (newVersion && !isValidNewVersion(oldVersion, newVersion, config.looseSemver)) {
-    throw new MessageError(reporter.lang('invalidVersion'));
+    throw new MessageError(reporter.lang('versionInvalidVersion'));
   }
 
   // get new version by bumping old version, if requested
@@ -100,10 +100,10 @@ export async function setVersion(
       break;
     }
 
-    newVersion = await reporter.question(reporter.lang('newVersion'));
+    newVersion = await reporter.question(reporter.lang('versionNewVersion'));
 
     if (!required && !newVersion) {
-      reporter.info(`${reporter.lang('noVersionOnPublish')}: ${oldVersion}`);
+      reporter.info(`${reporter.lang('versionNoVersionOnPublish')}: ${oldVersion}`);
       return function(): Promise<void> {
         return Promise.resolve();
       };
@@ -113,7 +113,7 @@ export async function setVersion(
       break;
     } else {
       newVersion = null;
-      reporter.error(reporter.lang('invalidSemver'));
+      reporter.error(reporter.lang('versionInvalidSemver'));
     }
   }
   if (newVersion) {
@@ -130,7 +130,7 @@ export async function setVersion(
   await runLifecycle('preversion');
 
   // update version
-  reporter.info(`${reporter.lang('newVersion')}: ${newVersion}`);
+  reporter.info(`${reporter.lang('versionNewVersion')}: ${newVersion}`);
   pkg.version = newVersion;
 
   // update versions in manifests

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -127,10 +127,10 @@ function toStandardPathString(pathString: string): string {
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
   if (!args.length) {
-    throw new MessageError(reporter.lang('missingWhyDependency'));
+    throw new MessageError(reporter.lang('whyMissingDependency'));
   }
   if (args.length > 1) {
-    throw new MessageError(reporter.lang('tooManyArguments', 1));
+    throw new MessageError(reporter.lang('commonTooManyArguments', 1));
   }
 
   const query = await cleanQuery(config, args[0]);

--- a/src/cli/commands/workspace.js
+++ b/src/cli/commands/workspace.js
@@ -18,7 +18,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const {workspaceRootFolder} = config;
 
   if (!workspaceRootFolder) {
-    throw new MessageError(reporter.lang('workspaceRootNotFound', config.cwd));
+    throw new MessageError(reporter.lang('workspacesRootNotFound', config.cwd));
   }
 
   if (flags.originalArgs < 1) {

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -20,7 +20,7 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
   const {workspaceRootFolder} = config;
 
   if (!workspaceRootFolder) {
-    throw new MessageError(reporter.lang('workspaceRootNotFound', config.cwd));
+    throw new MessageError(reporter.lang('workspacesRootNotFound', config.cwd));
   }
 
   const manifest = await config.findManifest(workspaceRootFolder, false);
@@ -66,7 +66,7 @@ export async function runScript(config: Config, reporter: Reporter, flags: Objec
   const {workspaceRootFolder} = config;
 
   if (!workspaceRootFolder) {
-    throw new MessageError(reporter.lang('workspaceRootNotFound', config.cwd));
+    throw new MessageError(reporter.lang('workspacesRootNotFound', config.cwd));
   }
 
   const manifest = await config.findManifest(workspaceRootFolder, false);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -250,11 +250,13 @@ export async function main({
   }
 
   if (commander.nodeVersionCheck && !semver.satisfies(process.versions.node, constants.SUPPORTED_NODE_VERSIONS)) {
-    reporter.warn(reporter.lang('unsupportedNodeVersion', process.versions.node, constants.SUPPORTED_NODE_VERSIONS));
+    reporter.warn(
+      reporter.lang('coreUnsupportedNodeVersion', process.versions.node, constants.SUPPORTED_NODE_VERSIONS),
+    );
   }
 
-  if (command.noArguments && commander.args.length) {
-    reporter.error(reporter.lang('noArguments'));
+  if (command.commonNoArguments && commander.args.length) {
+    reporter.error(reporter.lang('commonNoArguments'));
     reporter.info(command.getDocsInfo);
     exit(1);
     return;
@@ -262,12 +264,12 @@ export async function main({
 
   //
   if (commander.yes) {
-    reporter.warn(reporter.lang('yesWarning'));
+    reporter.warn(reporter.lang('coreYesWarning'));
   }
 
   //
   if (!commander.offline && network.isOffline()) {
-    reporter.warn(reporter.lang('networkWarning'));
+    reporter.warn(reporter.lang('coreNetworkWarning'));
   }
 
   //
@@ -275,7 +277,7 @@ export async function main({
     invariant(command, 'missing command');
 
     if (warnAboutRunDashDash) {
-      reporter.warn(reporter.lang('dashDashDeprecation'));
+      reporter.warn(reporter.lang('coreDoubleDashDeprecation'));
     }
 
     return command.run(config, reporter, commander, commander.args).then(exitCode => {
@@ -293,7 +295,7 @@ export async function main({
       lockfile.lock(lockFilename, {realpath: false}, (err: mixed, release: () => void) => {
         if (err) {
           if (isFirstTime) {
-            reporter.warn(reporter.lang('waitingInstance'));
+            reporter.warn(reporter.lang('coreWaitingInstance'));
           }
           setTimeout(() => {
             resolve(runEventuallyWithFile(mutexFilename, false));
@@ -406,10 +408,10 @@ export async function main({
           response.on('end', () => {
             try {
               const {cwd, pid} = JSON.parse(Buffer.concat(buffers).toString());
-              reporter.warn(reporter.lang('waitingNamedInstance', pid, cwd));
+              reporter.warn(reporter.lang('coreWaitingNamedInstance', pid, cwd));
             } catch (error) {
               reporter.verbose(error);
-              reject(new Error(reporter.lang('mutexPortBusy', connectionOptions.port)));
+              reject(new Error(reporter.lang('coreMutexPortBusy', connectionOptions.port)));
               return;
             }
             waitForTheNetwork();
@@ -472,10 +474,10 @@ export async function main({
 
     const errorReportLoc = writeErrorReport(log);
 
-    reporter.error(reporter.lang('unexpectedError', err.message));
+    reporter.error(reporter.lang('coreUnexpectedError', err.message));
 
     if (errorReportLoc) {
-      reporter.info(reporter.lang('bugReport', errorReportLoc));
+      reporter.info(reporter.lang('coreBugReport', errorReportLoc));
     }
   }
 
@@ -487,7 +489,7 @@ export async function main({
     try {
       fs.writeFileSync(errorReportLoc, log.join('\n\n') + '\n');
     } catch (err) {
-      reporter.error(reporter.lang('fileWriteError', errorReportLoc, err.message));
+      reporter.error(reporter.lang('coreFileWriteError', errorReportLoc, err.message));
       return undefined;
     }
 
@@ -531,7 +533,7 @@ export async function main({
     .then(() => {
       // lockfile check must happen after config.init sets lockfileFolder
       if (command.requireLockfile && !fs.existsSync(path.join(config.lockfileFolder, constants.LOCKFILE_FILENAME))) {
-        throw new MessageError(reporter.lang('noRequiredLockfile'));
+        throw new MessageError(reporter.lang('coreNoRequiredLockfile'));
       }
 
       // option "no-progress" stored in yarn config

--- a/src/config.js
+++ b/src/config.js
@@ -257,7 +257,7 @@ export default class Config {
 
     // using focus in a workspace root is not allowed
     if (this.focus && (!this.workspaceRootFolder || this.cwd === this.workspaceRootFolder)) {
-      throw new MessageError(this.reporter.lang('workspacesFocusRootCheck'));
+      throw new MessageError(this.reporter.lang('configWorkspacesFocusRootCheck'));
     }
 
     if (this.focus) {
@@ -363,17 +363,17 @@ export default class Config {
         fs.constants.W_OK | fs.constants.X_OK | fs.constants.R_OK, // eslint-disable-line no-bitwise
       );
       for (const skippedEntry of cacheFolderQuery.skipped) {
-        this.reporter.warn(this.reporter.lang('cacheFolderSkipped', skippedEntry.folder));
+        this.reporter.warn(this.reporter.lang('configCacheFolderSkipped', skippedEntry.folder));
       }
 
       cacheRootFolder = cacheFolderQuery.folder;
       if (cacheRootFolder && cacheFolderQuery.skipped.length > 0) {
-        this.reporter.warn(this.reporter.lang('cacheFolderSelected', cacheRootFolder));
+        this.reporter.warn(this.reporter.lang('configCacheFolderSelected', cacheRootFolder));
       }
     }
 
     if (!cacheRootFolder) {
-      throw new MessageError(this.reporter.lang('cacheFolderMissing'));
+      throw new MessageError(this.reporter.lang('configCacheFolderMissing'));
     } else {
       this._cacheRootFolder = String(cacheRootFolder);
     }
@@ -397,7 +397,7 @@ export default class Config {
 
     if (process.platform === 'win32') {
       if (this.plugnplayEnabled) {
-        this.reporter.warn(this.reporter.lang('plugnplayWindowsSupport'));
+        this.reporter.warn(this.reporter.lang('configPlugNPlayWindowsSupport'));
       }
       this.plugnplayEnabled = false;
       this.plugnplayPersist = false;
@@ -436,7 +436,7 @@ export default class Config {
     }
 
     if (this.workspaceRootFolder && !this.workspacesEnabled) {
-      throw new MessageError(this.reporter.lang('workspacesDisabled'));
+      throw new MessageError(this.reporter.lang('configWorkspacesDisabled'));
     }
   }
 
@@ -681,7 +681,7 @@ export default class Config {
       if (manifest) {
         return manifest;
       } else {
-        throw new MessageError(this.reporter.lang('couldntFindPackagejson', dir), 'ENOENT');
+        throw new MessageError(this.reporter.lang('configNoPackageJson', dir), 'ENOENT');
       }
     });
   }
@@ -768,7 +768,7 @@ export default class Config {
     let previous = null;
     let current = path.normalize(initial);
     if (!await fs.exists(current)) {
-      throw new MessageError(this.reporter.lang('folderMissing', current));
+      throw new MessageError(this.reporter.lang('configFolderMissing', current));
     }
 
     do {
@@ -800,7 +800,7 @@ export default class Config {
     const patterns = ws && ws.packages ? ws.packages : [];
 
     if (!Array.isArray(patterns)) {
-      throw new MessageError(this.reporter.lang('workspacesSettingMustBeArray'));
+      throw new MessageError(this.reporter.lang('configWorkspacesSettingMustBeArray'));
     }
 
     const registryFilenames = registryNames
@@ -828,16 +828,16 @@ export default class Config {
       }
 
       if (!manifest.name) {
-        this.reporter.warn(this.reporter.lang('workspaceNameMandatory', loc));
+        this.reporter.warn(this.reporter.lang('configWorkspaceNameMandatory', loc));
         continue;
       }
       if (!manifest.version) {
-        this.reporter.warn(this.reporter.lang('workspaceVersionMandatory', loc));
+        this.reporter.warn(this.reporter.lang('configWorkspaceVersionMandatory', loc));
         continue;
       }
 
       if (Object.prototype.hasOwnProperty.call(workspaces, manifest.name)) {
-        throw new MessageError(this.reporter.lang('workspaceNameDuplicate', manifest.name));
+        throw new MessageError(this.reporter.lang('configWorkspaceNameDuplicate', manifest.name));
       }
 
       workspaces[manifest.name] = {loc, manifest};
@@ -865,16 +865,16 @@ export default class Config {
 
     // packages
     if (wsCopy.packages && wsCopy.packages.length > 0 && !manifest.private) {
-      errors.push(this.reporter.lang('workspacesRequirePrivateProjects'));
+      errors.push(this.reporter.lang('configWorkspacesRequirePrivateProjects'));
       wsCopy = undefined;
     }
     // nohoist
     if (wsCopy && wsCopy.nohoist && wsCopy.nohoist.length > 0) {
       if (!this.workspacesNohoistEnabled) {
-        warnings.push(this.reporter.lang('workspacesNohoistDisabled', manifest.name));
+        warnings.push(this.reporter.lang('configWorkspacesNoHoistDisabled', manifest.name));
         wsCopy.nohoist = undefined;
       } else if (!manifest.private) {
-        errors.push(this.reporter.lang('workspacesNohoistRequirePrivatePackages', manifest.name));
+        errors.push(this.reporter.lang('configWorkspacesNoHoistRequirePrivatePackages', manifest.name));
         wsCopy.nohoist = undefined;
       }
     }
@@ -961,7 +961,7 @@ export default class Config {
       return factory(loc);
     } catch (err) {
       if (err instanceof SyntaxError) {
-        throw new MessageError(this.reporter.lang('jsonError', loc, err.message));
+        throw new MessageError(this.reporter.lang('configJsonError', loc, err.message));
       } else {
         throw err;
       }

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -76,7 +76,7 @@ export default class GitFetcher extends BaseFetcher {
 
     return new Promise((resolve, reject) => {
       if (!stream) {
-        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarPaths)));
+        reject(new MessageError(this.reporter.lang('fetchersTarballNotInNetworkOrCache', this.reference, tarPaths)));
         return;
       }
       invariant(stream, 'cachedStream should be available at this point');
@@ -105,7 +105,7 @@ export default class GitFetcher extends BaseFetcher {
             reject(
               new SecurityError(
                 this.config.reporter.lang(
-                  'fetchBadHashWithPath',
+                  'fetchersBadHashWithPath',
                   this.packageName,
                   this.remote.reference,
                   expectHash,
@@ -116,7 +116,7 @@ export default class GitFetcher extends BaseFetcher {
           }
         })
         .on('error', function(err) {
-          reject(new MessageError(this.reporter.lang('fetchErrorCorrupt', err.message, tarballPath)));
+          reject(new MessageError(this.reporter.lang('fetchersErrorCorrupt', err.message, tarballPath)));
         });
     });
   }

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -145,7 +145,9 @@ export default class TarballFetcher extends BaseFetcher {
     });
 
     untarStream.on('error', err => {
-      reject(new MessageError(this.config.reporter.lang('errorExtractingTarball', err.message, tarballPath)));
+      reject(
+        new MessageError(this.config.reporter.lang('tarballFetcherErrorExtractingTarball', err.message, tarballPath)),
+      );
     });
 
     extractorStream.pipe(untarStream).on('finish', () => {
@@ -163,7 +165,7 @@ export default class TarballFetcher extends BaseFetcher {
       if (integrityInfo.algorithms.length === 0) {
         return reject(
           new SecurityError(
-            this.config.reporter.lang('fetchBadIntegrityAlgorithm', this.packageName, this.remote.reference),
+            this.config.reporter.lang('tarballFetcherBadIntegrityAlgorithm', this.packageName, this.remote.reference),
           ),
         );
       }
@@ -175,7 +177,7 @@ export default class TarballFetcher extends BaseFetcher {
           return reject(
             new SecurityError(
               this.config.reporter.lang(
-                'fetchBadHashWithPath',
+                'fetchersBadHashWithPath',
                 this.packageName,
                 this.remote.reference,
                 error.found.toString(),
@@ -209,7 +211,7 @@ export default class TarballFetcher extends BaseFetcher {
 
     return new Promise((resolve, reject) => {
       if (!stream) {
-        reject(new MessageError(this.reporter.lang('tarballNotInNetworkOrCache', this.reference, tarPaths)));
+        reject(new MessageError(this.reporter.lang('fetchersTarballNotInNetworkOrCache', this.reference, tarPaths)));
         return;
       }
       invariant(stream, 'stream should be available at this point');
@@ -218,7 +220,7 @@ export default class TarballFetcher extends BaseFetcher {
       const {validateStream, extractorStream} = this.createExtractor(resolve, reject, tarballPath);
 
       stream.pipe(validateStream).pipe(extractorStream).on('error', err => {
-        reject(new MessageError(this.config.reporter.lang('fetchErrorCorrupt', err.message, tarballPath)));
+        reject(new MessageError(this.config.reporter.lang('fetchersErrorCorrupt', err.message, tarballPath)));
       });
     });
   }

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -13,14 +13,14 @@ const invariant = require('invariant');
 const path = require('path');
 
 export const integrityErrors = {
-  EXPECTED_IS_NOT_A_JSON: 'integrityFailedExpectedIsNotAJSON',
-  FILES_MISSING: 'integrityFailedFilesMissing',
-  LOCKFILE_DONT_MATCH: 'integrityLockfilesDontMatch',
-  FLAGS_DONT_MATCH: 'integrityFlagsDontMatch',
-  LINKED_MODULES_DONT_MATCH: 'integrityCheckLinkedModulesDontMatch',
-  PATTERNS_DONT_MATCH: 'integrityPatternsDontMatch',
-  MODULES_FOLDERS_MISSING: 'integrityModulesFoldersMissing',
-  SYSTEM_PARAMS_DONT_MATCH: 'integritySystemParamsDontMatch',
+  EXPECTED_IS_NOT_A_JSON: 'integrityCheckerFileNotJson',
+  FILES_MISSING: 'integrityCheckerFailedFilesMissing',
+  LOCKFILE_DONT_MATCH: 'integrityCheckerLockfilesDontMatch',
+  FLAGS_DONT_MATCH: 'integrityCheckerFlagsDontMatch',
+  LINKED_MODULES_DONT_MATCH: 'integrityCheckerLinkedModulesDontMatch',
+  PATTERNS_DONT_MATCH: 'integrityCheckerPatternsDontMatch',
+  MODULES_FOLDERS_MISSING: 'integrityCheckerModulesFoldersMissing',
+  SYSTEM_PARAMS_DONT_MATCH: 'integrityCheckerSystemParamsDontMatch',
 };
 
 type IntegrityError = $Keys<typeof integrityErrors>;

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -176,7 +176,7 @@ export default class Lockfile {
 
       lockfile = parseResult.object;
     } else if (reporter) {
-      reporter.info(reporter.lang('noLockfileFound'));
+      reporter.info(reporter.lang('lockfileNotFound'));
     }
 
     return new Lockfile({cache: lockfile, source: rawLockfile, parseResultType: parseResult && parseResult.type});

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -117,7 +117,7 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
 
       reporter.info(`${human}: ${msg}`);
       if (!didIgnore) {
-        reporter.info(reporter.lang('optionalCompatibilityExcluded', human));
+        reporter.info(reporter.lang('packageCompatibilityOptionalCompatibilityExcluded', human));
         didIgnore = true;
       }
     } else {
@@ -130,13 +130,13 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
     !config.ignorePlatform && Array.isArray(info.os) && info.os.length > 0 && !isValidPlatform(info.os);
 
   if (invalidPlatform) {
-    pushError(reporter.lang('incompatibleOS', process.platform));
+    pushError(reporter.lang('packageCompatibilityIncompatibleOs', process.platform));
   }
 
   const invalidCpu = !config.ignorePlatform && Array.isArray(info.cpu) && info.cpu.length > 0 && !isValidArch(info.cpu);
 
   if (invalidCpu) {
-    pushError(reporter.lang('incompatibleCPU', process.arch));
+    pushError(reporter.lang('packageCompatibilityIncompatibleCpu', process.arch));
   }
 
   if (!ignoreEngines && typeof info.engines === 'object') {
@@ -150,16 +150,16 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
 
       if (VERSIONS[name]) {
         if (!testEngine(name, range, VERSIONS, config.looseSemver)) {
-          pushError(reporter.lang('incompatibleEngine', name, range, VERSIONS[name]));
+          pushError(reporter.lang('packageCompatibilityIncompatibleEngine', name, range, VERSIONS[name]));
         }
       } else if (ignore.indexOf(name) < 0) {
-        reporter.warn(`${human}: ${reporter.lang('invalidEngine', name)}`);
+        reporter.warn(`${human}: ${reporter.lang('packageCompatibilityInvalidEngine', name)}`);
       }
     }
   }
 
   if (didError) {
-    throw new MessageError(reporter.lang('foundIncompatible'));
+    throw new MessageError(reporter.lang('packageCompatibilityFoundIncompatible'));
   }
 }
 

--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -35,7 +35,7 @@ export async function fetchOneRemote(
 
   const Fetcher = fetchers[remote.type];
   if (!Fetcher) {
-    throw new MessageError(config.reporter.lang('unknownFetcherFor', remote.type));
+    throw new MessageError(config.reporter.lang('packageFetcherUnknownFetcher', remote.type));
   }
 
   const fetcher = new Fetcher(dest, remote, config);
@@ -91,7 +91,7 @@ export function fetch(pkgs: Array<Manifest>, config: Config): Promise<Array<Mani
     const otherPkg = pkgsPerDest.get(dest);
     if (otherPkg) {
       config.reporter.warn(
-        config.reporter.lang('multiplePackagesCantUnpackInSameDestination', ref.patterns, dest, otherPkg.patterns),
+        config.reporter.lang('packageFetcherMultiplePackagesSameDestination', ref.patterns, dest, otherPkg.patterns),
       );
       return false;
     }

--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -153,8 +153,8 @@ export default class PackageInstallScripts {
       if (ref.optional) {
         ref.ignore = true;
         ref.incompatible = true;
-        this.reporter.warn(this.reporter.lang('optionalModuleScriptFail', err.message));
-        this.reporter.info(this.reporter.lang('optionalModuleFail'));
+        this.reporter.warn(this.reporter.lang('packageInstallScriptsOptionalModuleScriptFail', err.message));
+        this.reporter.info(this.reporter.lang('packageInstallScriptsOptionalModuleFail'));
 
         // Cleanup node_modules
         try {
@@ -164,7 +164,7 @@ export default class PackageInstallScripts {
             }),
           );
         } catch (e) {
-          this.reporter.error(this.reporter.lang('optionalModuleCleanupFail', e.message));
+          this.reporter.error(this.reporter.lang('packageInstallScriptsOptionalModuleCleanupFail', e.message));
         }
       } else {
         throw err;

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -620,7 +620,7 @@ export default class PackageLinker {
         const range = peerDeps[peerDepName];
         const peerPkgs = this.resolver.getAllInfoForPackageName(peerDepName);
 
-        let peerError = 'unmetPeer';
+        let peerError = 'packageLinkerUnmetPeer';
         let resolvedLevelDistance = Infinity;
         let resolvedPeerPkg;
         for (const peerPkg of peerPkgs) {
@@ -634,7 +634,7 @@ export default class PackageLinker {
               resolvedLevelDistance = levelDistance;
               resolvedPeerPkg = peerPkgRef;
             } else {
-              peerError = 'incorrectPeer';
+              peerError = 'packageLinkerIncorrectPeer';
             }
           }
         }
@@ -643,7 +643,7 @@ export default class PackageLinker {
           ref.addDependencies(resolvedPeerPkg.patterns);
           this.reporter.verbose(
             this.reporter.lang(
-              'selectedPeer',
+              'packageLinkerSelectedPeer',
               `${pkg.name}@${pkg.version}`,
               `${peerDepName}@${resolvedPeerPkg.version}`,
               resolvedPeerPkg.level,
@@ -677,7 +677,7 @@ export default class PackageLinker {
         if (locsExist.some(e => !e)) {
           //if any of the locs do not exist
           const pkgHuman = `${pkg.name}@${pkg.version}`;
-          this.reporter.warn(this.reporter.lang('missingBundledDependency', pkgHuman, depName));
+          this.reporter.warn(this.reporter.lang('packageLinkerMissingBundledDependency', pkgHuman, depName));
         }
       }
     }

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -124,7 +124,12 @@ export default class PackageRequest {
       // thow a more readable error
       if (!(err instanceof MessageError) && this.parentRequest && this.parentRequest.pattern) {
         throw new MessageError(
-          this.reporter.lang('requiredPackageNotFoundRegistry', pattern, this.parentRequest.pattern, this.registry),
+          this.reporter.lang(
+            'packageRequestRequiredPackageNotFoundRegistry',
+            pattern,
+            this.parentRequest.pattern,
+            this.registry,
+          ),
         );
       }
       throw err;
@@ -140,7 +145,7 @@ export default class PackageRequest {
     if (Resolver) {
       return Resolver;
     } else {
-      throw new MessageError(this.reporter.lang('unknownRegistryResolver', this.registry));
+      throw new MessageError(this.reporter.lang('packageRequestUnknownRegistryResolver', this.registry));
     }
   }
 
@@ -152,7 +157,7 @@ export default class PackageRequest {
     if (!semver.validRange(pattern)) {
       try {
         if (await fs.exists(path.join(this.config.cwd, pattern, constants.NODE_PACKAGE_JSON))) {
-          this.reporter.warn(this.reporter.lang('implicitFileDeprecated', pattern));
+          this.reporter.warn(this.reporter.lang('packageRequestImplicitFileDeprecated', pattern));
           return `file:${pattern}`;
         }
       } catch (err) {
@@ -238,7 +243,7 @@ export default class PackageRequest {
     const info: Manifest = await this.findVersionInfo();
 
     if (!semver.valid(info.version)) {
-      throw new MessageError(this.reporter.lang('invalidPackageVersion', info.name, info.version));
+      throw new MessageError(this.reporter.lang('packageRequestInvalidPackageVersion', info.name, info.version));
     }
 
     info.fresh = fresh;
@@ -261,7 +266,7 @@ export default class PackageRequest {
     }
 
     if (info.flat && !this.resolver.flat) {
-      throw new MessageError(this.reporter.lang('flatGlobalError'));
+      throw new MessageError(this.reporter.lang('packageRequestFlatGlobalError'));
     }
 
     // validate version info
@@ -355,7 +360,7 @@ export default class PackageRequest {
 
     for (const key of constants.REQUIRED_PACKAGE_KEYS) {
       if (!info[key]) {
-        throw new MessageError(reporter.lang('missingRequiredPackageKey', human, key));
+        throw new MessageError(reporter.lang('packageRequestMissingRequiredPackageKey', human, key));
       }
     }
   }
@@ -406,7 +411,7 @@ export default class PackageRequest {
       depReqPatterns.map(async ({pattern, hint, workspaceName, workspaceLoc}): Promise<Dependency> => {
         const locked = lockfile.getLocked(pattern);
         if (!locked) {
-          throw new MessageError(reporter.lang('lockfileOutdated'));
+          throw new MessageError(reporter.lang('packageRequestLockfileOutdated'));
         }
 
         const {name, version: current} = locked;

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -514,7 +514,7 @@ export default class PackageResolver {
         const {range, hasVersion} = normalizePattern(req.pattern);
 
         if (this.isLockfileEntryOutdated(lockfileEntry.version, range, hasVersion)) {
-          this.reporter.warn(this.reporter.lang('incorrectLockfileEntry', req.pattern));
+          this.reporter.warn(this.reporter.lang('packageResolverIncorrectLockfileEntry', req.pattern));
           this.removePattern(req.pattern);
           this.lockfile.removePattern(req.pattern);
           fresh = true;

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -247,9 +247,9 @@ export default class NpmRegistry extends Registry {
 
     const actuals = [];
     for (const [isHome, loc] of possibles) {
-      reporter.verbose(reporter.lang('configPossibleFile', loc));
+      reporter.verbose(reporter.lang('npmRegistryConfigPossibleFile', loc));
       if (await fs.exists(loc)) {
-        reporter.verbose(reporter.lang('configFileFound', loc));
+        reporter.verbose(reporter.lang('npmRegistryConfigFileFound', loc));
         actuals.push([isHome, loc, await fs.readFile(loc)]);
       }
     }

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -218,7 +218,7 @@ export default class ConsoleReporter extends BaseReporter {
             reject(err);
           } else {
             if (!answer && options.required) {
-              this.error(this.lang('answerRequired'));
+              this.error(this.lang('consoleReporterAnswerRequired'));
               resolve(this.question(question, options));
             } else {
               resolve(answer);

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -1,413 +1,420 @@
 /* @flow */
 /* eslint max-len: 0 */
 
+/* This file has been organized and alphabetized for ease of maintenance and use.
+ * It will also help when the file is being translated to another language as it
+ * can be broken down by command. The naming pattern is simply a prefix of the
+ * command the string is associated with, "common" if it is shared, and "core"
+ * if it is used by the index itself.
+ */
+
 const messages = {
-  upToDate: 'Already up-to-date.',
-  folderInSync: 'Folder in sync.',
-  nothingToInstall: 'Nothing to install.',
-  resolvingPackages: 'Resolving packages',
-  checkingManifest: 'Validating package.json',
-  fetchingPackages: 'Fetching packages',
-  linkingDependencies: 'Linking dependencies',
-  rebuildingPackages: 'Rebuilding all packages',
-  buildingFreshPackages: 'Building fresh packages',
-  cleaningModules: 'Cleaning modules',
-  bumpingVersion: 'Bumping version',
-  savingHar: 'Saving HAR file: $0',
-  answer: 'Answer?',
-  usage: 'Usage',
-  installCommandRenamed: '`install` has been replaced with `add` to add new dependencies. Run $0 instead.',
-  globalFlagRemoved: '`--global` has been deprecated. Please run $0 instead.',
-  waitingInstance: 'Waiting for the other yarn instance to finish (pid $0, inside $1)',
-  waitingNamedInstance: 'Waiting for the other yarn instance to finish ($0)',
-  offlineRetrying: 'There appears to be trouble with your network connection. Retrying...',
-  internalServerErrorRetrying: 'There appears to be trouble with the npm registry (returned $1). Retrying...',
-  clearedCache: 'Cleared cache.',
-  couldntClearPackageFromCache: "Couldn't clear package $0 from cache",
-  clearedPackageFromCache: 'Cleared package $0 from cache',
-  packWroteTarball: 'Wrote tarball to $0.',
+  addAllDependencies: 'All dependencies',
+  addDirectDependencies: 'Direct dependencies',
+  addMissingAddDependencies: 'Missing list of packages to add to your project.',
+  addModuleAlreadyInManifest: '$0 is already in $1. Please remove existing entry first before adding it to $2.',
+  addSavedNewDependency: 'Saved 1 new dependency.',
+  addSavedNewDependencies: 'Saved $0 new dependencies.',
+  addWorkspacesAddRootCheck:
+    'Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
 
-  helpExamples: '  Examples:\n$0\n',
-  helpCommands: '  Commands:\n$0\n',
-  helpCommandsMore: '  Run `$0` for more information on specific commands.',
-  helpLearnMore: '  Visit $0 to learn more about Yarn.\n',
+  autoCleanAlreadyExists: '$0 already exists. To revert to the default file, delete $0 then rerun this command.',
+  autoCleanCleaning: 'Cleaning modules',
+  autoCleanCreatingFile: 'Creating $0',
+  autoCleanCreatedFile:
+    'Created $0. Please review the contents of this file then run `yarn autoclean --force` to perform a clean.',
+  autoCleanDoesNotExist:
+    '$0 does not exist. Autoclean will delete files specified by $0. Run `autoclean --init` to create $0 with the default entries.',
+  autoCleanSavedSize: 'Saved $0 MB.',
+  autoCleanRequiresForce:
+    'This command required the `--force` flag to perform the clean. This is a destructive operation. Files specified in $0 will be deleted.',
+  autoCleanRemovedFiles: 'Removed $0 files',
 
-  manifestPotentialTypo: 'Potential typo $0, did you mean $1?',
-  manifestBuiltinModule: '$0 is also the name of a node core module',
-  manifestNameDot: "Name can't start with a dot",
-  manifestNameIllegalChars: 'Name contains illegal characters',
-  manifestNameBlacklisted: 'Name is blacklisted',
-  manifestLicenseInvalid: 'License should be a valid SPDX license expression',
-  manifestLicenseNone: 'No license field',
-  manifestStringExpected: '$0 is not a string',
-  manifestDependencyCollision:
-    '$0 has dependency $1 with range $2 that collides with a dependency in $3 of the same name with version $4',
-  manifestDirectoryNotFound: 'Unable to read $0 directory of module $1',
+  binPackageBinaryNotFound: 'Could not find a binary named $0',
 
-  verboseFileCopy: 'Copying $0 to $1.',
-  verboseFileLink: 'Creating hardlink at $0 to $1.',
-  verboseFileSymlink: 'Creating symlink at $0 to $1.',
-  verboseFileSkip: 'Skipping copying of file $0 as the file at $1 is the same size ($2) and mtime ($3).',
-  verboseFileSkipSymlink: 'Skipping copying of $0 as the file at $1 is the same symlink ($2).',
-  verboseFileSkipHardlink: 'Skipping copying of $0 as the file at $1 is the same hardlink ($2).',
-  verboseFileRemoveExtraneous: 'Removing extraneous file $0.',
-  verboseFilePhantomExtraneous:
-    "File $0 would be marked as extraneous but has been removed as it's listed as a phantom file.",
-  verboseFileSkipArtifact: 'Skipping copying of $0 as the file is marked as a built artifact and subject to change.',
-  verboseFileFolder: 'Creating directory $0.',
+  buildSubCommandsInvalidCommand: 'Invalid sub-command. Try $0',
+  buildSubCommandsUsage: 'Usage',
 
-  verboseRequestStart: 'Performing $0 request to $1.',
-  verboseRequestFinish: 'Request $0 finished with status code $1.',
+  cacheClearedCache: 'Cleared cache.',
+  cacheClearedPackageFromCache: 'Cleared package $0 from cache',
 
-  configSet: 'Set $0 to $1.',
+  checkCouldBeDeduped: '$0 could be deduped from $1 to $2',
+  checkFolderInSync: 'Folder in sync.',
+  checkFoundWarnings: 'Found $0 warnings.',
+  checkFoundErrors: 'Found $0 errors.',
+  checkIntegrityCheckFailed: 'Integrity check failed',
+  checkLockfileNotContainPattern: 'Lockfile does not contain pattern: $0',
+  checkNoIntegrityFile: 'Could not find an integrity file',
+  checkOptionalDepNotInstalled: 'Optional dependency $0 not installed',
+  checkPackageDoesntSatisfy: '$0 does not satisfy found match of $1',
+  checkPackageNotInstalled: '$0 not installed',
+  checkPackageWrongVersion: '$0 is wrong version: expected $1, got $2',
+
+  commonInvalidPackageName: 'Invalid package name.',
+  commonLegendColorsForVersionUpdates:
+    'Legend : \n $0 : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2 : Patch Update backward-compatible bug fixes \n',
+  commonLoggingIn: 'Logging in',
+  commonNoArguments: 'This command does not require any arguments.',
+  commonNoPackageName: 'Package does not have a name.',
+  commonNoPackageVersion: 'Package does not have a version.',
+  commonPackageNotFoundRegistry: 'Could not find package $0 on the $1 registry.',
+  commonRevokingToken: 'Revoking token',
+  commonTooFewArguments: 'Not enough arguments, expected at least $0.',
+  commonTooManyArguments: 'Too many arguments, maximum of $0.',
+  commonUnknownPackage: 'Could not find package $0.',
+  commonUnknownPackageName: 'Could not find package name.',
+
+  configCacheFolderMissing:
+    'Yarn has not been able to find a cache folder it can use. Please use the explicit --cache-folder option to tell it what location to use, or make one of the preferred locations writable.',
   configDelete: 'Deleted $0.',
+  configCacheFolderSelected: 'Selected the next writable cache folder in the list, will be $0.',
+  configCacheFolderSkipped: 'Skipping preferred cache folder $0 because it is not writable.',
+  configFolderMissing: 'Directory $0 does not exist',
+  configJsonError: 'Error parsing JSON at $0, $1.',
+  configNoPackageJson: 'Could not find a package.json file in $0',
   configNpm: 'npm config',
+  configPlugNPlayWindowsSupport:
+    'Plug-n-Play is ignored on Windows for now - contributions welcome! https://github.com/yarnpkg/yarn/issues/6402',
+  configSet: 'Set $0 to $1.',
+  configWorkspacesFocusRootCheck: 'This command can only be run inside an individual workspace.',
+  configWorkspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects.',
+  configWorkspacesSettingMustBeArray: 'The workspaces field in package.json must be an array.',
+  configWorkspacesDisabled:
+    'Your project root defines workspaces but the feature is disabled in your Yarn config. Please check `workspaces-experimental` in your .yarnrc file.',
+  configWorkspaceNameDuplicate: 'There are more than one workspace with name $0',
+  configWorkspaceNameMandatory: 'Missing name in workspace at $0, ignoring.',
+  configWorkspacesNoHoistRequirePrivatePackages:
+    'nohoist config is ignored in $0 because it is not a private package. If you think nohoist should be allowed in public packages, please submit an issue for your use case.',
+  configWorkspacesNoHoistDisabled:
+    '$0 defines nohoist but the feature is disabled in your Yarn config (`workspaces-nohoist-experimental` in .yarnrc file)',
+  configWorkspaceVersionMandatory: 'Missing version in workspace at $0, ignoring.',
   configYarn: 'yarn config',
 
-  couldntFindPackagejson: "Couldn't find a package.json file in $0",
-  couldntFindMatch: "Couldn't find match for $0 in $1 for $2.",
-  couldntFindPackageInCache:
-    "Couldn't find any versions for $0 that matches $1 in our cache (possible versions are $2). This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.",
-  couldntFindVersionThatMatchesRange: "Couldn't find any versions for $0 that matches $1",
-  chooseVersionFromList: 'Please choose a version of $0 from this list:',
-  moduleNotInManifest: "This module isn't specified in a package.json file.",
-  moduleAlreadyInManifest: '$0 is already in $1. Please remove existing entry first before adding it to $2.',
-  unknownFolderOrTarball: "Passed folder/tarball doesn't exist,",
-  unknownPackage: "Couldn't find package $0.",
-  unknownPackageName: "Couldn't find package name.",
-  unknownUser: "Couldn't find user $0.",
-  unknownRegistryResolver: 'Unknown registry resolver $0',
-  userNotAnOwner: "User $0 isn't an owner of this package.",
-  invalidVersionArgument: 'Use the $0 flag to create a new version.',
-  invalidVersion: 'Invalid version supplied.',
-  requiredVersionInRange: 'Required version in range.',
-  packageNotFoundRegistry: "Couldn't find package $0 on the $1 registry.",
-  requiredPackageNotFoundRegistry: "Couldn't find package $0 required by $1 on the $2 registry.",
-  doesntExist: "Package $1 refers to a non-existing file '$0'.",
-  missingRequiredPackageKey: `Package $0 doesn't have a $1.`,
-  invalidAccess: 'Invalid argument for access, expected public or restricted.',
-  invalidCommand: 'Invalid subcommand. Try $0',
-  invalidGistFragment: 'Invalid gist fragment $0.',
-  invalidHostedGitFragment: 'Invalid hosted git fragment $0.',
-  invalidFragment: 'Invalid fragment $0.',
-  invalidPackageName: 'Invalid package name.',
-  invalidPackageVersion: "Can't add $0: invalid package version $1.",
-  couldntFindManifestIn: "Couldn't find manifest in $0.",
-  shrinkwrapWarning:
-    'npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.',
-  npmLockfileWarning:
-    'package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.',
-  lockfileOutdated: 'Outdated lockfile. Please run `yarn install` and try again.',
-  lockfileMerged: 'Merge conflict detected in yarn.lock and successfully merged.',
-  lockfileConflict:
-    'A merge conflict was found in yarn.lock but it could not be successfully merged, regenerating yarn.lock from scratch.',
-  ignoredScripts: 'Ignored scripts due to flag.',
-  missingAddDependencies: 'Missing list of packages to add to your project.',
-  yesWarning:
+  consoleReporterAnswerRequired: 'An answer is required.',
+
+  coreBugReport: 'If you think this is a bug, please open a bug report with the information provided in $0.',
+  coreDoubleDashDeprecation:
+    'From Yarn 1.0 onwards, scripts do not require `--` for options to be forwarded. In a future version, any explicit `--` will be forwarded as-is to the scripts.',
+  coreFileWriteError: 'Could not write file $0: $1',
+  coreMutexPortBusy: 'Cannot use the network mutex on port $0. It is probably used by another app.',
+  coreNetworkWarning:
+    'You do not appear to have an internet connection. Try the --offline flag to use the cache for registry queries.',
+  coreNoRequiredLockfile: 'No lockfile in this directory. Run `yarn install` to generate one.',
+  coreUnexpectedError: 'An unexpected error occurred: $0.',
+  coreUnsupportedNodeVersion:
+    'You are using Node $0 which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: $1',
+  coreWaitingInstance: 'Waiting for the other yarn instance to finish (pid $0, inside $1)',
+  coreWaitingNamedInstance: 'Waiting for the other yarn instance to finish ($0)',
+  coreYesWarning:
     'The yes flag has been set. This will automatically answer yes to all questions, which may have security implications.',
-  networkWarning:
-    "You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.",
-  flatGlobalError:
-    'The package $0@$1 requires a flat dependency graph. Add `"flat": true` to your package.json and try again.',
-  noName: `Package doesn't have a name.`,
-  noVersion: `Package doesn't have a version.`,
-  answerRequired: 'An answer is required.',
-  missingWhyDependency: 'Missing package name, folder or path to file to identify why a package has been installed',
-  bugReport: 'If you think this is a bug, please open a bug report with the information provided in $0.',
-  unexpectedError: 'An unexpected error occurred: $0.',
-  jsonError: 'Error parsing JSON at $0, $1.',
-  noPermission: 'Cannot create $0 due to insufficient permissions.',
-  noGlobalFolder: 'Cannot find a suitable global folder. Tried these: $0',
-  allDependenciesUpToDate: 'All of your dependencies are up to date.',
-  legendColorsForVersionUpdates:
-    'Color legend : \n $0    : Major Update backward-incompatible updates \n $1 : Minor Update backward-compatible features \n $2  : Patch Update backward-compatible bug fixes',
-  frozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
-  fileWriteError: 'Could not write file $0: $1',
-  multiplePackagesCantUnpackInSameDestination:
-    'Pattern $0 is trying to unpack in the same destination $1 as pattern $2. This could result in non-deterministic behavior, skipping.',
-  incorrectLockfileEntry: 'Lockfile has incorrect entry for $0. Ignoring it.',
-
-  invalidResolutionName: 'Resolution field $0 does not end with a valid package name and will be ignored',
-  invalidResolutionVersion: 'Resolution field $0 has an invalid version entry and may be ignored',
-  incompatibleResolutionVersion: 'Resolution field $0 is incompatible with requested version $1',
-
-  yarnOutdated: "Your current version of Yarn is out of date. The latest version is $0, while you're on $1.",
-  yarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',
-  yarnOutdatedCommand: 'To upgrade, run the following command:',
-
-  tooManyArguments: 'Too many arguments, maximum of $0.',
-  tooFewArguments: 'Not enough arguments, expected at least $0.',
-  noArguments: "This command doesn't require any arguments.",
-
-  ownerRemoving: 'Removing owner $0 from package $1.',
-  ownerRemoved: 'Owner removed.',
-  ownerRemoveError: "Couldn't remove owner.",
-  ownerGetting: 'Getting owners for package $0',
-  ownerGettingFailed: "Couldn't get list of owners.",
-  ownerAlready: 'This user is already an owner of this package.',
-  ownerAdded: 'Added owner.',
-  ownerAdding: 'Adding owner $0 to package $1',
-  ownerAddingFailed: "Couldn't add owner.",
-  ownerNone: 'No owners.',
-
-  teamCreating: 'Creating team',
-  teamRemoving: 'Removing team',
-  teamAddingUser: 'Adding user to team',
-  teamRemovingUser: 'Removing user from team',
-  teamListing: 'Listing teams',
-
-  cleaning: 'Cleaning modules',
-  cleanCreatingFile: 'Creating $0',
-  cleanCreatedFile:
-    'Created $0. Please review the contents of this file then run "yarn autoclean --force" to perform a clean.',
-  cleanAlreadyExists: '$0 already exists. To revert to the default file, delete $0 then rerun this command.',
-  cleanRequiresForce:
-    'This command required the "--force" flag to perform the clean. This is a destructive operation. Files specified in $0 will be deleted.',
-  cleanDoesNotExist:
-    '$0 does not exist. Autoclean will delete files specified by $0. Run "autoclean --init" to create $0 with the default entries.',
-
-  binLinkCollision:
-    "There's already a linked binary called $0 in your global Yarn bin. Could not link this package's $0 bin entry.",
-  linkCollision:
-    "There's already a package called $0 registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.",
-  linkMissing: 'No registered package found called $0.',
-  linkRegistered: 'Registered $0.',
-  linkRegisteredMessage:
-    'You can now run `yarn link $0` in the projects where you want to use this package and it will be used instead.',
-  linkUnregistered: 'Unregistered $0.',
-  linkUnregisteredMessage:
-    'You can now run `yarn unlink $0` in the projects where you no longer want to use this package.',
-  linkUsing: 'Using linked package for $0.',
-  linkDisusing: 'Removed linked package $0.',
-  linkDisusingMessage: 'You will need to run `yarn` to re-install the package that was linked.',
-  linkTargetMissing: 'The target of linked package $0 is missing. Removing link.',
-
-  createInvalidBin: 'Invalid bin entry found in package $0.',
-  createMissingPackage:
-    'Package not found - this is probably an internal error, and should be reported at https://github.com/yarnpkg/yarn/issues.',
-
-  workspacesAddRootCheck:
-    'Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
-  workspacesRemoveRootCheck:
-    'Running this command will remove the dependency from the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
-  workspacesFocusRootCheck: 'This command can only be run inside an individual workspace.',
-  workspacesRequirePrivateProjects: 'Workspaces can only be enabled in private projects.',
-  workspacesSettingMustBeArray: 'The workspaces field in package.json must be an array.',
-  workspacesDisabled:
-    'Your project root defines workspaces but the feature is disabled in your Yarn config. Please check "workspaces-experimental" in your .yarnrc file.',
-
-  workspacesNohoistRequirePrivatePackages:
-    'nohoist config is ignored in $0 because it is not a private package. If you think nohoist should be allowed in public packages, please submit an issue for your use case.',
-  workspacesNohoistDisabled: `$0 defines nohoist but the feature is disabled in your Yarn config ("workspaces-nohoist-experimental" in .yarnrc file)`,
-
-  workspaceRootNotFound: "Cannot find the root of your workspace - are you sure you're currently in a workspace?",
-  workspaceMissingWorkspace: 'Missing workspace name.',
-  workspaceMissingCommand: 'Missing command name.',
-  workspaceUnknownWorkspace: 'Unknown workspace $0.',
-  workspaceVersionMandatory: 'Missing version in workspace at $0, ignoring.',
-  workspaceNameMandatory: 'Missing name in workspace at $0, ignoring.',
-  workspaceNameDuplicate: 'There are more than one workspace with name $0',
-
-  cacheFolderSkipped: 'Skipping preferred cache folder $0 because it is not writable.',
-  cacheFolderMissing:
-    "Yarn hasn't been able to find a cache folder it can use. Please use the explicit --cache-folder option to tell it what location to use, or make one of the preferred locations writable.",
-  cacheFolderSelected: 'Selected the next writable cache folder in the list, will be $0.',
 
   execMissingCommand: 'Missing command name.',
 
-  noScriptsAvailable: 'There are no scripts specified inside package.json.',
-  noBinAvailable: 'There are no binary scripts available.',
-  dashDashDeprecation: `From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`,
-  commandNotSpecified: 'No command specified.',
-  binCommands: 'Commands available from binary scripts: ',
-  possibleCommands: 'Project commands',
-  commandQuestion: 'Which command would you like to run?',
-  commandFailedWithCode: 'Command failed with exit code $0.',
-  commandFailedWithSignal: 'Command failed with signal $0.',
-  packageRequiresNodeGyp:
-    'This package requires node-gyp, which is not currently installed. Yarn will attempt to automatically install it. If this fails, you can run "yarn global add node-gyp" to manually install it.',
-  nodeGypAutoInstallFailed:
-    'Failed to auto-install node-gyp. Please run "yarn global add node-gyp" manually. Error: $0',
+  executeLifecycleScriptCommandFailedWithCode: 'Command failed with exit code $0.',
+  executeLifecycleScriptCommandFailedWithSignal: 'Command failed with signal $0.',
+  executeLifecycleScriptPackageRequiresNodeGyp:
+    'This package requires node-gyp, which is not currently installed. Yarn will attempt to automatically install it. If this fails, you can run `yarn global add node-gyp` to manually install it.',
+  executeLifecycleScriptNodeGypAutoInstallFailed:
+    'Failed to auto-install node-gyp. Please run `yarn global add node-gyp` manually. Error: $0',
 
-  foundIncompatible: 'Found incompatible module',
-  incompatibleEngine: 'The engine $0 is incompatible with this module. Expected version $1. Got $2',
-  incompatibleCPU: 'The CPU architecture $0 is incompatible with this module.',
-  incompatibleOS: 'The platform $0 is incompatible with this module.',
-  invalidEngine: 'The engine $0 appears to be invalid.',
-
-  optionalCompatibilityExcluded:
-    '$0 is an optional dependency and failed compatibility check. Excluding it from installation.',
-  optionalModuleFail: 'This module is OPTIONAL, you can safely ignore this error',
-  optionalModuleScriptFail: 'Error running install script for optional dependency: $0',
-  optionalModuleCleanupFail: 'Could not cleanup build artifacts from failed install: $0',
-
-  unmetPeer: '$0 has unmet peer dependency $1.',
-  incorrectPeer: '$0 has incorrect peer dependency $1.',
-  selectedPeer: 'Selecting $1 at level $2 as the peer dependency of $0.',
-  missingBundledDependency: '$0 is missing a bundled dependency $1. This should be reported to the package maintainer.',
-
-  savedNewDependency: 'Saved 1 new dependency.',
-  savedNewDependencies: 'Saved $0 new dependencies.',
-  directDependencies: 'Direct dependencies',
-  allDependencies: 'All dependencies',
-
-  foundWarnings: 'Found $0 warnings.',
-  foundErrors: 'Found $0 errors.',
-
-  savedLockfile: 'Saved lockfile.',
-  noRequiredLockfile: 'No lockfile in this directory. Run `yarn install` to generate one.',
-  noLockfileFound: 'No lockfile found.',
-
-  invalidSemver: 'Invalid semver version',
-  newVersion: 'New version',
-  currentVersion: 'Current version',
-  noVersionOnPublish: 'Proceeding with current version',
-
-  manualVersionResolution:
-    'Unable to find a suitable version for $0, please choose one by typing one of the numbers below:',
-  manualVersionResolutionOption: '$0 which resolved to $1',
-
-  createdTag: 'Created tag.',
-  createdTagFail: "Couldn't add tag.",
-  deletedTag: 'Deleted tag.',
-  deletedTagFail: "Couldn't delete tag.",
-  gettingTags: 'Getting tags',
-  deletingTags: 'Deleting tag',
-  creatingTag: 'Creating tag $0 = $1',
-
-  whyStart: 'Why do we have the module $0?',
-  whyFinding: 'Finding dependency',
-  whyCalculating: 'Calculating file sizes',
-  whyUnknownMatch: "We couldn't find a match!",
-  whyInitGraph: 'Initialising dependency graph',
-  whyWhoKnows: "We don't know why this module exists",
-  whyDiskSizeWithout: 'Disk size without dependencies: $0',
-  whyDiskSizeUnique: 'Disk size with unique dependencies: $0',
-  whyDiskSizeTransitive: 'Disk size with transitive dependencies: $0',
-  whySharedDependencies: 'Number of shared dependencies: $0',
-  whyHoistedTo: `Has been hoisted to $0`,
-
-  whyHoistedFromSimple: `This module exists because it's hoisted from $0.`,
-  whyNotHoistedSimple: `This module exists here because it's in the nohoist list $0.`,
-  whyDependedOnSimple: `This module exists because $0 depends on it.`,
-  whySpecifiedSimple: `This module exists because it's specified in $0.`,
-  whyReasons: 'Reasons this module exists',
-  whyHoistedFrom: 'Hoisted from $0',
-  whyNotHoisted: `in the nohoist list $0`,
-  whyDependedOn: '$0 depends on it',
-  whySpecified: `Specified in $0`,
-
-  whyMatch: `\r=> Found $0`,
-
-  uninstalledPackages: 'Uninstalled packages.',
-  uninstallRegenerate: 'Regenerating lockfile and installing missing dependencies',
-
-  cleanRemovedFiles: 'Removed $0 files',
-  cleanSavedSize: 'Saved $0 MB.',
-
-  configFileFound: 'Found configuration file $0.',
-  configPossibleFile: 'Checking for configuration file $0.',
-
-  npmUsername: 'npm username',
-  npmPassword: 'npm password',
-  npmEmail: 'npm email',
-
-  loggingIn: 'Logging in',
-  loggedIn: 'Logged in.',
-  notRevokingEnvToken: 'Not revoking login token, specified via environment variable.',
-  notRevokingConfigToken: 'Not revoking login token, specified via config file.',
-  noTokenToRevoke: 'No login token to revoke.',
-  revokingToken: 'Revoking token',
-  revokedToken: 'Revoked login token.',
-
-  loginAsPublic: 'Logging in as public',
-  incorrectCredentials: 'Incorrect username or password.',
-  clearedCredentials: 'Cleared login credentials.',
-
-  publishFail: "Couldn't publish package: $0",
-  publishPrivate: 'Package marked as private, not publishing.',
-  published: 'Published.',
-  publishing: 'Publishing',
-
-  nonInteractiveNoVersionSpecified:
-    'You must specify a new version with --new-version when running with --non-interactive.',
-  nonInteractiveNoToken: "No token found and can't prompt for login when running with --non-interactive.",
-
-  infoFail: 'Received invalid response from npm.',
-  malformedRegistryResponse: 'Received malformed response from registry for $0. The registry may be down.',
-  registryNoVersions: 'No valid versions found for $0. The package may be unpublished.',
-
-  cantRequestOffline: "Can't make a request in offline mode ($0)",
-  requestManagerNotSetupHAR: 'RequestManager was not setup to capture HAR files',
-  requestError: 'Request $0 returned a $1',
-  requestFailed: 'Request failed $0',
-  tarballNotInNetworkOrCache: '$0: Tarball is not in network and can not be located in cache ($1)',
-  fetchBadHashWithPath: "Integrity check failed for $0 (computed integrity doesn't match our records, got $2)",
-  fetchBadIntegrityAlgorithm: 'Integrity checked failed for $0 (none of the specified algorithms are supported)',
-  fetchErrorCorrupt:
+  fetchersTarballNotInNetworkOrCache: '$0: Tarball is not in network and can not be located in cache ($1)',
+  fetchersBadHashWithPath: 'Integrity check failed for $0 (computed integrity does not match our records, got $2)',
+  fetchersErrorCorrupt:
     '$0. Mirror tarball appears to be corrupt. You can resolve this by running:\n\n  rm -rf $1\n  yarn install',
-  errorExtractingTarball: 'Extracting tar content of $1 failed, the file appears to be corrupt: $0',
-  updateInstalling: 'Installing $0...',
-  hostedGitResolveError: 'Error connecting to repository. Please, check the url.',
 
-  unknownFetcherFor: 'Unknown fetcher for $0',
+  fileResolverPackageDoesntExist: 'Package $1 refers to a non-existing file `$0`.',
 
-  downloadGitWithoutCommit: 'Downloading the git repo $0 over plain git without a commit hash',
-  downloadHTTPWithoutCommit: 'Downloading the git repo $0 over HTTP without a commit hash',
+  gistResolverInvalidGistFragment: 'Invalid gist fragment $0.',
 
-  unplugDisabled: "Packages can only be unplugged when Plug'n'Play is enabled.",
+  getDownloadGitWithoutCommit: 'Downloading the git repo $0 over plain git without a commit hash',
+  getDownloadHttpWithoutCommit: 'Downloading the git repo $0 over HTTP without a commit hash',
+  gitNoMatch: 'Could not find match for $0 in $1 for $2.',
 
-  plugnplayWindowsSupport:
-    "Plug'n'Play is ignored on Windows for now - contributions welcome! https://github.com/yarnpkg/yarn/issues/6402",
+  globalNoFolder: 'Cannot find a suitable global folder. Tried these: $0',
+  globalNoPermission: 'Cannot create $0 due to insufficient permissions.',
+  globalPackageContainsYarnAsGlobal:
+    'Installing Yarn via Yarn will result in you having two separate versions of Yarn installed at the same time, which is not recommended. To update Yarn please follow https://yarnpkg.com/en/docs/install .',
+  globalPackageHasBinaries: '$0 has binaries:',
+  globalPackageHasNoBinaries: '$0 has no binaries',
+  globalPackageInstalledWithBinaries: 'Installed $0 with binaries:',
 
-  packageInstalledWithBinaries: 'Installed $0 with binaries:',
-  packageHasBinaries: '$0 has binaries:',
-  packageHasNoBinaries: '$0 has no binaries',
-  packageBinaryNotFound: "Couldn't find a binary named $0",
+  helpCommands: '  Commands:\n$0\n',
+  helpCommandsMore: '  Run `$0` for more information on specific commands.',
+  helpExamples: '  Examples:\n$0\n',
+  helpLearnMore: '  Visit $0 to learn more about Yarn.\n',
 
-  couldBeDeduped: '$0 could be deduped from $1 to $2',
-  lockfileNotContainPattern: 'Lockfile does not contain pattern: $0',
-  integrityCheckFailed: 'Integrity check failed',
-  noIntegrityFile: "Couldn't find an integrity file",
-  integrityFailedExpectedIsNotAJSON: 'Integrity check: integrity file is not a json',
-  integrityCheckLinkedModulesDontMatch: "Integrity check: Linked modules don't match",
-  integrityFlagsDontMatch: "Integrity check: Flags don't match",
-  integrityLockfilesDontMatch: "Integrity check: Lock files don't match",
-  integrityFailedFilesMissing: 'Integrity check: Files are missing',
-  integrityPatternsDontMatch: "Integrity check: Top level patterns don't match",
-  integrityModulesFoldersMissing: 'Integrity check: Some module folders are missing',
-  integritySystemParamsDontMatch: "Integrity check: System parameters don't match",
-  packageNotInstalled: '$0 not installed',
-  optionalDepNotInstalled: 'Optional dependency $0 not installed',
-  packageWrongVersion: '$0 is wrong version: expected $1, got $2',
-  packageDontSatisfy: "$0 doesn't satisfy found match of $1",
+  hostedGitResolverError: 'Error connecting to repository. Please, check the url.',
+  hostedGitResolverInvalidHostedGitFragment: 'Invalid hosted git fragment $0.',
 
-  lockfileExists: 'Lockfile already exists, not importing.',
-  skippingImport: 'Skipping import of $0 for $1',
+  importLockfileExists: 'Lockfile already exists, not importing.',
+  importSkipping: 'Skipping import of $0 for $1',
   importFailed: 'Import of $0 for $1 failed, resolving normally.',
   importResolveFailed: 'Import of $0 failed starting in $1',
   importResolvedRangeMatch: 'Using version $0 of $1 instead of $2 for $3',
   importSourceFilesCorrupted: 'Failed to import from package-lock.json, source file(s) corrupted',
   importPackageLock: 'found npm package-lock.json, converting to yarn.lock',
   importNodeModules: 'creating yarn.lock from local node_modules folder',
-  packageContainsYarnAsGlobal:
-    'Installing Yarn via Yarn will result in you having two separate versions of Yarn installed at the same time, which is not recommended. To update Yarn please follow https://yarnpkg.com/en/docs/install .',
 
-  scopeNotValid: 'The specified scope is not valid.',
+  infoFail: 'Received invalid response from npm.',
 
-  deprecatedCommand: '$0 is deprecated. Please use $1.',
-  deprecatedListArgs: 'Filtering by arguments is deprecated. Please use the pattern option instead.',
-  implicitFileDeprecated:
-    'Using the "file:" protocol implicitly is deprecated. Please either prepend the protocol or prepend the path $0 with "./".',
-  unsupportedNodeVersion:
-    'You are using Node $0 which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: $1',
+  installAnswerPrompt: 'Answer?',
+  installBuildingFreshPackages: 'Building fresh packages',
+  installCheckingManifest: 'Validating package.json',
+  installCleaningModules: 'Cleaning modules',
+  installCommandRenamed: '`install` has been replaced with `add` to add new dependencies. Run $0 instead.',
+  installFetchingPackages: 'Fetching packages',
+  installFrozenLockfileError: 'Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.',
+  installNpmLockfileWarning:
+    'package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.',
+  installGlobalFlagRemoved: '`--global` has been deprecated. Please run $0 instead.',
+  installIgnoredScripts: 'Ignored scripts due to flag.',
+  installLinkingDependencies: 'Linking dependencies',
+  installManualVersionResolution:
+    'Unable to find a suitable version for $0, please choose one by typing one of the numbers below:',
+  installManualVersionResolutionOption: '$0 which resolved to $1',
+  installNothingToInstall: 'Nothing to install.',
+  installRebuildingPackages: 'Rebuilding all packages',
+  installResolvingPackages: 'Resolving packages',
+  installSavedLockfile: 'Saved lockfile.',
+  installSavingHar: 'Saving HAR file: $0',
+  installShrinkWrapWarning:
+    'npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.',
+  installUpToDate: 'Already up-to-date.',
+  installYarnOutdated: 'Your current version of Yarn is out of date. The latest version is $0, while you are on $1.',
+  installYarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',
+  installYarnOutdatedCommand: 'To upgrade, run the following command:',
 
-  verboseUpgradeBecauseRequested: 'Considering upgrade of $0 to $1 because it was directly requested.',
-  verboseUpgradeBecauseOutdated: 'Considering upgrade of $0 to $1 because a newer version exists in the registry.',
-  verboseUpgradeNotUnlocking: 'Not unlocking $0 in the lockfile because it is a new or direct dependency.',
-  verboseUpgradeUnlocking: 'Unlocking $0 in the lockfile.',
-  folderMissing: "Directory $0 doesn't exist",
-  mutexPortBusy: 'Cannot use the network mutex on port $0. It is probably used by another app.',
+  integrityCheckerFileNotJson: 'Integrity check: integrity file is not a json',
+  integrityCheckerLinkedModulesDontMatch: 'Integrity check: Linked modules do not match',
+  integrityCheckerFlagsDontMatch: 'Integrity check: Flags do not match',
+  integrityCheckerLockfilesDontMatch: 'Integrity check: Lock files do not match',
+  integrityCheckerFailedFilesMissing: 'Integrity check: Files are missing',
+  integrityCheckerPatternsDontMatch: 'Integrity check: Top level patterns do not match',
+  integrityCheckerModulesFoldersMissing: 'Integrity check: Some module folders are missing',
+  integrityCheckerSystemParamsDontMatch: 'Integrity check: System parameters do not match',
+
+  linkBinCollision:
+    'There is already a linked binary called $0 in your global Yarn bin. Could not link the current package $0 bin entry.',
+  linkCollision:
+    'There is already a package called $0 registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.',
+  linkDisusing: 'Removed linked package $0.',
+  linkDisusingMessage: 'You will need to run `yarn` to re-install the package that was linked.',
+  linkMissing: 'No registered package found called $0.',
+  linkRegistered: 'Registered $0.',
+  linkRegisteredMessage:
+    'You can now run `yarn link $0` in the projects where you want to use this package and it will be used instead.',
+  linkTargetMissing: 'The target of linked package $0 is missing. Removing link.',
+  linkUnregistered: 'Unregistered $0.',
+  linkUnregisteredMessage:
+    'You can now run `yarn unlink $0` in the projects where you no longer want to use this package.',
+  linkUsing: 'Using linked package for $0.',
+
+  listDeprecatedArgs: 'Filtering by arguments is deprecated. Please use the pattern option instead.',
+
+  lockfileConflict:
+    'A merge conflict was found in yarn.lock but it could not be successfully merged, regenerating yarn.lock from scratch.',
+  lockfileMerged: 'Merge conflict detected in yarn.lock and successfully merged.',
+  lockfileNotFound: 'No lockfile found.',
+
+  loginAsPublic: 'Logging in as public',
+  loginLoggedIn: 'Logged in.',
+  loginIncorrectCredentials: 'Incorrect username or password.',
+  loginNoTokenToRevoke: 'No login token to revoke.',
+  loginNonInteractiveNoToken: 'No token found and cannot prompt for login when running with --non-interactive.',
+  loginNotRevokingEnvToken: 'Not revoking login token, specified via environment variable.',
+  loginNotRevokingConfigToken: 'Not revoking login token, specified via config file.',
+  loginNpmEmail: 'npm email',
+  loginNpmPassword: 'npm password',
+  loginNpmUsername: 'npm username',
+  loginRevokedToken: 'Revoked login token.',
+
+  logoutClearedCredentials: 'Cleared login credentials.',
+
+  manifestBuiltinModule: '$0 is also the name of a node core module',
+  manifestDependencyCollision:
+    '$0 has dependency $1 with range $2 that collides with a dependency in $3 of the same name with version $4',
+  manifestDirectoryNotFound: 'Unable to read $0 directory of module $1',
+  manifestPotentialTypo: 'Potential typo $0, did you mean $1?',
+  manifestLicenseInvalid: 'License should be a valid SPDX license expression',
+  manifestLicenseNone: 'No license field',
+  manifestNameDot: 'Name cannot start with a dot',
+  manifestNameIllegalChars: 'Name contains illegal characters',
+  manifestNameBlacklisted: 'Name is blacklisted',
+  manifestStringExpected: '$0 is not a string',
+
+  npmRegistryConfigFileFound: 'Found configuration file $0.',
+  npmRegistryConfigPossibleFile: 'Checking for configuration file $0.',
+
+  npmResolverChooseVersionFromList: 'Please choose a version of $0 from this list:',
+  npmResolverMalformedRegistryResponse: 'Received malformed response from registry for $0. The registry may be down.',
+  npmResolverNoPackageInCache:
+    'Could not find any versions for $0 that matches $1 in our cache (possible versions are $2). This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.',
+  npmResolverNoVersionMatchesRange: 'Could not find any versions for $0 that matches $1',
+
+  npmResolverRegistryNoVersions: 'No valid versions found for $0. The package may be unpublished.',
+
+  ownerAdded: 'Added owner.',
+  ownerAdding: 'Adding owner $0 to package $1',
+  ownerAddingFailed: 'Could not add owner.',
+  ownerAlready: 'This user is already an owner of this package.',
+  ownerGetting: 'Getting owners for package $0',
+  ownerGettingFailed: 'Could not get list of owners.',
+  ownerNone: 'No owners.',
+  ownerRemoveError: 'Could not remove owner.',
+  ownerRemoved: 'Owner removed.',
+  ownerRemoving: 'Removing owner $0 from package $1.',
+  ownerUnknownUser: 'Could not find user $0.',
+  ownerUserNotAnOwner: 'User $0 is not an owner of this package.',
+
+  packWroteTarball: 'Wrote tarball to $0.',
+
+  packageCompatibilityFoundIncompatible: 'Found incompatible module',
+  packageCompatibilityIncompatibleEngine: 'The engine $0 is incompatible with this module. Expected version $1. Got $2',
+  packageCompatibilityIncompatibleCpu: 'The CPU architecture $0 is incompatible with this module.',
+  packageCompatibilityIncompatibleOs: 'The platform $0 is incompatible with this module.',
+  packageCompatibilityInvalidEngine: 'The engine $0 appears to be invalid.',
+  packageCompatibilityOptionalCompatibilityExcluded:
+    '$0 is an optional dependency and failed compatibility check. Excluding it from installation.',
+
+  packageFetcherMultiplePackagesSameDestination:
+    'Pattern $0 is trying to unpack in the same destination $1 as pattern $2. This could result in non-deterministic behavior, skipping.',
+  packageFetcherUnknownFetcher: 'Unknown fetcher for $0',
+
+  packageInstallScriptsOptionalModuleCleanupFail: 'Could not cleanup build artifacts from failed install: $0',
+  packageInstallScriptsOptionalModuleFail: 'This module is OPTIONAL, you can safely ignore this error',
+  packageInstallScriptsOptionalModuleScriptFail: 'Error running install script for optional dependency: $0',
+
+  packageLinkerIncorrectPeer: '$0 has incorrect peer dependency $1.',
+  packageLinkerMissingBundledDependency:
+    '$0 is missing a bundled dependency $1. This should be reported to the package maintainer.',
+  packageLinkerSelectedPeer: 'Selecting $1 at level $2 as the peer dependency of $0.',
+  packageLinkerUnmetPeer: '$0 has unmet peer dependency $1.',
+
+  packageRequestFlatGlobalError:
+    'The package $0@$1 requires a flat dependency graph. Add `"flat": true` to your package.json and try again.',
+  packageRequestImplicitFileDeprecated:
+    'Using the "file:" protocol implicitly is deprecated. Please either prepend the protocol or prepend the path $0 with `./`.',
+  packageRequestInvalidPackageVersion: 'Cannot add $0: invalid package version $1.',
+  packageRequestLockfileOutdated: 'Outdated lockfile. Please run `yarn install` and try again.',
+  packageRequestMissingRequiredPackageKey: 'Package $0 does not have a $1.',
+  packageRequestRequiredPackageNotFoundRegistry: 'Could not find package $0 required by $1 on the $2 registry.',
+  packageRequestUnknownRegistryResolver: 'Unknown registry resolver $0',
+
+  packageResolverIncorrectLockfileEntry: 'Lockfile has incorrect entry for $0. Ignoring it.',
+
+  publishBumpingVersion: 'Bumping version',
+  publishFail: 'Could not publish package: $0',
+  publishInvalidAccess: 'Invalid argument for access, expected public or restricted.',
+  publishPending: 'Publishing',
+  publishPrivate: 'Package marked as private, not publishing.',
+  publishSuccess: 'Published.',
+  publishUnknownFolderOrTarball: 'Passed folder/tarball does not exist,',
+
+  registryResolverInvalidFragment: 'Invalid fragment $0.',
+
+  removeModuleNotInManifest: 'This module is not specified in a package.json file.',
+  removeUninstallRegenerate: 'Regenerating lockfile and installing missing dependencies',
+  removeUninstalledPackages: 'Uninstalled packages.',
+  removeWorkspacesRemoveRootCheck:
+    'Running this command will remove the dependency from the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).',
+
+  requestManagerCantRequestOffline: 'Cannot make a request in offline mode ($0)',
+  requestManagerError: 'Request $0 returned a $1',
+  requestManagerFailed: 'Request failed $0',
+  requestManagerInternalErrorRetrying: 'There appears to be trouble with the npm registry (returned $1). Retrying...',
+  requestManagerNotSetupHar: 'RequestManager was not setup to capture HAR files',
+  requestManagerOfflineRetrying: 'There appears to be trouble with your network connection. Retrying...',
+
+  resolutionMapIncompatibleResolutionVersion: 'Resolution field $0 is incompatible with requested version $1',
+  resolutionMapInvalidResolutionName: 'Resolution field $0 does not end with a valid package name and will be ignored',
+  resolutionMapInvalidResolutionVersion: 'Resolution field $0 has an invalid version entry and may be ignored',
+
+  runBinCommands: 'Commands available from binary scripts: ',
+  runCommandNotSpecified: 'No command specified.',
+  runCommandQuestion: 'Which command would you like to run?',
+  runNoBinAvailable: 'There are no binary scripts available.',
+  runNoScriptsAvailable: 'There are no scripts specified inside package.json.',
+  runPossibleCommands: 'Project commands',
+
+  tagCreatedTag: 'Created tag.',
+  tagCreatedTagFail: 'Could not add tag.',
+  tagCreatingTag: 'Creating tag $0 = $1',
+  tagDeletedTag: 'Deleted tag.',
+  tagDeletedTagFail: 'Could not delete tag.',
+  tagDeletingTags: 'Deleting tag',
+  tagGettingTags: 'Getting tags',
+  tagRequiredVersionInRange: 'Required version in range.',
+
+  tarballFetcherBadIntegrityAlgorithm:
+    'Integrity checked failed for $0 (none of the specified algorithms are supported)',
+  tarballFetcherErrorExtractingTarball: 'Extracting tar content of $1 failed, the file appears to be corrupt: $0',
+
+  teamAddingUser: 'Adding user to team',
+  teamCreating: 'Creating team',
+  teamDeprecatedCommand: '$0 is deprecated. Please use $1.',
+  teamListing: 'Listing teams',
+  teamRemoving: 'Removing team',
+  teamRemovingUser: 'Removing user from team',
+
+  unplugDisabled: 'Packages can only be unplugged when Plug-n-Play is enabled.',
+
+  upgradeBecauseOutdated: 'Considering upgrade of $0 to $1 because a newer version exists in the registry.',
+  upgradeBecauseRequested: 'Considering upgrade of $0 to $1 because it was directly requested.',
+  upgradeNotUnlocking: 'Not unlocking $0 in the lockfile because it is a new or direct dependency.',
+  upgradeUnlocking: 'Unlocking $0 in the lockfile.',
+
+  upgradeInteractiveUpToDate: 'All of your dependencies are up to date.',
+  upgradeInteractiveUpdateInstalling: 'Installing $0...',
+
+  verboseFileCopy: 'Copying $0 to $1.',
+  verboseFileFolder: 'Creating directory $0.',
+  verboseFileLink: 'Creating hardlink at $0 to $1.',
+  verboseFilePhantomExtraneous:
+    'File $0 would be marked as extraneous but has been removed as it is listed as a phantom file.',
+  verboseFileRemoveExtraneous: 'Removing extraneous file $0.',
+  verboseFileSkip: 'Skipping copying of file $0 as the file at $1 is the same size ($2) and mtime ($3).',
+  verboseFileSkipArtifact: 'Skipping copying of $0 as the file is marked as a built artifact and subject to change.',
+  verboseFileSkipSymlink: 'Skipping copying of $0 as the file at $1 is the same symlink ($2).',
+  verboseFileSkipHardlink: 'Skipping copying of $0 as the file at $1 is the same hardlink ($2).',
+  verboseFileSymlink: 'Creating symlink at $0 to $1.',
+
+  verboseRequestFinish: 'Request $0 finished with status code $1.',
+  verboseRequestStart: 'Performing $0 request to $1.',
+
+  versionCurrentVersion: 'Current version',
+  versionInvalidSemver: 'Invalid semver version',
+  versionInvalidVersion: 'Invalid version supplied.',
+  versionInvalidVersionArgument: 'Use the $0 flag to create a new version.',
+  versionNewVersion: 'New version',
+  versionNoVersionOnPublish: 'Proceeding with current version',
+
+  whyCalculating: 'Calculating file sizes',
+  whyDependedOn: '$0 depends on it',
+  whyDependedOnSimple: 'This module exists because $0 depends on it.',
+  whyDiskSizeTransitive: 'Disk size with transitive dependencies: $0',
+  whyDiskSizeUnique: 'Disk size with unique dependencies: $0',
+  whyDiskSizeWithout: 'Disk size without dependencies: $0',
+  whyFinding: 'Finding dependency',
+  whyHoistedFrom: 'Hoisted from $0',
+  whyHoistedFromSimple: 'This module exists because it is hoisted from $0.',
+  whyHoistedTo: 'Has been hoisted to $0',
+  whyInitGraph: 'Initialising dependency graph',
+  whyMatch: '\r=> Found $0',
+  whyMissingDependency: 'Missing package name, folder or path to file to identify why a package has been installed',
+  whyNotHoisted: 'in the nohoist list $0',
+  whyNotHoistedSimple: 'This module exists here because it is in the nohoist list $0.',
+  whyReasons: 'Reasons this module exists',
+  whySharedDependencies: 'Number of shared dependencies: $0',
+  whySpecified: 'Specified in $0',
+  whySpecifiedSimple: 'This module exists because it is specified in $0.',
+  whyStart: 'Why do we have the module $0?',
+  whyUnknownMatch: 'We could not find a match!',
+  whyWhoKnows: 'We do not know why this module exists',
+
+  workspacesRootNotFound: 'Cannot find the root of your workspace - are you sure you are currently in a workspace?',
+  workspaceMissingWorkspace: 'Missing workspace name.',
+  workspaceMissingCommand: 'Missing command name.',
+  workspaceUnknownWorkspace: 'Unknown workspace $0.',
 };
 
 export type LanguageKeys = $Keys<typeof messages>;

--- a/src/resolution-map.js
+++ b/src/resolution-map.js
@@ -59,7 +59,7 @@ export default class ResolutionMap {
 
   parsePatternInfo(globPattern: string, range: string): ?Object {
     if (!isValidPackagePath(globPattern)) {
-      this.reporter.warn(this.reporter.lang('invalidResolutionName', globPattern));
+      this.reporter.warn(this.reporter.lang('resolutionMapInvalidResolutionName', globPattern));
       return null;
     }
 
@@ -67,7 +67,7 @@ export default class ResolutionMap {
     const name = directories.pop();
 
     if (!semver.validRange(range) && !getExoticResolver(range)) {
-      this.reporter.warn(this.reporter.lang('invalidResolutionVersion', range));
+      this.reporter.warn(this.reporter.lang('resolutionMapInvalidResolutionVersion', range));
       return null;
     }
 
@@ -97,7 +97,7 @@ export default class ResolutionMap {
 
     if (pattern) {
       if (semver.validRange(reqRange) && semver.valid(range) && !semver.satisfies(range, reqRange)) {
-        this.reporter.warn(this.reporter.lang('incompatibleResolutionVersion', pattern, reqPattern));
+        this.reporter.warn(this.reporter.lang('resolutionMapIncompatibleResolutionVersion', pattern, reqPattern));
       }
     }
 

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -49,7 +49,7 @@ export default class FileResolver extends ExoticResolver {
       return manifest;
     }
     if (!await fs.exists(loc)) {
-      throw new MessageError(this.reporter.lang('doesntExist', loc, this.pattern.split('@')[0]));
+      throw new MessageError(this.reporter.lang('fileResolverPackageDoesntExist', loc, this.pattern.split('@')[0]));
     }
 
     const manifest: Manifest = await (async () => {

--- a/src/resolvers/exotics/gist-resolver.js
+++ b/src/resolvers/exotics/gist-resolver.js
@@ -19,7 +19,7 @@ export function explodeGistFragment(fragment: string, reporter: Reporter): {id: 
       hash: parts[1] || '',
     };
   } else {
-    throw new MessageError(reporter.lang('invalidGistFragment', fragment));
+    throw new MessageError(reporter.lang('gistResolverInvalidGistFragment', fragment));
   }
 }
 

--- a/src/resolvers/exotics/hosted-git-resolver.js
+++ b/src/resolvers/exotics/hosted-git-resolver.js
@@ -39,7 +39,7 @@ export function explodeHostedGitFragment(fragment: string, reporter: Reporter): 
   const repo = parts[parts.length - 1];
 
   if (user === undefined || repo === undefined) {
-    throw new MessageError(reporter.lang('invalidHostedGitFragment', fragment));
+    throw new MessageError(reporter.lang('hostedGitResolverInvalidHostedGitFragment', fragment));
   }
 
   return {
@@ -118,7 +118,7 @@ export default class HostedGitResolver extends ExoticResolver {
 
       out = lines.join('\n');
     } else {
-      throw new Error(this.reporter.lang('hostedGitResolveError'));
+      throw new Error(this.reporter.lang('hostedGitResolverError'));
     }
 
     return client.setRefHosted(out);

--- a/src/resolvers/exotics/registry-resolver.js
+++ b/src/resolvers/exotics/registry-resolver.js
@@ -14,7 +14,7 @@ export default class RegistryResolver extends ExoticResolver {
       this.range = match[4] || 'latest';
       this.name = match[2];
     } else {
-      throw new MessageError(this.reporter.lang('invalidFragment', fragment));
+      throw new MessageError(this.reporter.lang('registryResolverInvalidFragment', fragment));
     }
 
     // $FlowFixMe

--- a/src/resolvers/registries/npm-resolver.js
+++ b/src/resolvers/registries/npm-resolver.js
@@ -36,11 +36,11 @@ export default class NpmResolver extends RegistryResolver {
     request: ?PackageRequest,
   ): Promise<Manifest> {
     if (body.versions && Object.keys(body.versions).length === 0) {
-      throw new MessageError(config.reporter.lang('registryNoVersions', body.name));
+      throw new MessageError(config.reporter.lang('npmResolverRegistryNoVersions', body.name));
     }
 
     if (!body['dist-tags'] || !body.versions) {
-      throw new MessageError(config.reporter.lang('malformedRegistryResponse', body.name));
+      throw new MessageError(config.reporter.lang('npmResolverMalformedRegistryResponse', body.name));
     }
 
     if (range in body['dist-tags']) {
@@ -62,7 +62,7 @@ export default class NpmResolver extends RegistryResolver {
       if (request.resolver && request.resolver.activity) {
         request.resolver.activity.end();
       }
-      config.reporter.log(config.reporter.lang('couldntFindVersionThatMatchesRange', body.name, range));
+      config.reporter.log(config.reporter.lang('npmResolverNoVersionMatchesRange', body.name, range));
       let pageSize;
       if (process.stdout instanceof tty.WriteStream) {
         pageSize = process.stdout.rows - 2;
@@ -71,7 +71,7 @@ export default class NpmResolver extends RegistryResolver {
         {
           name: 'package',
           type: 'list',
-          message: config.reporter.lang('chooseVersionFromList', body.name),
+          message: config.reporter.lang('npmResolverChooseVersionFromList', body.name),
           choices: (semver: Object).rsort(Object.keys(body.versions)),
           pageSize,
         },
@@ -80,7 +80,7 @@ export default class NpmResolver extends RegistryResolver {
         return body.versions[response.package];
       }
     }
-    throw new MessageError(config.reporter.lang('couldntFindVersionThatMatchesRange', body.name, range));
+    throw new MessageError(config.reporter.lang('npmResolverNoVersionMatchesRange', body.name, range));
   }
 
   async resolveRequest(desiredVersion: ?string): Promise<?Manifest> {
@@ -135,7 +135,7 @@ export default class NpmResolver extends RegistryResolver {
       return versions[satisfied];
     } else if (!this.config.preferOffline) {
       throw new MessageError(
-        this.reporter.lang('couldntFindPackageInCache', this.name, this.range, Object.keys(versions).join(', ')),
+        this.reporter.lang('npmResolverNoPackageInCache', this.name, this.range, Object.keys(versions).join(', ')),
       );
     } else {
       return null;
@@ -182,7 +182,7 @@ export default class NpmResolver extends RegistryResolver {
     const desiredVersion = shrunk && shrunk.version ? shrunk.version : null;
     const info: ?Manifest = await this.resolveRequest(desiredVersion);
     if (info == null) {
-      throw new MessageError(this.reporter.lang('packageNotFoundRegistry', this.name, NPM_REGISTRY_ID));
+      throw new MessageError(this.reporter.lang('commonPackageNotFoundRegistry', this.name, NPM_REGISTRY_ID));
     }
 
     const {deprecated, dist} = info;

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -309,12 +309,12 @@ async function _checkForGyp(config: Config, paths: Array<string>): Promise<void>
     return;
   }
 
-  reporter.info(reporter.lang('packageRequiresNodeGyp'));
+  reporter.info(reporter.lang('executeLifecycleScriptPackageRequiresNodeGyp'));
 
   try {
     await globalRun(config, reporter, {}, ['add', 'node-gyp']);
   } catch (e) {
-    throw new MessageError(reporter.lang('nodeGypAutoInstallFailed', e.message));
+    throw new MessageError(reporter.lang('executeLifecycleScriptNodeGypAutoInstallFailed', e.message));
   }
 }
 
@@ -354,8 +354,8 @@ export async function execCommand({
     if (err instanceof ProcessTermError) {
       throw new MessageError(
         err.EXIT_SIGNAL
-          ? reporter.lang('commandFailedWithSignal', err.EXIT_SIGNAL)
-          : reporter.lang('commandFailedWithCode', err.EXIT_CODE),
+          ? reporter.lang('executeLifecycleScriptCommandFailedWithSignal', err.EXIT_SIGNAL)
+          : reporter.lang('executeLifecycleScriptCommandFailedWithCode', err.EXIT_CODE),
       );
     } else {
       throw err;

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -200,7 +200,7 @@ export default class Git implements GitRefResolvingInterface {
       if (await Git.repoExists(secureUrl)) {
         return secureUrl;
       } else {
-        reporter.warn(reporter.lang('downloadGitWithoutCommit', ref.repository));
+        reporter.warn(reporter.lang('getDownloadGitWithoutCommit', ref.repository));
         return ref;
       }
     }
@@ -210,7 +210,7 @@ export default class Git implements GitRefResolvingInterface {
       if (await Git.repoExists(secureRef)) {
         return secureRef;
       } else {
-        reporter.warn(reporter.lang('downloadHTTPWithoutCommit', ref.repository));
+        reporter.warn(reporter.lang('getDownloadHttpWithoutCommit', ref.repository));
         return ref;
       }
     }
@@ -500,7 +500,7 @@ export default class Git implements GitRefResolvingInterface {
     });
     if (!resolvedResult) {
       throw new MessageError(
-        this.reporter.lang('couldntFindMatch', version, Array.from(refs.keys()).join(','), this.gitUrl.repository),
+        this.reporter.lang('gitNoMatch', version, Array.from(refs.keys()).join(','), this.gitUrl.repository),
       );
     }
 

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -223,7 +223,7 @@ export default class RequestManager {
 
   request<T>(params: RequestParams<T>): Promise<T> {
     if (this.offlineNoRequests) {
-      return Promise.reject(new MessageError(this.reporter.lang('cantRequestOffline', params.url)));
+      return Promise.reject(new MessageError(this.reporter.lang('requestManagerCantRequestOffline', params.url)));
     }
 
     const cached = this.cache[params.url];
@@ -398,7 +398,7 @@ export default class RequestManager {
       calledOnError = true;
 
       if (this.isPossibleOfflineError(err)) {
-        if (!queueForRetry(this.reporter.lang('offlineRetrying'))) {
+        if (!queueForRetry(this.reporter.lang('requestManagerOfflineRetrying'))) {
           reject(err);
         }
       }
@@ -419,8 +419,8 @@ export default class RequestManager {
 
         if (res.statusCode === 408 || res.statusCode >= 500) {
           const description = `${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`;
-          if (!queueForRetry(this.reporter.lang('internalServerErrorRetrying', description))) {
-            throw new ResponseError(this.reporter.lang('requestFailed', description), res.statusCode);
+          if (!queueForRetry(this.reporter.lang('requestManagerInternalErrorRetrying', description))) {
+            throw new ResponseError(this.reporter.lang('requestManagerFailed', description), res.statusCode);
           } else {
             return;
           }
@@ -435,7 +435,7 @@ export default class RequestManager {
           // So this is actually a rejection ... the hosted git resolver uses this to know whether http is supported
           resolve(false);
         } else if (res.statusCode >= 400) {
-          const errMsg = (body && body.message) || reporter.lang('requestError', params.url, res.statusCode);
+          const errMsg = (body && body.message) || reporter.lang('requestManagerError', params.url, res.statusCode);
           reject(new Error(errMsg));
         } else {
           resolve(body);
@@ -511,7 +511,7 @@ export default class RequestManager {
 
   saveHar(filename: string) {
     if (!this.captureHar) {
-      throw new Error(this.reporter.lang('requestManagerNotSetupHAR'));
+      throw new Error(this.reporter.lang('requestManagerNotSetupHar'));
     }
     // No request may have occurred at all.
     this._getRequestModule();


### PR DESCRIPTION
**Summary**
I was doing some work on a feature and a saw how unorganized the localization file was. Not only does it make it a crap shoot for where to put a new string (if you even feel like doing it), it also makes it really difficult to approach translating into a new language at all. To that end, I made my best effort to organize the strings. I have grouped them by command (using common and core for things that don't relate to a specific command) alphabetized the groups, and alphabetized the strings within the groups. I also added a header to explain the organization within the file.

This will make the file much cleaner and more maintainable. It also makes it easy to catch people not adding strings in the right place during code review.

I do understand this will be a pain for a little bit because it will cause a number of merge conflicts. I feel that the organization and maintenance gains will make it worth it, though.

**Test plan**
If the tests pass, this should be good. I am not intentionally changing any functionality.
