### PR TITLE
Fix link to security advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes the advisory link printed by `yarn audit`
+
+  [#7091](https://github.com/yarnpkg/yarn/pull/7091) - [**Jakob Krigovsky**](https://github.com/sonicdoe)
+
 - Fixes `npm_config_` environment variable parsing to support those prefixed with underscore (ex: `_auth`)
 
   [#7070](https://github.com/yarnpkg/yarn/pull/7070) - [**Nicholas Boll**](https://github.com/NicholasBoll)

--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -565,7 +565,7 @@ export default class ConsoleReporter extends BaseReporter {
         ...patchRows,
         {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
         {Path: resolution.path.split('>').join(' > ')},
-        {'More info': `https://nodesecurity.io/advisories/${auditAdvisory.id}`},
+        {'More info': `https://www.npmjs.com/advisories/${auditAdvisory.id}`},
       ];
     }
 


### PR DESCRIPTION
**Summary**

Fixes the link provided in the “More info” row when running `yarn audit`.

The Node Security Platform (nodesecurity.io) [was acquired by npm](https://medium.com/npm-inc/npm-acquires-lift-security-258e257ef639) in April 2018. [nodesecurity.io/advisories](https://nodesecurity.io/advisories) is no longer available nowadays, however, all security advisories are available on [npmjs.com/advisories](https://www.npmjs.com/advisories).

**Test plan**

```console
$ yarn audit
yarn audit v1.15.0-0
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.11                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/782                         │
└───────────────┴──────────────────────────────────────────────────────────────┘
1 vulnerabilities found - Packages audited: 1
Severity: 1 Moderate
✨  Done in 3.74s.
```

Before, the defunct link https://nodesecurity.io/advisories/782 was printed. Now, it prints https://nodesecurity.io/advisories/782 in the “More info” row.