### PR TITLE
Use node scripts to avoid Windows interoperability issues.

### DIFF
--- a/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/package.json
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/package.json
@@ -2,8 +2,8 @@
     "name": "no-deps-scripted",
     "version": "1.0.0",
     "scripts": {
-        "preinstall": ":; echo 'module.exports.push(100);' >> log.js; exit $?\necho module.exports.push(100); >> log.js",
-        "install": ":; echo 'module.exports.push(200);' >> log.js; exit $?\necho module.exports.push(100); >> log.js",
-        "postinstall": ":; echo 'module.exports.push(300);' >> log.js && echo 'module.exports = '\"$(node -p 'Math.floor(Math.random() * 512000)')\"';' > rnd.js; exit $?\n:<<\"::CMDLITERAL\"\necho module.exports.push(300); >> log.js && echo module.exports = $(node -p 'Math.floor(Math.random() * 512000)'); > rnd.js\n::CMDLITERAL"
+        "preinstall": "node scripts/preinstall",
+        "install": "node scripts/install",
+        "postinstall": "node scripts/postinstall"
     }
 }

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/install.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/install.js
@@ -1,0 +1,2 @@
+var fs = require('fs');
+fs.appendFileSync('log.js', 'module.exports.push("install");', 'utf8');

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/postinstall.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/postinstall.js
@@ -1,0 +1,5 @@
+var fs = require('fs');
+fs.appendFileSync('log.js', 'module.exports.push("postinstall");', 'utf8');
+
+var fs = require('fs');
+fs.appendFileSync('rnd.js', `module.exports = ${Math.floor(Math.random() * 512000)};`, 'utf8');

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/preinstall.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/preinstall.js
@@ -1,0 +1,2 @@
+var fs = require('fs');
+fs.appendFileSync('log.js', 'module.exports.push("preinstall");', 'utf8');

--- a/packages/pkg-tests/pkg-tests-specs/sources/script.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/script.js
@@ -200,7 +200,7 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
       makeTemporaryEnv({dependencies: {[`no-deps-scripted`]: `1.0.0`}}, async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`require('no-deps-scripted/log.js')`)).resolves.toEqual([100, 200, 300]);
+        await expect(source(`require('no-deps-scripted/log.js')`)).resolves.toEqual(['preinstall', 'install', 'postinstall']);
       }),
     );
   });


### PR DESCRIPTION
@arcanis Is this what you propose? It's working great in Windows, and it should in other OS.
Btw I've replaced 100, 200, 300 by more meaningful values.