### PR TITLE
Prevents the link: protocol from crashing when no package.json is used

### DIFF
--- a/src/resolvers/exotics/link-resolver.js
+++ b/src/resolvers/exotics/link-resolver.js
@@ -30,7 +30,9 @@ export default class LinkResolver extends ExoticResolver {
     const name = path.basename(loc);
     const registry: RegistryNames = 'npm';
 
-    const manifest: Manifest = {_uid: '', name: 'pkg', version: '0.0.0', _registry: registry};
+    const manifest: Manifest = !await fs.exists(`${loc}/package.json`)
+      ? {_uid: '', name, version: '0.0.0', _registry: registry}
+      : await this.config.readManifest(loc, this.registry);
 
     manifest._remote = {
       type: 'link',

--- a/src/resolvers/exotics/link-resolver.js
+++ b/src/resolvers/exotics/link-resolver.js
@@ -30,9 +30,7 @@ export default class LinkResolver extends ExoticResolver {
     const name = path.basename(loc);
     const registry: RegistryNames = 'npm';
 
-    const manifest: Manifest = !await fs.exists(loc)
-      ? {_uid: '', name, version: '0.0.0', _registry: registry}
-      : await this.config.readManifest(loc, this.registry);
+    const manifest: Manifest = {_uid: '', name: 'pkg', version: '0.0.0', _registry: registry};
 
     manifest._remote = {
       type: 'link',


### PR DESCRIPTION
**Summary**

The current code tries to read the manifest when possible, and fallback to a dummy object otherwise. This behavior is problematic (we should never read from the local manifest, as that makes the exact behavior change depending on the state of the repository), but we won't be able to change it in the 1.x (it will however behave as I described in the 2.x, thanks to the split between `link:` and `portal:`).

**Test plan**

Tests should still pass.