### PR TITLE
Don't try to run scripts that aren't defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
 ## Master
+- Stop `yarn workspaces run` error if command not defined in workspace
 
 ## 1.13.0
 

--- a/__tests__/commands/workspaces.js
+++ b/__tests__/commands/workspaces.js
@@ -48,7 +48,7 @@ test('workspaces info should list the workspaces', (): Promise<void> => {
   });
 });
 
-test('workspaces run should spawn command for each workspace', (): Promise<void> => {
+test('workspaces run should spawn command for each workspace with that script defined', (): Promise<void> => {
   const originalArgs = ['run', 'script', 'arg1', '--flag1'];
   return runWorkspaces({originalArgs}, ['run', 'script', 'arg1', '--flag1'], 'run-basic', config => {
     expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'script', 'arg1', '--flag1'], {
@@ -58,6 +58,16 @@ test('workspaces run should spawn command for each workspace', (): Promise<void>
     expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'script', 'arg1', '--flag1'], {
       stdio: 'inherit',
       cwd: path.join(fixturesLoc, 'run-basic', 'packages', 'workspace-child-2'),
+    });
+  });
+});
+
+test('workspaces run should not report error if command is not defined for a workspace', (): Promise<void> => {
+  const originalArgs = ['run', 'workspace-1-only-script', 'arg1', '--flag1'];
+  return runWorkspaces({originalArgs}, ['run', 'workspace-1-only-script', 'arg1', '--flag1'], 'run-basic', config => {
+    expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'workspace-1-only-script', 'arg1', '--flag1'], {
+      stdio: 'inherit',
+      cwd: path.join(fixturesLoc, 'run-basic', 'packages', 'workspace-child-1'),
     });
   });
 });

--- a/__tests__/fixtures/workspace/run-basic/packages/workspace-child-1/package.json
+++ b/__tests__/fixtures/workspace/run-basic/packages/workspace-child-1/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "prescript": "echo workspace-1 prescript",
     "script": "echo workspace-1 script",
-    "postscript": "echo workspace-1 postscript"
+    "postscript": "echo workspace-1 postscript",
+    "workspace-1-only-script": "echo workspace-1-only script"
   }
 }

--- a/packages/pkg-tests/pkg-tests-core/package.json
+++ b/packages/pkg-tests/pkg-tests-core/package.json
@@ -10,5 +10,8 @@
         "super-resolve": "^1.0.0",
         "tar-fs": "^1.16.0",
         "tmp": "^0.0.33"
+    },
+    "scripts": {
+        "script": "echo pkg-tests-core script"
     }
 }

--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -77,8 +77,26 @@ export async function runScript(config: Config, reporter: Reporter, flags: Objec
   try {
     const [_, ...rest] = flags.originalArgs || [];
 
+    // first arg not prefixed by `-` is the script that will be run
+    let scriptName = '';
+    for (const arg of rest) {
+      if (arg.startsWith('-')) {
+        continue;
+      }
+      scriptName = arg;
+      break;
+    }
+
     for (const workspaceName of Object.keys(workspaces)) {
-      const {loc} = workspaces[workspaceName];
+      const {loc, manifest} = workspaces[workspaceName];
+
+      if (!manifest.scripts) {
+        reporter.info(`${workspaceName}: no scripts defined.`);
+        continue;
+      } else if (!manifest.scripts[scriptName]) {
+        reporter.info(`${workspaceName}: ${scriptName} not defined.`);
+        continue;
+      }
 
       await child.spawn(NODE_BIN_PATH, [YARN_BIN_PATH, ...rest], {
         stdio: 'inherit',


### PR DESCRIPTION
Right now, running `yarn workspaces run script` will error if `script` is not defined in all workspaces.  This is because `yarn workspaces run` blindly spawns a child process without determining if the script exists.  This pull request checks that the script exists in the workspace before attempting to spawn a new child process to run the script.

I have added unit tests, and tested it within yarn/packages/pkg-tests:

![image](https://user-images.githubusercontent.com/1267171/50187177-40d85400-02eb-11e9-9c0d-a0324f3e0cff.png)
