### PR TITLE
Add quotes arround path segments that includes spaces on Windows

### DIFF
--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -4,8 +4,9 @@ import type Config from '../../config.js';
 import {MessageError} from '../../errors.js';
 import type {Reporter} from '../../reporters/index.js';
 import * as child from '../../util/child.js';
-import {makeEnv} from '../../util/execute-lifecycle-script';
+import {makeEnv} from '../../util/execute-lifecycle-script.js';
 import * as fs from '../../util/fs.js';
+import {fixCmdWinSpaces} from '../../util/fix-cmd-win-spaces.js';
 import {run as runGlobal, getBinFolder} from './global.js';
 
 const path = require('path');
@@ -68,7 +69,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   }
 
   const binFolder = await getBinFolder(config, {});
-  const command = path.resolve(binFolder, commandName);
+  let command = path.resolve(binFolder, commandName);
+
+  if (process.platform === 'win32') {
+    command = fixCmdWinSpaces(command);
+  }
+
   const env = await makeEnv('create', config.cwd, config);
 
   await child.spawn(command, rest, {stdio: `inherit`, shell: true, env});

--- a/src/util/fix-cmd-win-spaces.js
+++ b/src/util/fix-cmd-win-spaces.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+import path from 'path';
+
+export function fixCmdWinSpaces(cmd: string): string {
+  if (!cmd.includes(' ')) {
+    return cmd;
+  }
+
+  return cmd
+    .split(path.sep)
+    .map(segment => {
+      return segment.includes(' ') ? `"${segment}"` : segment;
+    })
+    .join(path.sep);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When one runs the `yarn create ...` command on Windows and his working directory includes a space, the command will throw an error.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Without these changes:
![image](https://user-images.githubusercontent.com/20819332/65587747-a5b19080-df86-11e9-9a4c-66b2cdc66c2c.png)

With these changes: 
![image](https://user-images.githubusercontent.com/20819332/65587651-7ef35a00-df86-11e9-8f61-517ac0fddf8a.png)

