### PR TITLE
fix absolute path in @zkochan/cmd-shim under win

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",
   "dependencies": {
-    "@zkochan/cmd-shim": "^3.1.0",
+    "@akosm/cmd-shim": "^4.0.2",
     "babel-runtime": "^6.26.0",
     "bytes": "^3.0.0",
     "camelcase": "^4.0.0",

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -19,7 +19,7 @@ import {satisfiesWithPrereleases} from './util/semver.js';
 import WorkspaceLayout from './workspace-layout.js';
 
 const invariant = require('invariant');
-const cmdShim = require('@zkochan/cmd-shim');
+const cmdShim = require('@akosm/cmd-shim');
 const path = require('path');
 const semver = require('semver');
 // Concurrency for creating bin links disabled because of the issue #1961


### PR DESCRIPTION
**Summary**

Relative path cannot be used under different partitions under windows,otherwise it may cause binary link error. If set prefix "C:\Program Files (x86)\Yarn", global folder "D:\Repository\.yarn" . In @zkochan/cmd-shim, it will cause
C:\Program Files (x86)\Yarn\bin\nodemon.cmd :
@"%~dp0\D:\Repository.yarn\node_modules.bin\nodemon.cmd" %*

**Test plan**

C:\Program Files (x86)\Yarn\bin\nodemon.cmd :
@"D:\Repository.yarn\node_modules.bin\nodemon.cmd" %*