### PR TITLE
Fixes how signals are forwarded

### DIFF
--- a/src/util/portable-script.js
+++ b/src/util/portable-script.js
@@ -45,7 +45,7 @@ async function makePortableProxyScriptUnix(
   } else {
     await fs.writeFile(
       filePath,
-      `#!/bin/sh\n\n${environment}"${sourcePath}"${prependedArguments} "$@"${appendedArguments}\n`,
+      `#!/bin/sh\n\n${environment}exec "${sourcePath}"${prependedArguments} "$@"${appendedArguments}\n`,
     );
     await fs.chmod(filePath, 0o755);
   }


### PR DESCRIPTION
**Summary**

Since the portable script doesn't use `exec`, signals seem to be trapped.

This diff ensures that we correctly replace the process rather than simply spawning a new one.

**Test plan**

CI