### PR TITLE
feat(policies): Use github access token when requesting releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Fixes PnP detection with workspaces (`installConfig` is now read at the top-level)
 
   [#6878](https://github.com/yarnpkg/yarn/pull/6878) - [**Maël Nison**](https://twitter.com/arcanis)
+  
+- Adds support for `GITHUB_TOKEN` in `yarn policies set-version`
+
+  [#6912](https://github.com/yarnpkg/yarn/pull/6912) - [**Billy Vong**](https://github.com/billyvg)
 
 ## 1.13.0
 

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -47,9 +47,11 @@ async function fetchReleases(
   config: Config,
   {includePrereleases = false}: FetchReleasesOptions = {},
 ): Promise<Array<Release>> {
+  const token = process.env.GITHUB_TOKEN;
+  const tokenUrlParameter = !!token  ? `?access_token=${token}` : '';
   const request: Array<Release> = await config.requestManager.request({
-    url: `https://api.github.com/repos/yarnpkg/yarn/releases`,
-    json: true,
+    url: `https://api.github.com/repos/yarnpkg/yarn/releases${tokenUrlParameter}`,
+    json: true
   });
 
   const releases = request.filter(release => {

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -48,10 +48,10 @@ async function fetchReleases(
   {includePrereleases = false}: FetchReleasesOptions = {},
 ): Promise<Array<Release>> {
   const token = process.env.GITHUB_TOKEN;
-  const tokenUrlParameter = !!token  ? `?access_token=${token}` : '';
+  const tokenUrlParameter = token ? `?access_token=${token}` : '';
   const request: Array<Release> = await config.requestManager.request({
     url: `https://api.github.com/repos/yarnpkg/yarn/releases${tokenUrlParameter}`,
-    json: true
+    json: true,
   });
 
   const releases = request.filter(release => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When using `yarn policies set-version`, yarn makes an API request to GitHub to fetch a list of yarn releases. This request can be [rate limited](https://developer.github.com/v3/#rate-limiting), but can be bypassed if request is [authenticated](https://developer.github.com/v3/#basic-authentication)

If the environment variable `GITHUB_TOKEN` is defined, append `?access_token=<GITHUB_TOKEN>` when requesting yarn releases from GitHub.

Closes https://github.com/yarnpkg/yarn/issues/6905


<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->