### PR TITLE
Preserve linked packages in create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Preserve linked packages in create command
+
+  [#7543](https://github.com/yarnpkg/yarn/pull/7543) - [**Nick McCurdy**](https://github.com/nickmccurdy)
+
 - Fixes the offline mirror filenames when using Verdaccio
 
   [#7499](https://github.com/yarnpkg/yarn/pull/7499) - [**xv2**](https://github.com/xv2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Preserve linked packages in create command
+- Preserves linked packages when calling `yarn create`
 
   [#7543](https://github.com/yarnpkg/yarn/pull/7543) - [**Nick McCurdy**](https://github.com/nickmccurdy)
 

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -5,6 +5,7 @@ import {MessageError} from '../../errors.js';
 import type {Reporter} from '../../reporters/index.js';
 import * as child from '../../util/child.js';
 import {makeEnv} from '../../util/execute-lifecycle-script';
+import * as fs from '../../util/fs.js';
 import {run as runGlobal, getBinFolder} from './global.js';
 
 const path = require('path');
@@ -58,7 +59,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   const {fullName: packageName, name: commandName} = coerceCreatePackageName(builderName);
-  await runGlobal(config, reporter, {}, ['add', packageName]);
+
+  const linkLoc = path.join(config.linkFolder, commandName);
+  if (!await fs.exists(linkLoc)) {
+    await runGlobal(config, reporter, {}, ['add', packageName]);
+  }
 
   const binFolder = await getBinFolder(config, {});
   const command = path.resolve(binFolder, commandName);

--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -61,7 +61,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   const {fullName: packageName, name: commandName} = coerceCreatePackageName(builderName);
 
   const linkLoc = path.join(config.linkFolder, commandName);
-  if (!await fs.exists(linkLoc)) {
+  if (await fs.exists(linkLoc)) {
+    reporter.info(reporter.lang('linkUsing', packageName));
+  } else {
     await runGlobal(config, reporter, {}, ['add', packageName]);
   }
 

--- a/src/resolvers/exotics/link-resolver.js
+++ b/src/resolvers/exotics/link-resolver.js
@@ -30,9 +30,10 @@ export default class LinkResolver extends ExoticResolver {
     const name = path.basename(loc);
     const registry: RegistryNames = 'npm';
 
-    const manifest: Manifest = !await fs.exists(`${loc}/package.json`) || loc === this.config.lockfileFolder
-      ? {_uid: '', name, version: '0.0.0', _registry: registry}
-      : await this.config.readManifest(loc, this.registry);
+    const manifest: Manifest =
+      !await fs.exists(`${loc}/package.json`) || loc === this.config.lockfileFolder
+        ? {_uid: '', name, version: '0.0.0', _registry: registry}
+        : await this.config.readManifest(loc, this.registry);
 
     manifest._remote = {
       type: 'link',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently, `yarn create` does not respect an existing package linked with `yarn link`, and will instead overwrite the package in development with the latest version from the registry. With this fix, the package will only be installed if it isn't already linked, allowing users to use `yarn create` to develop locally linked packages without removing their global link. This matches the functionality of `npm init` and `npm create` with linked packages.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

## Test plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### Fixed test cases

#### Package is linked
Package is not installed globally and linked package is used instead
```
$ cd PACKAGE_SOURCE
$ yarn link
yarn global v1.18.0-0
success Registered "PACKAGE".
info You can now run `yarn link "PACKAGE"` in the projects where you want to use this package and it will be used instead.
$ yarn create PACKAGE_SUFFIX --version
yarn create v1.18.0-0
LINKED_VERSION
```

### Unchanged test cases

#### Package is not linked or installed
Package is installed globally before running the command
```
$ yarn create PACKAGE_SUFFIX --version
yarn global v1.18.0-0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Installed "PACKAGE@PUBLISHED_VERSION" with binaries:
      - COMMAND
PUBLISHED_VERSION
```

#### Package is installed
Package is reinstalled globally (which may update it) before running the command
```
$ yarn global add PACKAGE
yarn global v1.18.0-0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Installed "PACKAGE@PUBLISHED_VERSION" with binaries:
      - COMMAND
$ yarn create PACKAGE_SUFFIX --version
yarn create v1.18.0-0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Installed "PACKAGE@PUBLISHED_VERSION" with binaries:
      - COMMAND
PUBLISHED_VERSION
```