### PR TITLE
Retry on connection timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Retries downloading a package on `yarn install` when we get a ETIMEDOUT error.
+
 - Implements `yarn audit --level [severity]` flag to filter the audit command's output.
 
 [#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Retries downloading a package on `yarn install` when we get a ETIMEDOUT error.
 
+[#7163](https://github.com/yarnpkg/yarn/pull/7163) - [**Vincent Bailly**](https://github.com/VincentBailly)
+
 - Implements `yarn audit --level [severity]` flag to filter the audit command's output.
 
 [#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -301,7 +301,7 @@ export default class RequestManager {
     }
 
     // TCP timeout
-    if (code === 'ESOCKETTIMEDOUT') {
+    if (code === 'ESOCKETTIMEDOUT' || code === 'ETIMEDOUT') {
       return true;
     }
 


### PR DESCRIPTION
**Summary**

yarn install randomly fails with a ETIMEDOUT error even though we have not reached the user defined timeout. In some cases, ETIMEDOUT error is not due to user defined timeout but to network instabilities, in such cases we should retry connecting (as we already do for ESOCKETTIMEDOUT errors)

**Test plan**

We tested this fork in production for a few days, no new issues or perf regression was observed, and the issue was fixed.
