### PR TITLE
[feat] Make `outdated` and `upgrade-interactive` more accessible

### DIFF
--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import PackageRequest from '../../package-request.js';
 import Lockfile from '../../lockfile';
 import {Install} from './install.js';
-import colorForVersions from '../../util/color-for-versions';
+import { colorAndEmojiForVersions } from '../../util/color-for-versions';
 import colorizeDiff from '../../util/colorize-diff.js';
 
 export const requireLockfile = true;
@@ -31,7 +31,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   const getNameFromHint = hint => (hint ? `${hint}Dependencies` : 'dependencies');
-  const colorizeName = ({current, latest, name}) => reporter.format[colorForVersions(current, latest)](name);
+  const colorizeName = ({current, latest, name}) => {
+    const [color, emoji] = colorAndEmojiForVersions(current, latest);
+    return reporter.format[color](reporter._prependEmoji(name, emoji));
+  }
 
   if (deps.length) {
     const usesWorkspaces = !!config.workspaceRootFolder;
@@ -51,9 +54,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       return row;
     });
 
-    const red = reporter.format.red('<red>');
-    const yellow = reporter.format.yellow('<yellow>');
-    const green = reporter.format.green('<green>');
+    const red = reporter.format.red(reporter._prependEmoji('<red>', '🛑'));
+    const yellow = reporter.format.yellow(reporter._prependEmoji(' <yellow>', '⚠️'));
+    const green = reporter.format.green(reporter._prependEmoji('<green>', '✅'));
     reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
 
     const header = ['Package', 'Current', 'Wanted', 'Latest', 'Workspace', 'Package Type', 'URL'];

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -5,7 +5,7 @@ import type Config from '../../config.js';
 import PackageRequest from '../../package-request.js';
 import Lockfile from '../../lockfile';
 import {Install} from './install.js';
-import { colorAndEmojiForVersions } from '../../util/color-for-versions';
+import {colorAndEmojiForVersions} from '../../util/color-for-versions';
 import colorizeDiff from '../../util/colorize-diff.js';
 
 export const requireLockfile = true;
@@ -34,7 +34,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const colorizeName = ({current, latest, name}) => {
     const [color, emoji] = colorAndEmojiForVersions(current, latest);
     return reporter.format[color](reporter._prependEmoji(name, emoji));
-  }
+  };
 
   if (deps.length) {
     const usesWorkspaces = !!config.workspaceRootFolder;

--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -7,7 +7,7 @@ import inquirer from 'inquirer';
 import Lockfile from '../../lockfile';
 import {Add} from './add.js';
 import {getOutdated, cleanLockfile} from './upgrade.js';
-import colorForVersions from '../../util/color-for-versions';
+import {colorAndEmojiForVersions} from '../../util/color-for-versions';
 import colorizeDiff from '../../util/colorize-diff.js';
 import {Install} from './install.js';
 
@@ -82,7 +82,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const headerPadding = (header, key) =>
     `${reporter.format.bold.underline(header)}${' '.repeat(maxLengthArr[key] - header.length)}`;
 
-  const colorizeName = (from, to) => reporter.format[colorForVersions(from, to)];
+  const colorizeName = (from, to) => {
+    const [color, emoji] = colorAndEmojiForVersions(from, to);
+    return msg => reporter.format[color](reporter._prependEmoji(msg, emoji));
+  };
 
   const getNameFromHint = hint => (hint ? `${hint}Dependencies` : 'dependencies');
 

--- a/src/util/color-for-versions.js
+++ b/src/util/color-for-versions.js
@@ -4,7 +4,7 @@ import {diffWithUnstable} from './semver.js';
 import {VERSION_COLOR_SCHEME} from '../constants.js';
 import type {VersionColor} from '../constants.js';
 
-export default function(from: string, to: string): VersionColor {
+export default function colorForVersions(from: string, to: string): VersionColor {
   const validFrom = semver.valid(from);
   const validTo = semver.valid(to);
   let versionBump = 'unknown';
@@ -12,4 +12,21 @@ export default function(from: string, to: string): VersionColor {
     versionBump = diffWithUnstable(validFrom, validTo) || 'unchanged';
   }
   return VERSION_COLOR_SCHEME[versionBump];
+}
+
+export function colorAndEmojiForVersions(from: string, to: string): [VersionColor, ?string] {
+  const color: VersionColor = colorForVersions(from, to);
+  let emoji = '';
+  switch (color) {
+    case 'red':
+      emoji = '🛑';
+      break;
+    case 'yellow':
+      emoji = '⚠️ ';
+      break;
+    case 'green':
+      emoji = '✅';
+      break;
+  }
+  return [color, emoji];
 }


### PR DESCRIPTION
**Summary**
As outlined in #5990, `outdated` and `upgrade-interactive` aren’t totally accessible to users with red-green colorblindness. This PR addresses the issue by prepending emoji to indicate the different server diffs:

- 🛑 <major>
- ⚠️ <minor>
- ✅ <patch>

**Test plan**

`outdated` screenshot:
<img width="1152" alt="Screenshot 2019-04-06 16 37 06" src="https://user-images.githubusercontent.com/439365/55676477-f6bfb200-588a-11e9-9d77-e175973ee0ed.png">

`upgrade-interactive` screenshot:
<img width="1180" alt="Screenshot 2019-04-06 16 37 26" src="https://user-images.githubusercontent.com/439365/55676480-0212dd80-588b-11e9-98b9-005767f23e5f.png">

**To do:**
[ ] Fix failing Flow test