### PR TITLE
Run the prepare script of git dependencies even if NODE_ENV=production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Run the prepare script of git dependencies even if NODE_ENV=production
+- Runs the `prepare` lifecycle of git dependencies even if `NODE_ENV` is set to `production`.
 
   [#7398](https://github.com/yarnpkg/yarn/pull/7398) - [**John Firebaugh**](https://github.com/jfirebaugh)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Run the prepare script of git dependencies even if NODE_ENV=production
+
+  [#7398](https://github.com/yarnpkg/yarn/pull/7398) - [**John Firebaugh**](https://github.com/jfirebaugh)
+
 - Enforces https for the Yarn and npm registries.
 
   [#7393](https://github.com/yarnpkg/yarn/pull/7393) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -164,6 +164,7 @@ export default class GitFetcher extends BaseFetcher {
           binLinks: true,
           cwd: prepareDirectory,
           disablePrepublish: true,
+          production: false,
         },
         this.reporter,
       ),


### PR DESCRIPTION
**Summary**

When installing a git dependency with the `NODE_ENV` environment variable set to `production`, yarn did not run the `prepare` lifecycle script, because `config.production` would default to true, and then `wrapLifecycle` would skip `prepare`:

https://github.com/yarnpkg/yarn/blob/b6569538de69e0ccd201f0a33f1f5b52f2656f5b/src/cli/commands/install.js#L1202-L1207

This is contrary to npm's behavior and the intent of `GitFetcher#fetchFromInstallAndPack`, which is to install the dependency with its devDependencies and run all the relevant lifecycle scripts (excluding `prepublish`), regardless of the configuration or environment settings of the parent install command.

**Test plan**

Added an automated test.

cc @Volune, who added the original feature in #3553. Thanks for the test case which I cribbed from!