### PR TITLE
Fixes dependencies using bins from their own dependencies

### DIFF
--- a/packages/pkg-tests/pkg-tests-fixtures/packages/one-dep-scripted-1.0.0/index.js
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/one-dep-scripted-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/pkg-tests/pkg-tests-fixtures/packages/one-dep-scripted-1.0.0/package.json
+++ b/packages/pkg-tests/pkg-tests-fixtures/packages/one-dep-scripted-1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "one-dep-scripted",
+    "version": "1.0.0",
+    "dependencies": {
+        "has-bin-entries": "1.0.0"
+    },
+    "scripts": {
+        "install": "has-bin-entries"
+    }
+}

--- a/packages/pkg-tests/pkg-tests-specs/sources/script.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/script.js
@@ -203,5 +203,17 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
         ]);
       }),
     );
+
+    test(
+      `it should allow dependencies with install scripts to run the binaries exposed by their own dependencies`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`one-dep-scripted`]: `1.0.0`},
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+        },
+      ),
+    );
   });
 };

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -203,11 +203,21 @@ export async function makeEnv(
     }
   }
 
-  const pnpFile = `${config.lockfileFolder}/${constants.PNP_FILENAME}`;
-  if (await fs.exists(pnpFile)) {
+  let pnpFile;
+
+  if (process.versions.pnp) {
+    pnpFile = dynamicRequire.resolve('pnpapi');
+  } else {
+    const candidate = `${config.lockfileFolder}/${constants.PNP_FILENAME}`;
+    if (await fs.exists(candidate)) {
+      pnpFile = candidate;
+    }
+  }
+
+  if (pnpFile) {
     const pnpApi = dynamicRequire(pnpFile);
 
-    const packageLocator = pnpApi.findPackageLocator(`${config.cwd}/`);
+    const packageLocator = pnpApi.findPackageLocator(`${cwd}/`);
     const packageInformation = pnpApi.getPackageInformation(packageLocator);
 
     for (const [name, reference] of packageInformation.packageDependencies.entries()) {


### PR DESCRIPTION
**Summary**

Fixes https://github.com/yarnpkg/yarn/issues/6709

This diff ensures that scripts have access to the binaries exposed from their dependencies, even when they don't belong to the top-level package.

**Test plan**

Added a test.
