### PR TITLE
Do not log `err.message` of `ProcessTermError`s if silent

### DIFF
--- a/__tests__/fixtures/index/run-failing-script/package.json
+++ b/__tests__/fixtures/index/run-failing-script/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test_run_failing_script",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "custom-script": "echo \"Hi\" && exit 1"
+  }
+}

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -49,9 +49,9 @@ async function execCommand(
         cwd: workingDir,
         env: cleanedEnv,
       },
-      (error, stdout) => {
+      (error, stdout, stderr) => {
         if (error) {
-          reject(Object.assign((new Error(error.message): any), {stdout}));
+          reject(Object.assign((new Error(error.message): any), {stdout, stderr}));
         } else {
           const stdoutLines = stdout
             .toString()
@@ -169,6 +169,15 @@ test.concurrent('should run custom script', async () => {
 test.concurrent('should run custom script without run command', async () => {
   const stdout = await execCommand('custom-script', [], 'run-custom-script');
   expectRunOutput(stdout);
+});
+
+test.concurrent('should run without extra output for failing sub commands', async () => {
+  try {
+    await execCommand('run', ['--silent', 'custom-script'], 'run-failing-script');
+    throw new Error('the command did not fail');
+  } catch (err) {
+    expect(err.stderr).toBe('');
+  }
 });
 
 test.concurrent('should run help command', async () => {

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -83,6 +83,7 @@ const getRandomPort = () => Math.floor(Math.random() * PORT_RANGE) + MIN_PORT_NU
 async function runYarn(args: Array<string> = [], options: Object = {}): Promise<Array<Buffer>> {
   if (!options['env']) {
     options['env'] = {...process.env};
+    options['env']['YARN_SILENT'] = 0;
     options['extendEnv'] = false;
   }
   options['env']['FORCE_COLOR'] = 0;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -585,6 +585,10 @@ export async function main({
     .catch((err: Error) => {
       reporter.verbose(err.stack);
 
+      if (err instanceof ProcessTermError && reporter.isSilent) {
+        return exit(err.EXIT_CODE || 1);
+      }
+
       if (err instanceof MessageError) {
         reporter.error(err.message);
       } else {


### PR DESCRIPTION
Fixes #5359

If sub commands called via `yarn run` fail yarn typically logs `error Command failed with exit code 1.` even if `--silent` is requested basically because a failing command throws (or rethrows) itself instead of just returning this failure as valid output. 

This is the simplest patch to suppress this output. 

