### PR TITLE
Use hammer emoji for install/reinstall stage

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -682,7 +682,7 @@ export class Install {
           curr,
           total,
           this.flags.force ? this.reporter.lang('rebuildingPackages') : this.reporter.lang('buildingFreshPackages'),
-          emoji.get('page_with_curl'),
+          emoji.get('hammer'),
         );
 
         if (this.flags.ignoreScripts) {

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -87,7 +87,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   // reinstall so we can get the updated lockfile
-  reporter.step(++step, totalSteps, reporter.lang('uninstallRegenerate'), emoji.get('page_with_curl'));
+  reporter.step(++step, totalSteps, reporter.lang('uninstallRegenerate'), emoji.get('hammer'));
   const installFlags = {force: true, workspaceRootIsCwd: true, ...flags};
   const reinstall = new Install(installFlags, config, new NoopReporter(), lockfile);
   await reinstall.init();


### PR DESCRIPTION
Switch from page_with_curl (📃) to hammer (🔨) emoji for this stage.

**Summary**
The hammer symbol is commonly used to indicate building or construction, or work in general:
https://en.wikipedia.org/wiki/Hammer#Symbolic_hammers

Using this as the glyph during the build or rebuild stages communicates more clearly to the user compared to the `page_with_curl` symbol, which would be more associated with composing / writing / authoring (eg during a hypothetical codegen stage of a process).

**Test plan**
Before this change, on my ubuntu:cosmic computer:
![image](https://user-images.githubusercontent.com/2538614/49314556-d173ff00-f4b8-11e8-93fc-485b717e2e1e.png)

After this change:
![image](https://user-images.githubusercontent.com/2538614/49314531-c1f4b600-f4b8-11e8-8f3b-f0511513ddbd.png)

