### PR TITLE
Respect authorization information when fetching URLs

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -496,6 +496,92 @@ describe('request', () => {
       ],
     },
     {
+      title: 'using regular npm and private registry for scoped packages with always-auth',
+      config: {
+        registry: 'https://registry.npmjs.org/',
+        '//registry.myorg.com/:_authToken': 'privateAuthToken',
+        '//registry.myorg.com/:always-auth': true,
+        '@private:registry': 'https://registry.myorg.com/',
+      },
+      requests: [
+        {
+          url: 'yarn',
+          pkg: 'yarn',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
+          url: '@yarn%2fcore',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
+          url: '-/package/yarn/dist-tags',
+          pkg: 'yarn',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
+          url: '-/package/@yarn%2fcore/dist-tags',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
+          url: '-/user/token/abcdef',
+          pkg: null,
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
+          url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: null,
+          expect: {root: 'https://registry.yarnpkg.com', auth: false},
+        },
+        {
+          url: 'https://some.cdn.com/@yarn/core.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+        {
+          url: 'https://some.cdn.com/@yarn/core.tgz',
+          pkg: null,
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+        {
+          url: '@private/pkg',
+          pkg: '@private/pkg',
+          expect: {root: 'https://registry.myorg.com', auth: 'privateAuthToken'},
+        },
+        {
+          url: 'https://registry.myorg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.myorg.com', auth: 'privateAuthToken'},
+        },
+        {
+          url: 'https://registry.myorg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: '@yarn/core',
+          expect: {root: 'https://registry.myorg.com', auth: 'privateAuthToken'},
+        },
+        {
+          url: 'https://registry.myorg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: null,
+          expect: {root: 'https://registry.myorg.com', auth: 'privateAuthToken'},
+        },
+        {
+          url: 'https://some.cdn.com/@private/pkg',
+          pkg: null,
+          expect: {root: 'https://some.cdn.com', auth: false},
+        },
+      ],
+    },
+    {
       title: 'registry url and request url path sensitivity',
       config: {
         '@private:registry': 'https://registry.myorg.com/api/npm/registry/',


### PR DESCRIPTION
**Summary**

When requesting packages Yarn currently only checks for scopes and global registry information.
While on the one hand Yarn currently assigns a non-scoped package to the global registry, it does not necessarily fetch the resource from the global registry if a lockfile exists.

Given a lockfile with a private NPM registry that requires auth and containing non-scoped packages, Yarn will still try to fetch from the private registry, but won't provide any credentials, as those are only respected for scopes.

This patch enhances the current logic to respect the actual URLs that will be used for download and consequently also use the credentials for this registry (if any).

Solves #2573 

**Test plan**

Extended existing NPM registry tests to cover the use-case.
Tests will fail without the patch.
