### PR TITLE
Resolve .bin path based on --modules-folder

### DIFF
--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -15,7 +15,7 @@ export function setFlags(commander: Object) {
 }
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
-  const binFolder = path.join(config.cwd, config.registryFolders[0], '.bin');
+  const binFolder = path.resolve(config.cwd, config.registryFolders[0], '.bin');
   if (args.length === 0) {
     reporter.log(binFolder, {force: true});
   } else {

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -192,10 +192,10 @@ export async function makeEnv(
   for (const registryFolder of config.registryFolders) {
     const binFolder = path.join(registryFolder, '.bin');
     if (config.workspacesEnabled && config.workspaceRootFolder) {
-      pathParts.unshift(path.join(config.workspaceRootFolder, binFolder));
+      pathParts.unshift(path.resolve(config.workspaceRootFolder, binFolder));
     }
-    pathParts.unshift(path.join(config.linkFolder, binFolder));
-    pathParts.unshift(path.join(cwd, binFolder));
+    pathParts.unshift(path.resolve(config.linkFolder, binFolder));
+    pathParts.unshift(path.resolve(cwd, binFolder));
   }
 
   let pnpFile;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #7519 

The first entry in registryFolders array corresponds to the location provided with `--modules-folder` to specify where to store node_modules. This currently does a `path.join` on the current location and the specified directory which prevents the modules folder from existing outside of the current tree.

For example, if we run:

```sh
yarn --modules-folder install
```

we will successfully get the modules installed into `/tmp/node_modules`, but when we later run

```sh
yarn --modules-folder /tmp/node_modules bin
```

we will get `/root/workspace/tmp/node_modules` instead of `/tmp/node_modules` as we expect.

This also happens when injecting the .bin directory into the PATH variable when executing lifecycle scripts.


<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

Comparison of before/after of `yarn bin` with absolute `--modules-folder`:
![image](https://user-images.githubusercontent.com/3004111/64282793-264f1500-cf24-11e9-8cb5-074da54a7183.png)

Comparison of before/after of `yarn which-jest` with absolute `--modules-folder`:
![image](https://user-images.githubusercontent.com/3004111/64283271-1e43a500-cf25-11e9-8c91-77c4a74c6b12.png)
(after the addition of a lifecycle script called `which-jest` that just runs `which jest`.