### PR TITLE
Fixes the resolution when a package has an invalid "main" but a valid…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes a resolution issue when a package had an invalid `main` entry
+
+  [#6682](https://github.com/yarnpkg/yarn/pull/6682) - [**Maël Nison**](https://twitter.com/arcanis)
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/invalid-main-1.0.0/index.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/invalid-main-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/invalid-main-1.0.0/package.json
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/invalid-main-1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "invalid-main",
+    "version": "1.0.0",
+    "main": "DoesntExists"
+}

--- a/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
@@ -592,6 +592,26 @@ module.exports = makeTemporaryEnv => {
     );
 
     test(
+      `it should ignore the "main" entry if it doesn't resolve`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`invalid-main`]: `1.0.0`,
+          },
+        },
+        {plugNPlay: true},
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require("invalid-main")`)).resolves.toMatchObject({
+            name: `invalid-main`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+
+    test(
       `it should use the regular Node resolution when requiring files outside of the pnp install tree`,
       makeTemporaryEnv({}, {plugNPlay: true}, async ({path, run, source}) => {
         await run(`install`);

--- a/src/util/generate-pnp-map-api.tpl.js
+++ b/src/util/generate-pnp-map-api.tpl.js
@@ -176,8 +176,11 @@ function applyNodeExtensionResolution(unqualifiedPath, {extensions}) {
       // If the "main" field changed the path, we start again from this new location
 
       if (nextUnqualifiedPath && nextUnqualifiedPath !== unqualifiedPath) {
-        unqualifiedPath = nextUnqualifiedPath;
-        continue;
+        const resolution = applyNodeExtensionResolution(nextUnqualifiedPath, {extensions});
+
+        if (resolution !== null) {
+          return resolution;
+        }
       }
     }
 


### PR DESCRIPTION
**Summary**

`relay-compiler` is a package with an invalid `main` entry, but a valid `index.js` file. Node manages to resolve it properly, but PnP trips over it because it fails as soon as the `main` entry is detected as invalid.

This diff fixes that by ensuring that we try both options when the `main` resolution fails.

**Test plan**

Added a test.