### PR TITLE
Adds a message when people use PnP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Suggests using the Yarn 2 development trunk on PnP-enabled projects
+
+  [#7512](https://github.com/yarnpkg/yarn/pull/7512) - [**Maël Nison**](https://twitter.com/arcanis)
+
 - Preserves linked packages when calling `yarn create`
 
   [#7543](https://github.com/yarnpkg/yarn/pull/7543) - [**Nick McCurdy**](https://github.com/nickmccurdy)

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -560,6 +560,11 @@ export class Install {
       this.reporter.warn(this.reporter.lang('npmLockfileWarning'));
     }
 
+    if (this.config.plugnplayEnabled) {
+      this.reporter.info(this.reporter.lang('plugnplaySuggestV2L1'));
+      this.reporter.info(this.reporter.lang('plugnplaySuggestV2L2'));
+    }
+
     let flattenedTopLevelPatterns: Array<string> = [];
     const steps: Array<(curr: number, total: number) => Promise<{bailout: boolean} | void>> = [];
     const {

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -361,6 +361,8 @@ const messages = {
 
   unplugDisabled: "Packages can only be unplugged when Plug'n'Play is enabled.",
 
+  plugnplaySuggestV2L1: "Plug'n'Play support has been greatly improved on the Yarn v2 development branch.",
+  plugnplaySuggestV2L2: "Please give it a try and tell us what you think! - https://next.yarnpkg.com/getting-started/install",
   plugnplayWindowsSupport: "Plug'n'Play on Windows doesn't support the cache and project to be kept on separate drives",
 
   packageInstalledWithBinaries: 'Installed $0 with binaries:',

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -362,7 +362,8 @@ const messages = {
   unplugDisabled: "Packages can only be unplugged when Plug'n'Play is enabled.",
 
   plugnplaySuggestV2L1: "Plug'n'Play support has been greatly improved on the Yarn v2 development branch.",
-  plugnplaySuggestV2L2: "Please give it a try and tell us what you think! - https://next.yarnpkg.com/getting-started/install",
+  plugnplaySuggestV2L2:
+    'Please give it a try and tell us what you think! - https://next.yarnpkg.com/getting-started/install',
   plugnplayWindowsSupport: "Plug'n'Play on Windows doesn't support the cache and project to be kept on separate drives",
 
   packageInstalledWithBinaries: 'Installed $0 with binaries:',


### PR DESCRIPTION
**Summary**

This PR adds a new info message when people use Plug'n'Play, suggesting to give the Yarn v2 development trunk a try.

This is because most of the recent development happened there, and we want to get early feedback from a subsection of our users before putting it out of beta (which will likely happen before the end of the year).

**Test plan**

![image](https://user-images.githubusercontent.com/1037931/65142960-1ea76a00-da14-11e9-94af-5532b431a6a4.png)
