### PR TITLE
Fix "files" option skipping file paths starting with "./"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Fixes paths in "files" which start with `./` not being included by `yarn pack`
+
+  [#7518](https://github.com/yarnpkg/yarn/pull/7518) - [**Samuel Meuli**](https://github.com/samuelmeuli)
+
 - Fixes the offline mirror filenames when using Verdaccio
 
   [#7499](https://github.com/yarnpkg/yarn/pull/7499) - [**xv2**](https://github.com/xv2)

--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -67,6 +67,17 @@ test.concurrent('pack should include all files listed in the files array', (): P
   });
 });
 
+test.concurrent('pack should include files whose paths begin with "./"', (): Promise<void> => {
+  return runPack([], {}, 'files-include-from-cwd', async (config): Promise<void> => {
+    const {cwd} = config;
+    const files = await getFilesFromArchive(
+      path.join(cwd, 'files-include-from-cwd-v1.0.0.tgz'),
+      path.join(cwd, 'files-include-from-cwd-v1.0.0'),
+    );
+    expect(files.sort()).toEqual(['a.js', 'b.js', 'dir', path.join('dir', 'nested.js'), 'index.js', 'package.json']);
+  });
+});
+
 test.concurrent('pack should include files based from the package’s root', (): Promise<void> => {
   return runPack([], {}, 'files-include-from-root', async (config): Promise<void> => {
     const {cwd} = config;

--- a/__tests__/fixtures/pack/files-include-from-cwd/a.js
+++ b/__tests__/fixtures/pack/files-include-from-cwd/a.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/files-include-from-cwd/b.js
+++ b/__tests__/fixtures/pack/files-include-from-cwd/b.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/files-include-from-cwd/c.js
+++ b/__tests__/fixtures/pack/files-include-from-cwd/c.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/files-include-from-cwd/dir/nested.js
+++ b/__tests__/fixtures/pack/files-include-from-cwd/dir/nested.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/files-include-from-cwd/index.js
+++ b/__tests__/fixtures/pack/files-include-from-cwd/index.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/files-include-from-cwd/package.json
+++ b/__tests__/fixtures/pack/files-include-from-cwd/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "files-include-from-cwd",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "files": ["./index.js", "./a.js", "./b.js", "./dir/"]
+}

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -85,7 +85,7 @@ export async function packTarball(
       '*', // ignore all files except those that are explicitly included with a negation filter
     ];
     lines = lines.concat(
-      onlyFiles.map((filename: string): string => `!${filename}`),
+      onlyFiles.map((filename: string): string => `!${path.normalize(filename)}`),
       onlyFiles.map((filename: string): string => `!${path.join(filename, '**')}`),
     );
     const regexes = ignoreLinesToRegex(lines, './');

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -85,7 +85,7 @@ export async function packTarball(
       '*', // ignore all files except those that are explicitly included with a negation filter
     ];
     lines = lines.concat(
-      onlyFiles.map((filename: string): string => `!${path.normalize(filename)}`),
+      onlyFiles.map((filename: string): string => `!${path.join(filename)}`),
       onlyFiles.map((filename: string): string => `!${path.join(filename, '**')}`),
     );
     const regexes = ignoreLinesToRegex(lines, './');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When running `yarn pack`, Yarn currently does not include files with paths that begin with `./` in the package. Example `package.json` file:

```js
{
  // ...
  "files": [
    "a.js",
    "./b.js"
  ]
}
```

`a.js` will be in the package, but `b.js` won't.

This PR should fix that by normalizing the paths before converting them into a filter regex. (This is already happening for directories because `path.join` is used on them.)

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

See the new test case.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
