### PR TITLE
Anchor package.json `files` to the package’s root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Run the engines check before showing the UI for `upgrade-interactive`
+- Ensures the engine check is ran before showing the UI for `upgrade-interactive`
 
   [#6536](https://github.com/yarnpkg/yarn/pull/6536) - [**Orta Therox**](https://github.com/orta)
 
-- Restore Node v4 support by downgrading `cli-table3`
+- Restores Node v4 support by downgrading `cli-table3`
 
   [#6535](https://github.com/yarnpkg/yarn/pull/6535) - [**Mark Stacey**](https://github.com/Gudahtt)
 
-- Prevent infinite loop when parsing corrupted lockfile with unterminated string
+- Prevents infinite loop when parsing corrupted lockfiles with unterminated strings
 
   [#4965](https://github.com/yarnpkg/yarn/pull/4965) - [**Ryan Hendrickson**](https://github.com/rhendric)
 
@@ -31,6 +31,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Adds support for basic auth for registries with paths, such as artifactory
 
   [#5322](https://github.com/yarnpkg/yarn/pull/5322) - [**Karolis Narkevicius**](https://twitter.com/KidkArolis)
+
+- Fixes how the `files` property is interpreted to bring it in line with npm
+
+  [#6562](https://github.com/yarnpkg/yarn/pull/6562) - [**Bertrand Marron**](https://github.com/tusbar)
 
 ## 1.12.0
 

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -67,6 +67,18 @@ test.concurrent('pack should include all files listed in the files array', (): P
   });
 });
 
+test.concurrent('pack should include files based from the package’s root', (): Promise<void> => {
+  return runPack([], {}, 'files-include-from-root', async (config): Promise<void> => {
+    const {cwd} = config;
+    const files = await getFilesFromArchive(
+      path.join(cwd, 'files-include-from-root-v1.0.0.tgz'),
+      path.join(cwd, 'files-include-from-root-v1.0.0'),
+    );
+    expect(files.indexOf('index.js')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('sub/index.js')).toEqual(-1);
+  });
+});
+
 test.concurrent('pack should included globbed files', (): Promise<void> => {
   return runPack([], {}, 'files-glob', async (config): Promise<void> => {
     const {cwd} = config;

--- a/__tests__/fixtures/pack/files-include-from-root/index.js
+++ b/__tests__/fixtures/pack/files-include-from-root/index.js
@@ -1,0 +1,1 @@
+console.log('included');

--- a/__tests__/fixtures/pack/files-include-from-root/package.json
+++ b/__tests__/fixtures/pack/files-include-from-root/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "files-include-from-root",
+  "version": "1.0.0",
+  "license": "MIT",
+  "files": ["index.js"]
+}

--- a/__tests__/fixtures/pack/files-include-from-root/sub/index.js
+++ b/__tests__/fixtures/pack/files-include-from-root/sub/index.js
@@ -1,0 +1,1 @@
+console.log('not included');

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -88,7 +88,7 @@ export async function packTarball(
       onlyFiles.map((filename: string): string => `!${filename}`),
       onlyFiles.map((filename: string): string => `!${path.join(filename, '**')}`),
     );
-    const regexes = ignoreLinesToRegex(lines, '.');
+    const regexes = ignoreLinesToRegex(lines, './');
     filters = filters.concat(regexes);
   }
 


### PR DESCRIPTION
**Summary**

`npm pack` bases paths in the `files` array from the package’s root.
This updates yarn pack to behave in the same way.

**Test plan**

Let’s consider the following package:

```js
{
  "name": "files-include-from-root",
  "version": "1.0.0",
  "license": "MIT",
  "files": ["index.js"]
}
```

With the following files:

```
$ tree ./files-include-from-root
├── index.js
├── package.json
└── sub
    └── index.js
```

`npm pack`’s current behavior:

```
$ npm pack --dry-run ./files-include-from-root
npm notice
npm notice 📦  files-include-from-root@1.0.0
npm notice === Tarball Contents ===
npm notice 107B package.json
npm notice 25B  index.js
npm notice === Tarball Details ===
npm notice name:          files-include-from-root
npm notice version:       1.0.0
npm notice filename:      files-include-from-root-1.0.0.tgz
npm notice package size:  237 B
npm notice unpacked size: 132 B
npm notice shasum:        e4f148d35450d9183afd42c54625fc6ae51ea2e7
npm notice integrity:     sha512-vunAN8bueT2bi[...]UsDOZrX48L8hA==
npm notice total files:   2
npm notice
files-include-from-root-1.0.0.tgz
```


`yarn pack`’s current behavior:

```
$ tree ./files-include-from-root/package
./files-include-from-root/package
├── index.js
├── package.json
└── sub
    └── index.js

1 directory, 3 files
```

`yarn pack` with this patch:

```
$ tree ./files-include-from-root/package
./files-include-from-root/package
├── index.js
└── package.json

1 directory, 2 files
```

Fix #5779.