### PR TITLE
Suppress warning when package sets engines.pnpm

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -49,6 +49,7 @@ const aliases = map({
 
 const ignore = [
   'npm', // we'll never satisfy this for obvious reasons
+  'pnpm', // used by alternative package manager
   'teleport', // a module bundler used by some modules
   'rhino', // once a target for older modules
   'cordovaDependencies', // http://bit.ly/2tkUePg


### PR DESCRIPTION
Fixes #7560

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Suppress warning for engines.pnpm similar to other alternative package managers, which will never be satisfied by Yarn.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tested locally by running `yarn-local add  @angular/cli@9.0.0-next.5` and observing that there are no warnings printed.