### PR TITLE
Properly reports network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6712](https://github.com/yarnpkg/yarn/pull/6712) - [**Maël Nison**](https://twitter.com/arcanis)
 
+- Properly reports the error codes when the npm registry throws 500's
+
+  [#6817](https://github.com/yarnpkg/yarn/pull/6817) - [**Maël Nison**](https://twitter.com/arcanis)
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -499,6 +499,16 @@ export default class RequestManager {
     }
 
     if (params.process) {
+      req.on('response', res => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          return;
+        }
+
+        const description = `${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`;
+        reject(new ResponseError(this.reporter.lang('requestFailed', description), res.statusCode));
+
+        req.abort();
+      });
       params.process(req, resolve, reject);
     }
   }

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -498,7 +498,8 @@ export default class RequestManager {
       req.on('data', queue.stillActive.bind(queue));
     }
 
-    if (params.process) {
+    const process = params.process;
+    if (process) {
       req.on('response', res => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           return;
@@ -509,7 +510,7 @@ export default class RequestManager {
 
         req.abort();
       });
-      params.process(req, resolve, reject);
+      process(req, resolve, reject);
     }
   }
 


### PR DESCRIPTION
**Summary**

This diff makes sure that we properly report the status codes coming from the npm registry when downloading the tarballs.

**Test plan**

Changed a tarball url from a lockfile to something invalid, ran `yarn cache clean`, ran yarn and saw the proper error message.