### PR TITLE
Fix wrong pwd path when running install commands in workspace. Fixes …

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -135,7 +135,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
           stage,
           config,
           cmd: cmdWithArgs,
-          cwd: flags.into || config.cwd,
+          cwd: fs.realpathSync(flags.into || config.cwd),
           isInteractive: true,
           customShell: customShell ? String(customShell) : undefined,
         });


### PR DESCRIPTION
…#6175

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->
Because pwd is wrong on windows when running postinstall scripts in workspace packages, if you have a script like: "install": "tsc -p .",
you will get an error

```
Error: Cannot find module 'C:\Users\xx\IdeaProjects\x\node_modules\node_modules\typescript\bin\tsc'
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
I haven't tested yet if it breaks the relative path logic on Linux.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
