### PR TITLE
Fixes link:.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 - Fixes using `link:.` to refer to the package folder
 
-  []() - [**Maël Nison**](https://twitter.com/arcanis)
+  [#7512](https://github.com/yarnpkg/yarn/pull/7512) - [**Maël Nison**](https://twitter.com/arcanis)
 
 - Runs the `prepare` lifecycle of git dependencies even if `NODE_ENV` is set to `production`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Update fixture certificates to prevent false negatives during testing
+- Fixes using `link:.` to refer to the package folder
 
-  [#7457](https://github.com/yarnpkg/yarn/pull/7457) - [**Thomas Jouannic**](https://github.com/eilgin)
+  []() - [**Maël Nison**](https://twitter.com/arcanis)
 
 - Runs the `prepare` lifecycle of git dependencies even if `NODE_ENV` is set to `production`.
 
@@ -15,7 +15,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Fixes the `postversion` lifecycle method not being called when using `--no-git-tag-version`.
 
   [#7154](https://github.com/yarnpkg/yarn/pull/7154) - [**Hampus Tågerud**](https://github.com/hampustagerud)
-  
+
 - Ignores potentially large vscode keys in package.json to avoid E2BIG errors.
 
   [#7419](https://github.com/yarnpkg/yarn/pull/7419) - [**Eric Amodio**](https://twitter.com/eamodio)
@@ -67,7 +67,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 - Exposes the script environment variables to `yarn create` spawned processes.
 
   [#7127](https://github.com/yarnpkg/yarn/pull/7127) - [**Eli Perelman**](https://github.com/eliperelman)
-  
+
 - Prevents EPIPE errors from being printed.
 
   [#7194](https://github.com/yarnpkg/yarn/pull/7194) - [**Abhishek Reddy**](https://github.com/arbscht)

--- a/src/resolvers/exotics/link-resolver.js
+++ b/src/resolvers/exotics/link-resolver.js
@@ -30,7 +30,7 @@ export default class LinkResolver extends ExoticResolver {
     const name = path.basename(loc);
     const registry: RegistryNames = 'npm';
 
-    const manifest: Manifest = !await fs.exists(`${loc}/package.json`)
+    const manifest: Manifest = !await fs.exists(`${loc}/package.json`) || loc === this.config.lockfileFolder
       ? {_uid: '', name, version: '0.0.0', _registry: registry}
       : await this.config.readManifest(loc, this.registry);
 


### PR DESCRIPTION
**Summary**

Using `link:.` currently generates an infinite loop (because we load the dependencies from our own folder, then from our own folder, then from our own folder, then ...).

**Test plan**

Added such a pattern to the Yarn repo and checked that it works.
