### PR TITLE
Increase Windows timeouts and better name Test results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,14 +3,15 @@ jobs:
 - job: Windows
   pool: 'Hosted VS2017'
 
+  variables:
+    os_name: Windows
+
   strategy:
     matrix:
       node_8_x:
         node_version: 8.x
-        os_name: Windows
       node_10_x:
         node_version: 10.x
-        os_name: Windows
 
   steps:
   - template: scripts/azure-run-tests.yml
@@ -19,14 +20,15 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
 
+  variables:
+    os_name: Linux
+
   strategy:
     matrix:
       node_8_x:
         node_version: 8.x
-        os_name: Linux
       node_10_x:
         node_version: 10.x
-        os_name: Linux
 
   steps:
   - template: scripts/azure-run-tests.yml
@@ -35,14 +37,15 @@ jobs:
   pool:
     vmImage: 'macOS 10.13'
 
+  variables:
+    os_name: OSX
+
   strategy:
     matrix:
       node_8_x:
         node_version: 8.x
-        os_name: OSX
       node_10_x:
         node_version: 10.x
-        os_name: OSX
 
   steps:
   - template: scripts/azure-run-tests.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ jobs:
 
   steps:
   - template: scripts/azure-run-tests.yml
+    parameters:
+        name: Windows
 
 - job: Linux
   pool:
@@ -26,6 +28,8 @@ jobs:
 
   steps:
   - template: scripts/azure-run-tests.yml
+    parameters:
+        name: Linux
 
 - job: OSX
   pool:
@@ -40,3 +44,5 @@ jobs:
 
   steps:
   - template: scripts/azure-run-tests.yml
+    parameters:
+        name: OSX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,13 +7,13 @@ jobs:
     matrix:
       node_8_x:
         node_version: 8.x
+        os_name: Windows
       node_10_x:
         node_version: 10.x
+        os_name: Windows
 
   steps:
   - template: scripts/azure-run-tests.yml
-    parameters:
-        name: Windows
 
 - job: Linux
   pool:
@@ -23,13 +23,13 @@ jobs:
     matrix:
       node_8_x:
         node_version: 8.x
+        os_name: Linux
       node_10_x:
         node_version: 10.x
+        os_name: Linux
 
   steps:
   - template: scripts/azure-run-tests.yml
-    parameters:
-        name: Linux
 
 - job: OSX
   pool:
@@ -39,10 +39,10 @@ jobs:
     matrix:
       node_8_x:
         node_version: 8.x
+        os_name: OSX
       node_10_x:
         node_version: 10.x
+        os_name: OSX
 
   steps:
   - template: scripts/azure-run-tests.yml
-    parameters:
-        name: OSX

--- a/packages/pkg-tests/yarn.test.js
+++ b/packages/pkg-tests/yarn.test.js
@@ -66,6 +66,10 @@ const pkgDriver = generatePkgDriver({
   },
 });
 
+if (process.platform === `win32`) {
+  jest.setTimeout(10000);
+}
+
 beforeEach(async () => {
   await startPackageServer();
   await getPackageRegistry();

--- a/scripts/azure-run-tests.yml
+++ b/scripts/azure-run-tests.yml
@@ -1,6 +1,3 @@
-parameters:
-  name: ''
-
 steps:
 
 - task: NodeTool@0
@@ -28,6 +25,6 @@ steps:
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '**/junit.xml'
-    testRunTitle: ${{ parameters.name }} Node $(node_version)
+    testRunTitle: $(os_name) Node $(node_version)
   displayName: 'Publishing the test results'
   condition: always()

--- a/scripts/azure-run-tests.yml
+++ b/scripts/azure-run-tests.yml
@@ -25,5 +25,6 @@ steps:
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '**/junit.xml'
+    testRunTitle: $(vmImage) Node $(node_version)
   displayName: 'Publishing the test results'
   condition: always()

--- a/scripts/azure-run-tests.yml
+++ b/scripts/azure-run-tests.yml
@@ -1,3 +1,6 @@
+parameters:
+  name: ''
+
 steps:
 
 - task: NodeTool@0
@@ -25,6 +28,6 @@ steps:
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '**/junit.xml'
-    testRunTitle: $(vmImage) Node $(node_version)
+    testRunTitle: ${{ parameters.name }} Node $(node_version)
   displayName: 'Publishing the test results'
   condition: always()

--- a/scripts/azure-run-tests.yml
+++ b/scripts/azure-run-tests.yml
@@ -22,7 +22,7 @@ steps:
 
 - script: |
     cd packages/pkg-tests
-    yarn jest yarn --detectOpenHandles --reporters=default --reporters=jest-junit
+    yarn jest yarn --reporters=default --reporters=jest-junit
   displayName: 'Run the acceptance tests'
 
 - task: PublishTestResults@2


### PR DESCRIPTION
Some tests in Windows may randomly take up to 5s, increasing to 10s.
Better name test results with its source job.

@arcanis Can you integrate this in your PR?
Let me know if you see any other blocker.
We're also looking into fastening up these tests,