### PR TITLE
Always run postversion lifecycle method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Always run postversion lifecycle method.
+
+  [#7154](https://github.com/yarnpkg/yarn/pull/7154) - [**Hampus Tågerud**](https://github.com/hampustagerud)
+
 ## 1.16.0
 
 - Retries downloading a package on `yarn install` when we get a ETIMEDOUT error.
@@ -21,10 +25,6 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Exposes the script environment variables to `yarn create` spawned processes.
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
-
-- Always run postversion lifecycle method.
-
-  [#7154](https://github.com/yarnpkg/yarn/pull/7154) - [**Hampus Tågerud**](https://github.com/hampustagerud)
   
 - Prevents EPIPE errors from being printed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Always run postversion lifecycle method.
+- Fixes the `postversion` lifecycle method not being called when using `--no-git-tag-version`.
 
   [#7154](https://github.com/yarnpkg/yarn/pull/7154) - [**Hampus Tågerud**](https://github.com/hampustagerud)
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Implements `yarn audit --level [severity]` flag to filter the audit command's output.
 
-  [#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
+[#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
 
 - Implements `yarn audit --groups group_name [group_name ...]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Implements `yarn audit --level [severity]` flag to filter the audit command's output.
 
-[#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
+  [#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
 
 - Implements `yarn audit --groups group_name [group_name ...]`.
 
@@ -15,6 +15,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Exposes the script environment variables to `yarn create` spawned processes.
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
+
+- Always run postversion lifecycle method.
+
+  [#7154](https://github.com/yarnpkg/yarn/pull/7154) - [**Hampus Tågerud**](https://github.com/hampustagerud)
 
 ## 1.15.2
 

--- a/__tests__/fixtures/version/no-args-no-git-tags/.yarnrc
+++ b/__tests__/fixtures/version/no-args-no-git-tags/.yarnrc
@@ -1,0 +1,1 @@
+version-git-tag false

--- a/__tests__/fixtures/version/no-args-no-git-tags/package.json
+++ b/__tests__/fixtures/version/no-args-no-git-tags/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "license": "BSD-2-Clause",
+  "scripts": {
+    "preversion": "echo preversion",
+    "version": "echo version",
+    "postversion": "echo postversion"
+  }
+}

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -153,47 +153,44 @@ export async function setVersion(
 
   await runLifecycle('version');
 
-  await runLifecycle('postversion');
-
-  // check if committing the new version to git is overriden
-  if (!flags.gitTagVersion || !config.getOption('version-git-tag')) {
-    // Don't tag the version in Git
-    return () => Promise.resolve();
-  }
-
   return async function(): Promise<void> {
     invariant(newVersion, 'expected version');
 
-    // add git commit and tag
-    let isGit = false;
-    const parts = config.cwd.split(path.sep);
-    while (parts.length) {
-      isGit = await fs.exists(path.join(parts.join(path.sep), '.git'));
+    // check if a new git tag should be created
+    if (flags.gitTagVersion && config.getOption('version-git-tag')) {
+      // add git commit and tag
+      let isGit = false;
+      const parts = config.cwd.split(path.sep);
+      while (parts.length) {
+        isGit = await fs.exists(path.join(parts.join(path.sep), '.git'));
+        if (isGit) {
+          break;
+        } else {
+          parts.pop();
+        }
+      }
+
       if (isGit) {
-        break;
-      } else {
-        parts.pop();
+        const message = (flags.message || String(config.getOption('version-git-message'))).replace(/%s/g, newVersion);
+        const sign: boolean = Boolean(config.getOption('version-sign-git-tag'));
+        const flag = sign ? '-sm' : '-am';
+        const prefix: string = String(config.getOption('version-tag-prefix'));
+        const args: Array<string> = ['commit', '-m', message, ...(isCommitHooksDisabled() ? ['-n'] : [])];
+
+        const gitRoot = (await spawnGit(['rev-parse', '--show-toplevel'], {cwd: config.cwd})).trim();
+
+        // add manifest
+        await spawnGit(['add', path.relative(gitRoot, pkgLoc)], {cwd: gitRoot});
+
+        // create git commit
+        await spawnGit(args, {cwd: gitRoot});
+
+        // create git tag
+        await spawnGit(['tag', `${prefix}${newVersion}`, flag, message], {cwd: gitRoot});
       }
     }
 
-    if (isGit) {
-      const message = (flags.message || String(config.getOption('version-git-message'))).replace(/%s/g, newVersion);
-      const sign: boolean = Boolean(config.getOption('version-sign-git-tag'));
-      const flag = sign ? '-sm' : '-am';
-      const prefix: string = String(config.getOption('version-tag-prefix'));
-      const args: Array<string> = ['commit', '-m', message, ...(isCommitHooksDisabled() ? ['-n'] : [])];
-
-      const gitRoot = (await spawnGit(['rev-parse', '--show-toplevel'], {cwd: config.cwd})).trim();
-
-      // add manifest
-      await spawnGit(['add', path.relative(gitRoot, pkgLoc)], {cwd: gitRoot});
-
-      // create git commit
-      await spawnGit(args, {cwd: gitRoot});
-
-      // create git tag
-      await spawnGit(['tag', `${prefix}${newVersion}`, flag, message], {cwd: gitRoot});
-    }
+    await runLifecycle('postversion');
   };
 }
 

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -153,6 +153,8 @@ export async function setVersion(
 
   await runLifecycle('version');
 
+  await runLifecycle('postversion');
+
   // check if committing the new version to git is overriden
   if (!flags.gitTagVersion || !config.getOption('version-git-tag')) {
     // Don't tag the version in Git
@@ -192,8 +194,6 @@ export async function setVersion(
       // create git tag
       await spawnGit(['tag', `${prefix}${newVersion}`, flag, message], {cwd: gitRoot});
     }
-
-    await runLifecycle('postversion');
   };
 }
 


### PR DESCRIPTION
**Summary**

After battling `yarn` for a while, trying to get the `postversion` lifecycle method to run without committing the new version, I found #5358 which indicated that it actually doesn't run when opting out committing the changes. The documentation doesn't indicate that a commit is needed for `postversion` to run so at least I assumed that I wouldn't need to commit in order for `postversion` to run. According to the previously mentioned issue there seems to be some people sharing my confusing around this. My use case for wanting `postversion` to run without committing is that I need to update other files before creating a commit.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

I tested using the following steps:

- Edited the `scripts` section of `package.json` and added `preversion` and `postversion`:

  ```js
  {
    "scripts": {
      ...otherScripts,
      "preversion": "echo before: $npm_package_version",
      "postversion": "echo after: $npm_package_version"
   }
  }
   ```
- Ran `yarn version --no-git-tag-version --new-version 1.17.0` with a fresh install from homebrew, result: 

  ```
  yarn version v1.15.2
  warning ../package.json: No license field
  info Current version: 1.16.0-0
  $ echo before: $npm_package_version
  before: 1.16.0-0
  info New version: 1.17.0
  ✨  Done in 0.15s.
  ```

- Reset `package.json` version field.
- Ran `yarn build && node ./lib/cli/index.js version --no-git-tag-version --new-version 1.17.0` with the change from this PR, result: 

  ```
  info Current version: 1.16.0-0
  $ echo before: $npm_package_version
  before: 1.16.0-0
  info New version: 1.17.0
  $ echo after: $npm_package_version
  after: 1.17.0
  ✨  Done in 0.31s.
  ```

**Final notes**

I realise that `version` can be used to achieve this since it also passes `$npm_package_version` but since there is some confusion (once again referencing #5358, latest post from about a month ago), and the docs doesn't really mention it, making `postversion` always run would be more consistent with both its name and the docs (in my opinion).

If the current behaviour is desired I'd accept that but right now it is pretty ambiguous so I thought a at least a discussion would be good since #5358 has been open for over a year now 🙂

If accepted this will fix #5358.