### PR TITLE
Add Parcel to the engines ignore list

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -52,7 +52,7 @@ const ignore = [
   'teleport', // a module bundler used by some modules
   'rhino', // once a target for older modules
   'cordovaDependencies', // http://bit.ly/2tkUePg
-  'parcel' // used for plugins of the Parcel bundler
+  'parcel', // used for plugins of the Parcel bundler
 ];
 
 type Versions = {

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -52,6 +52,7 @@ const ignore = [
   'teleport', // a module bundler used by some modules
   'rhino', // once a target for older modules
   'cordovaDependencies', // http://bit.ly/2tkUePg
+  'parcel' // used for plugins of the Parcel bundler
 ];
 
 type Versions = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

Parcel requires plugins to use engines.parcel to specify the Parcel version the plugin supports.

Currently yarn is throwing warnings for this, this PR adds parcel to the ignore list so this no longer happens.

See: https://github.com/parcel-bundler/parcel/blob/master/PARCEL_2_RFC.md#engines

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
