### PR TITLE
:sparkles: Add support for --registry with audit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Adds support for the npm enterprise URLs when computing the offline mirror filenames.
 
   [#7200](https://github.com/yarnpkg/yarn/pull/7200) - [**John Millikin**](https://john-millikin.com)
-  
+
 - Tweaks the lockfile parser logic to parse a few extra cases
 
   [#7210](https://github.com/yarnpkg/yarn/pull/7210) - [**Maël Nison**](https://twitter.com/arcanis)
+
+- Implements `yarn audit --registry [url]`.
+  [#7263](https://github.com/yarnpkg/yarn/pull/7263) - [**Charles-Henri Guérin**](https://twitter.com/charlyx)
 
 ## 1.15.2
 
@@ -107,7 +110,7 @@ The 1.15.1 doesn't exist due to a release hiccup.
 - Packages won't be auto-unplugged anymore if `ignore-scripts` is set in the yarnrc file
 
   [#6983](https://github.com/yarnpkg/yarn/pull/6983) - [**Micha Reiser**](https://github.com/MichaReiser)
-  
+
 - Enables displaying Emojis on [Terminus](https://github.com/Eugeny/terminus) by default
 
   [#7093](https://github.com/yarnpkg/yarn/pull/7093) - [**David Refoua**](https://github.com/DRSDavidSoft)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
   [#7210](https://github.com/yarnpkg/yarn/pull/7210) - [**Maël Nison**](https://twitter.com/arcanis)
 
 - Implements `yarn audit --registry [url]`.
+
   [#7263](https://github.com/yarnpkg/yarn/pull/7263) - [**Charles-Henri Guérin**](https://twitter.com/charlyx)
 
 ## 1.15.2

--- a/__tests__/commands/audit.js
+++ b/__tests__/commands/audit.js
@@ -450,3 +450,12 @@ test.concurrent('sends correct dependency map to audit api for workspaces.', () 
     expect(calledWith).toEqual(expectedApiPost);
   });
 });
+
+test('calls specified registry when using --registry high flag', () => {
+  const privateRegistry = 'https://my-private.registry.org';
+  const expectedUrl = `${privateRegistry}/-/npm/v1/security/audits`;
+
+  return runAudit([], {registry: privateRegistry}, 'single-vulnerable-dep-installed', (config, reporter) => {
+    expect(config.requestManager.request).toHaveBeenCalledWith(expect.objectContaining({url: expectedUrl}));
+  });
+});

--- a/src/cli/commands/audit.js
+++ b/src/cli/commands/audit.js
@@ -19,6 +19,7 @@ const gzip = promisify(zlib.gzip);
 export type AuditOptions = {
   groups: Array<string>,
   level?: string,
+  registry?: string,
 };
 
 export type AuditNode = {
@@ -145,6 +146,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const audit = new Audit(config, reporter, {
     groups: flags.groups || OWNED_DEPENDENCY_TYPES,
     level: flags.level || DEFAULT_LOG_LEVEL,
+    registry: flags.registry,
   });
   const lockfile = await Lockfile.fromDirectory(config.lockfileFolder, reporter);
   const install = new Install({}, config, reporter, lockfile);
@@ -238,7 +240,7 @@ export default class Audit {
 
   async _fetchAudit(auditTree: AuditTree): Object {
     let responseJson;
-    const registry = YARN_REGISTRY;
+    const registry = this.options.registry || YARN_REGISTRY;
     this.reporter.verbose(`Audit Request: ${JSON.stringify(auditTree, null, 2)}`);
     const requestBody = await gzip(JSON.stringify(auditTree));
     const response = await this.config.requestManager.request({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Hi 👋 

First of all, thanks for your work!
I use **yarn** everyday and I love its workspaces feature 😄 

This PR adds support for the `--registry` flag when running `audit` command as described in #7012 .
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

I have added a test case where I check if the audit command is calling the registry specified with the high flag `--registry`.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
