### PR TITLE
Add installationMethod for portage (Gentoo Linux)

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -115,6 +115,10 @@ function getUpdateCommand(installationMethod: InstallationMethod): ?string {
     return 'apk update && apk add -u yarn';
   }
 
+  if (installationMethod === 'portage') {
+    return 'sudo emerge --sync && sudo emerge -au sys-apps/yarn';
+  }
+
   return null;
 }
 

--- a/src/util/yarn-version.js
+++ b/src/util/yarn-version.js
@@ -37,4 +37,14 @@ export async function getInstallationMethod(): Promise<InstallationMethod> {
   return installationMethod;
 }
 
-export type InstallationMethod = 'tar' | 'homebrew' | 'deb' | 'rpm' | 'msi' | 'chocolatey' | 'apk' | 'npm' | 'unknown';
+export type InstallationMethod =
+  | 'tar'
+  | 'homebrew'
+  | 'deb'
+  | 'rpm'
+  | 'msi'
+  | 'chocolatey'
+  | 'apk'
+  | 'npm'
+  | 'portage'
+  | 'unknown';


### PR DESCRIPTION
Currently, portage is not an enumerated installation method for yarn despite being available through that package manager (ref: https://packages.gentoo.org/packages/sys-apps/yarn). This means that the update notification is wrong for users that install yarn via portage.

To prevent this, I added portage as a installation method and provide a portage-specific update notification.

Note: a patch to the Gentoo ebuild (package build script) for yarn makes this useful: https://github.com/gentoo/gentoo/pull/11395

Test:
I forced an update to be "available" by overwriting the `latestVersion` to be '1.17.0' and removing all of the frequency checks etc to force the message to appear when yarn is run:

```
warning Your current version of Yarn is out of date. The latest version is "1.17.0", while you're on "1.16.0-0".
info To upgrade, run the following command:
$ sudo emerge --sync && sudo emerge -au sys-apps/yarn
```