### PR TITLE
Handle EPIPE on stdout gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
 
+- Prevents EPIPE errors from being printed.
+
+  [#7194](https://github.com/yarnpkg/yarn/pull/7194) - [**Abhishek Reddy**](https://github.com/arbscht)
+
 ## 1.15.2
 
 The 1.15.1 doesn't exist due to a release hiccup.

--- a/__tests__/pipe.js
+++ b/__tests__/pipe.js
@@ -1,0 +1,96 @@
+/* @flow */
+/* eslint max-len: 0 */
+
+import execa from 'execa';
+import {sh} from 'puka';
+import makeTemp from './_temp.js';
+import * as fs from '../src/util/fs.js';
+
+const path = require('path');
+
+function runYarnStreaming(args: Array<string> = [], options: Object = {}): execa.ExecaChildPromise {
+  if (!options['env']) {
+    options['env'] = {...process.env};
+    options['extendEnv'] = false;
+  }
+  options['env']['FORCE_COLOR'] = 0;
+
+  return execa.shell(sh`${path.resolve(__dirname, '../bin/yarn')} ${args}`, options);
+}
+
+test('terminate console stream quietly on EPIPE', async () => {
+  const cwd = await makeTemp();
+  const packageJsonPath = path.join(cwd, 'package.json');
+  const initialManifestFile = JSON.stringify({name: 'test', license: 'ISC', version: '1.0.0'});
+
+  await fs.writeFile(packageJsonPath, initialManifestFile);
+
+  const {stdout, stderr} = runYarnStreaming(['versions'], {cwd});
+
+  stdout.destroy();
+
+  await new Promise((resolve, reject) => {
+    let stderrOutput = '';
+    stderr.on('readable', () => {
+      const chunk = stderr.read();
+      if (chunk) {
+        stderrOutput += chunk;
+      } else {
+        resolve(stderrOutput);
+      }
+    });
+    stderr.on('error', err => {
+      reject(err);
+    });
+  })
+    .then(stderrOutput => {
+      expect(stderrOutput).not.toMatch(/EPIPE/);
+    })
+    .catch(err => {
+      expect(err).toBeFalsy();
+    });
+});
+
+test('terminate console stream preserving zero exit code on EPIPE', async () => {
+  const cwd = await makeTemp();
+  const packageJsonPath = path.join(cwd, 'package.json');
+  const initialManifestFile = JSON.stringify({name: 'test', license: 'ISC', version: '1.0.0'});
+
+  await fs.writeFile(packageJsonPath, initialManifestFile);
+
+  const proc = runYarnStreaming(['versions'], {cwd});
+
+  const {stdout} = proc;
+
+  stdout.destroy();
+
+  await new Promise(resolve => {
+    proc.on('exit', function(code, signal) {
+      resolve(code);
+    });
+  }).then(exitCode => {
+    expect(exitCode).toEqual(0);
+  });
+});
+
+test('terminate console stream preserving non-zero exit code on EPIPE', async () => {
+  const cwd = await makeTemp();
+  const packageJsonPath = path.join(cwd, 'package.json');
+  const initialManifestFile = JSON.stringify({name: 'test', license: 'ISC', version: '1.0.0'});
+
+  await fs.writeFile(packageJsonPath, initialManifestFile);
+
+  const proc = runYarnStreaming(['add'], {cwd});
+
+  const {stdout} = proc;
+
+  stdout.destroy();
+
+  await new Promise(resolve => {
+    proc.on('exit', function(code, signal) {
+      resolve(code);
+    });
+  }).then(exitCode => {
+    expect(exitCode).toEqual(1);
+  });
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -26,6 +26,14 @@ import handleSignals from '../util/signal-handler.js';
 import {boolify, boolifyWithDefault} from '../util/conversion.js';
 import {ProcessTermError} from '../errors';
 
+process.stdout.prependListener('error', err => {
+  // swallow err only if downstream consumer process closed pipe early
+  if (err.code === 'EPIPE' || err.code === 'ERR_STREAM_DESTROYED') {
+    return;
+  }
+  throw err;
+});
+
 function findProjectRoot(base: string): string {
   let prev = null;
   let dir = base;


### PR DESCRIPTION
**Problem:** when yarn outputs to a pipe, it is sensitive to the pipe closing prematurely. If the pipe is closed before output is finished, a noisy error message appears on stderr.

It appears all commands with reporter output are affected. (`yarn help` appears to be unaffected, for example.)

**Expected:** yarn should handle the broken stdout pipe error quietly and complete its work (and exit with whatever status it would have otherwise).

**To reproduce:** trivial examples on node versions 8.x through 11.x, using `head` to truncate output before the last line:

```
$ yarn versions | head -n 16
yarn versions v1.15.2
{ yarn: '1.16.0-0',
  http_parser: '2.8.0',
  node: '8.15.1',
  v8: '6.2.414.75',
  uv: '1.23.2',
...
  tz: '2017c' }
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.afterWrite [as oncomplete] (net.js:868:14)
```

```
$ yarn versions | head -n 16
yarn versions v1.15.2
{ yarn: '1.16.0-0',
  http_parser: '2.8.0',
  node: '9.11.2',
  v8: '6.2.414.46-node.23',
  uv: '1.19.2',
...
  tz: '2018c' }
events.js:165
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.afterWrite [as oncomplete] (net.js:844:14)
Emitted 'error' event at:
    at onwriteError (_stream_writable.js:431:12)
    at onwrite (_stream_writable.js:453:5)
    at _destroy (internal/streams/destroy.js:39:7)
    at Socket.stdout._destroy (internal/process/stdio.js:19:7)
    at Socket.destroy (internal/streams/destroy.js:32:8)
    at WriteWrap.afterWrite [as oncomplete] (net.js:846:10)
```

```
$ yarn versions | head -n 31
yarn versions v1.15.2
{ yarn:
   '1.16.0-0',
  http_parser:
   '2.8.0',
  node:
   '10.15.3',
  v8:
   '6.8.275.32-node.51',
  uv:
   '1.23.2',
...
  tz:
   '2018e' }
events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.afterWrite [as oncomplete] (net.js:779:14)
Emitted 'error' event at:
    at onwriteError (_stream_writable.js:431:12)
    at onwrite (_stream_writable.js:456:5)
    at _destroy (internal/streams/destroy.js:40:7)
    at Socket.dummyDestroy [as _destroy] (internal/process/stdio.js:11:34)
    at Socket.destroy (internal/streams/destroy.js:32:8)
    at WriteWrap.afterWrite [as oncomplete] (net.js:781:10)
```

```
$ yarn versions | head -n 35
yarn versions v1.15.2
{ yarn:
   '1.16.0-0',
  node:
   '11.13.0',
  v8:
   '7.0.276.38-node.18',
  uv:
   '1.27.0',
...
  unicode:
   '11.0' }
events.js:170
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (internal/stream_base_commons.js:67:16)
Emitted 'error' event at:
    at errorOrDestroy (internal/streams/destroy.js:107:12)
    at onwriteError (_stream_writable.js:436:5)
    at onwrite (_stream_writable.js:461:5)
    at _destroy (internal/streams/destroy.js:49:7)
    at Socket.dummyDestroy [as _destroy] (internal/process/stdio.js:11:5)
    at Socket.destroy (internal/streams/destroy.js:37:8)
    at WriteWrap.onWriteComplete [as oncomplete] (internal/stream_base_commons.js:68:12)

```

For comparison, `npm` (on node `v11.13.0`) behaves as expected:

```
$ npm version | head -n 15
{ yarn: '1.16.0-0',
  npm: '6.7.0',
...
  uv: '1.27.0',
  v8: '7.0.276.38-node.18',
```

This PR demonstrates a possible fix, which swallows pipe and stream errors on stdout without taking action, allowing yarn to complete quietly and exit as it would otherwise.

The correct behavior is visible like this (on node `v11.13.0`) for example:

```
$ yarn-local versions | head -n 35
yarn versions v1.16.0-0
{ yarn:
   '1.16.0-0',
  node:
   '11.13.0',
  v8:
   '7.0.276.38-node.18',
  uv:
   '1.27.0',
...
  unicode:
   '11.0' }
```

Please discuss.