### PR TITLE
fix(config): allow global-folder to be set in .yarnrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Allow `global-folder` to be set in `.yarnrc`.
+
+  [#7056](https://github.com/yarnpkg/yarn/pull/7056) - [**Hsiao-nan Cheung**](https://github.com/niheaven)
+
 - Fix yarn `upgrade --scope` when using exotic (github) dependencies.
 
   [#7017](https://github.com/yarnpkg/yarn/pull/7017) - [**Jeff Valore**](https://twitter.com/codingwithspike)

--- a/__tests__/commands/config.js
+++ b/__tests__/commands/config.js
@@ -36,6 +36,24 @@ test('cache-folder flag has higher priorities than .yarnrc file', (): Promise<vo
   );
 });
 
+test('write global-folder config into .yarnrc file', (): Promise<void> => {
+  return runConfig(['set', 'global-folder', 'folder_dir_for_test'], {}, '', async config => {
+    const configFile = await fs.readFile(config.registries.yarn.homeConfigLoc);
+    expect(configFile).toContain('folder_dir_for_test');
+  });
+});
+
+test('global-folder flag has higher priorities than .yarnrc file', (): Promise<void> => {
+  return runConfig(
+    ['set', 'global-folder', 'set_config_folder_dir'],
+    {globalFolder: 'flag_config_folder_dir'},
+    '',
+    config => {
+      expect(config.globalFolder).toContain('flag_config_folder_dir');
+    },
+  );
+});
+
 test('bin-links flag has higher priorities than .yarnrc file', (): Promise<void> => {
   return runConfig(['set', 'bin-links', 'true'], {binLinks: false}, '', config => {
     expect(config.binLinks).toBe(false);

--- a/src/config.js
+++ b/src/config.js
@@ -353,6 +353,11 @@ export default class Config {
       networkTimeout: this.networkTimeout,
     });
 
+    this.globalFolder = opts.globalFolder || String(this.getOption('global-folder', true));
+    if (this.globalFolder === 'undefined') {
+      this.globalFolder = constants.GLOBAL_MODULE_DIRECTORY;
+    }
+
     let cacheRootFolder = opts.cacheFolder || this.getOption('cache-folder', true);
 
     if (!cacheRootFolder) {
@@ -397,7 +402,7 @@ export default class Config {
       this.plugnplayPersist = false;
     } else {
       this.plugnplayEnabled = false;
-      this.plugnplayEnabled = false;
+      this.plugnplayPersist = false;
     }
 
     if (process.platform === 'win32') {
@@ -472,7 +477,6 @@ export default class Config {
 
     this.preferOffline = !!opts.preferOffline;
     this.modulesFolder = opts.modulesFolder;
-    this.globalFolder = opts.globalFolder || constants.GLOBAL_MODULE_DIRECTORY;
     this.linkFolder = opts.linkFolder || constants.LINK_REGISTRY_DIRECTORY;
     this.offline = !!opts.offline;
     this.binLinks = !!opts.binLinks;

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -31,8 +31,8 @@ export const DEFAULTS = {
   'user-agent': [`yarn/${version}`, 'npm/?', `node/${process.version}`, process.platform, process.arch].join(' '),
 };
 
-const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder', 'offline-cache-folder', 'yarn-path'];
-const FOLDER_KEY = ['yarn-offline-mirror', 'cache-folder', 'offline-cache-folder'];
+const RELATIVE_KEYS = ['yarn-offline-mirror', 'cache-folder', 'global-folder', 'offline-cache-folder', 'yarn-path'];
+const FOLDER_KEY = ['yarn-offline-mirror', 'cache-folder', 'global-folder', 'offline-cache-folder'];
 
 const npmMap = {
   'version-git-sign': 'sign-git-tag',


### PR DESCRIPTION

**Summary**

Close #5637. Allow `global-folder` to be set in `.yarnrc`, and be used if `--global-folder` is not set. Fallback setting remain unchanged.

**Test plan**

![yarn-patch](https://user-images.githubusercontent.com/5832170/53225569-7adf2100-36b3-11e9-8337-9bb1b11f985e.png)

