### PR TITLE
fix(E2BIG): Ignore potentially large vscode keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Ignores potentially large vscode keys in package.json to avoid E2BIG errors.
+
+  [#7419](https://github.com/yarnpkg/yarn/pull/7419) - [**Eric Amodio**](https://twitter.com/eamodio)
+
 - Enforces https for the Yarn and npm registries.
 
   [#7393](https://github.com/yarnpkg/yarn/pull/7393) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -18,7 +18,13 @@ export type LifecycleReturn = Promise<{
   stdout: string,
 }>;
 
-export const IGNORE_MANIFEST_KEYS: Set<string> = new Set(['readme', 'notice', 'licenseText']);
+export const IGNORE_MANIFEST_KEYS: Set<string> = new Set([
+  'readme',
+  'notice',
+  'licenseText',
+  'activationEvents',
+  'contributes',
+]);
 
 // We treat these configs as internal, thus not expose them to process.env.
 // This helps us avoid some gyp issues when building native modules.


### PR DESCRIPTION
**Summary**

Ignores 2 VS Code extension specific `package.json` keys that tend to get large and can cause E2BIG errors. I just moved my vscode extension ([GitLens](https://github.com/eamodio/vscode-gitlens/)) from `npm` to `yarn` hoping this issue (a large `package.json`) wouldn't manifest itself, but sadly it was still an issue.

Here is the original issue I commented on: https://github.com/yarnpkg/yarn/issues/5420#issuecomment-513100428

Fixes #5420 for another instance.
