### PR TITLE
Return semantic exit code for audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6712](https://github.com/yarnpkg/yarn/pull/6712) - [**Maël Nison**](https://twitter.com/arcanis)
 
+- Fixes yarn audit exit code overflow
+
+  [#6748](https://github.com/yarnpkg/yarn/issues/6748) - [**Andrey Vetlugin**](https://github.com/antrew)
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/src/cli/commands/audit.js
+++ b/src/cli/commands/audit.js
@@ -131,12 +131,19 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   });
 
   const vulnerabilities = await audit.performAudit(manifest, install.resolver, install.linker, patterns);
-  const totalVulnerabilities =
-    vulnerabilities.info +
-    vulnerabilities.low +
-    vulnerabilities.moderate +
-    vulnerabilities.high +
-    vulnerabilities.critical;
+
+  const EXIT_INFO = 1;
+  const EXIT_LOW = 2;
+  const EXIT_MODERATE = 4;
+  const EXIT_HIGH = 8;
+  const EXIT_CRITICAL = 16;
+
+  const exitCode =
+    (vulnerabilities.info ? EXIT_INFO : 0) +
+    (vulnerabilities.low ? EXIT_LOW : 0) +
+    (vulnerabilities.moderate ? EXIT_MODERATE : 0) +
+    (vulnerabilities.high ? EXIT_HIGH : 0) +
+    (vulnerabilities.critical ? EXIT_CRITICAL : 0);
 
   if (flags.summary) {
     audit.summary();
@@ -144,7 +151,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     audit.report();
   }
 
-  return totalVulnerabilities;
+  return exitCode;
 }
 
 export default class Audit {


### PR DESCRIPTION
**Summary**

Resolve https://github.com/yarnpkg/yarn/issues/6748

`yarn audit` currently returns the number of found vulnerabilities. This can lead to an overflow and a false negative. E.g., if the number of vulnerable dependencies is equal to 256, the exit code will be equal 0. Furthermore, it is not very practical, as this number does not indicate the severity level of found vulnerabilities.

This pull request modifies this behavior by returning a number that is a sum of found severities:
* 1 for INFO
* 2 for LOW
* 4 for MODERATE
* 8 for HIGH
* 16 for CRITICAL

That is, if only INFO and MODERATE vulnerabilities were found, then the exit code will be `1+4 = 5`.

With this change it would be possible to check for particular severity levels. E.g., if someone wants to know, if there are HIGH and CRITICAL dependencies, then one could check for exit code >= 8.

**Test plan**

Current behavior:
```
$ yarn audit
9 vulnerabilities found - Packages audited: 31177
Severity: 9 Low
Done in 1.94s.
$ echo $? 
9
```

New behavior:
```
$ yarn-local audit
...
9 vulnerabilities found - Packages audited: 31177
Severity: 9 Low
Done in 1.69s.
$ echo $?
2
```