### PR TITLE
Implements the pnp hook for the `resolve` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6712](https://github.com/yarnpkg/yarn/pull/6712) - [**Maël Nison**](https://twitter.com/arcanis)
 
+- Adds transparent support for the [`resolve`](https://github.com/browserify/resolve) package when using Plug'n'Play
+
+  [#6816](https://github.com/yarnpkg/yarn/pull/6816) - [**Maël Nison**](https://twitter.com/arcanis)
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
@@ -1432,5 +1432,28 @@ module.exports = makeTemporaryEnv => {
         });
       }),
     );
+
+    test(
+      `it should transparently support the "resolve" package`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`resolve`]: `https://github.com/browserify/resolve.git`,
+          },
+          resolutions: {
+            [`path-parse`]: `https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz`,
+          },
+        },
+        {plugNPlay: true},
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('resolve').sync('resolve')`)).resolves.toEqual(
+            await source(`require.resolve('resolve')`),
+          );
+        },
+      ),
+      15000,
+    );
   });
 };


### PR DESCRIPTION
**Summary**

This PR adds builtin `resolve` support using the mechanisms described in https://github.com/browserify/resolve/pull/174. I've also added an escape hatch (`forceNodeResolution`) in case something goes awry.

cc @ljharb

**Test plan**

Added an automated test.
