### PR TITLE
Add registry paramter to revokedToken request

### DIFF
--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -120,6 +120,7 @@ export async function getToken(
       reporter.success(reporter.lang('revokedToken'));
       await config.registries.npm.request(`-/user/token/${token}`, {
         method: 'DELETE',
+        registry,
       });
     };
   } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When set `publishConfig.registry` in package.json , revokedToken should use `publishConfig.registry`.

Similar PR: #7312


<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
Too lazy! 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
