### PR TITLE
Added a --no-legend flag to the outdated command, to allow not showing the legend.

### DIFF
--- a/__tests__/commands/outdated.js
+++ b/__tests__/commands/outdated.js
@@ -64,10 +64,25 @@ test.concurrent('no output when current matches latest', (): Promise<void> => {
 });
 
 test.concurrent('works with no arguments', (): Promise<void> => {
-  return runOutdated([], {}, 'no-args', (config, reporter, out): ?Promise<void> => {
+  return runOutdated([], {legend: true}, 'no-args', (config, reporter, out): ?Promise<void> => {
     const json: Object = JSON.parse(out);
 
     expect(json.data.body.length).toBe(1);
+    expect(reporter.format.red).toHaveBeenCalledWith('<red>');
+    expect(reporter.format.yellow).toHaveBeenCalledWith('<yellow>');
+    expect(reporter.format.green).toHaveBeenCalledWith('<green>');
+    expect(reporter.format.green).toHaveBeenCalledWith('left-pad');
+  });
+});
+
+test.concurrent('works with no arguments and --no-legend', (): Promise<void> => {
+  return runOutdated([], {legend: false}, 'no-args', (config, reporter, out): ?Promise<void> => {
+    const json: Object = JSON.parse(out);
+
+    expect(json.data.body.length).toBe(1);
+    expect(reporter.format.red).not.toHaveBeenCalledWith('<red>');
+    expect(reporter.format.yellow).not.toHaveBeenCalledWith('<yellow>');
+    expect(reporter.format.green).not.toHaveBeenCalledWith('<green>');
     expect(reporter.format.green).toHaveBeenCalledWith('left-pad');
   });
 });

--- a/src/cli/commands/outdated.js
+++ b/src/cli/commands/outdated.js
@@ -13,6 +13,7 @@ export const requireLockfile = true;
 export function setFlags(commander: Object) {
   commander.description('Checks for outdated package dependencies.');
   commander.usage('outdated [packages ...]');
+  commander.option('--no-legend', "don't show the legend");
 }
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
@@ -51,10 +52,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       return row;
     });
 
-    const red = reporter.format.red('<red>');
-    const yellow = reporter.format.yellow('<yellow>');
-    const green = reporter.format.green('<green>');
-    reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
+    if (flags.legend) {
+      const red = reporter.format.red('<red>');
+      const yellow = reporter.format.yellow('<yellow>');
+      const green = reporter.format.green('<green>');
+      reporter.info(reporter.lang('legendColorsForVersionUpdates', red, yellow, green));
+    }
 
     const header = ['Package', 'Current', 'Wanted', 'Latest', 'Workspace', 'Package Type', 'URL'];
     if (!usesWorkspaces) {


### PR DESCRIPTION
**Summary**

This is a minor change to allow specifying --no-legend when running the outdated command, to not show the legend.  It is useful when copying and pasting the output of "yarn outdated" to not include the legend.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

__tests__/commands/outdated.js has been updated.