### PR TITLE
Add importable scripts

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ import type {Reporter} from './reporters/index.js';
 import type {Manifest, PackageRemote, WorkspacesManifestMap, WorkspacesConfig} from './types.js';
 import type PackageReference from './package-reference.js';
 import {execFromManifest} from './util/execute-lifecycle-script.js';
+import {checkImportScripts} from './util/script-utils';
 import {resolveWithHome} from './util/path.js';
 import {boolifyWithDefault} from './util/conversion.js';
 import normalizeManifest from './util/normalize-manifest/index.js';
@@ -747,6 +748,7 @@ export default class Config {
       const data = await this.readJson(loc);
       data._registry = registry;
       data._loc = loc;
+      data.scripts = await checkImportScripts(data.scripts, this.reporter);
       return normalizeManifest(data, dir, this, isRoot);
     } else {
       return null;

--- a/src/util/script-utils.js
+++ b/src/util/script-utils.js
@@ -1,0 +1,56 @@
+/* @flow */
+
+import * as fs from './fs.js';
+import type {Reporter} from '../reporters/index.js';
+
+export async function checkImportScripts(scripts: string | Object, reporter: Reporter): Promise<Object> {
+  if (typeof scripts === 'string' && scripts.length > 0) {
+    if (await fs.exists(scripts)) {
+      const module = require(await fs.realpath(scripts));
+      if (module && typeof module.scripts === 'object') {
+        scripts = iterateScripts(module.scripts, '', module.delimiter, reporter);
+      } else {
+        reporter &&
+          reporter.warn(
+            `Invalid scripts module: ${scripts}.  The module must be exported and include a root scripts object.`,
+          );
+      }
+    }
+  }
+  return scripts;
+}
+
+function iterateScripts(node: Object, path: string = '', delim: string = '.', reporter: Reporter): Object {
+  const scripts = {};
+
+  const addScript = (key, script) => {
+    scripts[key] &&
+      reporter &&
+      reporter.warn(`Duplicate script key detected: ${key}.  Scripts should be structured to have unique keys.`);
+    scripts[key] = script;
+  };
+
+  if (node['script'] && typeof node['script'] === 'string') {
+    addScript(path, node['script']); // Add script, ignore other non object keys
+  } else {
+    Object.keys(node)
+      .filter(k => typeof node[k] === 'string')
+      .forEach(k => {
+        if (k === 'default') {
+          addScript(path, node[k]);
+        } else {
+          addScript([path, k].filter(Boolean).join(delim), node[k]);
+        }
+      });
+  }
+
+  // Process remaining object nodes
+  Object.keys(node)
+    .filter(k => typeof node[k] === 'object')
+    .forEach(k => {
+      const nodepath = k === 'default' ? path : [path, k].filter(Boolean).join(delim);
+      const iteratedScripts = iterateScripts(node[k], nodepath, delim, reporter);
+      Object.keys(iteratedScripts).forEach(k => addScript(k, iteratedScripts[k]));
+    });
+  return scripts;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

[RFC #116](https://github.com/yarnpkg/rfcs/pull/116)
Allow scripts to be imported from a file as an alternative to the standard object hash in the packages.json scripts field.  Also define the basic structure of the imported file.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

The code was tested with this example input file: 

```
module.exports = {
  delimiter: '.',
  scripts: {
    argos: 'argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN',
    docs: {
      api: {
        default: {
          script: 'yarn docs.api.clean && yarn docs.api.mui && yarn docs.api.lab',
          description: 'Generates the api documentation',
        },
        clean: {
          script: 'rimraf ./pages/api',
          description: 'Removes all previously generated documenation',
          watch: {
            script: 'yarn docs.api.clean --watch',
          },
        },
      },
      build: {
        default: {
          script: 'yarn docs.build.clean && yarn docs.build.compile',
          description: 'Builds the documents.',
        },
        clean: {
          default: 'rimraf .next',
          watch: 'rimraf .next --watch',
        },
        compile: 'cross-env NODE_ENV=production BABEL_ENV=docs-production next build',
      },
      typescript: {
        default: 'node docs/scripts/formattedTSDemos --watch',
        check: 'tslint -p docs/tsconfig.json',
        formatted: 'node docs/scripts/formattedTSDemos',
      },
    },
    typescript: 'lerna run typescript && yarn docs.typescript.check',
  },
};

```

Which generates these scripts when executing yarn run:
![image](https://user-images.githubusercontent.com/24579103/57980857-c6247980-79ed-11e9-91ee-db489554e38c.png)
