### PR TITLE
Console info, success, warning and error messages now contain emoji's

### DIFF
--- a/__tests__/reporters/__snapshots__/console-reporter.js.snap
+++ b/__tests__/reporters/__snapshots__/console-reporter.js.snap
@@ -32,14 +32,14 @@ Object {
 exports[`ConsoleReporter.footer 1`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G✨  Done in 0.00s.",
+  "stdout": "[2K[1GDone in 0.00s.",
 }
 `;
 
 exports[`ConsoleReporter.footer 2`] = `
 Object {
   "stderr": "",
-  "stdout": "[2K[1G✨  Done in 0.00s. Peak memory usage 0.00MB.",
+  "stdout": "[2K[1GDone in 0.00s. Peak memory usage 0.00MB.",
 }
 `;
 

--- a/__tests__/reporters/_mock.js
+++ b/__tests__/reporters/_mock.js
@@ -44,7 +44,7 @@ export default function<T>(
       stdin: new Stdin(),
       stdout: buildStream('stdout'),
       stderr: buildStream('stderr'),
-      emoji: true,
+      emoji: false,
       ...(opts || {}),
     };
 

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -28,6 +28,7 @@ const chalk = require('chalk');
 const stripAnsi = require('strip-ansi');
 const read = require('read');
 const tty = require('tty');
+const emoji = require('node-emoji');
 
 const AUDIT_COL_WIDTHS = [15, 62];
 
@@ -189,16 +190,19 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   success(msg: string) {
-    this._logCategory('success', 'green', msg);
+    const category = this._prependEmoji('success', emoji.get('white_check_mark'));
+    this._logCategory(category, 'green', msg);
   }
 
   error(msg: string) {
+    const category = this._prependEmoji('error', emoji.get('red_cirle'));
     clearLine(this.stderr);
-    this.stderr.write(`${this.format.red('error')} ${msg}\n`);
+    this.stderr.write(`${this.format.red(category)} ${msg}\n`);
   }
 
   info(msg: string) {
-    this._logCategory('info', 'blue', msg);
+    const category = this._prependEmoji('info', emoji.get('information_source'));
+    this._logCategory(category, 'blue', msg);
   }
 
   command(command: string) {
@@ -206,8 +210,9 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   warn(msg: string) {
+    const category = this._prependEmoji('warning', emoji.get('warning'));
     clearLine(this.stderr);
-    this.stderr.write(`${this.format.yellow('warning')} ${msg}\n`);
+    this.stderr.write(`${this.format.yellow(category)} ${msg}\n`);
   }
 
   question(question: string, options?: QuestionOptions = {}): Promise<string> {


### PR DESCRIPTION
**Summary**
Self-explanatory, these console messages didn't display emoji's while the steps did, now it's easier to see if it is a warning, error or info message. 

**Test plan**
Run `yarn install --emoji` on a project, cause some errors, warnings and info messages and see it has now emoji's.