### PR TITLE
Adds basic support for .yamlrc.yml (yarnPath only, v2)

### DIFF
--- a/src/rc.js
+++ b/src/rc.js
@@ -43,7 +43,11 @@ export function getRcConfigForCwd(cwd: string, args: Array<string>): {[key: stri
 }
 
 function loadRcFile(fileText: string, filePath: string): {[key: string]: string} {
-  const {object: values} = parse(fileText, 'yarnrc');
+  let {object: values} = parse(fileText, 'yarnrc');
+
+  if (filePath.match(/\.yml$/)) {
+    values = {yarnPath: values.yarnPath};
+  }
 
   // some keys reference directories so keep their relativity
   for (const key in values) {

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -11,26 +11,36 @@ const home = isWin ? process.env.USERPROFILE : process.env.HOME;
 function getRcPaths(name: string, cwd: string): Array<string> {
   const configPaths = [];
 
-  function addConfigPath(...segments) {
+  function pushConfigPath(...segments) {
     configPaths.push(path.join(...segments));
+    if (segments[segments.length - 1] === `.${name}rc`) {
+      configPaths.push(path.join(...segments.slice(0, -1), `.${name}rc.yml`));
+    }
+  }
+
+  function unshiftConfigPath(...segments) {
+    configPaths.unshift(path.join(...segments));
+    if (segments[segments.length - 1] === `.${name}rc`) {
+      configPaths.unshift(path.join(...segments.slice(0, -1), `.${name}rc.yml`));
+    }
   }
 
   if (!isWin) {
-    addConfigPath(etc, name, 'config');
-    addConfigPath(etc, `${name}rc`);
+    pushConfigPath(etc, name, 'config');
+    pushConfigPath(etc, `${name}rc`);
   }
 
   if (home) {
-    addConfigPath(CONFIG_DIRECTORY);
-    addConfigPath(home, '.config', name, 'config');
-    addConfigPath(home, '.config', name);
-    addConfigPath(home, `.${name}`, 'config');
-    addConfigPath(home, `.${name}rc`);
+    pushConfigPath(CONFIG_DIRECTORY);
+    pushConfigPath(home, '.config', name, 'config');
+    pushConfigPath(home, '.config', name);
+    pushConfigPath(home, `.${name}`, 'config');
+    pushConfigPath(home, `.${name}rc`);
   }
 
   // add .yarnrc locations relative to the cwd
   while (true) {
-    configPaths.unshift(path.join(cwd, `.${name}rc`));
+    unshiftConfigPath(cwd, `.${name}rc`);
 
     const upperCwd = path.dirname(cwd);
     if (upperCwd === cwd) {
@@ -45,7 +55,7 @@ function getRcPaths(name: string, cwd: string): Array<string> {
   const envVariable = `${name}_config`.toUpperCase();
 
   if (process.env[envVariable]) {
-    addConfigPath(process.env[envVariable]);
+    pushConfigPath(process.env[envVariable]);
   }
 
   return configPaths;


### PR DESCRIPTION
**Summary**

Ref: https://github.com/yarnpkg/berry/issues/239

I'm planning to rename `.yarnrc` files into `.yarnrc.yml` in order to avoid problems where configuration for two different syntaxes / documentations would have to be used together. My hope is that it'll help the migration plan become smoother and less unpredictable.

This proposal has one drawback: the `yarn-path` settings. The v1 (which I expect to stay the version in the global path for some time) doesn't know how to read the `.yarnrc.yml` file, and to look for the `yarn-path` settings there. We could make the v2 write the `yarn-path` settings into the old `.yarnrc` file (rather than `.yarnrc.yml`), but that would require to have both `.yarnrc` and `.yarnrc.yml` at the same time when using the v2, which I'd prefer to avoid.

To solve this, my plan is to:

1. continue to make the v1 reading the `.yarnrc` files
2. update the v1 to also look for `yarn-path` in the `.yarnrc.yml` file
3. make the v2 exclusively read/write from the `.yarnrc.yml` file
4. update the v1 to make `yarn policies set-version` write a `.yarnrc.yml` when installing the v2

This diff solves 1, 2, and 3. The fourth point is optional and will be done at a later point if at all.

**Test plan**

Ran Yarn with a local `.yarnrc.yml`, worked successfully. Tests will validate that the old workflow also work.