### PR TITLE
Added a useful help message for a potential git misconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Adds a useful error message to a git failure that might be due to misconfiguration
+
+  [#7344](https://github.com/yarnpkg/yarn/pull/7344) - [**Marton Meszaros**](https://github.com/meza)
+
 - Adds prereleases flags and prerelease identifier to `yarn version`.
 
   [#7336](https://github.com/yarnpkg/yarn/pull/7336) - [**Daniel Seijo**](https://github.com/daniseijo)

--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -249,3 +249,32 @@ test('resolveCommit', async () => {
   expect(lastCall[0]).toContain('rev-list');
   expect(lastCall[0]).toContain('7a053e2');
 });
+
+test('A proper error message', async () => {
+  const spawnGitMock = (spawnGit: any);
+  const config = await Config.create();
+  const git = new Git(
+    config,
+    {
+      protocol: 'ssh',
+      hostname: 'test.url',
+      repository: 'some',
+    },
+    '',
+  );
+  spawnGitMock.mockRejectedValueOnce({
+    EXIT_CODE: 128,
+    message: 'TEST ERROR MESSAGE',
+  });
+
+  try {
+    await git.init();
+    expect('This to never happen').toBeFalsy();
+  } catch (error) {
+    expect(error.message).toContain('This error might be due to your ssh-agent not configured properly');
+    expect(error.message).toContain(
+      'https://help.github.com/en/enterprise/2.16/user/articles/' +
+        'generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent',
+    );
+  }
+});

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -417,7 +417,17 @@ export default class Git implements GitRefResolvingInterface {
     if (isLocal) {
       stdout = await spawnGit(['show-ref', '--tags', '--heads'], {cwd: this.gitUrl.repository});
     } else {
-      stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository]);
+      try {
+        stdout = await spawnGit(['ls-remote', '--tags', '--heads', this.gitUrl.repository]);
+      } catch (e) {
+        if (e.EXIT_CODE === 128) {
+          e.message +=
+            '\n\nThis error might be due to your ssh-agent not configured properly.\n' +
+            'Please refer to https://help.github.com/en/enterprise/2.16/user/articles/' +
+            'generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent for more details\n';
+        }
+        throw e;
+      }
     }
 
     const refs = parseRefs(stdout);


### PR DESCRIPTION
Co-authored-by: @sleepingevil

**Summary**
Added a useful error message for the scenario when git fails to reach a repo. More often than not this is due to the ssh-agent not configured properly. The error message git returns is all but useful for someone who doesn't know what is going on.
It will forward the user to [this page](https://help.github.com/en/enterprise/2.16/user/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent

[![asciicast](https://asciinema.org/a/252462.svg)](https://asciinema.org/a/252462)

**Test plan**

- Make sure your ssh-agent doesn't know about your identity
- Add a private git repo dependency to a package.json
- try installing it