### PR TITLE
feat: allow cancelling yarn version with ctrl-c or empty version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Allow cancelling `yarn version` with ctrl-c or empty version number.
+- Makes `yarn version` cancellable via ctrl-c or empty string
 
   [#7064](https://github.com/yarnpkg/yarn/pull/7064) - [**Olle Lauri Boström**](https://github.com/ollelauribostrom)
 
@@ -12,7 +12,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#7041](https://github.com/yarnpkg/yarn/pull/7041/files) - [**Maël Nison**](https://twitter.com/arcanis)
 
-- Fix yarn `upgrade --scope` when using exotic (github) dependencies.
+- Fixes yarn `upgrade --scope` when using exotic (github) dependencies
 
   [#7017](https://github.com/yarnpkg/yarn/pull/7017) - [**Jeff Valore**](https://twitter.com/codingwithspike)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Allow cancelling `yarn version` with ctrl-c or empty version number.
+
+  [#7064](https://github.com/yarnpkg/yarn/pull/7064) - [**Olle Lauri Boström**](https://github.com/ollelauribostrom)
+
 - Adds support for `yarn policies set-version berry`
 
   [#7041](https://github.com/yarnpkg/yarn/pull/7041/files) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -100,7 +100,15 @@ export async function setVersion(
       break;
     }
 
-    newVersion = await reporter.question(reporter.lang('newVersion'));
+    // Make sure we dont exit with an error message when pressing Ctrl-C or enter to abort
+    try {
+      newVersion = await reporter.question(reporter.lang('newVersion'));
+      if (!newVersion) {
+        newVersion = oldVersion;
+      }
+    } catch (err) {
+      newVersion = oldVersion;
+    }
 
     if (!required && !newVersion) {
       reporter.info(`${reporter.lang('noVersionOnPublish')}: ${oldVersion}`);


### PR DESCRIPTION
**Summary**
As proposed in #7050. This allows cancelling `yarn version` with ctrl-c or empty version number.

**Test plan**
Run `yarn version`
Press Ctrl-C without entering a new version number
Yarn exits (no longer with an error message)

Run: `yarn version`
Press enter without entering a new version number
Yarn exits (no longer saying error Invalid semver version)
