### PR TITLE
feat(auth): Support two factor authentication for NPM accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#5322](https://github.com/yarnpkg/yarn/pull/5322) - [**Karolis Narkevicius**](https://twitter.com/KidkArolis)
 
+- Adds 2FA (Two Factor Authentication) support to publish & alike
+
+  [#6555](https://github.com/yarnpkg/yarn/pull/6555) - [**Krzysztof Zbudniewek**](https://github.com/neonowy)
+
 ## 1.12.0
 
 - Adds initial support for PnP on Windows

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -86,7 +86,7 @@ describe('request', () => {
     npmRegistry.config = config;
     return {
       setOtp(otp: string) {
-        npmRegistry.otp = otp;
+        npmRegistry.setOtp(otp);
       },
 
       request(url: string, options: Object, packageName: string): Object {

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -85,6 +85,10 @@ describe('request', () => {
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
     npmRegistry.config = config;
     return {
+      setOtp(otp: string) {
+        npmRegistry.otp = otp;
+      },
+
       request(url: string, options: Object, packageName: string): Object {
         npmRegistry.request(url, options, packageName);
         const lastIndex = mockRequestManager.request.mock.calls.length - 1;
@@ -99,6 +103,17 @@ describe('request', () => {
     const config = {};
     const requestParams = createRegistry(config).request(url);
     expect(requestParams.url).toBe(url);
+  });
+
+  test('should add `npm-otp` header', () => {
+    const url = 'https://registry.npmjs.org/yarn';
+    const config = {};
+    const registry = createRegistry(config);
+
+    registry.setOtp('123 456');
+
+    const requestParams = registry.request(url);
+    expect(requestParams.headers['npm-otp']).toBe('123 456');
   });
 
   const testCases = [

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint max-len: 0 */
 
-import {OneTimePasswordRequiredError} from '../../src/errors.js';
+import {OneTimePasswordError} from '../../src/errors.js';
 import {Reporter} from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
 import * as fs from '../../src/util/fs.js';
@@ -210,7 +210,7 @@ for (const statusCode of [403, 442]) {
   });
 }
 
-test('RequestManager.execute one time password required error on npm request', async () => {
+test('RequestManager.execute one time password error on npm request', async () => {
   jest.resetModules();
   jest.mock('request', factory => options => {
     options.callback(
@@ -229,11 +229,11 @@ test('RequestManager.execute one time password required error on npm request', a
       url: 'https://registry.npmjs.org/yarn',
     });
   } catch (err) {
-    expect(err).toBeInstanceOf(OneTimePasswordRequiredError);
+    expect(err).toBeInstanceOf(OneTimePasswordError);
   }
 });
 
-test('RequestManager.execute one time password required error on npm login request', async () => {
+test('RequestManager.execute one time password error on npm login request', async () => {
   jest.resetModules();
   jest.mock('request', factory => options => {
     options.callback('', {statusCode: 401, headers: {'www-authenticate': 'otp'}}, {ok: false});
@@ -248,7 +248,7 @@ test('RequestManager.execute one time password required error on npm login reque
       url: 'https://registry.npmjs.org/-/user/org.couchdb.user:user',
     });
   } catch (err) {
-    expect(err).toBeInstanceOf(OneTimePasswordRequiredError);
+    expect(err).toBeInstanceOf(OneTimePasswordError);
   }
 });
 

--- a/__tests__/util/request-manager.js
+++ b/__tests__/util/request-manager.js
@@ -1,6 +1,7 @@
 /* @flow */
 /* eslint max-len: 0 */
 
+import {OneTimePasswordRequiredError} from '../../src/errors.js';
 import {Reporter} from '../../src/reporters/index.js';
 import Config from '../../src/config.js';
 import * as fs from '../../src/util/fs.js';
@@ -208,6 +209,48 @@ for (const statusCode of [403, 442]) {
     });
   });
 }
+
+test('RequestManager.execute one time password required error on npm request', async () => {
+  jest.resetModules();
+  jest.mock('request', factory => options => {
+    options.callback(
+      '',
+      {statusCode: 401, headers: {'www-authenticate': 'otp'}},
+      {error: 'You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.'},
+    );
+    return {
+      on: () => {},
+    };
+  });
+
+  try {
+    const config = await Config.create({});
+    await config.requestManager.request({
+      url: 'https://registry.npmjs.org/yarn',
+    });
+  } catch (err) {
+    expect(err).toBeInstanceOf(OneTimePasswordRequiredError);
+  }
+});
+
+test('RequestManager.execute one time password required error on npm login request', async () => {
+  jest.resetModules();
+  jest.mock('request', factory => options => {
+    options.callback('', {statusCode: 401, headers: {'www-authenticate': 'otp'}}, {ok: false});
+    return {
+      on: () => {},
+    };
+  });
+
+  try {
+    const config = await Config.create({});
+    await config.requestManager.request({
+      url: 'https://registry.npmjs.org/-/user/org.couchdb.user:user',
+    });
+  } catch (err) {
+    expect(err).toBeInstanceOf(OneTimePasswordRequiredError);
+  }
+});
 
 // Cloudflare will occasionally return an html response with a 500 status code on some calls
 for (const statusCode of [408, 500, 542]) {

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -36,6 +36,10 @@ async function getCredentials(
   return {username, email};
 }
 
+export function getOneTimePassword(config: Config, reporter: Reporter): Promise<string> {
+  return reporter.question(reporter.lang('npmOneTimePassword'));
+}
+
 export async function getToken(
   config: Config,
   reporter: Reporter,
@@ -44,6 +48,10 @@ export async function getToken(
   registry: string = '',
 ): Promise<() => Promise<void>> {
   const auth = registry ? config.registries.npm.getAuthByRegistry(registry) : config.registries.npm.getAuth(name);
+
+  if (config.otp) {
+    config.registries.npm.setOtp(config.otp);
+  }
 
   if (auth) {
     config.registries.npm.setToken(auth);

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -36,7 +36,7 @@ async function getCredentials(
   return {username, email};
 }
 
-export function getOneTimePassword(config: Config, reporter: Reporter): Promise<string> {
+export function getOneTimePassword(reporter: Reporter): Promise<string> {
   return reporter.question(reporter.lang('npmOneTimePassword'));
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -122,6 +122,7 @@ export async function main({
   );
   commander.option('--no-node-version-check', 'do not warn when using a potentially unsupported Node version');
   commander.option('--focus', 'Focus on a single workspace by installing remote copies of its sibling workspaces.');
+  commander.option('--otp <otpcode>', 'one-time password for two factor authentication');
 
   // if -v is the first command, then always exit after returning the version
   if (args[0] === '-v') {
@@ -527,6 +528,7 @@ export async function main({
       nonInteractive: commander.nonInteractive,
       updateChecksums: commander.updateChecksums,
       focus: commander.focus,
+      otp: commander.otp,
     })
     .then(() => {
       // lockfile check must happen after config.init sets lockfileFolder

--- a/src/config.js
+++ b/src/config.js
@@ -68,6 +68,8 @@ export type ConfigOptions = {
   updateChecksums?: boolean,
 
   focus?: boolean,
+
+  otp?: string,
 };
 
 type PackageMetadata = {
@@ -206,6 +208,8 @@ export default class Config {
   focusedWorkspaceName: string;
 
   autoAddIntegrity: boolean;
+
+  otp: ?string;
 
   /**
    * Execute a promise produced by factory if it doesn't exist in our cache with
@@ -495,6 +499,8 @@ export default class Config {
 
     this.focus = !!opts.focus;
     this.focusedWorkspaceName = '';
+
+    this.otp = opts.otp || '';
   }
 
   /**

--- a/src/errors.js
+++ b/src/errors.js
@@ -34,4 +34,4 @@ export class ResponseError extends Error {
   responseCode: number;
 }
 
-export class OneTimePasswordRequiredError extends Error {}
+export class OneTimePasswordError extends Error {}

--- a/src/errors.js
+++ b/src/errors.js
@@ -33,3 +33,5 @@ export class ResponseError extends Error {
 
   responseCode: number;
 }
+
+export class OneTimePasswordRequiredError extends Error {}

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -66,6 +66,9 @@ export default class BaseRegistry {
   token: string;
 
   //
+  otp: string;
+
+  //
   cwd: string;
 
   //
@@ -79,6 +82,10 @@ export default class BaseRegistry {
 
   setToken(token: string) {
     this.token = token;
+  }
+
+  setOtp(otp: string) {
+    this.otp = otp;
   }
 
   getOption(key: string): mixed {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -186,7 +186,7 @@ export default class NpmRegistry extends Registry {
         }
 
         this.reporter.info(this.reporter.lang('twoFactorAuthenticationEnabled'));
-        this.otp = await getOneTimePassword(this.config, this.reporter);
+        this.otp = await getOneTimePassword(this.reporter);
 
         this.requestManager.clearCache();
 

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -15,7 +15,7 @@ import {addSuffix} from '../util/misc';
 import {getPosixPath, resolveWithHome} from '../util/path';
 import normalizeUrl from 'normalize-url';
 import {default as userHome, home} from '../util/user-home-dir';
-import {MessageError, OneTimePasswordRequiredError} from '../errors.js';
+import {MessageError, OneTimePasswordError} from '../errors.js';
 import {getOneTimePassword} from '../cli/commands/login.js';
 import path from 'path';
 import url from 'url';
@@ -180,7 +180,7 @@ export default class NpmRegistry extends Registry {
         gzip: true,
       });
     } catch (error) {
-      if (error instanceof OneTimePasswordRequiredError) {
+      if (error instanceof OneTimePasswordError) {
         if (this.otp) {
           throw new MessageError(this.reporter.lang('incorrectOneTimePassword'));
         }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -311,6 +311,7 @@ const messages = {
   npmUsername: 'npm username',
   npmPassword: 'npm password',
   npmEmail: 'npm email',
+  npmOneTimePassword: 'npm one-time password',
 
   loggingIn: 'Logging in',
   loggedIn: 'Logged in.',
@@ -322,6 +323,8 @@ const messages = {
 
   loginAsPublic: 'Logging in as public',
   incorrectCredentials: 'Incorrect username or password.',
+  incorrectOneTimePassword: 'Incorrect one-time password.',
+  twoFactorAuthenticationEnabled: 'Two factor authentication enabled.',
   clearedCredentials: 'Cleared login credentials.',
 
   publishFail: "Couldn't publish package: $0",

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -8,7 +8,7 @@ import invariant from 'invariant';
 import RequestCaptureHar from 'request-capture-har';
 
 import type {Reporter} from '../reporters/index.js';
-import {MessageError, ResponseError, OneTimePasswordRequiredError} from '../errors.js';
+import {MessageError, ResponseError, OneTimePasswordError} from '../errors.js';
 import BlockingQueue from './blocking-queue.js';
 import * as constants from '../constants.js';
 import * as network from './network.js';
@@ -430,7 +430,7 @@ export default class RequestManager {
           const authMethods = res.headers['www-authenticate'].split(/,\s*/).map(s => s.toLowerCase());
 
           if (authMethods.indexOf('otp') !== -1) {
-            reject(new OneTimePasswordRequiredError());
+            reject(new OneTimePasswordError());
             return;
           }
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Added support for logging into NPM account with 2FA enabled, based on [`npm-profile`](https://github.com/npm/npm-profile/tree/latest/lib) implementation.
Fixes #4904.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
1. Enable 2FA for your account: https://docs.npmjs.com/getting-started/using-two-factor-authentication
2. Run `yarn publish`:

![image](https://user-images.githubusercontent.com/5042328/47120241-3dced200-d26e-11e8-8796-c862d2529073.png)

**Issues**
I've added some basic tests, but don't know where should I put functional test with the whole one-time password prompt flow (like in the screenshot above). Are there any similar high-level tests you could point me to?

I also don't support `--non-interactive`, because AFAIK there's no way to access `Config` nor `flags` (Do we need to check both of them?) from `NpmRegistry.request(...)`, as it's done in the case of `getToken(config, reporter, name, flags, registry)` which is always called directly inside `run(config, reporter, flags, args)` function:
https://github.com/yarnpkg/yarn/blob/aa4e713c30c40ac35934e45aca5b4683d61e1829/src/cli/commands/login.js#L65-L68

I see two possible solutions here:
1. Add `Config`/`flags` (both?) to the arguments of `NpmRegistry.request(...)`:
https://github.com/yarnpkg/yarn/blob/aa4e713c30c40ac35934e45aca5b4683d61e1829/src/registries/npm-registry.js#L136
2. Handle catching `OneTimePasswordError` with every call of `npm.request(...)`, which could unnecessary obfuscate `run(...)` functions.

Any feedback would be appreciated ✌️ 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
