### PR TITLE
Add `YARN_DATA` environment variable for windows user to configurate where to store all yarn data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
 ## Master
+- Add `YARN_DATA` environment variable for define where to store yarn data under windows
 
 - Improves PnP compatibility with Node 6
 

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -52,6 +52,6 @@ export function getConfigDir(): string {
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
   return process.env.YARN_DATA
-    ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA
-    ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+    ? path.join(process.env.YARN_DATA, 'Yarn') 
+    : process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -50,5 +50,6 @@ export function getConfigDir(): string {
 }
 
 function getLocalAppDataDir(): ?string {
-  return process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+  // add YARN_DATA env,may better to have a user defined global data path for windows users?
+  return process.env.YARN_DATA?path.join(process.env.YARN_DATA, 'Yarn'):process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -9,7 +9,9 @@ const FALLBACK_CACHE_DIR = path.join(userHome, '.cache', 'yarn');
 export function getDataDir(): string {
   if (process.platform === 'win32') {
     const WIN32_APPDATA_DIR = getLocalAppDataDir();
-    return WIN32_APPDATA_DIR == null ? FALLBACK_CONFIG_DIR : path.join(WIN32_APPDATA_DIR, 'Data');
+    return WIN32_APPDATA_DIR == null
+      ? FALLBACK_CONFIG_DIR
+      : path.join(WIN32_APPDATA_DIR, 'Data');
   } else if (process.env.XDG_DATA_HOME) {
     return path.join(process.env.XDG_DATA_HOME, 'yarn');
   } else {
@@ -26,7 +28,10 @@ export function getDataDir(): string {
 export function getCacheDir(): string {
   if (process.platform === 'win32') {
     // process.env.TEMP also exists, but most apps put caches here
-    return path.join(getLocalAppDataDir() || path.join(userHome, 'AppData', 'Local', 'Yarn'), 'Cache');
+    return path.join(
+      getLocalAppDataDir() || path.join(userHome, 'AppData', 'Local', 'Yarn'),
+      'Cache'
+    );
   } else if (process.env.XDG_CACHE_HOME) {
     return path.join(process.env.XDG_CACHE_HOME, 'yarn');
   } else if (process.platform === 'darwin') {
@@ -41,7 +46,9 @@ export function getConfigDir(): string {
     // Use our prior fallback. Some day this could be
     // return path.join(WIN32_APPDATA_DIR, 'Config')
     const WIN32_APPDATA_DIR = getLocalAppDataDir();
-    return WIN32_APPDATA_DIR == null ? FALLBACK_CONFIG_DIR : path.join(WIN32_APPDATA_DIR, 'Config');
+    return WIN32_APPDATA_DIR == null
+      ? FALLBACK_CONFIG_DIR
+      : path.join(WIN32_APPDATA_DIR, 'Config');
   } else if (process.env.XDG_CONFIG_HOME) {
     return path.join(process.env.XDG_CONFIG_HOME, 'yarn');
   } else {
@@ -51,6 +58,9 @@ export function getConfigDir(): string {
 
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
-  return process.env.YARN_DATA ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA ? 
-    path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+  return process.env.YARN_DATA
+    ? path.join(process.env.YARN_DATA, 'Yarn')
+    : process.env.LOCALAPPDATA
+    ? path.join(process.env.LOCALAPPDATA, 'Yarn')
+    : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -52,8 +52,6 @@ export function getConfigDir(): string {
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
   return process.env.YARN_DATA
-? path.join(process.env.YARN_DATA, 'Yarn') 
-: process.env.LOCALAPPDATA 
-? path.join(process.env.LOCALAPPDATA, 'Yarn') 
-: null;
+    ? path.join(process.env.YARN_DATA, 'Yarn') 
+    : process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -51,6 +51,7 @@ export function getConfigDir(): string {
 
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
-  return process.env.YARN_DATA? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA?
-    path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+  return process.env.YARN_DATA
+    ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA
+    ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -51,6 +51,6 @@ export function getConfigDir(): string {
 
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
-  return process.env.YARN_DATA ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA 
-    ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+  return process.env.YARN_DATA? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA?
+    path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -52,8 +52,8 @@ export function getConfigDir(): string {
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
   return process.env.YARN_DATA
-    ? path.join(process.env.YARN_DATA, 'Yarn') 
-    : process.env.LOCALAPPDATA 
-    ? path.join(process.env.LOCALAPPDATA, 'Yarn') 
-    : null;
+? path.join(process.env.YARN_DATA, 'Yarn') 
+: process.env.LOCALAPPDATA 
+? path.join(process.env.LOCALAPPDATA, 'Yarn') 
+: null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -51,5 +51,5 @@ export function getConfigDir(): string {
 
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
-  return process.env.YARN_DATA?path.join(process.env.YARN_DATA, 'Yarn'):process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+  return process.env.YARN_DATA ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -52,6 +52,6 @@ export function getConfigDir(): string {
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
   return process.env.YARN_DATA
-    ? path.join(process.env.YARN_DATA, 'Yarn') 
+    ? path.join(process.env.YARN_DATA, 'Yarn')
     : process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -9,9 +9,7 @@ const FALLBACK_CACHE_DIR = path.join(userHome, '.cache', 'yarn');
 export function getDataDir(): string {
   if (process.platform === 'win32') {
     const WIN32_APPDATA_DIR = getLocalAppDataDir();
-    return WIN32_APPDATA_DIR == null
-      ? FALLBACK_CONFIG_DIR
-      : path.join(WIN32_APPDATA_DIR, 'Data');
+    return WIN32_APPDATA_DIR == null ? FALLBACK_CONFIG_DIR : path.join(WIN32_APPDATA_DIR, 'Data');
   } else if (process.env.XDG_DATA_HOME) {
     return path.join(process.env.XDG_DATA_HOME, 'yarn');
   } else {
@@ -28,10 +26,7 @@ export function getDataDir(): string {
 export function getCacheDir(): string {
   if (process.platform === 'win32') {
     // process.env.TEMP also exists, but most apps put caches here
-    return path.join(
-      getLocalAppDataDir() || path.join(userHome, 'AppData', 'Local', 'Yarn'),
-      'Cache'
-    );
+    return path.join(getLocalAppDataDir() || path.join(userHome, 'AppData', 'Local', 'Yarn'), 'Cache');
   } else if (process.env.XDG_CACHE_HOME) {
     return path.join(process.env.XDG_CACHE_HOME, 'yarn');
   } else if (process.platform === 'darwin') {
@@ -46,9 +41,7 @@ export function getConfigDir(): string {
     // Use our prior fallback. Some day this could be
     // return path.join(WIN32_APPDATA_DIR, 'Config')
     const WIN32_APPDATA_DIR = getLocalAppDataDir();
-    return WIN32_APPDATA_DIR == null
-      ? FALLBACK_CONFIG_DIR
-      : path.join(WIN32_APPDATA_DIR, 'Config');
+    return WIN32_APPDATA_DIR == null ? FALLBACK_CONFIG_DIR : path.join(WIN32_APPDATA_DIR, 'Config');
   } else if (process.env.XDG_CONFIG_HOME) {
     return path.join(process.env.XDG_CONFIG_HOME, 'yarn');
   } else {
@@ -58,9 +51,6 @@ export function getConfigDir(): string {
 
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
-  return process.env.YARN_DATA
-    ? path.join(process.env.YARN_DATA, 'Yarn')
-    : process.env.LOCALAPPDATA
-    ? path.join(process.env.LOCALAPPDATA, 'Yarn')
-    : null;
+  return process.env.YARN_DATA ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA 
+    ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -51,5 +51,6 @@ export function getConfigDir(): string {
 
 function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
-  return process.env.YARN_DATA ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+  return process.env.YARN_DATA ? path.join(process.env.YARN_DATA, 'Yarn') : process.env.LOCALAPPDATA ? 
+    path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -53,5 +53,6 @@ function getLocalAppDataDir(): ?string {
   // add YARN_DATA env,may better to have a user defined global data path for windows users?
   return process.env.YARN_DATA
     ? path.join(process.env.YARN_DATA, 'Yarn') 
-    : process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+    : process.env.LOCALAPPDATA 
+    ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
 }

--- a/src/util/user-dirs.js
+++ b/src/util/user-dirs.js
@@ -54,5 +54,6 @@ function getLocalAppDataDir(): ?string {
   return process.env.YARN_DATA
     ? path.join(process.env.YARN_DATA, 'Yarn') 
     : process.env.LOCALAPPDATA 
-    ? path.join(process.env.LOCALAPPDATA, 'Yarn') : null;
+    ? path.join(process.env.LOCALAPPDATA, 'Yarn') 
+    : null;
 }


### PR DESCRIPTION


**Summary**
Add `YARN_DATA` environment variable for windows user to configurate where to store all yarn data files.

Because of  `local  application data` had become a nightmare for many windows users. for me this folder
is greatter than 20GB. many my friends or workmate do wan;t some development tools data could be save into some other place.

**Test plan**

this change will no side effect, and being tested .
