### PR TITLE
Add command-line argument to hide dedupe warnings

### DIFF
--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -23,6 +23,7 @@ export function hasWrapper(commander: Object): boolean {
 export function setFlags(commander: Object) {
   commander.description('Verifies if versions in the current project’s package.json match that of yarn’s lock file.');
   commander.option('--integrity');
+  commander.option('--no-dedupe-warnings', "don't show or count warnings about deduplication");
   commander.option('--verify-tree');
 }
 
@@ -373,6 +374,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
             const bundledDep = bundledDeps[rootDep] && bundledDeps[rootDep].indexOf(packageName) !== -1;
             if (
+              flags.dedupeWarnings &&
               !bundledDep &&
               (packageJson.version === depPkg.version ||
                 (semver.satisfies(packageJson.version, range, config.looseSemver) &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

yarn's "could be deduped from" warnings are unhelpful, noisy, and annoying. There's no clear path to fixing them and the deluge of output obfuscates other issues that would normally be seen easily. This commit adds a simple command-line flag to suppress these warnings from appearing in the output and the final count.

More details and complaining here: https://github.com/yarnpkg/yarn/issues/2287

**Test plan**

Before this change, `yarn check` would result in hundreds of warnings in our project:

```
$ yarn check
yarn check v1.13.0
warning Resolution field "braces@2.3.1" is incompatible with requested version "braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "braces@^0.1.2"
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
warning "@babel/helper-create-class-features-plugin##@babel/core@^7.0.0" could be deduped from "7.3.4" to "@babel\\core@7.3.4"
warning "@babel/plugin-transform-async-to-generator##@babel/core@^7.0.0-0" could be deduped from "7.3.4" to "@babel\\core@7.3.4"
warning "@babel/plugin-transform-block-scoping##@babel/core@^7.0.0-0" could be deduped from "7.3.4" to "@babel\\core@7.3.4"
warning "@babel/plugin-transform-classes##@babel/core@^7.0.0-0" could be deduped from "7.3.4" to "@babel\\core@7.3.4"
warning "@babel/plugin-transform-modules-systemjs##@babel/core@^7.0.0-0" could be deduped from "7.3.4" to "@babel\\core@7.3.4"

...

warning "istanbul-reports#handlebars#async@^2.5.0" could be deduped from "2.6.2" to "async@2.6.2"
warning "jest-jasmine2#jest-each#chalk@^2.0.1" could be deduped from "2.4.2" to "chalk@2.4.2"
warning "@storybook/mantra-core#@storybook/react-simple-di##prop-types@^15.6.0" could be deduped from "15.7.2" to "prop-types@15.7.2"
warning "react-treebeard#velocity-react#prop-types@^15.5.8" could be deduped from "15.7.2" to "prop-types@15.7.2"
info Found 295 warnings.
success Folder in sync.
Done in 11.38s.
```

After this change, only legitimate warnings are shown:

```
$ yarn check --no-dedupe-warnings
yarn check v1.16.0-0
warning Resolution field "braces@2.3.1" is incompatible with requested version "braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "braces@^0.1.2"
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
warning Resolution field "braces@2.3.1" is incompatible with requested version "karma#expand-braces#braces@^0.1.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "jest-cli#micromatch#braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "jest-config#micromatch#braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "test-exclude#micromatch#braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "jest-runtime#micromatch#braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "jest-message-util#micromatch#braces@^1.8.2"
warning Resolution field "braces@2.3.1" is incompatible with requested version "jest-haste-map#micromatch#braces@^1.8.2"
info Found 7 warnings.
success Folder in sync.
Done in 10.33s.
```