### PR TITLE
Add environment variables to spawned create process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6724](https://github.com/yarnpkg/yarn/pull/6724) - [**Tom Milligan**](https://github.com/tommilligan)
 
+- Add environment variables to spawned `create` process.
+
+  [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
+
 ## 1.15.2
 
 The 1.15.1 doesn't exist due to a release hiccup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#6724](https://github.com/yarnpkg/yarn/pull/6724) - [**Tom Milligan**](https://github.com/tommilligan)
 
-- Add environment variables to spawned `create` process.
+- Exposes the script environment variables to `yarn create` spawned processes.
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
 

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -4,6 +4,7 @@ import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
 import type {Reporter} from '../../reporters/index.js';
 import * as child from '../../util/child.js';
+import {makeEnv} from '../../util/execute-lifecycle-script';
 import {run as runGlobal, getBinFolder} from './global.js';
 
 const path = require('path');
@@ -61,6 +62,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
   const binFolder = await getBinFolder(config, {});
   const command = path.resolve(binFolder, commandName);
+  const env = await makeEnv('create', config.cwd, config);
 
-  await child.spawn(command, rest, {stdio: `inherit`, shell: true});
+  await child.spawn(command, rest, {stdio: `inherit`, shell: true, env});
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #5063.

When a user is running a package via `yarn create` or `npx`, the package is unable to determine whether it was yarn that launched the package. This is useful for running additional yarn commands in the repo over npm-based ones.

**Test plan**