### PR TITLE
Show problem path in invariant message

### DIFF
--- a/src/cli/commands/cache.js
+++ b/src/cli/commands/cache.js
@@ -31,7 +31,7 @@ export async function getCachedPackagesDirs(config: Config, currentPath: string)
     const candidates = await fs.readdir(packageParentPath);
     invariant(
       candidates.length === 1,
-      `There should only be one folder in a package cache (got ${candidates.join(',')})`,
+      `There should only be one folder in a package cache (got ${candidates.join(',')} in ${packageParentPath})`,
     );
 
     for (const candidate of candidates) {
@@ -40,7 +40,7 @@ export async function getCachedPackagesDirs(config: Config, currentPath: string)
         const subCandidates = await fs.readdir(candidatePath);
         invariant(
           subCandidates.length === 1,
-          `There should only be one folder in a package cache (got ${subCandidates.join(',')})`,
+          `There should only be one folder in a package cache (got ${subCandidates.join(',')} in ${candidatePath})`,
         );
 
         for (const subCandidate of subCandidates) {


### PR DESCRIPTION
**Summary**

Sometimes, `yarn add` will fail unexpectedly, and it leaves the cache in an invalid state. To cause your yarn cache to become corrupted:

```
$ yarn add antd@3.11.6
yarn add v1.12.3
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "Unexpected end of data"
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.

$ yarn cache list
yarn cache v1.12.3
error An unexpected error occurred: "There should only be one folder in a package cache (got  )".
info If you think this is a bug, please open a bug report with the information provided in "/Users/rpatterson/Projects/chess2/www2/client/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/cache for documentation about this command.
```

Note that the error message provides no information about how to resolve the error. This commit adds the problem path to the invariant message. Deleting this problem path will allow `yarn cache list` to work properly again.

The root cause of this issue is #6805 which has been closed. This commit does not resolve the issue, so that issue should likely be reopened.

**Test plan**

Simply running `yarn cache list` while the cache is in an invalid state as described above produces a more useful error message.