### PR TITLE
Fix a bug when git padding warning message start with /[a-f]/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes a bug when git padding warning message start with /[a-f]/.
+
+  [#7428](https://github.com/yarnpkg/yarn/pull/7428) - [**CMUH**](https://github.com/CMUH)
+
 - Makes running scripts with Plug'n Play possible on node 13
 
   [#7650](https://github.com/yarnpkg/yarn/pull/7650) - [**Sander Verweij**](https://github.com/sverweij)
@@ -11,7 +15,6 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Change run command to check cwd/node_modules/.bin for commands. Fixes run in workspaces.
 
   [#7151](https://github.com/yarnpkg/yarn/pull/7151) - [**Jeff Valore**](https://twitter.com/codingwithspike)
-
 
 ## 1.19.1
 

--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -1,19 +1,7 @@
 /* @flow */
 
 jest.mock('../../src/util/git/git-spawn.js', () => ({
-  spawn: jest.fn(([command]) => {
-    switch (command) {
-      case 'ls-remote':
-        return `Identity added: /Users/example/.ssh/id_dsa (/Users/example/.ssh/id_dsa)
-ref: refs/heads/master  HEAD
-7a053e2ca07d19b2e2eebeeb0c27edaacfd67904        HEAD`;
-      case 'rev-list':
-        return Promise.resolve('7a053e2ca07d19b2e2eebeeb0c27edaacfd67904 Fix ...');
-      case 'show-ref':
-        return `7a053e2ca07d19b2e2eebeeb0c27edaacfd67904 refs/remotes/origin/HEAD`;
-    }
-    return Promise.resolve('');
-  }),
+  spawn: jest.fn(),
 }));
 
 import Config from '../../src/config.js';
@@ -189,44 +177,64 @@ test('secureGitUrl', async function(): Promise<void> {
   expect(gitURL.repository).toEqual('https://github.com/yarnpkg/yarn.git');
 });
 
-test('resolveDefaultBranch when local', async () => {
-  const spawnGitMock = (spawnGit: any).mock;
-  const config = await Config.create();
-  const git = new Git(
-    config,
-    {
-      protocol: 'file:',
-      hostname: undefined,
-      repository: 'example',
-    },
-    '',
-  );
-  expect(await git.resolveDefaultBranch()).toEqual({
-    sha: '7a053e2ca07d19b2e2eebeeb0c27edaacfd67904',
-    ref: undefined,
-  });
-  const lastCall = spawnGitMock.calls[spawnGitMock.calls.length - 1];
-  expect(lastCall[0]).toContain('show-ref');
-});
+describe('resolveDefaultBranch()', () => {
+  const DEFAULT_LS_REMOTE = `ref: refs/heads/master  HEAD
+7a053e2ca07d19b2e2eebeeb0c27edaacfd67904        HEAD`;
+  const DEFAULT_REV_LIST = '7a053e2ca07d19b2e2eebeeb0c27edaacfd67904 Fix ...';
+  const DEFAULT_SHOW_REF = '7a053e2ca07d19b2e2eebeeb0c27edaacfd67904 refs/remotes/origin/HEAD';
+  const spawnWrapper = message => ([command]) => {
+    switch (command) {
+      case 'ls-remote':
+        return Promise.resolve(message);
+      case 'rev-list':
+        return Promise.resolve(DEFAULT_REV_LIST);
+      case 'show-ref':
+        return Promise.resolve(DEFAULT_SHOW_REF);
+    }
+    return Promise.resolve('');
+  };
 
-test('resolveDefaultBranch when remote', async () => {
-  const spawnGitMock = (spawnGit: any).mock;
-  const config = await Config.create();
-  const git = new Git(
-    config,
-    {
-      protocol: 'https:',
-      hostname: '//example.com',
-      repository: 'example',
-    },
-    '',
-  );
-  expect(await git.resolveDefaultBranch()).toEqual({
-    sha: '7a053e2ca07d19b2e2eebeeb0c27edaacfd67904',
-    ref: 'refs/heads/master',
+  test('when local', async () => {
+    const spawnGitMock = (spawnGit: any).mock;
+    const config = await Config.create();
+    const git = new Git(
+      config,
+      {
+        protocol: 'file:',
+        hostname: undefined,
+        repository: 'example',
+      },
+      '',
+    );
+    (spawnGit: any).mockImplementation(spawnWrapper(''));
+    expect(await git.resolveDefaultBranch()).toEqual({
+      sha: '7a053e2ca07d19b2e2eebeeb0c27edaacfd67904',
+      ref: undefined,
+    });
+    const lastCall = spawnGitMock.calls[spawnGitMock.calls.length - 1];
+    expect(lastCall[0]).toContain('show-ref');
   });
-  const lastCall = spawnGitMock.calls[spawnGitMock.calls.length - 1];
-  expect(lastCall[0]).toContain('ls-remote');
+
+  test('when remote', async () => {
+    const spawnGitMock = (spawnGit: any).mock;
+    const config = await Config.create();
+    const git = new Git(
+      config,
+      {
+        protocol: 'https:',
+        hostname: '//example.com',
+        repository: 'example',
+      },
+      '',
+    );
+    (spawnGit: any).mockImplementation(spawnWrapper(DEFAULT_LS_REMOTE));
+    expect(await git.resolveDefaultBranch()).toEqual({
+      sha: '7a053e2ca07d19b2e2eebeeb0c27edaacfd67904',
+      ref: 'refs/heads/master',
+    });
+    const lastCall = spawnGitMock.calls[spawnGitMock.calls.length - 1];
+    expect(lastCall[0]).toContain('ls-remote');
+  });
 });
 
 test('resolveCommit', async () => {

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -22,7 +22,7 @@ const GIT_PROTOCOL_PREFIX = 'git+';
 const SSH_PROTOCOL = 'ssh:';
 const SCP_PATH_PREFIX = '/:';
 const FILE_PROTOCOL = 'file:';
-const GIT_VALID_REF_LINE_REGEXP = /^([a-fA-F0-9]+|ref)/;
+const GIT_VALID_REF_LINE_REGEXP = /^([a-fA-F0-9]+|ref:)\s/;
 
 const validRef = line => {
   return GIT_VALID_REF_LINE_REGEXP.exec(line);


### PR DESCRIPTION
**Summary**

Fix #5077 #5013 #7239 
The regex filter in #5081 is too simple to match some use case.
If there is a warning message start with `/[a-f]/`, it will broken its behavior.

**Test plan**

Modify `spawnGit` mock implementation with 5 use case:

1. resolveDefaultBranch when remote
2. resolveDefaultBranch when remote with 'Identity added' warning message (#5077)
3. resolveDefaultBranch when remote with 'Failed to add the host' warning message (#5013)
4. resolveDefaultBranch when remote with "Warning:" message (#5013)
5. resolveDefaultBranch when remote with 'fatal:' error message (#7239)
