### PR TITLE
Precompiles inquirer for Node 4 compat

### DIFF
--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -121,7 +121,7 @@ const compilerLegacy = webpack({
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: /node_modules\/(?!inquirer)/,
         use: [
           {
             loader:'babel-loader',


### PR DESCRIPTION
**Summary**

Inquirer dropped support for Node 4. We recently upgraded via #6635, which breaks Node 4 compat.

This PR ensures that inquirer is properly transpiled in the legacy build.

**Test plan**

CI; ran `yarn upgrade-interactive` and `yarn add lodash@doesnt-exist`