### PR TITLE
Fix PATH priority for windows

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -185,11 +185,11 @@ export async function makeEnv(
   // Add node_modules .bin folders to the PATH
   for (const registryFolder of config.registryFolders) {
     const binFolder = path.join(registryFolder, '.bin');
+    pathParts.unshift(path.join(config.linkFolder, binFolder));
+    pathParts.unshift(path.join(cwd, binFolder));
     if (config.workspacesEnabled && config.workspaceRootFolder) {
       pathParts.unshift(path.join(config.workspaceRootFolder, binFolder));
     }
-    pathParts.unshift(path.join(config.linkFolder, binFolder));
-    pathParts.unshift(path.join(cwd, binFolder));
   }
 
   let pnpFile;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

> Fix #6175 

The example code caused this issue is [here](https://github.com/3846masa-tmp/issue-6175-yarn).

---

On windows, yarn create `.cmd` file as below when installing workspaces.

```cmd
@IF EXIST "%~dp0\node.exe" (
  "%~dp0\node.exe"  "%~dp0\..\..\..\node_modules\rimraf\bin.js" %*
) ELSE (
  @SETLOCAL
  @SET PATHEXT=%PATHEXT:;.JS;=;%
  node  "%~dp0\..\..\..\node_modules\rimraf\bin.js" %*
)
```

However, `%~dp0` cannot resolve symlink path, so `%~dp0` maybe changed.

---

For example,  you have workspaces as below,

```
root
|- package.json
+- package-a
   +- package.json
```

`package-a/package.json` will install `rimraf`.

After running `yarn install`, change to below,

```
root
|- package.json
|- node_modules
|  |- rimraf
|  |  +- bin.js
|  +- .bin
|  |  +- rimraf.cmd
|  +- package-a // symlink to root/package-a
|     +- node_modules
|        +- .bin
|           +- rimraf.cmd
+- package-a
   |- package.json
   +- node_modules
      +- .bin
         +- rimraf.cmd
```

`package-a/node_modules/.bin/rimraf.cmd` and `node_modules/package-a/node_modules/.bin/rimraf.cmd` are same file as below,

```cmd
@IF EXIST "%~dp0\node.exe" (
  "%~dp0\node.exe"  "%~dp0\..\..\..\node_modules\rimraf\bin.js" %*
) ELSE (
  @SETLOCAL
  @SET PATHEXT=%PATHEXT:;.JS;=;%
  node  "%~dp0\..\..\..\node_modules\rimraf\bin.js" %*
)
```

`%~dp0\..\..\..\node_modules\rimraf\bin.js` from `package-a/node_modules/.bin/rimraf.cmd` is `node_modules/rimraf/bin.js`.

However, after installing, postinstall script will be resolved from installed folder.
The installed folder in this example is `node_modules/package-a`.

Because of that, postinstall run `node_modules/pacakge-a/node_modules/.bin/rimraf.cmd`.
`%~dp0\..\..\..\node_modules\rimraf\bin.js` from  `node_modules/pacakge-a/node_modules/.bin/rimraf.cmd` is `node_modules/node_modules/rimraf/bin.js`.
This is invalid path.

---

This PR fixes PATH priority for using `node_modules/.bin` when workspace mode.
In other words, after installing, postinstall script will be resolved from root folder at first.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

Run `yarn install` in root folder on Windows using [this sample code](https://github.com/3846masa-tmp/issue-6175-yarn).

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
