### PR TITLE
Implements "yarn self set"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Implements `yarn self set [range]`. Check [the documentation]() for usage & tips.
+
+  [#6673](https://github.com/yarnpkg/yarn/pull/6673) - [**Maël Nison**](https://twitter.com/arcanis)
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -32,10 +32,10 @@ import * as node from './node.js';
 import * as outdated from './outdated.js';
 import * as owner from './owner.js';
 import * as pack from './pack.js';
+import * as policies from './policies.js';
 import * as publish from './publish.js';
 import * as remove from './remove.js';
 import * as run from './run.js';
-import * as self from './self.js';
 import * as tag from './tag.js';
 import * as team from './team.js';
 import * as unplug from './unplug.js';
@@ -79,11 +79,11 @@ const commands = {
   outdated,
   owner,
   pack,
+  policies,
   prune: buildUseless("The prune command isn't necessary. `yarn install` will prune extraneous packages."),
   publish,
   remove,
   run,
-  self,
   tag,
   team,
   unplug,

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -35,6 +35,7 @@ import * as pack from './pack.js';
 import * as publish from './publish.js';
 import * as remove from './remove.js';
 import * as run from './run.js';
+import * as self from './self.js';
 import * as tag from './tag.js';
 import * as team from './team.js';
 import * as unplug from './unplug.js';
@@ -82,6 +83,7 @@ const commands = {
   publish,
   remove,
   run,
+  self,
   tag,
   team,
   unplug,

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -94,10 +94,12 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
   return false;
 }
 
-const {run, setFlags, examples} = buildSubCommands('self', {
-  async set(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+const {run, setFlags, examples} = buildSubCommands('policies', {
+  async setVersion(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
     let range = args[0] || 'latest';
     let allowRc = flags.rc;
+
+    reporter.log(`Resolving ${chalk.yellow(range)} to a url...`);
 
     if (range === 'rc') {
       range = 'latest';

--- a/src/cli/commands/self.js
+++ b/src/cli/commands/self.js
@@ -1,0 +1,135 @@
+/* @flow */
+
+import type {Reporter} from '../../reporters/index.js';
+import type Config from '../../config.js';
+import buildSubCommands from './_build-sub-commands.js';
+import {getRcConfigForCwd} from '../../rc.js';
+import * as fs from '../../util/fs.js';
+import {stringify} from '../../lockfile';
+
+const chalk = require('chalk');
+const invariant = require('invariant');
+const path = require('path');
+const semver = require('semver');
+
+type ReleaseAsset = {|
+  id: any,
+
+  name: string,
+  browser_download_url: string,
+|};
+
+type Release = {|
+  id: any,
+
+  draft: boolean,
+  prerelease: boolean,
+
+  tag_name: string,
+  version: {|
+    version: string,
+  |},
+
+  assets: Array<ReleaseAsset>,
+|};
+
+function getBundleAsset(release: Release): ?ReleaseAsset {
+  return release.assets.find(asset => {
+    return asset.name.match(/^yarn-[0-9]+\.[0-9]+\.[0-9]+\.js$/);
+  });
+}
+
+type FetchReleasesOptions = {|
+  includePrereleases: boolean,
+|};
+
+async function fetchReleases(
+  config: Config,
+  {includePrereleases = false}: FetchReleasesOptions = {},
+): Promise<Array<Release>> {
+  const request: Array<Release> = await config.requestManager.request({
+    url: `https://api.github.com/repos/yarnpkg/yarn/releases`,
+    json: true,
+  });
+
+  const releases = request.filter(release => {
+    if (release.draft) {
+      return false;
+    }
+
+    if (release.prerelease && !includePrereleases) {
+      return false;
+    }
+
+    // $FlowFixMe
+    release.version = semver.coerce(release.tag_name);
+
+    if (!release.version) {
+      return false;
+    }
+
+    if (!getBundleAsset(release)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  releases.sort((a, b) => {
+    // $FlowFixMe
+    return -semver.compare(a.version, b.version);
+  });
+
+  return releases;
+}
+
+async function fetchBundle(config: Config, asset: ReleaseAsset): Promise<string> {
+  const data: Buffer = await config.requestManager.request({
+    url: asset.browser_download_url,
+    buffer: true,
+  });
+
+  return data.toString();
+}
+
+export function hasWrapper(flags: Object, args: Array<string>): boolean {
+  return false;
+}
+
+const {run, setFlags, examples} = buildSubCommands('self', {
+  async set(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+    const releases = await fetchReleases(config);
+
+    const release = releases.find(release => {
+      // $FlowFixMe
+      return semver.satisfies(release.version, args[0]);
+    });
+
+    if (!release) {
+      throw new Error(`Release not found: ${args[0]}`);
+    }
+
+    const asset = getBundleAsset(release);
+    invariant(asset, 'The bundle asset should exist');
+
+    reporter.log(`Downloading ${chalk.green(asset.name)}...`);
+
+    const bundle = await fetchBundle(config, asset);
+    const rc = getRcConfigForCwd(config.lockfileFolder, []);
+
+    const yarnPath = path.resolve(config.lockfileFolder, `.yarn/releases/${release.version.version}.js`);
+    reporter.log(`Saving it into ${chalk.magenta(yarnPath)}...`);
+    await fs.mkdirp(path.dirname(yarnPath));
+    await fs.writeFile(yarnPath, bundle);
+    await fs.chmod(yarnPath, 0o755);
+
+    const rcPath = `${config.lockfileFolder}/.yarnrc`;
+    reporter.log(`Updating ${chalk.magenta(rcPath)}...`);
+    rc['yarn-path'] = path.relative(config.lockfileFolder, yarnPath);
+    await fs.writeFilePreservingEol(rcPath, `${stringify(rc)}\n`);
+
+    reporter.log(`Done!`);
+  },
+});
+
+export {run, setFlags, examples};

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -31,7 +31,8 @@ export const DEFAULTS = {
   'user-agent': [`yarn/${version}`, 'npm/?', `node/${process.version}`, process.platform, process.arch].join(' '),
 };
 
-const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder', 'offline-cache-folder'];
+const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder', 'offline-cache-folder', 'yarn-path'];
+const FOLDER_KEY = ['yarn-offline-mirror', 'cache-folder', 'offline-cache-folder'];
 
 const npmMap = {
   'version-git-sign': 'sign-git-tag',
@@ -96,7 +97,10 @@ export default class YarnRegistry extends NpmRegistry {
 
         if (!this.config[key] && valueLoc) {
           const resolvedLoc = (config[key] = path.resolve(path.dirname(loc), valueLoc));
-          await fs.mkdirp(resolvedLoc);
+
+          if (FOLDER_KEY.includes(key)) {
+            await fs.mkdirp(resolvedLoc);
+          }
         }
       }
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -28,7 +28,9 @@ export const lockQueue = new BlockingQueue('fs lock');
 
 export const readFileBuffer = promisify(fs.readFile);
 export const open: (path: string, flags: string, mode?: number) => Promise<Array<string>> = promisify(fs.open);
-export const writeFile: (path: string, data: string, options?: Object) => Promise<void> = promisify(fs.writeFile);
+export const writeFile: (path: string, data: string | Buffer, options?: Object) => Promise<void> = promisify(
+  fs.writeFile,
+);
 export const readlink: (path: string, opts: void) => Promise<string> = promisify(fs.readlink);
 export const realpath: (path: string, opts: void) => Promise<string> = promisify(fs.realpath);
 export const readdir: (path: string, opts: void) => Promise<Array<string>> = promisify(fs.readdir);


### PR DESCRIPTION
**Summary**

This feature implements a new command:

```
$> yarn self set [range]
# Examples:
$> yarn self set nightly
$> yarn self set rc
$> yarn self set ^1.12
$> yarn self set 1.12.3
```

When run, Yarn will download from Github the latest release matching the specified range, will put it inside the `<lockfileFolder>/.yarn/releases` directory, and will update `<lockfileFolder>/.yarnrc` to point to this new binary.

Essentially, this command allows:

- to upgrade Yarn in a single swoop
- to rely on npm much less (which always was a bit funny)
- to enforce a specific Yarn version for a single project

This last point is especially important: we've been recommending people to use the same Yarn release across a team, but they usually had to discover by themselves that the `yarn-path` settings existed (despite it being one of the selling points in term of build reproducibility). Once they did they loved it, but it wasn't an easy find.

**Test plan**

I'm not too sure how to test this automatically, but I've tested it manually and it works just fine.