### PR TITLE
Allow Terminus to also display emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Packages won't be auto-unplugged anymore if `ignore-scripts` is set in the yarnrc file
 
   [#6983](https://github.com/yarnpkg/yarn/pull/6983) - [**Micha Reiser**](https://github.com/MichaReiser)
+  
+- Enables displaying Emojis on [Terminus](https://github.com/Eugeny/terminus) by default
+
+  [#7093](https://github.com/yarnpkg/yarn/pull/7093) - [**David Refoua**](https://github.com/DRSDavidSoft)
 
 ## 1.14.0
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -104,7 +104,10 @@ export async function main({
     '--emoji [bool]',
     'enable emoji in output',
     boolify,
-    process.platform === 'darwin' || process.env.TERM_PROGRAM === 'Hyper' || process.env.TERM_PROGRAM === 'HyperTerm' || process.env.TERM_PROGRAM === 'Terminus',
+    process.platform === 'darwin' ||
+      process.env.TERM_PROGRAM === 'Hyper' ||
+      process.env.TERM_PROGRAM === 'HyperTerm' ||
+      process.env.TERM_PROGRAM === 'Terminus',
   );
   commander.option('-s, --silent', 'skip Yarn console logs, other types of logs (script output) will be printed');
   commander.option('--cwd <cwd>', 'working directory to use', process.cwd());

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -104,7 +104,7 @@ export async function main({
     '--emoji [bool]',
     'enable emoji in output',
     boolify,
-    process.platform === 'darwin' || process.env.TERM_PROGRAM === 'Hyper' || process.env.TERM_PROGRAM === 'HyperTerm',
+    process.platform === 'darwin' || process.env.TERM_PROGRAM === 'Hyper' || process.env.TERM_PROGRAM === 'HyperTerm' || process.env.TERM_PROGRAM === 'Terminus',
   );
   commander.option('-s, --silent', 'skip Yarn console logs, other types of logs (script output) will be printed');
   commander.option('--cwd <cwd>', 'working directory to use', process.cwd());


### PR DESCRIPTION
### Summary
add Terminus to the list of supported terminal emulators for emoji

### Motivation
Since [Terminus](https://eugeny.github.io/terminus/) is also a xterm.js terminal emulator (same as [Hyper](https://hyper.is/)), and recently [it sets](https://github.com/Eugeny/terminus/commit/e246e22bfd51b1ee5e9e97a391ba6f51230070bb) `TERM_PROGRAM` to `Terminus` (like how Hyper sets it to `Hyper`), it is proper for Yarn to display Emojis also on Terminus.

### Example
Notice the `✨` emoji on the last line:

<img width="430" alt="wmoj" src="https://user-images.githubusercontent.com/4673812/53727831-76222600-3e86-11e9-8bf8-915f05fcaf14.png">