### PR TITLE
feat(cli): warning on relative paths provided by --cwd param

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -454,6 +454,12 @@ export default class Config {
     this.registries = map();
     this.cache = map();
 
+    if (opts.cwd !== undefined) {
+      if (!path.isAbsolute(opts.cwd)) {
+        this.reporter.warn(this.reporter.lang('yarnAddRelativePathDetected'));
+      }
+    }
+
     // Ensure the cwd is always an absolute path.
     this.cwd = path.resolve(opts.cwd || this.cwd || process.cwd());
 

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -135,6 +135,9 @@ const messages = {
   yarnOutdatedInstaller: 'To upgrade, download the latest installer at $0.',
   yarnOutdatedCommand: 'To upgrade, run the following command:',
 
+  yarnAddRelativePathDetected:
+    'Detected a relative path. --cwd only supports an absolute path. A current working directory will be used instead.',
+
   tooManyArguments: 'Too many arguments, maximum of $0.',
   tooFewArguments: 'Not enough arguments, expected at least $0.',
   noArguments: "This command doesn't require any arguments.",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When a user executes `yarn add --cwd relative-path-to-the-dir dependency-name` command and passes a relative path to the directory, [the path is resolved](https://nodejs.org/api/path.html#path_path_resolve_paths) and a [current working directory](https://nodejs.org/api/process.html#process_process_cwd) is used instead. 

https://github.com/yarnpkg/yarn/blob/49332faf9d22f5c4ae33d4d3343895e189b3fac3/src/config.js#L458

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

A user might be surprised by described behaviour, so adding a warning can be really helpful. You can find more details about it in [this issue](https://github.com/yarnpkg/yarn/issues/5206).

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I did perform manual testing for a relative path:

<img width="858" alt="Screen Shot 2019-07-04 at 10 14 20" src="https://user-images.githubusercontent.com/10795657/60650471-8225f080-9e44-11e9-9cfa-b5481391f2c3.png">

The new warning is added ☝️🎊 

Also tested the potential regression, if we passed an absolute path to the command:

<img width="848" alt="Screen Shot 2019-07-04 at 10 16 09" src="https://user-images.githubusercontent.com/10795657/60650615-c31e0500-9e44-11e9-8ebf-04cb85db9d6a.png">

Worked as expected 👍 

I wish I could add unit tests to check the warning. Any suggestion on that would be appreciated 🙏 Was thinking about adding it to `config.js` tests - checking the warning while `config` initialisation for a relative path.

closes https://github.com/yarnpkg/yarn/issues/5206