### PR TITLE
Pluralizing `workspace` in a workspaceNameDuplicate message

### DIFF
--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -206,7 +206,7 @@ const messages = {
   workspaceUnknownWorkspace: 'Unknown workspace $0.',
   workspaceVersionMandatory: 'Missing version in workspace at $0, ignoring.',
   workspaceNameMandatory: 'Missing name in workspace at $0, ignoring.',
-  workspaceNameDuplicate: 'There are more than one workspace with name $0',
+  workspaceNameDuplicate: 'There are more than one workspaces with name $0',
 
   cacheFolderSkipped: 'Skipping preferred cache folder $0 because it is not writable.',
   cacheFolderMissing:


### PR DESCRIPTION
When creating a workspace that already exists, the following message is displayed:

'There are more than one workspace with name $0'

The workspaceNameDuplicate message uses `workspace` instead of `workspaces`. This commit pluralizes the word.

Ran the testing suite and lint-test, no new tests were needed.