### PR TITLE
feat(version): Allow for prereleases flags and prerelease identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Adds prereleases flags and prerelease identifier to `yarn version`.
+
+  [#7336](https://github.com/yarnpkg/yarn/pull/7336) - [**Daniel Seijo**](https://github.com/daniseijo)
+
 - Yarn will tolerate Yaml at parse time. Full support isn't ready yet and will only come at the next major.
 
   [#7300](https://github.com/yarnpkg/yarn/pull/7300) - [**Maël Nison**](https://twitter.com/arcanis)
@@ -33,7 +37,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Adds support for the npm enterprise URLs when computing the offline mirror filenames.
 
   [#7200](https://github.com/yarnpkg/yarn/pull/7200) - [**John Millikin**](https://john-millikin.com)
-  
+
 - Tweaks the lockfile parser logic to parse a few extra cases
 
   [#7210](https://github.com/yarnpkg/yarn/pull/7210) - [**Maël Nison**](https://twitter.com/arcanis)
@@ -111,7 +115,7 @@ The 1.15.1 doesn't exist due to a release hiccup.
 - Packages won't be auto-unplugged anymore if `ignore-scripts` is set in the yarnrc file
 
   [#6983](https://github.com/yarnpkg/yarn/pull/6983) - [**Micha Reiser**](https://github.com/MichaReiser)
-  
+
 - Enables displaying Emojis on [Terminus](https://github.com/Eugeny/terminus) by default
 
   [#7093](https://github.com/yarnpkg/yarn/pull/7093) - [**David Refoua**](https://github.com/DRSDavidSoft)

--- a/__tests__/commands/version.js
+++ b/__tests__/commands/version.js
@@ -182,3 +182,101 @@ test('run version with --patch flag and make sure patch version is incremented',
     expect(pkg.version).toEqual('1.0.1');
   });
 });
+
+test('run version with --premajor flag and make sure premajor version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, premajor: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('2.0.0-0');
+  });
+});
+
+test('run version with --premajor flag with preid and make sure premajor version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, premajor: true, preid: 'alpha'}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('2.0.0-alpha.0');
+  });
+});
+
+test('run version with --preminor flag and make sure preminor version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, preminor: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.1.0-0');
+  });
+});
+
+test('run version with --preminor flag with preid and make sure preminor version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, preminor: true, preid: 'alpha'}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.1.0-alpha.0');
+  });
+});
+
+test('run version with --prepatch flag and make sure prepatch version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, prepatch: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1-0');
+  });
+});
+
+test('run version with --prepatch flag with preid and make sure prepatch version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, prepatch: true, preid: 'alpha'}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1-alpha.0');
+  });
+});
+
+test('run version with --prerelease flag and make sure prerelease version is incremented', (): Promise<void> => {
+  return runRun([], {gitTagVersion, prerelease: true}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1-0');
+  });
+});
+
+test('run version with --prerelease flag with preid and make sure prerelease version is incremented', (): Promise<
+  void,
+> => {
+  return runRun([], {gitTagVersion, prerelease: true, preid: 'alpha'}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1-alpha.0');
+  });
+});
+
+test('run version with --new-version prerelease flag and make sure prerelease version is incremented', (): Promise<
+  void,
+> => {
+  return runRun([], {gitTagVersion, newVersion: 'prerelease'}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1-0');
+  });
+});
+
+test('run version with --new-version and preid flags and make sure prerelease version is incremented', (): Promise<
+  void,
+> => {
+  return runRun([], {gitTagVersion, newVersion: 'prerelease', preid: 'beta'}, 'no-args', async (config): ?Promise<
+    void,
+  > => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('1.0.1-beta.0');
+  });
+});
+
+test('run version with --new-version and preid flags and make sure premajor version is incremented', (): Promise<
+  void,
+> => {
+  return runRun([], {gitTagVersion, newVersion: 'premajor', preid: 'beta'}, 'no-args', async (config): ?Promise<
+    void,
+  > => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('2.0.0-beta.0');
+  });
+});
+
+test('run version with main release and --new-version and preid flags and make sure identifier is ignored', (): Promise<
+  void,
+> => {
+  return runRun([], {gitTagVersion, newVersion: 'major', preid: 'beta'}, 'no-args', async (config): ?Promise<void> => {
+    const pkg = await fs.readJson(path.join(config.cwd, 'package.json'));
+    expect(pkg.version).toEqual('2.0.0');
+  });
+});

--- a/flow-typed/npm/semver_v5.1.x.js
+++ b/flow-typed/npm/semver_v5.1.x.js
@@ -41,7 +41,8 @@ declare module 'semver' {
   // Functions
   declare function clean(v: string, loose?: boolean): string | null;
   declare function valid(v: string, loose?: boolean): string | null;
-  declare function inc(v: string, release: string, loose?: boolean): string | null;
+  declare function inc(v: string, release: string, loose?: boolean, identifier?: string): string | null;
+  declare function inc(v: string, release: string, identifier: string): string | null;
   declare function major(v: string, loose?: boolean): number;
   declare function minor(v: string, loose?: boolean): number;
   declare function patch(v: string, loose?: boolean): number;

--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -14,8 +14,8 @@ const semver = require('semver');
 const path = require('path');
 
 const NEW_VERSION_FLAG = '--new-version [version]';
-function isValidNewVersion(oldVersion: string, newVersion: string, looseSemver: boolean): boolean {
-  return !!(semver.valid(newVersion, looseSemver) || semver.inc(oldVersion, newVersion, looseSemver));
+function isValidNewVersion(oldVersion: string, newVersion: string, looseSemver: boolean, identifier?: string): boolean {
+  return !!(semver.valid(newVersion, looseSemver) || semver.inc(oldVersion, newVersion, looseSemver, identifier));
 }
 
 export function setFlags(commander: Object) {
@@ -24,6 +24,11 @@ export function setFlags(commander: Object) {
   commander.option('--major', 'auto-increment major version number');
   commander.option('--minor', 'auto-increment minor version number');
   commander.option('--patch', 'auto-increment patch version number');
+  commander.option('--premajor', 'auto-increment premajor version number');
+  commander.option('--preminor', 'auto-increment preminor version number');
+  commander.option('--prepatch', 'auto-increment prepatch version number');
+  commander.option('--prerelease', 'auto-increment prerelease version number');
+  commander.option('--preid [preid]', 'add a custom identifier to the prerelease');
   commander.option('--message [message]', 'message');
   commander.option('--no-git-tag-version', 'no git tag version');
   commander.option('--no-commit-hooks', 'bypass git hooks when committing new version');
@@ -44,6 +49,10 @@ export async function setVersion(
   const pkgLoc = pkg._loc;
   const scripts = map();
   let newVersion = flags.newVersion;
+  let identifier = undefined;
+  if (flags.preid) {
+    identifier = flags.preid;
+  }
   invariant(pkgLoc, 'expected package location');
 
   if (args.length && !newVersion) {
@@ -76,7 +85,7 @@ export async function setVersion(
   }
 
   // get new version
-  if (newVersion && !isValidNewVersion(oldVersion, newVersion, config.looseSemver)) {
+  if (newVersion && !isValidNewVersion(oldVersion, newVersion, config.looseSemver, identifier)) {
     throw new MessageError(reporter.lang('invalidVersion'));
   }
 
@@ -88,6 +97,14 @@ export async function setVersion(
       newVersion = semver.inc(oldVersion, 'minor');
     } else if (flags.patch) {
       newVersion = semver.inc(oldVersion, 'patch');
+    } else if (flags.premajor) {
+      newVersion = semver.inc(oldVersion, 'premajor', identifier);
+    } else if (flags.preminor) {
+      newVersion = semver.inc(oldVersion, 'preminor', identifier);
+    } else if (flags.prepatch) {
+      newVersion = semver.inc(oldVersion, 'prepatch', identifier);
+    } else if (flags.prerelease) {
+      newVersion = semver.inc(oldVersion, 'prerelease', identifier);
     }
   }
 
@@ -117,7 +134,7 @@ export async function setVersion(
       };
     }
 
-    if (isValidNewVersion(oldVersion, newVersion, config.looseSemver)) {
+    if (isValidNewVersion(oldVersion, newVersion, config.looseSemver, identifier)) {
       break;
     } else {
       newVersion = null;
@@ -125,7 +142,7 @@ export async function setVersion(
     }
   }
   if (newVersion) {
-    newVersion = semver.inc(oldVersion, newVersion, config.looseSemver) || newVersion;
+    newVersion = semver.inc(oldVersion, newVersion, config.looseSemver, identifier) || newVersion;
   }
   invariant(newVersion, 'expected new version');
 


### PR DESCRIPTION
**Summary**

This pull request implements the feature requested in https://github.com/yarnpkg/yarn/issues/6059 and https://github.com/yarnpkg/yarn/issues/5367

It adds four new flags (`--premajor|--preminor|--prepatch|--prerelease`) to allow automatic increment of new prereleases.

It also adds a new flag `--preid` to add a custom identifier to the new prerelease

**Test plan**

Example:

```
$ yarn version --premajor --preid beta
info Current version: 1.3.0
info New version: 2.0.0-beta.0
```

I've included Jest test cases for each of the new versioning flags.

This feature only adds new flags and should not modified the previous behaviour of version.
