### PR TITLE
Forces using https for the regular registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Enforces https for the Yarn and npm registries.
+
+  [#7393](https://github.com/yarnpkg/yarn/pull/7393) - [**Maël Nison**](https://twitter.com/arcanis)
+
 - Adds support for reading `yarnPath` from v2-produced `.yarnrc.yml` files.
 
   [#7350](https://github.com/yarnpkg/yarn/pull/7350) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -782,25 +782,17 @@ describe('getRequestUrl functional test', () => {
     expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://my.registry.co/registry/foo/bar/baz');
   });
 
-  test('enforces loading packages through https when they come from yarn', () => {
-    const testCwd = '.';
-    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
-    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
-    const registry = 'http://registry.yarnpkg.com/registry';
-    const pathname = 'foo/bar/baz';
+  for (const host of [`registry.yarnpkg.com`, `registry.npmjs.org`, `registry.npmjs.com`]) {
+    test(`enforces loading packages through https when they come from ${host}`, () => {
+      const testCwd = '.';
+      const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+      const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+      const registry = `http://${host}/registry`;
+      const pathname = 'foo/bar/baz';
 
-    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://registry.yarnpkg.com/registry/foo/bar/baz');
-  });
-
-  test('enforces loading packages through https when they come from npm', () => {
-    const testCwd = '.';
-    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
-    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
-    const registry = 'http://registry.npmjs.org/registry';
-    const pathname = 'foo/bar/baz';
-
-    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://registry.npmjs.org/registry/foo/bar/baz');
-  });
+      expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual(`https://${host}/registry/foo/bar/baz`);
+    });
+  }
 
   test("doesn't change the protocol for packages from other registries", () => {
     const testCwd = '.';

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -781,6 +781,36 @@ describe('getRequestUrl functional test', () => {
 
     expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://my.registry.co/registry/foo/bar/baz');
   });
+
+  test('enforces loading packages through https when they come from yarn', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+    const registry = 'http://registry.yarnpkg.com/registry';
+    const pathname = 'foo/bar/baz';
+
+    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://registry.yarnpkg.com/registry/foo/bar/baz');
+  });
+
+  test('enforces loading packages through https when they come from yarn', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+    const registry = 'http://registry.npmjs.org/registry';
+    const pathname = 'foo/bar/baz';
+
+    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://registry.npmjs.org/registry/foo/bar/baz');
+  });
+
+  test('doesn\'t change the protocol for packages from other registries', () => {
+    const testCwd = '.';
+    const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
+    const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
+    const registry = 'http://registry.mylittlepony.org/registry';
+    const pathname = 'foo/bar/baz';
+
+    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('http://registry.mylittlepony.org/registry/foo/bar/baz');
+  });
 });
 
 describe('getScope functional test', () => {

--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -792,7 +792,7 @@ describe('getRequestUrl functional test', () => {
     expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://registry.yarnpkg.com/registry/foo/bar/baz');
   });
 
-  test('enforces loading packages through https when they come from yarn', () => {
+  test('enforces loading packages through https when they come from npm', () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
@@ -802,14 +802,16 @@ describe('getRequestUrl functional test', () => {
     expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('https://registry.npmjs.org/registry/foo/bar/baz');
   });
 
-  test('doesn\'t change the protocol for packages from other registries', () => {
+  test("doesn't change the protocol for packages from other registries", () => {
     const testCwd = '.';
     const {mockRequestManager, mockRegistries, mockReporter} = createMocks();
     const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, mockReporter, true, []);
     const registry = 'http://registry.mylittlepony.org/registry';
     const pathname = 'foo/bar/baz';
 
-    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual('http://registry.mylittlepony.org/registry/foo/bar/baz');
+    expect(npmRegistry.getRequestUrl(registry, pathname)).toEqual(
+      'http://registry.mylittlepony.org/registry/foo/bar/baz',
+    );
   });
 });
 

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -22,6 +22,7 @@ import url from 'url';
 import ini from 'ini';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+const REGEX_REGISTRY_ENFORCED_HTTPS = /^https?:\/\/([^\/]+\.)?(yarnpkg\.com|npmjs\.org)(\/|$)/;
 const REGEX_REGISTRY_HTTP_PROTOCOL = /^https?:/i;
 const REGEX_REGISTRY_PREFIX = /^(https?:)?\/\//i;
 const REGEX_REGISTRY_SUFFIX = /registry\/?$/;
@@ -112,13 +113,17 @@ export default class NpmRegistry extends Registry {
   }
 
   getRequestUrl(registry: string, pathname: string): string {
-    const isUrl = REGEX_REGISTRY_PREFIX.test(pathname);
+    let resolved = pathname;
 
-    if (isUrl) {
-      return pathname;
-    } else {
-      return url.resolve(addSuffix(registry, '/'), pathname);
+    if (!REGEX_REGISTRY_PREFIX.test(pathname)) {
+      resolved = url.resolve(addSuffix(registry, '/'), pathname);
     }
+
+    if (REGEX_REGISTRY_ENFORCED_HTTPS.test(resolved)) {
+      resolved = resolved.replace(/^http:\/\//, 'https://');
+    }
+
+    return resolved;
   }
 
   isRequestToRegistry(requestUrl: string, registryUrl: string): boolean {

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -22,7 +22,7 @@ import url from 'url';
 import ini from 'ini';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
-const REGEX_REGISTRY_ENFORCED_HTTPS = /^https?:\/\/([^\/]+\.)?(yarnpkg\.com|npmjs\.org)(\/|$)/;
+const REGEX_REGISTRY_ENFORCED_HTTPS = /^https?:\/\/([^\/]+\.)?(yarnpkg\.com|npmjs\.(org|com))(\/|$)/;
 const REGEX_REGISTRY_HTTP_PROTOCOL = /^https?:/i;
 const REGEX_REGISTRY_PREFIX = /^(https?:)?\/\//i;
 const REGEX_REGISTRY_SUFFIX = /registry\/?$/;


### PR DESCRIPTION
**Summary**

The npm registry had an outage some time ago and returned `http:` protocols instead of `https:` for various projects. The following diff ensures that we always use https no matter what for both the npm registry and the yarn registry.

**Test plan**

Added unit tests.