### PR TITLE
Implements optional peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Implements a new `package.json` field: `peerDependenciesMeta`
+
+  [#6671](https://github.com/yarnpkg/yarn/pull/6671) - [**Maël Nison**](https://twitter.com/arcanis)
+
+- Adds an `optional` settings to `peerDependenciesMeta` to silence missing peer dependency warnings
+
+  [#6671](https://github.com/yarnpkg/yarn/pull/6671) - [**Maël Nison**](https://twitter.com/arcanis)
+
 - Fixes a resolution issue when a package had an invalid `main` entry
 
   [#6682](https://github.com/yarnpkg/yarn/pull/6682) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -1123,3 +1123,19 @@ test('install will not warn for missing peerDep when both shallower and deeper',
     const warningMessage = messageParts.every(part => stdout.includes(part));
     expect(warningMessage).toBe(false);
   }));
+
+test('install will warn for missing peer dependencies', () =>
+  runInstall({}, 'missing-peer-dep', (config, reporter, install, getStdout) => {
+    const stdout = getStdout();
+    const messageParts = reporter.lang('unmetPeer', 'undefined').split('undefined');
+    const warningMessage = messageParts.every(part => stdout.includes(part));
+    expect(warningMessage).toBe(true);
+  }));
+
+test('install will not warn for missing optional peer dependencies', () =>
+  runInstall({}, 'missing-opt-peer-dep', (config, reporter, install, getStdout) => {
+    const stdout = getStdout();
+    const messageParts = reporter.lang('unmetPeer', 'undefined').split('undefined');
+    const warningMessage = messageParts.every(part => stdout.includes(part));
+    expect(warningMessage).toBe(false);
+  }));

--- a/__tests__/fixtures/install/missing-opt-peer-dep/foo/package.json
+++ b/__tests__/fixtures/install/missing-opt-peer-dep/foo/package.json
@@ -2,6 +2,11 @@
   "name": "foo",
   "version": "1.0.0",
   "peerDependencies": {
-    "bar": "optional:*"
+    "bar": "*"
+  },
+  "peerDependenciesMeta": {
+    "bar": {
+      "optional": true
+    }
   }
 }

--- a/__tests__/fixtures/install/missing-opt-peer-dep/foo/package.json
+++ b/__tests__/fixtures/install/missing-opt-peer-dep/foo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "bar": "optional:*"
+  }
+}

--- a/__tests__/fixtures/install/missing-opt-peer-dep/package.json
+++ b/__tests__/fixtures/install/missing-opt-peer-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "missing-peer-dep",
+  "dependencies": {
+    "foo": "file:./foo"
+  }
+}

--- a/__tests__/fixtures/install/missing-peer-dep/foo/package.json
+++ b/__tests__/fixtures/install/missing-peer-dep/foo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "bar": "*"
+  }
+}

--- a/__tests__/fixtures/install/missing-peer-dep/package.json
+++ b/__tests__/fixtures/install/missing-peer-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "missing-peer-dep",
+  "dependencies": {
+    "foo": "file:./foo"
+  }
+}

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -617,7 +617,9 @@ export default class PackageLinker {
       };
 
       for (const peerDepName in peerDeps) {
-        const range = peerDeps[peerDepName];
+        const range = peerDeps[peerDepName].replace(/^optional:/, '');
+        const isOptional = peerDeps[peerDepName].startsWith('optional:');
+
         const peerPkgs = this.resolver.getAllInfoForPackageName(peerDepName);
 
         let peerError = 'unmetPeer';
@@ -649,7 +651,7 @@ export default class PackageLinker {
               resolvedPeerPkg.level,
             ),
           );
-        } else {
+        } else if (!isOptional) {
           this.reporter.warn(
             this.reporter.lang(
               peerError,

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -624,7 +624,7 @@ export default class PackageLinker {
         const range = peerDeps[peerDepName];
         const meta = peerDepsMeta && peerDepsMeta[peerDepName];
 
-        const isOptional = meta && meta.optional ? true : false;
+        const isOptional = !!(meta && meta.optional);
 
         const peerPkgs = this.resolver.getAllInfoForPackageName(peerDepName);
 

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -595,11 +595,15 @@ export default class PackageLinker {
   resolvePeerModules() {
     for (const pkg of this.resolver.getManifests()) {
       const peerDeps = pkg.peerDependencies;
+      const peerDepsMeta = pkg.peerDependenciesMeta;
+
       if (!peerDeps) {
         continue;
       }
+
       const ref = pkg._reference;
       invariant(ref, 'Package reference is missing');
+
       // TODO: We are taking the "shortest" ref tree but there may be multiple ref trees with the same length
       const refTree = ref.requests.map(req => req.parentNames).sort((arr1, arr2) => arr1.length - arr2.length)[0];
 
@@ -617,8 +621,10 @@ export default class PackageLinker {
       };
 
       for (const peerDepName in peerDeps) {
-        const range = peerDeps[peerDepName].replace(/^optional:/, '');
-        const isOptional = peerDeps[peerDepName].startsWith('optional:');
+        const range = peerDeps[peerDepName];
+        const meta = peerDepsMeta && peerDepsMeta[peerDepName];
+
+        const isOptional = meta && meta.optional ? true : false;
 
         const peerPkgs = this.resolver.getAllInfoForPackageName(peerDepName);
 

--- a/src/types.js
+++ b/src/types.js
@@ -24,7 +24,7 @@ export type PeerDependencyMeta = {
 };
 
 export type PeerDependenciesMeta = {
-  [name: string]: DependencyMeta,
+  [name: string]: PeerDependencyMeta,
 };
 
 // dependency request pattern data structure that's used to request dependencies from a

--- a/src/types.js
+++ b/src/types.js
@@ -13,6 +13,21 @@ export type CLIFunction = (config: Config, reporter: Reporter, flags: Object, ar
 type _CLIFunctionReturn = boolean;
 export type CLIFunctionReturn = ?_CLIFunctionReturn | Promise<?_CLIFunctionReturn>;
 
+export type DependencyMeta = {
+};
+
+export type DependenciesMeta = {
+  [name: string]: DependencyMeta,
+};
+
+export type PeerDependencyMeta = {
+  optional?: boolean,
+};
+
+export type PeerDependenciesMeta = {
+  [name: string]: DependencyMeta,
+};
+
 // dependency request pattern data structure that's used to request dependencies from a
 // PackageResolver
 export type DependencyRequestPattern = {
@@ -131,6 +146,9 @@ export type Manifest = {
   devDependencies?: Dependencies,
   peerDependencies?: Dependencies,
   optionalDependencies?: Dependencies,
+
+  dependenciesMeta?: DependenciesMeta,
+  peerDependenciesMeta?: PeerDependenciesMeta,
 
   bundleDependencies?: Array<string>,
   bundledDependencies?: Array<string>,

--- a/src/types.js
+++ b/src/types.js
@@ -13,8 +13,7 @@ export type CLIFunction = (config: Config, reporter: Reporter, flags: Object, ar
 type _CLIFunctionReturn = boolean;
 export type CLIFunctionReturn = ?_CLIFunctionReturn | Promise<?_CLIFunctionReturn>;
 
-export type DependencyMeta = {
-};
+export type DependencyMeta = {};
 
 export type DependenciesMeta = {
   [name: string]: DependencyMeta,


### PR DESCRIPTION
**Summary**

This PR implements https://github.com/yarnpkg/rfcs/pull/105 (Optional Peer Dependencies).

It uses a new `peerDependenciesMeta` field to specify which peer dependency warnings can be safely ignored.

**Test plan**

Added tests.