### PR TITLE
Adding call to generate-disclaimer to get dep licenses

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -23,6 +23,7 @@ mkdir artifacts
 mkdir dist{,/bin,/lib}
 
 # Workaround for https://github.com/yarnpkg/yarn/issues/2591
+eval $system_yarn licenses generate-disclaimer > dist/DEPENDENCY_LICENSES
 eval $system_yarn run build
 eval $system_yarn run build-bundle
 chmod +x artifacts/*.js


### PR DESCRIPTION
**Summary**
Adding a build step for the dist version to create a license file for all dependencies and move it into the dist directory.
 This is to resolve #549