### PR TITLE
feat(audit): add filtering by severity level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Implements `yarn audit --level [severity]` flag to filter the audit command's output.
+
+[#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
+
 - Implements `yarn audit --groups group_name [group_name ...]`.
 
   [#6724](https://github.com/yarnpkg/yarn/pull/6724) - [**Tom Milligan**](https://github.com/tommilligan)

--- a/__tests__/commands/audit.js
+++ b/__tests__/commands/audit.js
@@ -214,6 +214,20 @@ test('audit groups only devDependencies omits dependencies from requires', () =>
   });
 });
 
+test('calls reporter auditAdvisory when using --level high flag', () => {
+  return runAudit([], {level: 'high'}, 'single-vulnerable-dep-installed', (config, reporter) => {
+    const apiResponse = getAuditResponse(config);
+    expect(reporter.auditAdvisory).toBeCalledWith(apiResponse.actions[0].resolves[0], apiResponse.advisories['118']);
+  });
+});
+
+test(`doesn't call reporter auditAdvisory when using --level critical flag`, () => {
+  return runAudit([], {level: 'critical'}, 'single-vulnerable-dep-installed', (config, reporter) => {
+    getAuditResponse(config);
+    expect(reporter.auditAdvisory).not.toHaveBeenCalled();
+  });
+});
+
 test('calls reporter auditAdvisory with correct data', () => {
   return runAudit([], {}, 'single-vulnerable-dep-installed', (config, reporter) => {
     const apiResponse = getAuditResponse(config);


### PR DESCRIPTION
**Summary**

This pull request implements the feature requested in #6668.

It basically adds a `--level` flag to the audit command allowing to filter the audit output by severity greater than or equal to the provided value which can be (info, low, moderate, high or critical).

**Test plan**

Example:

```sh
yarn audit --level high
```
This outputs all advisories ranked `high` and `critical`.

By default without this new flag, the audit command will behave as it always did.
