### PR TITLE
Exposes pnpapi through resolveToUnqualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Fixes an issue with how symlinks are setup into the cache on Windows
 
   [#6621](https://github.com/yarnpkg/yarn/pull/6621) - [**Yoad Snapir**](https://github.com/yoadsn)
-  
+
 - Upgrades `inquirer`, fixing `upgrade-interactive` for users using both Node 10 and Windows
 
   [#6635](https://github.com/yarnpkg/yarn/pull/6635) - [**Philipp Feigl**](https://github.com/pfeigl)
+
+- Exposes the path to the PnP file using `require.resolve('pnpapi')`
+
+  [#6623](https://github.com/yarnpkg/yarn/pull/6623) - [**Maël Nison**](https://twitter.com/arcanis)
 
 ## 1.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Exposes the path to the PnP file using `require.resolve('pnpapi')`
 
-  [#6623](https://github.com/yarnpkg/yarn/pull/6623) - [**Maël Nison**](https://twitter.com/arcanis)
+  [#6643](https://github.com/yarnpkg/yarn/pull/6643) - [**Maël Nison**](https://twitter.com/arcanis)
 
 ## 1.12.1
 

--- a/packages/pkg-tests/pkg-tests-specs/sources/pnpapi-v1.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/pnpapi-v1.js
@@ -1,9 +1,10 @@
+const {normalize} = require('path');
 const {fs: {writeFile, writeJson}} = require('pkg-tests-core');
 
 module.exports = makeTemporaryEnv => {
   describe(`Plug'n'Play API (v1)`, () => {
     test(
-      `it should expost VERSIONS`,
+      `it should expose VERSIONS`,
       makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
         await run(`install`);
 
@@ -12,7 +13,7 @@ module.exports = makeTemporaryEnv => {
     );
 
     test(
-      `it should expost resolveToUnqualified`,
+      `it should expose resolveToUnqualified`,
       makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
         await run(`install`);
 
@@ -21,7 +22,7 @@ module.exports = makeTemporaryEnv => {
     );
 
     test(
-      `it should expost resolveToUnqualified`,
+      `it should expose resolveToUnqualified`,
       makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
         await run(`install`);
 
@@ -30,7 +31,7 @@ module.exports = makeTemporaryEnv => {
     );
 
     test(
-      `it should expost resolveToUnqualified`,
+      `it should expose resolveToUnqualified`,
       makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
         await run(`install`);
 
@@ -39,6 +40,17 @@ module.exports = makeTemporaryEnv => {
     );
 
     describe(`resolveRequest`, () => {
+      test(
+        `it should return the path to the PnP file for when 'pnpapi' is requested`,
+        makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('pnpapi').resolveRequest('pnpapi', '${path}/')`)).resolves.toEqual(
+            normalize(`${path}/.pnp.js`),
+          );
+        }),
+      );
+
       test(
         `it should return null for builtins`,
         makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {

--- a/src/util/generate-pnp-map-api.tpl.js
+++ b/src/util/generate-pnp-map-api.tpl.js
@@ -13,6 +13,7 @@ const StringDecoder = require('string_decoder');
 
 const ignorePattern = $$BLACKLIST ? new RegExp($$BLACKLIST) : null;
 
+const pnpFile = path.resolve(__dirname, __filename);
 const builtinModules = new Set(Module.builtinModules || Object.keys(process.binding('natives')));
 
 const topLevelLocator = {name: null, reference: null};
@@ -313,6 +314,12 @@ exports.getPackageInformation = function getPackageInformation({name, reference}
  */
 
 exports.resolveToUnqualified = function resolveToUnqualified(request, issuer, {considerBuiltins = true} = {}) {
+  // The 'pnpapi' request is reserved and will always return the path to the PnP file, from everywhere
+
+  if (request === `pnpapi`) {
+    return pnpFile;
+  }
+
   // Bailout if the request is a native module
 
   if (considerBuiltins && builtinModules.has(request)) {


### PR DESCRIPTION
**Summary**

The hook was only exposing `pnpapi` through the `require` function, not the actual PnP API. In most cases this isn't a problem, but non-Node things that depend on resolving the dependencies for a project (such as the Jest resolver) weren't able to allow their scripts to access the PnP API.

**Test plan**

Added a test to make sure that it was correctly exported.