### PR TITLE
Runtime wrapper handling

### DIFF
--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -88,6 +88,7 @@ export function makeConfigFromDirectory(cwd: string, reporter: Reporter, flags: 
       ignoreScripts: flags.ignoreScripts,
       globalFolder: flags.globalFolder || path.join(cwd, '.yarn-global'),
       cacheFolder: flags.cacheFolder || path.join(cwd, '.yarn-cache'),
+      wrapperFolder: flags.wrapperFolder || path.join(cwd, '.yarn-wrapper'),
       linkFolder: flags.linkFolder || path.join(cwd, '.yarn-link'),
       prefix: flags.prefix,
       production: flags.production,

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -51,6 +51,7 @@ async function updateCwd(config: Config): Promise<void> {
     binLinks: true,
     globalFolder: config.globalFolder,
     cacheFolder: config._cacheRootFolder,
+    wrapperFolder: config.wrapperFolder,
     linkFolder: config.linkFolder,
     enableDefaultRc: config.enableDefaultRc,
     extraneousYarnrcFiles: config.extraneousYarnrcFiles,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -100,6 +100,10 @@ export async function main({
   );
   commander.option('--preferred-cache-folder <path>', 'specify a custom folder to store the yarn cache if possible');
   commander.option('--cache-folder <path>', 'specify a custom folder that must be used to store the yarn cache');
+  commander.option(
+    '--wrapper-folder <path>',
+    'specify a custom base folder that must be used to store the node wrappers',
+  );
   commander.option('--mutex <type>[:specifier]', 'use a mutex to ensure only one yarn instance is executing');
   commander.option(
     '--emoji [bool]',
@@ -516,6 +520,7 @@ export async function main({
       globalFolder: commander.globalFolder,
       preferredCacheFolder: commander.preferredCacheFolder,
       cacheFolder: commander.cacheFolder,
+      wrapperFolder: commander.wrapperFolder,
       preferOffline: commander.preferOffline,
       captureHar: commander.har,
       ignorePlatform: commander.ignorePlatform,

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,7 @@ export type ConfigOptions = {
   _cacheRootFolder?: ?string,
   cacheFolder?: ?string,
   tempFolder?: ?string,
+  wrapperFolder?: ?string,
   modulesFolder?: ?string,
   globalFolder?: ?string,
   linkFolder?: ?string,
@@ -156,6 +157,9 @@ export default class Config {
 
   //
   tempFolder: string;
+
+  //
+  wrapperFolder: string;
 
   //
   reporter: Reporter;
@@ -429,6 +433,7 @@ export default class Config {
     //init & create cacheFolder, tempFolder
     this.cacheFolder = path.join(this._cacheRootFolder, 'v' + String(constants.CACHE_VERSION));
     this.tempFolder = opts.tempFolder || path.join(this.cacheFolder, '.tmp');
+    this.wrapperFolder = opts.wrapperFolder || '';
     await fs.mkdirp(this.cacheFolder);
     await fs.mkdirp(this.tempFolder);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -84,6 +84,7 @@ export const POSIX_GLOBAL_PREFIX = `${process.env.DESTDIR || ''}/usr/local`;
 export const FALLBACK_GLOBAL_PREFIX = path.join(userHome, '.yarn');
 
 export const META_FOLDER = '.yarn-meta';
+export const WRAPPER_FOLDER = '.yarn.wrapper';
 export const INTEGRITY_FILENAME = '.yarn-integrity';
 export const LOCKFILE_FILENAME = 'yarn.lock';
 export const METADATA_FILENAME = '.yarn-metadata.json';

--- a/src/rc.js
+++ b/src/rc.js
@@ -16,6 +16,7 @@ const PATH_KEYS = new Set([
   'modules-folder',
   'cwd',
   'offline-cache-folder',
+  'wrapper-folder',
 ]);
 
 // given a cwd, load all .yarnrc files relative to it

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -4,6 +4,7 @@
 import * as constants from '../constants.js';
 import BlockingQueue from './blocking-queue.js';
 import {ProcessSpawnError, ProcessTermError} from '../errors.js';
+import * as fs from './fs.js';
 import {promisify} from './promise.js';
 
 const child = require('child_process');
@@ -94,6 +95,7 @@ export function spawn(
         }
 
         function finish() {
+          fs.unlink(opts.env[constants.WRAPPER_FOLDER]);
           delete spawnedProcesses[key];
           if (err) {
             reject(err);

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -32,7 +32,7 @@ export async function getWrappersFolder(config: Config): Promise<string> {
     return wrappersFolder;
   }
 
-  wrappersFolder = await fs.makeTempDir();
+  wrappersFolder = await fs.makeTempDir(null, config.wrapperFolder);
 
   await makePortableProxyScript(process.execPath, wrappersFolder, {
     proxyBasename: 'node',

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -228,7 +228,10 @@ export async function makeEnv(
     env.NODE_OPTIONS = `--require ${pnpFile} ${env.NODE_OPTIONS}`;
   }
 
-  pathParts.unshift(await getWrappersFolder(config));
+  // Track our wrapper folder so we can clean up after ourselves … 'cause we're awesome!
+  const wrapperFolder = await getWrappersFolder(config);
+  env[constants.WRAPPER_FOLDER] = wrapperFolder;
+  pathParts.unshift(wrapperFolder);
 
   // join path back together
   env[constants.ENV_PATH_KEY] = pathParts.join(path.delimiter);

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -806,8 +806,8 @@ export async function hardlinksWork(dir: string): Promise<boolean> {
 }
 
 // not a strict polyfill for Node's fs.mkdtemp
-export async function makeTempDir(prefix?: string): Promise<string> {
-  const dir = path.join(os.tmpdir(), `yarn-${prefix || ''}-${Date.now()}-${Math.random()}`);
+export async function makeTempDir(prefix?: string, base?: string): Promise<string> {
+  const dir = path.join(base || os.tmpdir(), `yarn-${prefix || ''}-${Date.now()}-${Math.random()}`);
   await unlink(dir);
   await mkdirp(dir);
   return dir;


### PR DESCRIPTION
Summary
-------

On each run of Yarn, a directory is created under the OS tmpdir with the following format:
```
path.join(os.tmpdir(), `yarn-${prefix || ''}-${Date.now()}-${Math.random()}`);
```

As these directories are not currently cleaned up by Yarn, they quickly become numerous and start eating up space. This can be problematic when the tmpdir has been mounted on `ramfs`/`tmpfs`, or on a CI machine that runs endlessly … with nobody watching disc usage … 'cause "it's just CI, not my job".

This PR offers two ways to approach this, happy to drop one, or the other, or both if it isn't a match for the project :smiley_cat: 

### Option 1 — `--wrapper-folder <path>`

This allows the end-user to optionally specify a location to dump this data, e.g. a nice big chunk of slow storage.

### Option 2 — Remove wrapper folder post-execution

I have my mother in my head right now reminding me to clean up my Lego when I was done playing. That memory & its metaphor seems to do a good job of explaining the rationale here.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

Test plan
---------

Test all the thingz!

Seriously, I'm a huge believer in writing good quality tests and will gladly add them to this PR. I held back on adding them to the initial submission as I wasn't sure where/what would be a good fit.

So if the PR is deemed to be eligible for inclusion, I'll happily add some tests if someone could, in exchange, give me a very quick pointer on where the coverage should go.

Thank you all for a wonderful tool! :+1: