### PR TITLE
Support passing auth tokens for aliased packages

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -206,8 +206,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: false},
         },
         {
+          url: 'yarn',
+          pkg: 'npm:yarn',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
           url: '@yarn%2fcore',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
+        },
+        {
+          url: '@yarn%2fcore',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
         },
         {
@@ -231,8 +241,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
         },
         {
+          url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
+        },
+        {
           url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNpmAuthToken'},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNpmAuthToken'},
         },
         {
@@ -281,8 +301,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: false},
         },
         {
+          url: 'yarn',
+          pkg: 'npm:yarn',
+          expect: {root: 'https://registry.npmjs.org', auth: false},
+        },
+        {
           url: '@yarn%2fcore',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
+        },
+        {
+          url: '@yarn%2fcore',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
         },
         {
@@ -306,8 +336,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
         },
         {
+          url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
+        },
+        {
           url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNpmAuthToken'},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNpmAuthToken'},
         },
         {
@@ -357,8 +397,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: 'npmAuthToken'},
         },
         {
+          url: 'yarn',
+          pkg: 'npm:yarn',
+          expect: {root: 'https://registry.npmjs.org', auth: 'npmAuthToken'},
+        },
+        {
           url: '@yarn%2fcore',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'npmAuthToken'},
+        },
+        {
+          url: '@yarn%2fcore',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.npmjs.org', auth: 'npmAuthToken'},
         },
         {
@@ -382,8 +432,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: 'npmAuthToken'},
         },
         {
+          url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'npmAuthToken'},
+        },
+        {
           url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'npmAuthToken'},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.yarnpkg.com', auth: 'npmAuthToken'},
         },
         {
@@ -434,8 +494,18 @@ describe('request', () => {
           expect: {root: 'https://registry.myorg.com', auth: 'privateAuthToken'},
         },
         {
+          url: 'yarn',
+          pkg: 'npm:yarn',
+          expect: {root: 'https://registry.myorg.com', auth: 'privateAuthToken'},
+        },
+        {
           url: '@yarn%2fcore',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
+        },
+        {
+          url: '@yarn%2fcore',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
         },
         {
@@ -459,8 +529,18 @@ describe('request', () => {
           expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
         },
         {
+          url: 'https://registry.npmjs.org/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
+          expect: {root: 'https://registry.npmjs.org', auth: 'scopedNpmAuthToken'},
+        },
+        {
           url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
           pkg: '@yarn/core',
+          expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNpmAuthToken'},
+        },
+        {
+          url: 'https://registry.yarnpkg.com/dist/-/@yarn-core-1.0.0.tgz',
+          pkg: 'npm:@yarn/core',
           expect: {root: 'https://registry.yarnpkg.com', auth: 'scopedNpmAuthToken'},
         },
         {
@@ -706,6 +786,8 @@ const packageIdents = [
   ['@scope%2fpkg%2fext', '@scope'],
   ['@scope%2fpkg?query=true', '@scope'],
   ['@scope%2fpkg%2f1.2.3', '@scope'],
+  ['npm:@scoped/notescaped', '@scoped'],
+  ['npm:@scope%2fpkg%2f1.2.3', '@scope'],
   ['http://foo.bar:80/normal', ''],
   ['http://foo.bar:80/@scopedNoPkg', ''],
   ['http://foo.bar:80/@scoped/notescaped', '@scoped'],

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -34,7 +34,7 @@ export const SCOPE_SEPARATOR = '%2f';
 // The reason for matching a plain `/` is NPM registry being inconsistent about escaping `/` in
 // scoped package names: when you're fetching a tarball, it is not escaped, when you want info
 // about the package, it is escaped.
-const SCOPED_PKG_REGEXP = /(?:^|\/)(@[^\/?]+?)(?=%2f|\/)/;
+const SCOPED_PKG_REGEXP = /(?:^|\/|npm:)(@[^\/?]+?)(?=%2f|\/)/;
 
 // TODO: Use the method from src/cli/commands/global.js for this instead
 function getGlobalPrefix(): string {


### PR DESCRIPTION
Today, `isScopedPackage` fails for [aliased packages](https://yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias) (e.g. `npm:@yarn/core`). With current versions of yarn, installing a private scoped package results in 404s from the registry (unless you turn on `always-auth = true` via .npmrc)

This fixes the regex to handle that case.