### PR TITLE
Check for existence of `.bin` dir in pnp dependencies before adding to `PATH`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Fixes a resolution issue when a package had an invalid `main` entry
 
   [#6682](https://github.com/yarnpkg/yarn/pull/6682) - [**Maël Nison**](https://twitter.com/arcanis)
-  
-- Fixes corruption of `PATH` when executing lifecycle scripts on Winows in 'pnp' mode
-  
+
+- Decreases the size of the generated `$PATH` environment variable for a better Windows support
+
   [#6683](https://github.com/yarnpkg/yarn/issues/6683) - [**Rowan Lonsdale**](https://github.com/hWorblehat)
 
 ## 1.12.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Fixes a resolution issue when a package had an invalid `main` entry
 
   [#6682](https://github.com/yarnpkg/yarn/pull/6682) - [**Maël Nison**](https://twitter.com/arcanis)
+  
+- Fixes corruption of `PATH` when executing lifecycle scripts on Winows in 'pnp' mode
+  
+  [#6683](https://github.com/yarnpkg/yarn/issues/6683) - [**Rowan Lonsdale**](https://github.com/hWorblehat)
 
 ## 1.12.3
 

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -217,7 +217,10 @@ export async function makeEnv(
         continue;
       }
 
-      pathParts.unshift(`${dependencyInformation.packageLocation}/.bin`);
+      const binFolder = `${dependencyInformation.packageLocation}/.bin`;
+      if (await fs.exists(binFolder)) {
+        pathParts.unshift(binFolder);
+      }
     }
 
     // Note that NODE_OPTIONS doesn't support any style of quoting its arguments at the moment


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Avoids #6683 in many situations by siginificantly reducing the length that the `PATH` is increased by.
This issue could still raise its head in some situations, if the user already has a `PATH` whose length is close to the Windows character limit.

**Test plan**

  - Ran `yarn build && yarn test` - all succeeded
  - Tested newly-built yarn against my own repository that was previously exhibiting #6683. Lifecycle scripts now work.
