### PR TITLE
Support NPM Enterprise URLs in offline mirror filename calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
 
+- Support NPM Enterprise URLs in offline mirror filename calculation.
+
+  [#7200](https://github.com/yarnpkg/yarn/pull/7200) - [**John Millikin**](https://john-millikin.com)
+
 ## 1.15.2
 
 The 1.15.1 doesn't exist due to a release hiccup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
 
-- Support NPM Enterprise URLs in offline mirror filename calculation.
+- Adds support for the npm enterprise URLs when computing the offline mirror filenames.
 
   [#7200](https://github.com/yarnpkg/yarn/pull/7200) - [**John Millikin**](https://john-millikin.com)
 

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -322,6 +322,27 @@ test('TarballFetcher.fetch properly stores tarball for scoped package resolved f
   expect(fetcher.getTarballMirrorPath()).toBe(path.join(offlineMirrorDir, '@exponent-configurator-1.0.2.tgz'));
 });
 
+test('TarballFetcher.fetch properly stores tarball for scoped package resolved from npm enterprise registry', async () => {
+  const dir = await mkdir('tarball-fetcher');
+  const offlineMirrorDir = await mkdir('offline-mirror');
+
+  const config = await Config.create();
+  config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
+
+  const fetcher = new TarballFetcher(
+    dir,
+    {
+      type: 'tarball',
+      hash: '6f0ab73cdd7b82d8e81e80838b49e9e4c7fbcc44',
+      reference: 'https://npm.internal.site:443/@/@exponent/configurator/_attachments/configurator-1.0.2.tgz',
+      registry: 'npm',
+    },
+    config,
+  );
+
+  expect(fetcher.getTarballMirrorPath()).toBe(path.join(offlineMirrorDir, '@exponent-configurator-1.0.2.tgz'));
+});
+
 test('TarballFetcher.fetch throws on truncated tar data', async () => {
   const dir = await mkdir('tarball-fetcher');
   const reporter = new Reporter();

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -18,7 +18,7 @@ const gunzip = require('gunzip-maybe');
 const invariant = require('invariant');
 const ssri = require('ssri');
 
-const RE_URL_NAME_MATCH = /\/(?:(@[^/]+)\/)?[^/]+\/-\/(?:@[^/]+\/)?([^/]+)$/;
+const RE_URL_NAME_MATCH = /\/(?:(@[^/]+)\/)?[^/]+\/(?:-|_attachments)\/(?:@[^/]+\/)?([^/]+)$/;
 
 const isHashAlgorithmSupported = name => {
   const cachedResult = isHashAlgorithmSupported.__cache[name];


### PR DESCRIPTION
**Summary**
Fixes https://github.com/yarnpkg/yarn/issues/7199

**Test plan**
I added a new test case to `__tests__/fetchers.js` for NPM Enterprise URLs.