### PR TITLE
Add a flag for pre-release for upgrade-interactive

### DIFF
--- a/__tests__/package-compatibility.js
+++ b/__tests__/package-compatibility.js
@@ -3,19 +3,19 @@
 import {testEngine} from '../src/package-compatibility.js';
 
 test('node semver semantics', () => {
-  expect(testEngine('node', '^5.0.0', {node: '5.1.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^5.0.0', {node: '5.01.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^5.0.0', {node: '5.01.0'}, false)).toEqual(false);
-  expect(testEngine('node', '^0.13.0', {node: '5.0.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^0.12.0', {node: '5.0.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^0.11.0', {node: '5.0.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^0.10.0', {node: '5.0.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^0.9.0', {node: '5.0.0'}, true)).toEqual(false);
-  expect(testEngine('node', '^0.12.0', {node: '0.12.0'}, true)).toEqual(true);
-  expect(testEngine('node', '^0.12.0', {node: '0.11.0'}, true)).toEqual(false);
-  expect(testEngine('node', '^1.3.0', {node: '1.4.1-20180208.2355'}, true)).toEqual(false);
+  expect(testEngine('node', '^5.0.0', {node: '5.1.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^5.0.0', {node: '5.01.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^5.0.0', {node: '5.01.0'}, {loose: false})).toEqual(false);
+  expect(testEngine('node', '^0.13.0', {node: '5.0.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^0.12.0', {node: '5.0.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^0.11.0', {node: '5.0.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^0.10.0', {node: '5.0.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^0.9.0', {node: '5.0.0'}, {loose: true})).toEqual(false);
+  expect(testEngine('node', '^0.12.0', {node: '0.12.0'}, {loose: true})).toEqual(true);
+  expect(testEngine('node', '^0.12.0', {node: '0.11.0'}, {loose: true})).toEqual(false);
+  expect(testEngine('node', '^1.3.0', {node: '1.4.1-20180208.2355'}, {loose: true})).toEqual(false);
 });
 
 test('ignore semver prerelease semantics for yarn', () => {
-  expect(testEngine('yarn', '^1.3.0', {yarn: '1.4.1-20180208.2355'}, true)).toEqual(true);
+  expect(testEngine('yarn', '^1.3.0', {yarn: '1.4.1-20180208.2355'}, {loose: true})).toEqual(true);
 });

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -959,6 +959,43 @@ describe('checkOutdated functional test', () => {
     });
   });
 
+  test('latest version with pre release versions', async () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+
+    mockRequestManager.request = () => {
+      return {
+        'dist-tags': {
+          latest: '2.0.0',
+        },
+        versions: {
+          '2.0.0': {
+            version: '2.0.0',
+            repository: {
+              url: 'http://package.repo.com',
+            },
+          },
+          '2.1.0': {
+            version: '2.1.0',
+            repository: {
+              url: 'http://package.repo.com',
+            },
+          },
+        },
+      };
+    };
+    const flags = {includePre: true};
+
+    const result = await npmRegistry.checkOutdated(mockConfig, 'left-pad', '2.0.0', flags);
+
+    expect(result).toMatchObject({
+      latest: '2.1.0',
+      wanted: '2.1.0',
+      url: 'http://package.repo.com',
+    });
+  });
+
   test('package with an empty response', async () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();

--- a/flow-typed/npm/semver_v5.1.x.js
+++ b/flow-typed/npm/semver_v5.1.x.js
@@ -25,6 +25,11 @@ declare module 'semver' {
     '<' |
     '<=';
 
+  declare type Options = {
+    loose?: boolean,
+    includePrerelease?: boolean,
+  }
+
   declare class SemVer {
     loose: ?boolean,
     raw: string,
@@ -35,33 +40,33 @@ declare module 'semver' {
     build: Array<string>,
     version: string,
 
-    constructor(range: string, loose?: boolean): SemVer | string
+    constructor(range: string, options?: Options): SemVer | string
   }
 
   // Functions
-  declare function clean(v: string, loose?: boolean): string | null;
-  declare function valid(v: string, loose?: boolean): string | null;
-  declare function inc(v: string, release: string, loose?: boolean): string | null;
-  declare function major(v: string, loose?: boolean): number;
-  declare function minor(v: string, loose?: boolean): number;
-  declare function patch(v: string, loose?: boolean): number;
+  declare function clean(v: string, options?: Options): string | null;
+  declare function valid(v: string, options?: Options): string | null;
+  declare function inc(v: string, release: string, options?: Options): string | null;
+  declare function major(v: string, options?: Options): number;
+  declare function minor(v: string, options?: Options): number;
+  declare function patch(v: string, options?: Options): number;
 
   // Comparison
-  declare function gt(v1: string, v2: string, loose?: boolean): boolean;
-  declare function gte(v1: string, v2: string, loose?: boolean): boolean;
-  declare function lt(v1: string, v2: string, loose?: boolean): boolean;
-  declare function lte(v1: string, v2: string, loose?: boolean): boolean;
-  declare function eq(v1: string, v2: string, loose?: boolean): boolean;
-  declare function neq(v1: string, v2: string, loose?: boolean): boolean;
+  declare function gt(v1: string, v2: string, options?: Options): boolean;
+  declare function gte(v1: string, v2: string, options?: Options): boolean;
+  declare function lt(v1: string, v2: string, options?: Options): boolean;
+  declare function lte(v1: string, v2: string, options?: Options): boolean;
+  declare function eq(v1: string, v2: string, options?: Options): boolean;
+  declare function neq(v1: string, v2: string, options?: Options): boolean;
   declare function cmp(v1: string, comparator: Comparator, v2: string): boolean;
   declare function compare(v1: string, v2: string): -1 | 0 | 1;
   declare function rcompare(v1: string, v2: string): -1 | 0 | 1;
   declare function diff(v1: string, v2: string): ?Release;
 
   // Ranges
-  declare function validRange(r: string, loose?: boolean): string | null;
-  declare function satisfies(version: string, range: string, loose?: boolean): boolean;
-  declare function maxSatisfying(versions: Array<string>, range: string, loose?: boolean): string | null;
+  declare function validRange(r: string, options?: Options): string | null;
+  declare function satisfies(version: string, range: string, options?: Options): boolean;
+  declare function maxSatisfying(versions: Array<string>, range: string, options?: Options): string | null;
   declare function gtr(version: string, range: string): boolean;
   declare function ltr(version: string, range: string): boolean;
   declare function outside(version: string, range: string, hilo: '>' | '<'): boolean;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "request": "^2.87.0",
     "request-capture-har": "^1.2.2",
     "rimraf": "^2.5.0",
-    "semver": "^5.1.0",
+    "semver": "^5.6.0",
     "ssri": "^5.3.0",
     "strip-ansi": "^4.0.0",
     "strip-bom": "^3.0.0",

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -105,8 +105,8 @@ export async function verifyTreeCheck(
     }
     const pkg = await config.readManifest(manifestLoc, registryName);
     if (
-      semver.validRange(dep.version, config.looseSemver) &&
-      !semver.satisfies(pkg.version, dep.version, config.looseSemver)
+      semver.validRange(dep.version, {loose: config.looseSemver}) &&
+      !semver.satisfies(pkg.version, dep.version, {loose: config.looseSemver})
     ) {
       reportError('packageWrongVersion', dep.originalKey, dep.version, pkg.version);
       continue;
@@ -304,7 +304,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
       for (const name in deps) {
         const range = deps[name];
-        if (!semver.validRange(range, config.looseSemver)) {
+        if (!semver.validRange(range, {loose: config.looseSemver})) {
           continue; // exotic
         }
 
@@ -338,14 +338,14 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         if (await fs.exists(depPkgLoc)) {
           const depPkg = await config.readJson(depPkgLoc);
           const foundHuman = `${humaniseLocation(path.dirname(depPkgLoc)).join('#')}@${depPkg.version}`;
-          if (!semver.satisfies(depPkg.version, range, config.looseSemver)) {
+          if (!semver.satisfies(depPkg.version, range, {loose: config.looseSemver})) {
             // module isn't correct semver
             const resPattern = install.resolutionMap.find(name, originalKey.split('#'));
             if (resPattern) {
               const resHuman = `${human}#${resPattern}`;
               const {range: resRange} = normalizePattern(resPattern);
 
-              if (semver.satisfies(depPkg.version, resRange, config.looseSemver)) {
+              if (semver.satisfies(depPkg.version, resRange, {loose: config.looseSemver})) {
                 reporter.warn(reporter.lang('incompatibleResolutionVersion', foundHuman, subHuman));
                 warningCount++;
               } else {
@@ -375,8 +375,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
             if (
               !bundledDep &&
               (packageJson.version === depPkg.version ||
-                (semver.satisfies(packageJson.version, range, config.looseSemver) &&
-                  semver.gt(packageJson.version, depPkg.version, config.looseSemver)))
+                (semver.satisfies(packageJson.version, range, {loose: config.looseSemver}) &&
+                  semver.gt(packageJson.version, depPkg.version, {loose: config.looseSemver})))
             ) {
               reporter.warn(
                 reporter.lang(

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -13,6 +13,10 @@ export const requireLockfile = true;
 export function setFlags(commander: Object) {
   commander.description('Checks for outdated package dependencies.');
   commander.usage('outdated [packages ...]');
+  commander.option(
+    '--include-pre',
+    'list the latest version of packages including pre release versions, ignoring version ranges in package.json',
+  );
 }
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -26,7 +26,7 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<number> {
   const lockfile = await Lockfile.fromDirectory(config.lockfileFolder);
   const install = new Install({...flags, includeWorkspaceDeps: true}, config, reporter, lockfile);
-  let deps = await PackageRequest.getOutdatedPackages(lockfile, install, config, reporter);
+  let deps = await PackageRequest.getOutdatedPackages(lockfile, install, config, reporter, [], flags);
 
   if (args.length) {
     const requested = new Set(args);

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -20,6 +20,10 @@ export function setFlags(commander: Object) {
   commander.usage('upgrade-interactive [flags]');
   commander.option('-S, --scope <scope>', 'upgrade packages under the specified scope');
   commander.option('--latest', 'list the latest version of packages, ignoring version ranges in package.json');
+  commander.option(
+    '--include-pre',
+    'list the latest version of packages including pre release versions, ignoring version ranges in package.json',
+  );
   commander.option('-E, --exact', 'install exact version. Only used when --latest is specified.');
   commander.option(
     '-T, --tilde',

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -148,6 +148,10 @@ export function setFlags(commander: Object) {
   commander.usage('upgrade [flags]');
   commander.option('-S, --scope <scope>', 'upgrade packages under the specified scope');
   commander.option('-L, --latest', 'list the latest version of packages, ignoring version ranges in package.json');
+  commander.option(
+    '--include-pre',
+    'list the latest version of packages including pre release versions, ignoring version ranges in package.json',
+  );
   commander.option('-E, --exact', 'install exact version. Only used when --latest is specified.');
   commander.option('-P, --pattern [pattern]', 'upgrade packages that match pattern');
   commander.option(

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -2,6 +2,7 @@
 
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
+import type {Options} from 'semver';
 import {registryNames} from '../../registries/index.js';
 import {execCommand} from '../../util/execute-lifecycle-script.js';
 import {MessageError} from '../../errors.js';
@@ -14,8 +15,8 @@ const semver = require('semver');
 const path = require('path');
 
 const NEW_VERSION_FLAG = '--new-version [version]';
-function isValidNewVersion(oldVersion: string, newVersion: string, looseSemver: boolean): boolean {
-  return !!(semver.valid(newVersion, looseSemver) || semver.inc(oldVersion, newVersion, looseSemver));
+function isValidNewVersion(oldVersion: string, newVersion: string, options: Options): boolean {
+  return !!(semver.valid(newVersion, options) || semver.inc(oldVersion, newVersion, options));
 }
 
 export function setFlags(commander: Object) {
@@ -76,7 +77,7 @@ export async function setVersion(
   }
 
   // get new version
-  if (newVersion && !isValidNewVersion(oldVersion, newVersion, config.looseSemver)) {
+  if (newVersion && !isValidNewVersion(oldVersion, newVersion, {loose: config.looseSemver})) {
     throw new MessageError(reporter.lang('invalidVersion'));
   }
 
@@ -109,7 +110,7 @@ export async function setVersion(
       };
     }
 
-    if (isValidNewVersion(oldVersion, newVersion, config.looseSemver)) {
+    if (isValidNewVersion(oldVersion, newVersion, {loose: config.looseSemver})) {
       break;
     } else {
       newVersion = null;
@@ -117,7 +118,7 @@ export async function setVersion(
     }
   }
   if (newVersion) {
-    newVersion = semver.inc(oldVersion, newVersion, config.looseSemver) || newVersion;
+    newVersion = semver.inc(oldVersion, newVersion, {loose: config.looseSemver}) || newVersion;
   }
   invariant(newVersion, 'expected new version');
 

--- a/src/package-constraint-resolver.js
+++ b/src/package-constraint-resolver.js
@@ -23,7 +23,7 @@ export default class PackageConstraintResolver {
       // Usually versions are already ordered and the last one is the latest
       return Promise.resolve(versions[versions.length - 1]);
     } else {
-      return Promise.resolve(semver.maxSatisfying(versions, range, this.config.looseSemver));
+      return Promise.resolve(semver.maxSatisfying(versions, range, {loose: this.config.looseSemver}));
     }
   }
 }

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -671,7 +671,7 @@ export default class PackageLinker {
   }
 
   _satisfiesPeerDependency(range: string, version: string): boolean {
-    return range === '*' || satisfiesWithPrereleases(version, range, this.config.looseSemver);
+    return range === '*' || satisfiesWithPrereleases(version, range, {loose: this.config.looseSemver});
   }
 
   async _warnForMissingBundledDependencies(pkg: Manifest): Promise<void> {

--- a/src/package-request.js
+++ b/src/package-request.js
@@ -422,7 +422,7 @@ export default class PackageRequest {
         } else {
           const registry = config.registries[locked.registry];
 
-          ({latest, wanted, url} = await registry.checkOutdated(config, name, normalized.range));
+          ({latest, wanted, url} = await registry.checkOutdated(config, name, normalized.range, flags));
         }
 
         return {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -241,7 +241,7 @@ export default class NpmRegistry extends Registry {
 
     if (flags && flags.includePre) {
       const versions = Object.keys(req['versions']);
-      latest = semver.maxSatisfying(versions, '*', {includePrerelease: true});
+      latest = semver.maxSatisfying(versions, '*', {includePrerelease: true}) || '';
       wanted = latest;
     }
 

--- a/src/util/git/git-ref-resolver.js
+++ b/src/util/git/git-ref-resolver.js
@@ -84,7 +84,7 @@ const computeSemverNames = ({config, refs}: ResolveVersionOptions): Names => {
       continue;
     }
     const [, type, name] = match;
-    if (semver.valid(name, config.looseSemver)) {
+    if (semver.valid(name, {loose: config.looseSemver})) {
       names[type].push(name);
     }
   }

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -2,6 +2,7 @@
 
 import {MANIFEST_FIELDS} from '../../constants';
 import type {Reporter} from '../../reporters/index.js';
+import type {Options} from 'semver';
 import {isValidLicense} from './util.js';
 import {normalizePerson, extractDescription} from './util.js';
 import {hostedGitFragmentToGitUrl} from '../../resolvers/index.js';
@@ -28,13 +29,13 @@ export default (async function(
   moduleLoc: string,
   reporter: Reporter,
   warn: WarnFunction,
-  looseSemver: boolean,
+  options: Options,
 ): Promise<void> {
   const files = await fs.readdir(moduleLoc);
 
   // clean info.version
   if (typeof info.version === 'string') {
-    info.version = semver.clean(info.version, looseSemver) || info.version;
+    info.version = semver.clean(info.version, options) || info.version;
   }
 
   // if name or version aren't set then set them to empty strings

--- a/src/util/normalize-manifest/index.js
+++ b/src/util/normalize-manifest/index.js
@@ -29,7 +29,7 @@ export default (async function(info: Object, moduleLoc: string, config: Config, 
     config.reporter.warn(msg);
   }
 
-  await fix(info, moduleLoc, config.reporter, warn, config.looseSemver);
+  await fix(info, moduleLoc, config.reporter, warn, {loose: config.looseSemver});
   resolveRelative(info, moduleLoc, config.lockfileFolder);
 
   if (config.cwd === config.globalFolder) {

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -1,17 +1,17 @@
 /* @flow */
 
-import semver, {type Release} from 'semver';
+import semver, {type Release, type Options} from 'semver';
 
 /**
  * Returns whether the given semver version satisfies the given range. Notably this supports
  * prerelease versions so that "2.0.0-rc.0" satisfies the range ">=1.0.0", for example.
  */
 
-export function satisfiesWithPrereleases(version: string, range: string, loose?: boolean = false): boolean {
+export function satisfiesWithPrereleases(version: string, range: string, options?: Options): boolean {
   let semverRange;
   try {
     // $FlowFixMe: Add a definition for the Range class
-    semverRange = new semver.Range(range, loose);
+    semverRange = new semver.Range(range, options);
   } catch (err) {
     return false;
   }
@@ -21,7 +21,7 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
   }
   let semverVersion;
   try {
-    semverVersion = new semver.SemVer(version, semverRange.loose);
+    semverVersion = new semver.SemVer(version, {loose: semverRange.loose});
   } catch (err) {
     return false;
   }
@@ -44,7 +44,7 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
 
       const comparatorString = comparator.operator + comparator.semver.version;
       // $FlowFixMe: Add a definition for the Comparator class
-      return new semver.Comparator(comparatorString, comparator.loose);
+      return new semver.Comparator(comparatorString, {loose: comparator.loose});
     });
 
     return !comparatorSet.some(comparator => !comparator.test(semverVersion));

--- a/src/workspace-layout.js
+++ b/src/workspace-layout.js
@@ -23,7 +23,7 @@ export default class WorkspaceLayout {
   getManifestByPattern(pattern: string): ?{loc: string, manifest: Manifest} {
     const {name, range} = normalizePattern(pattern);
     const workspace = this.getWorkspaceManifest(name);
-    if (!workspace || !semver.satisfies(workspace.manifest.version, range, this.config.looseSemver)) {
+    if (!workspace || !semver.satisfies(workspace.manifest.version, range, {loose: this.config.looseSemver})) {
       return null;
     }
     return workspace;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,10 +6621,15 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
   integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
+
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Summary**

Fixes #3698

yarn upgrade-interactive only shows non-prerelease versions. This is for adding a flag --include-pre so it suggests pre-release versions as well.

The main modification was in `checkOutdated` method for npm-registry to switch wanted and latest to maximum semver available. For this last thing it was needed to update semver to the latest version and some other code involved calls to semver needed to be updated as well.

The expected behavior is to call upgrade-interactive like this: 

```$ yarn upgrade-interactive --include-pre```

**Test plan**

Added tests for `npm-registry` `checkOutdated` method.
Fixed methods related to `semver` calls without options object.
