### PR TITLE
Fixes offline mirror filename calculation for scoped packages URLs in the taobao npm registry

### DIFF
--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -396,6 +396,27 @@ test('TarballFetcher.fetch properly stores tarball for scoped package resolved f
   expect(fetcher.getTarballMirrorPath()).toBe(path.join(offlineMirrorDir, '@exponent-configurator-1.0.2.tgz'));
 });
 
+test('TarballFetcher.fetch properly stores tarball for scoped package resolved from taobao npm registry', async () => {
+  const dir = await mkdir('tarball-fetcher');
+  const offlineMirrorDir = await mkdir('offline-mirror');
+
+  const config = await Config.create();
+  config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
+
+  const fetcher = new TarballFetcher(
+    dir,
+    {
+      type: 'tarball',
+      hash: '0e58ae66773d7fd7c372a493aff740878ec9ceaa',
+      reference: 'https://registry.npm.taobao.org:443/@types/prop-types/download/@types/prop-types-15.7.2.tgz',
+      registry: 'npm',
+    },
+    config,
+  );
+
+  expect(fetcher.getTarballMirrorPath()).toBe(path.join(offlineMirrorDir, '@types-prop-types-15.7.2.tgz'));
+});
+
 test('TarballFetcher.fetch throws on truncated tar data', async () => {
   const dir = await mkdir('tarball-fetcher');
   const reporter = new Reporter();

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -18,7 +18,7 @@ const gunzip = require('gunzip-maybe');
 const invariant = require('invariant');
 const ssri = require('ssri');
 
-const RE_URL_NAME_MATCH = /\/(?:(@[^/]+)(?:\/|%2f))?[^/]+\/(?:-|_attachments)\/(?:@[^/]+\/)?([^/]+)$/;
+const RE_URL_NAME_MATCH = /\/(?:(@[^/]+)(?:\/|%2f))?[^/]+\/(?:-|_attachments|download)\/(?:@[^/]+\/)?([^/]+)$/;
 
 const isHashAlgorithmSupported = name => {
   const cachedResult = isHashAlgorithmSupported.__cache[name];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The taobao registry gives tarball urls for scoped packages in formats like `https://registry.npm.taobao.org/@types/prop-types/download/@types/prop-types-15.7.2.tgz`, which cannot be parsed by the current regex `/\/(?:(@[^/]+)(?:\/|%2f))?[^/]+\/(?:-|_attachments)\/(?:@[^/]+\/)?([^/]+)$/`. The result will thus fallback to `prop-types-15.7.2.tgz` which conflicts with the cache for the package `prop-types`. This will result in checksum mismatch.


Fix #7532.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added a test in `__tests__/fetchers.js`.