### PR TITLE
test: Default `nonInteractive` to true in cli tests to prevent timeouts

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -92,6 +92,7 @@ export function makeConfigFromDirectory(cwd: string, reporter: Reporter, flags: 
       production: flags.production,
       updateChecksums: !!flags.updateChecksums,
       offline: !!flags.offline,
+      nonInteractive: typeof flags.nonInteractive !== 'undefined' ? Boolean(flags.nonInteractive) : true,
       focus: !!flags.focus,
       enableDefaultRc: !flags.noDefaultRc,
       extraneousYarnrcFiles: flags.useYarnrc,


### PR DESCRIPTION
**Summary**

The last three tests in `__tests__/commands/publish.js` were regularly timing
out locally, yet they were doing fine on CI. They were apparently running in
interactive mode, and were waiting for user input after `publish` was called
(to set the next version number).

Setting `nonInteractive` to false by default in `__tests__/commands/_helpers`
ensures that all command tests run in non-interactive mode unless otherwise
specified. This prevents this problem from occuring again, at least among the
tests that use this helper.

This change won't improve tests on CI, as this problem never
affected CI. The tests were running in non-interactive mode on CI
already due to an `isCi` check in `config.js`.

**Test plan**

The last three tests in `__tests__/commands/publish.js` would regularly fail before this change (due to a timeout). Now they consistently finish within milliseconds. 
