### PR TITLE
Clean up node path prepending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Removes `--scripts-prepend-node-path` as Yarn has this behavior by default
+
+  [#7057](https://github.com/yarnpkg/yarn/pull/7057/files) - [**Jason Grout**](https://github.com/jasongrout)
+
 - Adds support for `yarn policies set-version berry`
 
   [#7041](https://github.com/yarnpkg/yarn/pull/7041/files) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Removes `--scripts-prepend-node-path` as Yarn has this behavior by default
+- Removes `--scripts-prepend-node-path` as Yarn's default behavior makes this obsolete
 
   [#7057](https://github.com/yarnpkg/yarn/pull/7057/files) - [**Jason Grout**](https://github.com/jasongrout)
 

--- a/src/config.js
+++ b/src/config.js
@@ -50,7 +50,6 @@ export type ConfigOptions = {
   nonInteractive?: boolean,
   enablePnp?: boolean,
   disablePnp?: boolean,
-  scriptsPrependNodePath?: boolean,
   offlineCacheFolder?: string,
 
   enableDefaultRc?: boolean,
@@ -179,8 +178,6 @@ export default class Config {
   plugnplayBlacklist: ?string;
   plugnplayUnplugged: Array<string>;
   plugnplayPurgeUnpluggedPackages: boolean;
-
-  scriptsPrependNodePath: boolean;
 
   workspacesEnabled: boolean;
   workspacesNohoistEnabled: boolean;
@@ -487,8 +484,6 @@ export default class Config {
 
     // $FlowFixMe$
     this.nonInteractive = !!opts.nonInteractive || isCi || !process.stdout.isTTY;
-
-    this.scriptsPrependNodePath = !!opts.scriptsPrependNodePath;
 
     this.requestManager.setOptions({
       offline: !!opts.offline && !opts.preferOffline,

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -165,13 +165,6 @@ export async function makeEnv(
   const envPath = env[constants.ENV_PATH_KEY];
   const pathParts = envPath ? envPath.split(path.delimiter) : [];
 
-  // Include the directory that contains node so that we can guarantee that the scripts
-  // will always run with the exact same Node release than the one use to run Yarn
-  const execBin = path.dirname(process.execPath);
-  if (pathParts.indexOf(execBin) === -1) {
-    pathParts.unshift(execBin);
-  }
-
   // Include node-gyp version that was bundled with the current Node.js version,
   // if available.
   pathParts.unshift(path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'node-gyp-bin'));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
#6382 makes the previous behavior of prepending the node path obsolete. This PR cleans up the bugs noted in #5935 and partially addressed in #6178. This PR supersedes #6213.

It makes two basic changes:

* remove the now-unused scriptsPrependNodePath config option.
* remove the code that prepends the node exec path in certain situations.
