### PR TITLE
Include key info for "expected hoisted" invariant

### DIFF
--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -838,7 +838,7 @@ export default class PackageHoister {
       for (let i = 0; i < keyParts.length; i++) {
         const key = keyParts.slice(0, i + 1).join('#');
         const hoisted = this.tree.get(key);
-        invariant(hoisted, 'expected hoisted manifest');
+        invariant(hoisted, `expected hoisted manifest for "${key}"`);
         parts.push(this.config.getFolder(hoisted.pkg));
         parts.push(keyParts[i]);
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Includes the key that we expected to find hoisted in the tree in the invariant message.

**motivation**
I hit this invariant.  I wanted to know what package "caused" it.

**Test plan**
Ran this in "broken" yarn environment
![screen shot 2019-02-06 at 1 56 55 pm](https://user-images.githubusercontent.com/1821462/52376489-19faec00-2a17-11e9-9c04-e7571c16dd50.png)

