### PR TITLE
Fix for devDependencies not upgrading within a workspace

### DIFF
--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -26,7 +26,7 @@ export class Add extends Install {
   constructor(args: Array<string>, flags: Object, config: Config, reporter: Reporter, lockfile: Lockfile) {
     const workspaceRootIsCwd = config.cwd === config.lockfileFolder;
     const _flags = flags ? {...flags, workspaceRootIsCwd} : {workspaceRootIsCwd};
-    super(_flags, config, reporter, lockfile);
+    super({..._flags, includeWorkspaceDeps: true}, config, reporter, lockfile);
     this.args = args;
     // only one flag is supported, so we can figure out which one was passed to `yarn add`
     this.flagToOrigin = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Fixes: https://github.com/yarnpkg/yarn/issues/4971

**Summary**
Performing a `yarn add <dependency>` within a workspace adds a new version to `dependencies` in the package.json instead of upgrading the version in `devDependencies`.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
1. Setup a package in a workspace with a single devDependency.
2. `yarn workspace package1 [add/upgrade] [dependencyName]`
3. Ensure devDependency is updated.
4. Repeat the same test but instead `cd package1 ` then `yarn [add/upgrade] [dependencyName]`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Notes**
Alternatively, removing this `if` statement would fix the issue as well:
https://github.com/the-realtom/yarn/blob/41507ab016361e1e0e3eebc4e59e11473e2dcc67/src/cli/commands/install.js#L357-L362