### PR TITLE
Fixes the resolve shim for liftoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes Gulp when used with Plug'n'Play
+
+  [#6623](https://github.com/yarnpkg/yarn/pull/6623) - [**Maël Nison**](https://twitter.com/arcanis)
+
 - Fixes an issue with `yarn audit` when the root package was missing a name
 
   [#6611](https://github.com/yarnpkg/yarn/pull/6611) - [**Jack Zhao**](https://github.com/bugzpodder)

--- a/src/util/generate-pnp-map-api.tpl.js
+++ b/src/util/generate-pnp-map-api.tpl.js
@@ -748,7 +748,7 @@ exports.setupCompatibilityLayer = () => {
   // at all unless modulePath is set, which we cannot configure from any other way than through
   // the Liftoff pipeline (the key isn't whitelisted for env or cli options).
 
-  patchedModules.set(/^resolve$/, realResolve => {
+  patchedModules.set('resolve', realResolve => {
     const mustBeShimmed = caller => {
       const callerLocator = exports.findPackageLocator(caller);
 


### PR DESCRIPTION
**Summary**

I accidentally broke the resolve shim in an experiment (I was considering make shim qualifiers regexps, which ended up unnecessary). This diff reverts the boggus change.

**Test plan**

I specifically don't want to test this part of the code, since it's a shim that we shouldn't even have in the first place.