### PR TITLE
Fix suggested command after unlinking a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6882](https://github.com/yarnpkg/yarn/pull/6882) - [**Zoran Regvart**](https://github.com/zregvart)
 
+- Fixes the command that `yarn unlink` recommend to run as a followup (now `yarn install --force`)
+
+  [#6931](https://github.com/yarnpkg/yarn/pull/6931) - [**Justin Sacbibit**](https://github.com/justinsacbibit)
+
 ## 1.13.0
 
 - Implements a new `package.json` field: `peerDependenciesMeta`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6882](https://github.com/yarnpkg/yarn/pull/6882) - [**Zoran Regvart**](https://github.com/zregvart)
 
-- Fixes the command that `yarn unlink` recommend to run as a followup (now `yarn install --force`)
+- Fixes the command that `yarn unlink` recommends to run as a followup (now `yarn install --force`)
 
   [#6931](https://github.com/yarnpkg/yarn/pull/6931) - [**Justin Sacbibit**](https://github.com/justinsacbibit)
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -179,7 +179,7 @@ const messages = {
     'You can now run `yarn unlink $0` in the projects where you no longer want to use this package.',
   linkUsing: 'Using linked package for $0.',
   linkDisusing: 'Removed linked package $0.',
-  linkDisusingMessage: 'You will need to run `yarn` to re-install the package that was linked.',
+  linkDisusingMessage: 'You will need to run `yarn install --check-files` to re-install the package that was linked.',
   linkTargetMissing: 'The target of linked package $0 is missing. Removing link.',
 
   createInvalidBin: 'Invalid bin entry found in package $0.',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -179,7 +179,7 @@ const messages = {
     'You can now run `yarn unlink $0` in the projects where you no longer want to use this package.',
   linkUsing: 'Using linked package for $0.',
   linkDisusing: 'Removed linked package $0.',
-  linkDisusingMessage: 'You will need to run `yarn install --check-files` to re-install the package that was linked.',
+  linkDisusingMessage: 'You will need to run `yarn install --force` to re-install the package that was linked.',
   linkTargetMissing: 'The target of linked package $0 is missing. Removing link.',
 
   createInvalidBin: 'Invalid bin entry found in package $0.',


### PR DESCRIPTION
Fixes #937, #1957

**Summary**

After unlinking a package, yarn suggests running `yarn` to re-install the package, but it doesn't actually end up re-installing the package. `yarn install --check-files` or `yarn install --force` is required.

**Test plan**

Not needed
