### PR TITLE
fix: handle npm prefix config environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fix `npm_config_` environment variable parsing to support `_auth`, `_authToken`, `_username` and `_password` config options
+
+  [#7070](https://github.com/yarnpkg/yarn/pull/7070) - [**Nicholas Boll**](https://github.com/NicholasBoll)
+
 - Adds support for `yarn policies set-version berry`
 
   [#7041](https://github.com/yarnpkg/yarn/pull/7041/files) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -731,6 +731,37 @@ describe('isScopedPackage functional test', () => {
   });
 });
 
+describe('environment variables functional test', () => {
+  beforeEach(() => {
+    process.env.npm_config_always_auth = 'true';
+    process.env.npm_config__auth = 'auth';
+    process.env.npm_config__authtoken = 'authToken';
+    process.env.npm_config__username = 'username';
+    process.env.npm_config__password = 'password';
+  });
+
+  afterEach(() => {
+    delete process.env.npm_config_always_auth;
+    delete process.env.npm_config__auth;
+    delete process.env.npm_config__authToken;
+    delete process.env.npm_config__username;
+    delete process.env.npm_config__password;
+  });
+
+  test('correctly escapes environment config variables', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+
+    npmRegistry.mergeEnv('npm_config_');
+    expect(npmRegistry.config).toHaveProperty('always-auth', true);
+    expect(npmRegistry.config).toHaveProperty('_auth', 'auth');
+    expect(npmRegistry.config).toHaveProperty('_authtoken', 'authToken');
+    expect(npmRegistry.config).toHaveProperty('_username', 'username');
+    expect(npmRegistry.config).toHaveProperty('_password', 'password');
+  });
+});
+
 describe('getRequestUrl functional test', () => {
   test('returns pathname when it is a full URL', () => {
     const testCwd = '.';

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -171,7 +171,9 @@ export default class BaseRegistry {
       key = key.replace(/__/g, '.');
 
       // replace underscores with dashes
-      key = key.replace(/_/g, '-');
+      if (!['_auth', '_authtoken', '_username', '_password'].includes(key)) {
+        key = key.replace(/_/g, '-');
+      }
 
       // set it via a path
       objectPath.set(this.config, key, val);

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -170,10 +170,8 @@ export default class BaseRegistry {
       // replace dunders with dots
       key = key.replace(/__/g, '.');
 
-      // replace underscores with dashes
-      if (!['_auth', '_authtoken', '_username', '_password'].includes(key)) {
-        key = key.replace(/_/g, '-');
-      }
+      // replace underscores with dashes ignoring keys that start with an underscore
+      key.replace(/([^_])_/g, '$1-');
 
       // set it via a path
       objectPath.set(this.config, key, val);

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -171,7 +171,7 @@ export default class BaseRegistry {
       key = key.replace(/__/g, '.');
 
       // replace underscores with dashes ignoring keys that start with an underscore
-      key.replace(/([^_])_/g, '$1-');
+      key = key.replace(/([^_])_/g, '$1-');
 
       // set it via a path
       objectPath.set(this.config, key, val);


### PR DESCRIPTION
Fixes #4682

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Passing `npm_config_` environment variables changed all underscores (`_`) to dashes (`-`) which isn't correct behavior for special config variables (`_auth`, `_authToken`, `_username` and `_password`). An additional check was added to `base-registry.js` to filter out these config keys from this processing.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
`yarn test` - all tests passed except two tests that have nothing with my change - they are integration tests (I assume my environment isn't set up correctly for these to pass? Maybe CI will verify?)
