### PR TITLE
fix: Restore Node v4 support by downgrading cli-table3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Restore Node v4 support by downgrading `cli-table3`
+
+  [#6535](https://github.com/yarnpkg/yarn/pull/6535) - [**Mark Stacey**](https://github.com/Gudahtt)
+
 - Prevent infinite loop when parsing corrupted lockfile with unterminated string
 
   [#4965](https://github.com/yarnpkg/yarn/pull/4965) - [**Ryan Hendrickson**](https://github.com/rhendric)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bytes": "^3.0.0",
     "camelcase": "^4.0.0",
     "chalk": "^2.1.0",
-    "cli-table3": "^0.5.1",
+    "cli-table3": "^0.4.0",
     "commander": "^2.9.0",
     "death": "^1.0.0",
     "debug": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,13 +1766,14 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-table3@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
-  integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
+cli-table3@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.4.0.tgz#a7fd50f011d734e3f16403cfcbedbea97659e417"
+  integrity sha512-o0slI6EFJNI2aKE9jG1bVN6jXJG2vjzYsGhyd9RqRV/YiiEmzSwNNXb5qJmfLDSOdvfA6sUvdKVvi3p3Y1apxA==
   dependencies:
+    kind-of "^3.0.4"
     object-assign "^4.1.0"
-    string-width "^2.1.1"
+    string-width "^1.0.1"
   optionalDependencies:
     colors "^1.1.2"
 
@@ -4774,7 +4775,7 @@ kind-of@^1.1.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
   integrity sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.0.4, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=


### PR DESCRIPTION
**Summary**

`cli-table3` no longer supports Node v4 as of v0.5.0. Downgrading to `cli-table3@0.4.0` restores Node v4 support, and should fix the nightly `test-e2e-ubuntu1604` CircleCI test that has been failing

This dependency was introduced in #6409, so this problem is present in v1.12.0

**Test plan**

Using Node.js `v4.8.7` and after running `yarn build-dist`, any command with the resulting artifact will give the following output:
```
C:\Development\git\yarn\artifacts\yarn-legacy-1.13.0-0.js:62791
  let code = codeRegex();
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3
```

After making this change, that error no longer occurs.
