### PR TITLE
Remove some reported code duplication

### DIFF
--- a/src/reporters/noop-reporter.js
+++ b/src/reporters/noop-reporter.js
@@ -45,25 +45,6 @@ export default class NoopReporter extends BaseReporter {
   footer(showPeakMemory: boolean) {}
   table(head: Array<string>, body: Array<Array<string>>) {}
 
-  activity(): ReporterSpinner {
-    return {
-      tick(name: string) {},
-      end() {},
-    };
-  }
-
-  activitySet(total: number, workers: number): ReporterSpinnerSet {
-    return {
-      spinners: Array(workers).fill({
-        clear() {},
-        setPrefix() {},
-        tick() {},
-        end() {},
-      }),
-      end() {},
-    };
-  }
-
   question(question: string, options?: QuestionOptions = {}): Promise<string> {
     return Promise.reject(new Error('Not implemented'));
   }

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -51,7 +51,7 @@ export function forwardSignalToSpawnedProcesses(signal: string) {
   }
 }
 
-type ProcessFn = (
+export type ProcessFn = (
   proc: child_process$ChildProcess,
   update: (chunk: string) => void,
   reject: (err: mixed) => void,


### PR DESCRIPTION
**Summary**

I was looking for contributions for Hacktoberfest, and contributing to a tool I use seems to be a good idea.

I thought I'd pick off some of the low-hanging fruit of issue #4950 and remove some of the
reported code duplication.

**Test plan**

As this is a refactor, I ran the existing tests to verify the functionality was unchanged. 

The previous report from `yarn dupe-check` was:

```23 matches found across 158 files```

Following the change, the report is:

```19 matches found across 158 files```
