### PR TITLE
Adds an undocumented run hook

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -4,6 +4,7 @@ import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import {execCommand, makeEnv} from '../../util/execute-lifecycle-script.js';
 import {dynamicRequire} from '../../util/dynamic-require.js';
+import {callThroughHook} from '../../util/hooks.js';
 import {MessageError} from '../../errors.js';
 import {checkOne as checkCompatibility} from '../../package-compatibility.js';
 import * as fs from '../../util/fs.js';
@@ -91,9 +92,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     }
   }
 
-  async function runCommand(args): Promise<void> {
-    const action = args.shift();
+  async function runCommand([action, ...args]): Promise<void> {
+    return callThroughHook('runScript', () => realRunCommand(action, args), {action, args});
+  }
 
+  async function realRunCommand(action, args): Promise<void> {
     // build up list of commands
     const cmds = [];
 

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -92,7 +92,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     }
   }
 
-  async function runCommand([action, ...args]): Promise<void> {
+  function runCommand([action, ...args]): Promise<void> {
     return callThroughHook('runScript', () => realRunCommand(action, args), {action, args});
   }
 

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-export type YarnHook = 'resolveStep' | 'fetchStep' | 'linkStep' | 'buildStep' | 'pnpStep' | 'auditStep';
+export type YarnHook = 'resolveStep' | 'fetchStep' | 'linkStep' | 'buildStep' | 'pnpStep' | 'auditStep' | 'runScript';
 
 const YARN_HOOKS_KEY = 'experimentalYarnHooks';
 
-export function callThroughHook<T>(type: YarnHook, fn: () => T): T {
+export function callThroughHook<T>(type: YarnHook, fn: () => T, context?: any): T {
   if (typeof global === 'undefined') {
     return fn();
   }
@@ -13,11 +13,11 @@ export function callThroughHook<T>(type: YarnHook, fn: () => T): T {
     return fn();
   }
 
-  const hook: (() => T) => T = global[YARN_HOOKS_KEY][type];
+  const hook: (() => T, context?: any) => T = global[YARN_HOOKS_KEY][type];
 
   if (!hook) {
     return fn();
   }
 
-  return hook(fn);
+  return hook(fn, context);
 }


### PR DESCRIPTION
**Summary**

This diff adds a (still undocumented, just like the existing ones) hook that gets triggered each time a `yarn run` command would run. This makes it possible to get basic informations about the scripts that are used the most, etc (note that this is not related to any kind of telemetrics - it's just a callback that you, as users, can set to whatever you want).
