### PR TITLE
Fixes offline mirror filename calculation for scoped packages URLs in Verdaccio (private npm repository)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes the offline mirror filenames when using Verdaccio
+
+  [#7499](https://github.com/yarnpkg/yarn/pull/7499) - [**xv2**](https://github.com/xv2)
+
 - Update fixture certificates to prevent false negatives during testing
 
   [#7457](https://github.com/yarnpkg/yarn/pull/7457) - [**Thomas Jouannic**](https://github.com/eilgin)

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -312,6 +312,29 @@ test('TarballFetcher.fetch properly stores tarball of scoped package in offline 
   expect(exists).toBe(true);
 });
 
+test('TarballFetcher.fetch properly stores tarball of scoped package in offline mirror for Verdaccio', async () => {
+  const dir = await mkdir('tarball-fetcher');
+  const offlineMirrorDir = await mkdir('offline-mirror');
+
+  const config = await Config.create();
+  config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
+
+  const fetcher = new TarballFetcher(
+    dir,
+    {
+      type: 'tarball',
+      hash: '6f0ab73cdd7b82d8e81e80838b49e9e4c7fbcc44',
+      reference: 'http://npm.xxxyyyzzz.ru/@types%2fevents/-/events-3.0.0.tgz',
+      registry: 'npm',
+    },
+    config,
+  );
+
+  await fetcher.fetch();
+  const exists = await fs.exists(path.join(offlineMirrorDir, '@types-events-3.0.0.tgz'));
+  expect(exists).toBe(true);
+});
+
 test('TarballFetcher.fetch properly stores tarball for scoped package resolved from artifactory registry', async () => {
   const dir = await mkdir('tarball-fetcher');
   const offlineMirrorDir = await mkdir('offline-mirror');

--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -313,11 +313,9 @@ test('TarballFetcher.fetch properly stores tarball of scoped package in offline 
 });
 
 test('TarballFetcher.fetch properly stores tarball of scoped package in offline mirror for Verdaccio', async () => {
-  const dir = await mkdir('tarball-fetcher');
-  const offlineMirrorDir = await mkdir('offline-mirror');
-
+  const dir = await mkdir('git-fetcher');
   const config = await Config.create();
-  config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
+  config.registries.yarn.config['yarn-offline-mirror'] = 'test';
 
   const fetcher = new TarballFetcher(
     dir,
@@ -329,10 +327,8 @@ test('TarballFetcher.fetch properly stores tarball of scoped package in offline 
     },
     config,
   );
-
-  await fetcher.fetch();
-  const exists = await fs.exists(path.join(offlineMirrorDir, '@types-events-3.0.0.tgz'));
-  expect(exists).toBe(true);
+  const cachePath = fetcher.getTarballMirrorPath();
+  expect(cachePath).toBe(path.join('test', '@types-events-3.0.0.tgz'));
 });
 
 test('TarballFetcher.fetch properly stores tarball for scoped package resolved from artifactory registry', async () => {

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -18,7 +18,7 @@ const gunzip = require('gunzip-maybe');
 const invariant = require('invariant');
 const ssri = require('ssri');
 
-const RE_URL_NAME_MATCH = /\/(?:(@[^/]+)\/)?[^/]+\/(?:-|_attachments)\/(?:@[^/]+\/)?([^/]+)$/;
+const RE_URL_NAME_MATCH = /\/(?:(@[^/]+)(?:\/|%2f))?[^/]+\/(?:-|_attachments)\/(?:@[^/]+\/)?([^/]+)$/;
 
 const isHashAlgorithmSupported = name => {
   const cachedResult = isHashAlgorithmSupported.__cache[name];


### PR DESCRIPTION
Fixes for `tarball` contains `%2f` instead of `/`
Sample: `http://npm.xxxyyyzzz.ru/@types%2fevents/-/events-3.0.0.tgz`
Issue: #7498 