### PR TITLE
Don't write cache path into yarn.lock for nested file dependencies

### DIFF
--- a/__tests__/commands/install/integration.js
+++ b/__tests__/commands/install/integration.js
@@ -375,6 +375,10 @@ test('root install with optional deps', () => runInstall({}, 'root-install-with-
 test('install file: protocol with relative paths', () =>
   runInstall({}, 'install-file-relative', async config => {
     expect(await fs.readFile(path.join(config.cwd, 'node_modules', 'root-a', 'index.js'))).toEqual('foobar;\n');
+    const lockFileContent = await fs.readFile(path.join(config.cwd, 'yarn.lock'));
+    const lockFileLines = explodeLockfile(lockFileContent);
+    expect(lockFileLines[5]).toMatch('"file:root-a"');
+    expect(lockFileLines[9]).toMatch('"file:root-b"');
   }));
 
 test('install file: protocol without force retains installed package', () =>

--- a/src/resolvers/exotics/file-resolver.js
+++ b/src/resolvers/exotics/file-resolver.js
@@ -19,9 +19,11 @@ export default class FileResolver extends ExoticResolver {
   constructor(request: PackageRequest, fragment: string) {
     super(request, fragment);
     this.loc = util.removePrefix(fragment, FILE_PROTOCOL_PREFIX);
+    this.resolvedFile = fragment;
   }
 
   loc: string;
+  resolvedFile: string;
 
   static protocol = 'file';
   static prefixMatcher = /^\.{1,2}\//;
@@ -75,6 +77,7 @@ export default class FileResolver extends ExoticResolver {
     manifest._remote = {
       type: 'copy',
       registry,
+      resolvedFile: this.resolvedFile,
       hash: `${uuid.v4()}-${new Date().getTime()}`,
       reference: loc,
     };

--- a/src/types.js
+++ b/src/types.js
@@ -54,6 +54,7 @@ export type PackageRemote = {
   registry: RegistryNames,
   reference: string,
   resolved?: ?string,
+  resolvedFile?: ?string,
   hash: ?string,
   integrity?: ?string,
   packageName?: string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Solves https://github.com/yarnpkg/yarn/issues/4388
Based on https://github.com/yarnpkg/yarn/pull/4717

The linked issue is unresolved for over a year now. It seems like solving the root cause of this issue by bypassing the cache for file-dependencies would require too much refactoring of the underlying architecture. At least I got lost while trying to do so 🙃 

So I chose this rather naive approach. All tests pass and I've tested it in a bigger monorepo where we regularly faced this issue.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
What was written to yarn.lock before:
![image](https://user-images.githubusercontent.com/665748/52980490-9fe54280-33da-11e9-88ed-eee08e328418.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
