### PR TITLE
chore(pacakge): Update @zkochan/cmd-shim to version 3.1.0

### DIFF
--- a/__tests__/commands/install/bin-links.js
+++ b/__tests__/commands/install/bin-links.js
@@ -51,9 +51,9 @@ afterEach(request.__resetAuthedRequests);
 test('install should hoist nested bin scripts', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-nested-bin', async config => {
     const binScripts = await fs.walk(path.join(config.cwd, 'node_modules', '.bin'));
-    // need to double the amount as windows makes 2 entries for each dependency
-    // so for below, there would be an entry for eslint and eslint.cmd on win32
-    const amount = process.platform === 'win32' ? 20 : 10;
+    // need to triple the amount as windows makes 3 entries for each dependency
+    // so for below, there would be an entry for eslint, eslint.cmd and eslint.ps1 on win32
+    const amount = process.platform === 'win32' ? 30 : 10;
     expect(binScripts).toHaveLength(amount);
 
     expect(await linkAt(config, 'node_modules', '.bin', 'standard')).toEqual('../standard/bin/cmd.js');
@@ -178,7 +178,7 @@ test('can use link protocol to install a package that would not be found via nod
 test('empty bin string does not create a link', (): Promise<void> => {
   return runInstall({binLinks: true}, 'install-empty-bin', async config => {
     const binScripts = await fs.walk(path.join(config.cwd, 'node_modules', '.bin'));
-    const linkCount = process.platform === 'win32' ? 2 : 1;
+    const linkCount = process.platform === 'win32' ? 3 : 1;
     expect(binScripts).toHaveLength(linkCount);
 
     expect(await linkAt(config, 'node_modules', '.bin', 'depB')).toEqual('../depB/depb.js');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",
   "dependencies": {
-    "@zkochan/cmd-shim": "^2.2.4",
+    "@zkochan/cmd-shim": "^3.1.0",
     "babel-runtime": "^6.26.0",
     "bytes": "^3.0.0",
     "camelcase": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,10 +37,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@zkochan/cmd-shim@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-2.2.4.tgz#5730a936491219d88487e92d12c6c3bdb16c3c6e"
-  integrity sha512-BDy1oz6aFYyY73618IkXzJzFghnXwVZDc3SVa6MVKTrrk4RgubahAF5yKK+Mx4a78tfO0OHeZnJKPs0pNy5uNA==
+"@zkochan/cmd-shim@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
+  integrity sha512-o8l0+x7C7sMZU3v9GuJIAU10qQLtwR1dtRQIOmlNMtyaqhmpXOzx1HWiYoWfmmf9HHZoAkXpc9TM9PQYF9d4Jg==
   dependencies:
     is-windows "^1.0.0"
     mkdirp-promise "^5.0.1"


### PR DESCRIPTION
This updates [@zkochan/cmd-shim](https://github.com/pnpm/cmd-shim) to version 3, which adds support for PowerShell.

## See also:
- https://github.com/pnpm/pnpm/issues/1199
- https://github.com/yarnpkg/yarn/pull/6462
- https://github.com/yarnpkg/yarn/pull/6073