### PR TITLE
Failing test for unplugged deps with bin scripts.

### DIFF
--- a/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/pnp.js
@@ -1340,6 +1340,28 @@ module.exports = makeTemporaryEnv => {
     );
 
     test(
+      `it should allow to execute an unplugged dependencies binaries`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`has-bin-entries`]: `1.0.0`,
+          },
+        },
+        {plugNPlay: true},
+        async ({path, run, source}) => {
+          await run(`install`);
+          await run(`unplug`, `has-bin-entries`);
+
+          await expect(
+            run(`run`, `has-bin-entries`, `success`),
+          ).resolves.toMatchObject({
+            stdout: `success\n`,
+          });
+        },
+      ),
+    );
+
+    test(
       `it should not cache the postinstall artifacts`,
       makeTemporaryEnv(
         {


### PR DESCRIPTION
**Summary**

An error occurs when using a bin script from an unplugged dependency inside a PnP project. When the dependency is _not_ unplugged (aka it is normally installed) there are no errors.

A similar test to this exists here:

https://github.com/yarnpkg/yarn/blob/d7811e41fa3ffec33535b3c00994ed85827cd5d8/packages/pkg-tests/pkg-tests-specs/sources/script.js#L46-L62

That test is ran and passes properly inside the `pnp` specific `pkg-tests` configured / ran here:

https://github.com/yarnpkg/yarn/blob/d7811e41fa3ffec33535b3c00994ed85827cd5d8/packages/pkg-tests/pkg-tests-specs/sources/pnp.js#L32-L36

**Test plan**

The test added here demonstrates an existing failure condition.