### PR TITLE
wip(link): Fix not found error when linkFolder is inside a symlinked directory

### DIFF
--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -56,12 +56,14 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       throw new MessageError(reporter.lang('unknownPackageName'));
     }
 
-    const linkLoc = path.join(config.linkFolder, name);
-    if (await fs.exists(linkLoc)) {
+    const realCwd = await fs.realpath(process.cwd())
+    const realLinkFolder = await fs.realpath(config.linkFolder)
+    const realLinkLoc = path.join(realLinkFolder, name);
+    if (await fs.exists(realLinkLoc)) {
       reporter.warn(reporter.lang('linkCollision', name));
     } else {
-      await fs.mkdirp(path.dirname(linkLoc));
-      await fs.symlink(config.cwd, linkLoc);
+      await fs.mkdirp(path.dirname(realLinkLoc));
+      await fs.symlink(realCwd, realLinkLoc);
 
       // If there is a `bin` defined in the package.json,
       // link each bin to the global bin
@@ -69,7 +71,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
         const globalBinFolder = await getGlobalBinFolder(config, flags);
         for (const binName in manifest.bin) {
           const binSrc = manifest.bin[binName];
-          const binSrcLoc = path.join(linkLoc, binSrc);
+          const binSrcLoc = path.join(realLinkLoc, binSrc);
           const binDestLoc = path.join(globalBinFolder, binName);
           if (await fs.exists(binDestLoc)) {
             reporter.warn(reporter.lang('binLinkCollision', binName));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

This is not a substantial feature request.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is the problem I was having (on macOS):

- `cd ~/.local/src/github.com/agentofuser/ipfs-deploy`
- `yarn link`
- link gets created in `~/.config/yarn/link/@agentofuser/ipfs-deploy`, pointing to `../../../../.local/src/github.com/agentofuser/ipfs-deploy`
- `cd ~/.config/yarn/link/@agentofuser/ipfs-deploy` gives a "file or directory not found" error
- link `~/.yarn/bin/ipfs-deploy` also gets created, pointing to `../../.config/yarn/link/@agentofuser/ipfs-deploy/bin/ipfs-deploy.js`
- trying to run `~/.yarn/bin/ipfs-deploy` gives a not found error

What is going on?

Here is the catch:

- `~/.config` itself is already a link. It points to an keybase encrypted git repo which backs up my dotfiles
- this repo is, say, on `~/keybase/repos/dotfiles`
- so when the OS is traversing all those 4 `../`s to get from `~/.config/yarn/link/@agentofuser/` to `~/` and then go down `.local`, it's not actually starting from `~/.config/yarn/link/@agentofuser/`, but from `~/keybase/repos/dotfiles/.config/yarn/link/@agentofuser/`
- after 4 `../`s, it's at `~/keybase/repos/dotfiles/`
- there is no `.local` there, so it errors out
- same reasoning goes for the `bin` symlink

In summary: the OS expands the symlinks before doing the traversal, so the first symlinked path (`linkFolder`) must be expanded into a `realpath` before creating a new symlink within it.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This is more of a bug report with a hacky "works for me" patch than an actual pull request. There are other parts of the code that interact with `linkFolder` (like `unlink`, which I haven't changed yet), and I'm not sure this is the right depth at which to turn it into a `realpath`.

I'm willing to work on the whole thing with tests and everything if there's someone willing to advise. Otherwise I can close the PR and open it as a regular issue.
