### PR TITLE
Remove trailing slash from path element

### DIFF
--- a/resources/winsetup/Yarn.wxs
+++ b/resources/winsetup/Yarn.wxs
@@ -35,7 +35,7 @@
 				<Environment
 					Id="Path"
 					Name="PATH"
-					Value="[INSTALLDIR]bin\"
+					Value="[INSTALLDIR]bin"
 					Permanent="no"
 					Part="last"
 					Action="set"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Every character in Windows environment is a precious resource, should not append an unnecessary slash at the end.

Furthermore, it's inconsistent with the missing trailing slash in the AppData path a few lines below.