### PR TITLE
Support Darwin bash in bin/yarn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6562](https://github.com/yarnpkg/yarn/pull/6562) - [**Bertrand Marron**](https://github.com/tusbar)
 
+- Fixes Yarn invocations on Darwin when the `yarn` binary was symlinked
+
+  [#6568](https://github.com/yarnpkg/yarn/pull/6568) - [**Hidde Boomsma**](https://github.com/hboomsma)
+
 ## 1.12.0
 
 - Adds initial support for PnP on Windows

--- a/bin/yarn
+++ b/bin/yarn
@@ -3,6 +3,7 @@ argv0=$(echo "$0" | sed -e 's,\\,/,g')
 basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
 
 case "$(uname -s)" in
+  Darwin) basedir="$( cd "$( dirname "$argv0" )" && pwd )";;
   Linux) basedir=$(dirname "$(readlink -f "$0" || echo "$argv0")");;
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
   *MSYS*) basedir=`cygpath -w "$basedir"`;;


### PR DESCRIPTION
If the yarn binary is a symlink the `basepath` is not correctly resolved on OSX/Darwin.

For example take the following structure:
```
vendor/yarnpkg/yarn/bin/yarn
vendor/bin/yarn -> ../yarnpkg/yarn/bin/yarn
```

And run yarn:
```
$ yarn
internal/modules/cjs/loader.js:582
    throw err;
    ^

Error: Cannot find module '/Users/yarnpkg/yarn/bin/yarn.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.Module._load (internal/modules/cjs/loader.js:506:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
    at startup (internal/bootstrap/node.js:285:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:739:3)
```
Since the symlink is not resolved the relative path in the symlink leads to the wrong path.

This PR, fixes that issue.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
