### PR TITLE
Check for Chocolatey version using "choco list" instead of OneGet

### DIFF
--- a/scripts/build-chocolatey.ps1
+++ b/scripts/build-chocolatey.ps1
@@ -25,14 +25,12 @@ if ($Env:YARN_VERSION) {
   $latest_version = [String](Invoke-WebRequest -Uri https://yarnpkg.com/latest-version -UseBasicParsing)
 }
 
-$latest_chocolatey_version = (Find-Package -Name Yarn).Version
-
-if ([Version]$latest_chocolatey_version -ge [Version]$latest_version) {
-  Write-Output ('Current version ({0}) is the latest' -f $latest_chocolatey_version)
+Write-Output "Checking if $latest_version is already on Chocolatey..."
+$choco_output = choco list yarn --exact --version $latest_version | Out-String
+if ($choco_output -notmatch '0 packages found') {
+  Write-Output 'Already on Chocolatey. Nothing to do!'
   Exit
 }
-
-Write-Output ('Latest version is {0}, version on Chocolatey is {1}. Updating...' -f $latest_version, $latest_chocolatey_version)
 
 if (-Not (Test-Path artifacts)) {
   mkdir artifacts


### PR DESCRIPTION
**Summary**
Updates `build-chocolatey.ps1` to search for an existing Yarn package using the `choco list` command, rather than using OneGet. For some reason I can't get OneGet to work properly on Windows Server 2016

The script now runs:
```
choco list yarn --exact --version $latest_version 
```

and checks if the output contains "0 packages found". This is a bit messy, but the `choco` command doesn't have an API that returns XML or JSON (ref https://github.com/chocolatey/choco/issues/159, https://github.com/chocolatey/choco/issues/1252), and I didn't want to hit their web API directly, so this will do for now.

Fixes #6189

**Test plan**
Manually executed the script