### PR TITLE
fix(upgrade) Fix basicSemverOperatorRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes yarn `upgrade --latest` for dependencies using `>` or `>=` range specifier
+
+  [#7080](https://github.com/yarnpkg/yarn/pull/7080) - [**Xukai Wu**](https://github.com/shilcare)
+
 - Fixes `--modules-folder` handling in several places (ex: `yarn check` now respects `--modules-folder`)
 
   [#6850](https://github.com/yarnpkg/yarn/pull/6850) - [**Jeff Valore**](https://twitter.com/codingwithspike)

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -12,7 +12,7 @@ import {Install} from './install.js';
 
 // used to detect whether a semver range is simple enough to preserve when doing a --latest upgrade.
 // when not matched, the upgraded version range will default to `^` the same as the `add` command would.
-const basicSemverOperatorRegex = new RegExp('^(\\^|~|>|<=|>=)?[^ |&,]+$');
+const basicSemverOperatorRegex = new RegExp('^(\\^|~|>=|<=|>)?[^ |&,]+$');
 
 // used to detect if a passed parameter is a scope or a package name.
 const validScopeRegex = /^@[a-zA-Z0-9-][a-zA-Z0-9_.-]*\/$/;

--- a/src/cli/commands/upgrade.js
+++ b/src/cli/commands/upgrade.js
@@ -12,7 +12,7 @@ import {Install} from './install.js';
 
 // used to detect whether a semver range is simple enough to preserve when doing a --latest upgrade.
 // when not matched, the upgraded version range will default to `^` the same as the `add` command would.
-const basicSemverOperatorRegex = new RegExp('^(\\^|~|>=|<=|>)?[^ |&,]+$');
+const basicSemverOperatorRegex = new RegExp('^(\\^|~|>=|<=)?[^ |&,]+$');
 
 // used to detect if a passed parameter is a scope or a package name.
 const validScopeRegex = /^@[a-zA-Z0-9-][a-zA-Z0-9_.-]*\/$/;
@@ -74,7 +74,7 @@ function setUserRequestedPackageVersions(
 }
 
 // this function attempts to determine the range operator on the semver range.
-// this will only handle the simple cases of a semver starting with '^', '~', '>', '>=', '<=', or an exact version.
+// this will only handle the simple cases of a semver starting with '^', '~', '>=', '<=', or an exact version.
 // "exotic" semver ranges will not be handled.
 function getRangeOperator(version): string {
   const result = basicSemverOperatorRegex.exec(version);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix bug #7079 of `basicSemverOperatorRegex`. It doesn't match the range operator correctly if the dependency range is specified with `>=`. For example, when running `yarn upgrade --latest`, if a dependency is specified with `>=`, the matched result will be `>`, which is not correct. 

This is because the regular expression engine looks for alternations one-by-one. We can fix it by putting `>=` before `>`.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

fixes #7079 

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
