### PR TITLE
Fix login for `yarn publish`

### DIFF
--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -105,6 +105,7 @@ export async function getToken(
   //
   const res = await config.registries.npm.request(`-/user/org.couchdb.user:${encodeURIComponent(username)}`, {
     method: 'PUT',
+    registry,
     body: userobj,
     auth: {username, password, email},
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Related issue: https://github.com/yarnpkg/yarn/issues/6258, and PR: https://github.com/yarnpkg/yarn/pull/6411.

Config:

```
// .yarnrc 
registry "https://registry.npm.taobao.org"
```
```
// package.json
"publishConfig": {
  "registry": "https://registry.yarnpkg.com/"
}
```
`yarn publish --verbose` Log:  
```
verbose 8.619632385 Performing "PUT" request to "https://registry.npm.taobao.org/-/user/org.couchdb.user:nodece".
verbose 9.237536659 Request "https://registry.npm.taobao.org/-/user/org.couchdb.user:nodece" finished with status code 201.
success Logged in.
......
......
verbose 13.892656022 Performing "PUT" request to "https://registry.yarnpkg.com/egg-authz".
verbose 17.747497997 Request "https://registry.yarnpkg.com/egg-authz" finished with status code 401.
......
......
verbose 17.761350103 Error: Couldn't publish package: "https://registry.yarnpkg.com/egg-authz: You must be logged in to publish packages."
```

I think it is wrong, Yarn should use `publishConfig.registry` to login. 
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
None.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
