### PR TITLE
Fixes PnP detection across workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Improves PnP compatibility with Node 6
 
   [#6871](https://github.com/yarnpkg/yarn/pull/6871) - [**Robert Jackson**](https://github.com/rwjblue)
+  
+- Fixes PnP detection with workspaces (`installConfig` is now read at the top-level)
+
+  [#6878](https://github.com/yarnpkg/yarn/pull/6878) - [**Maël Nison**](https://twitter.com/arcanis)
 
 ## 1.13.0
 

--- a/src/config.js
+++ b/src/config.js
@@ -383,7 +383,7 @@ export default class Config {
       this._cacheRootFolder = String(cacheRootFolder);
     }
 
-    const manifest = await this.maybeReadManifest(this.cwd);
+    const manifest = await this.maybeReadManifest(this.lockfileFolder);
 
     const plugnplayByEnv = this.getOption('plugnplay-override');
     if (plugnplayByEnv != null) {


### PR DESCRIPTION
**Summary**

The detection was bogus for workspaces - it was checking the configuration of the workspace instead of the configuration of the root project folder. The reason why it should have checked this file is that the PnP configuration should be project-wide, not workspace-wide. Doing otherwise causes the installs to change depending on the folder where you run `yarn install`.

Fixing this bug has a slight risk of breaking someone's setup, unfortunately 😞 

**Test plan**

Will add a test.