### PR TITLE
Don’t call `release` with an exit code

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -303,7 +303,7 @@ export async function main({
           onDeath(() => {
             process.exitCode = 1;
           });
-          resolve(run().then(release));
+          resolve(run().then(() => release()));
         }
       });
     });

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -291,7 +291,7 @@ export async function main({
   const runEventuallyWithFile = (mutexFilename: ?string, isFirstTime?: boolean): Promise<void> => {
     return new Promise(resolve => {
       const lockFilename = mutexFilename || path.join(config.cwd, constants.SINGLE_INSTANCE_FILENAME);
-      lockfile.lock(lockFilename, {realpath: false}, (err: mixed, release: () => void) => {
+      lockfile.lock(lockFilename, {realpath: false}, (err: mixed, release: (() => void) => void) => {
         if (err) {
           if (isFirstTime) {
             reporter.warn(reporter.lang('waitingInstance'));
@@ -303,7 +303,7 @@ export async function main({
           onDeath(() => {
             process.exitCode = 1;
           });
-          resolve(run().then(() => release()));
+          resolve(run().then(() => new Promise(resolve => release(resolve))));
         }
       });
     });


### PR DESCRIPTION
The `release` signature is incorrect, because its first argument is a callback function that will be called when the release is done. By attaching it to the `run()` promise however, release will be called with the exit code as argument. When the exit code is `1`, the code will crash. 

This is very rare, but we’re seeing this when calling yarn from another node process (and possibly killing it too soon):
```
<redacted>/node_modules/yarn/lib/cli.js:78119
         callback();
         ^
 TypeError: callback is not a function
     at options.fs.rmdir (<redacted>/node_modules/yarn/lib/cli.js:78119:9)
     at FSReqWrap.oncomplete (fs.js:141:20)
```