### PR TITLE
Adds support for parsing Yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Yarn will tolerate Yaml at parse time. Full support isn't ready yet and will only come at the next major.
+
+  [#7300](https://github.com/yarnpkg/yarn/pull/7300) - [**Maël Nison**](https://twitter.com/arcanis)
+
 ## 1.16.0
 
 - Retries downloading a package on `yarn install` when we get a ETIMEDOUT error.
 
-[#7163](https://github.com/yarnpkg/yarn/pull/7163) - [**Vincent Bailly**](https://github.com/VincentBailly)
+  [#7163](https://github.com/yarnpkg/yarn/pull/7163) - [**Vincent Bailly**](https://github.com/VincentBailly)
 
 - Implements `yarn audit --level [severity]` flag to filter the audit command's output.
 
-[#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
+  [#6716](https://github.com/yarnpkg/yarn/pull/6716) - [**Rogério Vicente**](https://twitter.com/rogeriopvl)
 
 - Implements `yarn audit --groups group_name [group_name ...]`.
 

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -340,7 +340,7 @@ test('parse merge conflict fail', () => {
   const file = `
 <<<<<<< HEAD
 b:
-  foo "bar
+  foo: "bar
 =======
 c:
   bar "foo"

--- a/__tests__/lockfile.js
+++ b/__tests__/lockfile.js
@@ -18,6 +18,9 @@ for (const obj of objs) {
 }
 
 test('parse', () => {
+  // Yaml
+  expect(parse('foo:\n  bar\n').object).toEqual(nullify({foo: 'bar'}));
+
   expect(parse('foo "bar"').object).toEqual(nullify({foo: 'bar'}));
   expect(parse('"foo" "bar"').object).toEqual(nullify({foo: 'bar'}));
   expect(parse('foo "bar"').object).toEqual(nullify({foo: 'bar'}));

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "is-builtin-module": "^2.0.0",
     "is-ci": "^1.0.10",
     "is-webpack-bundle": "^1.0.0",
+    "js-yaml": "^3.13.1",
     "leven": "^2.0.0",
     "loud-rejection": "^1.2.0",
     "micromatch": "^2.3.11",

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -9,6 +9,8 @@ import {LOCKFILE_VERSION} from '../constants.js';
 import {MessageError} from '../errors.js';
 import map from '../util/map.js';
 
+const {safeLoad, FAILSAFE_SCHEMA} = require('js-yaml');
+
 type Token = {
   line: number,
   col: number,
@@ -382,7 +384,17 @@ function hasMergeConflicts(str: string): boolean {
 function parse(str: string, fileLoc: string): Object {
   const parser = new Parser(str, fileLoc);
   parser.next();
-  return parser.parse();
+  try {
+    return parser.parse();
+  } catch (error1) {
+    try {
+      return safeLoad(str, {
+        schema: FAILSAFE_SCHEMA,
+      });
+    } catch (error2) {
+      throw error1;
+    }
+  }
 }
 
 /**

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -27,8 +27,6 @@ dnscache({
 const successHosts = map();
 const controlOffline = network.isOffline();
 
-let id = 0;
-
 interface RequestError extends Error {
   hostname?: ?string,
   code?: ?string,
@@ -224,7 +222,6 @@ export default class RequestManager {
    */
 
   request<T>(params: RequestParams<T>): Promise<T> {
-    require('fs').writeFileSync(`/tmp/helloworld.${id++}`, JSON.stringify(params, null, 2));
     if (this.offlineNoRequests) {
       return Promise.reject(new MessageError(this.reporter.lang('cantRequestOffline', params.url)));
     }

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -27,6 +27,8 @@ dnscache({
 const successHosts = map();
 const controlOffline = network.isOffline();
 
+let id = 0;
+
 interface RequestError extends Error {
   hostname?: ?string,
   code?: ?string,
@@ -222,6 +224,7 @@ export default class RequestManager {
    */
 
   request<T>(params: RequestParams<T>): Promise<T> {
+    require('fs').writeFileSync(`/tmp/helloworld.${id++}`, JSON.stringify(params, null, 2));
     if (this.offlineNoRequests) {
       return Promise.reject(new MessageError(this.reporter.lang('cantRequestOffline', params.url)));
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4681,6 +4681,14 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.7.0, js-yaml@^3.8.4:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"


### PR DESCRIPTION
**Summary**

This PR adds support for Yarn to read Yaml files. This is needed because now that we switch to Yaml in Berry we need the Yarn v1 branch to parse the v2 `.yarnrc` files out of the box (in order to make `yarn-path` work).

Note that the Yaml support here is fickle and purely for reading (emitted files are still using the custom format). In particular, defining a lockfile using the Yaml syntax wouldn't work because the keys are not split on commas.

Ref https://github.com/yarnpkg/berry/pull/183

**Test plan**

Added a test.