### PR TITLE
Consistent formatting for keys in config list; Fix #4496

### DIFF
--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -139,7 +139,7 @@ export default class ConsoleReporter extends BaseReporter {
         //colors: this.isTTY,
         depth: null,
         maxArrayLength: null,
-        stylize(str, styleType): String {
+        stylize(str, styleType): string {
           if (_this.isTTY) {
             if (styleType === 'name') {
               str = `'${str}'`;


### PR DESCRIPTION
**Summary**

Fixes #4496. Defines a custom 'stylize' function instead of the defaults in util.inspect(stylizeNoColor and stylizeWithColor)

**Test plan**

Test manually by running `yarn config list`

Before,

![screen shot 2018-10-10 at 1 47 32 am](https://user-images.githubusercontent.com/17273984/46696106-012c2680-cc2f-11e8-8742-fdbfe8f46cbd.png)

After,

![screen shot 2018-10-10 at 1 46 05 am](https://user-images.githubusercontent.com/17273984/46696132-11440600-cc2f-11e8-8116-0e6c32fb9f58.png)

