### PR TITLE
fix(config): Adds support for --offline flag to global add command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Adds support for --offline flag to global add command
 
+  [#7330](https://github.com/yarnpkg/yarn/pull/7330) - [**Francis Crick**](https://guthub.com/fcrick)
+
 - Yarn will tolerate Yaml at parse time. Full support isn't ready yet and will only come at the next major.
 
   [#7300](https://github.com/yarnpkg/yarn/pull/7300) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Adds support for --offline flag to global add command
+
 - Yarn will tolerate Yaml at parse time. Full support isn't ready yet and will only come at the next major.
 
   [#7300](https://github.com/yarnpkg/yarn/pull/7300) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/__tests__/fixtures/index/run-global-add-offline/package.json
+++ b/__tests__/fixtures/index/run-global-add-offline/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test_global_add_offline",
+  "version": "1.0.0",
+  "license": "UNLICENSED"
+}

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -155,8 +155,9 @@ test.concurrent('should fail to find non-existent package offline', async () => 
   );
   await expectAnErrorMessage(
     command,
-    `error Couldn't find any versions for "doesnotexistqwertyuiop" that matches "2.0.0-doesnotexist" in our cache (possible versions are ""). ` +
-      'This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.',
+    `error Couldn't find any versions for "doesnotexistqwertyuiop" that matches "2.0.0-doesnotexist" in our cache ` +
+      '(possible versions are ""). This is usually caused by a missing entry in the lockfile, running Yarn without ' +
+      'the --offline flag may help fix this issue.',
   );
 });
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -146,6 +146,20 @@ if (semver.satisfies(ver, '>=5.0.0')) {
   });
 }
 
+test.concurrent('should fail to find non-existent package offline', async () => {
+  const command = execCommand(
+    '--offline',
+    ['global', 'add', 'doesnotexistqwertyuiop@2.0.0-doesnotexist', '--global-folder', './global'],
+    'run-global-add-offline',
+    true,
+  );
+  await expectAnErrorMessage(
+    command,
+    `error Couldn't find any versions for "doesnotexistqwertyuiop" that matches "2.0.0-doesnotexist" in our cache (possible versions are ""). ` +
+      'This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.',
+  );
+});
+
 test.concurrent('should run custom script', async () => {
   const stdout = await execCommand('run', ['custom-script'], 'run-custom-script');
   expectRunOutput(stdout);

--- a/src/cli/commands/global.js
+++ b/src/cli/commands/global.js
@@ -48,6 +48,7 @@ async function updateCwd(config: Config): Promise<void> {
 
   await config.init({
     cwd: config.globalFolder,
+    offline: config.offline,
     binLinks: true,
     globalFolder: config.globalFolder,
     cacheFolder: config._cacheRootFolder,


### PR DESCRIPTION
**Summary**

Adds support for --offline flag to global add command. 

Previously, this argument was ignored, resulting in issue #4913.

**Test plan**

Observe below how yarn currently goes to network when --offline is set with global add:
```
$ yarn --offline global add packagethatdoesnotexist@1.0.0
yarn global v1.16.0
[1/4] Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/packagethatdoesnotexist: Not found".
info If you think this is a bug, please open a bug report with the information provided in "C:\\Users\\fcrick\\AppData\\Local\\Yarn\\Data\\global\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
```
With fix, it now suggests running without `--offline`
```
$ node ./bin/yarn.js --offline global add packagethatdoesnotexist@1.0.0
yarn global v1.17.0-0
[1/4] Resolving packages...
error Couldn't find any versions for "packagethatdoesnotexist" that matches "1.0.0" in our cache (possible versions are ""). This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
```

Added test to verify this behavior.