### PR TITLE
fix: drive letter casing for win32 pnp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes occasionally mismatching upper/lowecases of drive letters in win32 pnp check
+
+  [#7007](https://github.com/yarnpkg/yarn/pull/7007) - [**Christoph Werner**](https://github.com/codepunkt)
+
 - Fixes the error reporting for non-HTTP network errors (such as invalid certificates)
 
   [#6968](https://github.com/yarnpkg/yarn/pull/6968) - [**Chih-Hsuan Yen**](https://github.com/yan12125)
@@ -14,18 +18,18 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Packages won't be auto-unplugged anymore if `ignore-scripts` is set in the yarnrc file
 
-  [#6983](https://github.com/yarnpkg/yarn/pull/6983) - [**Micha Reiser**](https://github.com/MichaReiser)  
+  [#6983](https://github.com/yarnpkg/yarn/pull/6983) - [**Micha Reiser**](https://github.com/MichaReiser)
 
 ## 1.14.0
 
 - Improves PnP compatibility with Node 6
 
   [#6871](https://github.com/yarnpkg/yarn/pull/6871) - [**Robert Jackson**](https://github.com/rwjblue)
-  
+
 - Fixes PnP detection with workspaces (`installConfig` is now read at the top-level)
 
   [#6878](https://github.com/yarnpkg/yarn/pull/6878) - [**Maël Nison**](https://twitter.com/arcanis)
-  
+
 - Fixes an interaction between `yarn pack` and bundled dependencies
 
   [#6908](https://github.com/yarnpkg/yarn/pull/6908) - [**Travis Hoover**](https://twitter.com/thoov)
@@ -48,7 +52,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Fixes a bug where `os` and `platform` requirements weren't properly checked when `engines` was missing
 
-  [#6976](https://github.com/yarnpkg/yarn/pull/6976) - [**Micha Reiser**](https://github.com/MichaReiser)  
+  [#6976](https://github.com/yarnpkg/yarn/pull/6976) - [**Micha Reiser**](https://github.com/MichaReiser)
 
 ## 1.13.0
 
@@ -91,7 +95,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Properly reports the error codes when the npm registry throws 500's
 
   [#6817](https://github.com/yarnpkg/yarn/pull/6817) - [**Maël Nison**](https://twitter.com/arcanis)
-  
+
 ## 1.12.3
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.

--- a/src/config.js
+++ b/src/config.js
@@ -401,8 +401,8 @@ export default class Config {
     }
 
     if (process.platform === 'win32') {
-      const cacheRootFolderDrive = path.parse(this._cacheRootFolder).root;
-      const lockfileFolderDrive = path.parse(this.lockfileFolder).root;
+      const cacheRootFolderDrive = path.parse(this._cacheRootFolder).root.toLowerCase();
+      const lockfileFolderDrive = path.parse(this.lockfileFolder).root.toLowerCase();
 
       if (cacheRootFolderDrive !== lockfileFolderDrive) {
         if (this.plugnplayEnabled) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Fixed potentially mismatching casing of drive letters in win32 pnp check by toLowerCasing both strings.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Fixes #7005 