### PR TITLE
Tweaks the yarnrc syntax parser

### DIFF
--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -337,7 +337,7 @@ test('parse merge conflict fail', () => {
   const file = `
 <<<<<<< HEAD
 b:
-  foo: "bar"
+  foo "bar
 =======
 c:
   bar "foo"

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -597,7 +597,7 @@ export async function main({
 
 async function start(): Promise<void> {
   const rc = getRcConfigForCwd(process.cwd(), process.argv.slice(2));
-  const yarnPath = rc['yarn-path'];
+  const yarnPath = rc['yarn-path'] || rc['yarnPath'];
 
   if (yarnPath && !boolifyWithDefault(process.env.YARN_IGNORE_PATH, false)) {
     const argv = process.argv.slice(2);

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -133,7 +133,7 @@ function* tokenise(input: string): Iterator<Token> {
     } else if (input[0] === ',') {
       yield buildToken(TOKEN_TYPES.comma);
       chop++;
-    } else if (/^[a-zA-Z\/-]/g.test(input)) {
+    } else if (/^[a-zA-Z\/.-]/g.test(input)) {
       let i = 0;
       for (; i < input.length; i++) {
         const char = input[i];
@@ -286,12 +286,19 @@ class Parser {
           this.next();
         }
 
-        const valToken = this.token;
-
-        if (valToken.type === TOKEN_TYPES.colon) {
-          // object
+        const wasColon = this.token.type === TOKEN_TYPES.colon;
+        if (wasColon) {
           this.next();
+        }
 
+        if (isValidPropValueToken(this.token)) {
+          // plain value
+          for (const key of keys) {
+            obj[key] = this.token.value;
+          }
+
+          this.next();
+        } else if (wasColon) {
           // parse object
           const val = this.parse(indent + 1);
 
@@ -302,13 +309,6 @@ class Parser {
           if (indent && this.token.type !== TOKEN_TYPES.indent) {
             break;
           }
-        } else if (isValidPropValueToken(valToken)) {
-          // plain value
-          for (const key of keys) {
-            obj[key] = valToken.value;
-          }
-
-          this.next();
         } else {
           this.unexpected('Invalid value type');
         }


### PR DESCRIPTION
**Summary**

In preparation for the v2 (which is yaml-like), I've slightly relaxed the parser so that the following construct wouldn't generate parse errors:

```
yarnPath: .yarn/releases/yarn-1.15.2.js
```

This will make it easier for v2 users to revert back to the v1 if they need to.

**Test plan**

Tested locally.