### PR TITLE
Stops unplugging packages when the install scripts are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6712](https://github.com/yarnpkg/yarn/pull/6712) - [**Maël Nison**](https://twitter.com/arcanis)
 
+- Stops automatically unplugging packages with postinstall script when running under `--ignore-scripts`
+
+  [#6820](https://github.com/yarnpkg/yarn/pull/6820) - [**Maël Nison**](https://twitter.com/arcanis)
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -698,7 +698,11 @@ export default class PackageLinker {
     }
 
     // If the package has a postinstall script, we also unplug it (otherwise they would run into the cache)
-    if (pkg.scripts && (pkg.scripts.preinstall || pkg.scripts.install || pkg.scripts.postinstall)) {
+    if (
+      !this.config.ignoreScripts &&
+      pkg.scripts &&
+      (pkg.scripts.preinstall || pkg.scripts.install || pkg.scripts.postinstall)
+    ) {
       return true;
     }
 


### PR DESCRIPTION
**Summary**

We currently unplug packages by default when they have postinstall scripts, since we can't run them from within the cache. This approach is fine, but we're a bit overzealous and we also do this when the user explicitly disabled the scripts.

This diff ensures that we don't automatically unplug packages anymore when the install scripts are disabled. Of note: packages that have already been unplugged won't be affected by this change (so for example, if you do `yarn install && yarn install --ignore-scripts`, the packages will *still* be unplugged).

**Test plan**

Should be simple enough not to be worth a test?