### PR TITLE
Check os and platform even when engines is not present in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6942](https://github.com/yarnpkg/yarn/pull/6942) - [**John-David Dalton**](https://twitter.com/jdalton)
 
+- Check `os` and `platform` requirements from `package.json` even when the package does not specify any `engines` requirements
+
+  [#6976](https://github.com/yarnpkg/yarn/pull/6976) - [**Micha Reiser**](https://github.com/MichaReiser)  
+
 ## 1.13.0
 
 - Implements a new `package.json` field: `peerDependenciesMeta`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6942](https://github.com/yarnpkg/yarn/pull/6942) - [**John-David Dalton**](https://twitter.com/jdalton)
 
-- Check `os` and `platform` requirements from `package.json` even when the package does not specify any `engines` requirements
+- Fixes a bug where `os` and `platform` requirements weren't properly checked when `engines` was missing
 
   [#6976](https://github.com/yarnpkg/yarn/pull/6976) - [**Micha Reiser**](https://github.com/MichaReiser)  
 

--- a/__tests__/package-compatibility.js
+++ b/__tests__/package-compatibility.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {testEngine} from '../src/package-compatibility.js';
+import {testEngine, shouldCheck} from '../src/package-compatibility.js';
 
 test('node semver semantics', () => {
   expect(testEngine('node', '^5.0.0', {node: '5.1.0'}, true)).toEqual(true);
@@ -18,4 +18,68 @@ test('node semver semantics', () => {
 
 test('ignore semver prerelease semantics for yarn', () => {
   expect(testEngine('yarn', '^1.3.0', {yarn: '1.4.1-20180208.2355'}, true)).toEqual(true);
+});
+
+test('shouldCheck returns true if ignorePlatform is false and the manifest specifies an os or cpu requirement', () => {
+  expect(
+    shouldCheck(
+      {
+        os: ['darwin'],
+      },
+      {ignorePlatform: false, ignoreEngines: false},
+    ),
+  ).toBe(true);
+
+  expect(
+    shouldCheck(
+      {
+        cpu: ['i32'],
+      },
+      {ignorePlatform: false, ignoreEngines: false},
+    ),
+  ).toBe(true);
+
+  expect(shouldCheck({}, {ignorePlatform: false, ignoreEngines: false})).toBe(false);
+
+  expect(
+    shouldCheck(
+      {
+        os: [],
+        cpu: [],
+      },
+      {ignorePlatform: false, ignoreEngines: false},
+    ),
+  ).toBe(false);
+
+  expect(
+    shouldCheck(
+      {
+        cpu: ['i32'],
+        os: ['darwin'],
+      },
+      {ignorePlatform: true, ignoreEngines: false},
+    ),
+  ).toBe(false);
+});
+
+test('shouldCheck returns true if ignoreEngines is false and the manifest specifies engines', () => {
+  expect(
+    shouldCheck(
+      {
+        engines: {node: '>= 10'},
+      },
+      {ignorePlatform: false, ignoreEngines: false},
+    ),
+  ).toBe(true);
+
+  expect(shouldCheck({}, {ignorePlatform: false, ignoreEngines: false})).toBe(false);
+
+  expect(
+    shouldCheck(
+      {
+        engines: {node: '>= 10'},
+      },
+      {ignorePlatform: false, ignoreEngines: true},
+    ),
+  ).toBe(false);
 });

--- a/packages/pkg-tests/pkg-tests-specs/sources/basic.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/basic.js
@@ -380,5 +380,69 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
         },
       ),
     );
+
+    test(
+      `it should fail if the environment does not satisfy the os platform`,
+      makeTemporaryEnv(
+        {
+          os: ['unicorn'],
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`)).rejects.toThrow(/The platform "\w+" is incompatible with this module\./);
+        },
+      ),
+    );
+
+    test(
+      `it should fail if the environment does not satisfy the cpu architecture`,
+      makeTemporaryEnv(
+        {
+          cpu: ['unicorn'],
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`)).rejects.toThrow(/The CPU architecture "\w+" is incompatible with this module\./);
+        },
+      ),
+    );
+
+    test(
+      `it should fail if the environment does not satisfy the engine requirements`,
+      makeTemporaryEnv(
+        {
+          engines: {
+            node: "0.18.1"
+          }
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`)).rejects.toThrow(/The engine "node" is incompatible with this module\. Expected version "0.18.1"./);
+        },
+      ),
+    );
+
+    test(
+      `it should not fail if the environment does not satisfy the os and cpu architecture but ignore platform is true`,
+      makeTemporaryEnv(
+        {
+          os: ['unicorn'],
+        },
+        async ({path, run, source}) => {
+          await run(`install`, '--ignore-platform');
+        },
+      ),
+    );
+
+    test(
+      `it should not fail if the environment does not satisfy the engine requirements but ignore engines is true`,
+      makeTemporaryEnv(
+        {
+          engines: {
+            node: "0.18.1"
+          }
+        },
+        async ({path, run, source}) => {
+          await run(`install`, '--ignore-engines');
+        },
+      ),
+    );
   });
 };

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -572,7 +572,7 @@ export class Install {
       this.scripts.setArtifacts(artifacts);
     }
 
-    if (!this.flags.ignoreEngines && typeof manifest.engines === 'object') {
+    if (compatibility.shouldCheck(manifest, this.flags)) {
       steps.push(async (curr: number, total: number) => {
         this.reporter.step(curr, total, this.reporter.lang('checkingManifest'), emoji.get('mag'));
         await this.checkCompatibility();

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -128,20 +128,17 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
     }
   };
 
-  const invalidPlatform =
-    shouldCheckPlatform(info, config.ignorePlatform) && info.os != null && !isValidPlatform(info.os);
+  const {os, cpu, engines} = info;
 
-  if (invalidPlatform) {
+  if (shouldCheckPlatform(os, config.ignorePlatform) && !isValidPlatform(os)) {
     pushError(reporter.lang('incompatibleOS', process.platform));
   }
 
-  const invalidCpu = shouldCheckCpu(info, config.ignorePlatform) && info.cpu != null && !isValidArch(info.cpu);
-
-  if (invalidCpu) {
+  if (shouldCheckCpu(cpu, config.ignorePlatform) && !isValidArch(cpu)) {
     pushError(reporter.lang('incompatibleCPU', process.arch));
   }
 
-  if (shouldCheckEngines(info, ignoreEngines)) {
+  if (shouldCheckEngines(engines, ignoreEngines)) {
     for (const entry of entries(info.engines)) {
       let name = entry[0];
       const range = entry[1];
@@ -171,16 +168,16 @@ export function check(infos: Array<Manifest>, config: Config, ignoreEngines: boo
   }
 }
 
-function shouldCheckCpu(manifest: PartialManifest, ignorePlatform: boolean): boolean {
-  return !ignorePlatform && Array.isArray(manifest.cpu) && manifest.cpu.length > 0;
+function shouldCheckCpu(cpu: $PropertyType<Manifest, 'cpu'>, ignorePlatform: boolean): boolean %checks {
+  return !ignorePlatform && Array.isArray(cpu) && cpu.length > 0;
 }
 
-function shouldCheckPlatform(manifest: PartialManifest, ignorePlatform: boolean): boolean {
-  return !ignorePlatform && Array.isArray(manifest.os) && manifest.os.length > 0;
+function shouldCheckPlatform(os: $PropertyType<Manifest, 'os'>, ignorePlatform: boolean): boolean %checks {
+  return !ignorePlatform && Array.isArray(os) && os.length > 0;
 }
 
-function shouldCheckEngines(manifest: PartialManifest, ignoreEngines: boolean): boolean {
-  return !ignoreEngines && typeof manifest.engines === 'object';
+function shouldCheckEngines(engines: $PropertyType<Manifest, 'engines'>, ignoreEngines: boolean): boolean %checks {
+  return !ignoreEngines && typeof engines === 'object';
 }
 
 export function shouldCheck(
@@ -188,8 +185,8 @@ export function shouldCheck(
   options: {ignoreEngines: boolean, ignorePlatform: boolean},
 ): boolean {
   return (
-    shouldCheckCpu(manifest, options.ignorePlatform) ||
-    shouldCheckPlatform(manifest, options.ignorePlatform) ||
-    shouldCheckEngines(manifest, options.ignoreEngines)
+    shouldCheckCpu(manifest.cpu, options.ignorePlatform) ||
+    shouldCheckPlatform(manifest.os, options.ignorePlatform) ||
+    shouldCheckEngines(manifest.engines, options.ignoreEngines)
   );
 }


### PR DESCRIPTION
**Summary**

This change ensures that the `cpu` and `os` requirements are checked if they are present in the `package.json` even when the package does not specify any `engines` requirements.

Fixes #6948 

**Test plan**

package.json:

```json
{
  "cpu": ["i32"],
  "os": ["win32"]
}
```

Running the following commands on a mac osx machine:

```bash
../bin/yarn
yarn install v1.15.0-0
warning package.json: No license field
warning No license field
[1/5] 🔍  Validating package.json...
warning No license field
error @: The platform "darwin" is incompatible with this module.
error @: The CPU architecture "x64" is incompatible with this module.
error Found incompatible module
```

```bash
../bin/yarn --ignore-platform
yarn install v1.15.0-0
warning package.json: No license field
warning No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.22s.
```