### PR TITLE
fix(install): Inherit optional property for resolutions

### DIFF
--- a/__tests__/commands/install/resolutions.js
+++ b/__tests__/commands/install/resolutions.js
@@ -46,6 +46,12 @@ test.concurrent('install with --frozen-lockfile with resolutions', async (): Pro
   }
 });
 
+test.concurrent('install with resolutions on optional dependencies should not resolve', (): Promise<void> => {
+  return runInstall({ignoreOptional: true}, {source: 'resolutions', cwd: 'optional-deps'}, async config => {
+    expect(await isPackagePresent(config, 'left-pad')).toEqual(false);
+  });
+});
+
 test.concurrent('install with exotic resolutions should override versions', (): Promise<void> => {
   return runInstall({}, {source: 'resolutions', cwd: 'exotic-version'}, async config => {
     expect(await getPackageVersion(config, 'left-pad')).toEqual('1.1.1');

--- a/__tests__/fixtures/install/resolutions/optional-deps/package.json
+++ b/__tests__/fixtures/install/resolutions/optional-deps/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "optionalDependencies": {
+    "left-pad": "^1.0.0"
+  },
+  "resolutions": {
+    "left-pad": "^1.1.1"
+  }
+}

--- a/src/cli/commands/check.js
+++ b/src/cli/commands/check.js
@@ -275,7 +275,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     const remoteType = pkg._reference.remote.type;
     const isLinkedDependency =
       remoteType === 'link' || remoteType === 'workspace' || (remoteType === 'file' && config.linkFileDependencies);
-    if (isLinkedDependency) {
+    const isResolution = pkg._reference.hint === 'resolution';
+    if (isLinkedDependency || isResolution) {
       continue;
     }
 

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import objectPath from 'object-path';
 import type {InstallationMethod} from '../../util/yarn-version.js';
 import type {Reporter} from '../../reporters/index.js';
 import type {ReporterSelectOption} from '../../reporters/types.js';
@@ -285,8 +286,9 @@ export class Install {
 
       this.resolutionMap.init(this.resolutions);
       for (const packageName of Object.keys(this.resolutionMap.resolutionsByPackage)) {
+        const optional = objectPath.has(manifest.optionalDependencies, packageName) && this.flags.ignoreOptional;
         for (const {pattern} of this.resolutionMap.resolutionsByPackage[packageName]) {
-          resolutionDeps = [...resolutionDeps, {registry, pattern, optional: false, hint: 'resolution'}];
+          resolutionDeps = [...resolutionDeps, {registry, pattern, optional, hint: 'resolution'}];
         }
       }
 


### PR DESCRIPTION
Fixes #6040

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Resolutions are a required for installing when there is a matching pattern in the resolutions map. When the resolver tries to dedupe dependencies and finds an optionalDependency that matches a resolution pattern, they merge into one no-longer optional request. This PR has resolutions inherit `optional` property if the dependency exists in the top level package.json. 
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I've added a test case under resolutions