### PR TITLE
Adds test for #6968

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -356,7 +356,7 @@ export default class RequestManager {
    */
 
   execute(opts: RequestOptions) {
-    const {params} = opts;
+    const {params} = {...opts};
     const {reporter} = this;
 
     const buildNext = fn => data => {


### PR DESCRIPTION
**Summary**

#6968 fixed a regression where a class of errors from `request` were unhandled (leaving ssl cert errors to be swallowed).

This PR just adds a test to hopefully catch future regressions.

While adding this test, I noticed some tests from #6413 were leaking and addressed that as well.

@arcanis and @yan12125 do these changes look helpful?

I did not update `CHANGELOG` as actual code was unchanged.

**Test plan**

Successfully ran `yarn test`

![image](https://user-images.githubusercontent.com/303941/52240898-218b8b00-2887-11e9-9c68-a53b5e5e879e.png)
