### PR TITLE
Add private field to workspaces info command

### DIFF
--- a/src/cli/commands/workspaces.js
+++ b/src/cli/commands/workspaces.js
@@ -56,6 +56,7 @@ export async function info(config: Config, reporter: Reporter, flags: Object, ar
       location: path.relative(config.lockfileFolder, loc).replace(/\\/g, '/'),
       workspaceDependencies: Array.from(workspaceDependencies),
       mismatchedWorkspaceDependencies: Array.from(mismatchedWorkspaceDependencies),
+      private: manifest.private,
     };
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

A common use case of `yarn workspaces info` is programmatically retrieving a list of all packages in a repo. For many purposes, it is desirable to skip packages marked as `private`.

This PR adds the private field to the returned JSON for each package.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

Suppose there are two packages, `foo` and `bar` (private).

`yarn workspaces info` now yields:

```
{
  "foo": {
    "location": "packages/foo",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": [],
  },
  "bar": {
    "location": "packages/bar",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": [],
    "private": true
  },
}
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->