### PR TITLE
Use different folders with integrity or without

### DIFF
--- a/__tests__/fixtures/install/install-production/yarn.lock
+++ b/__tests__/fixtures/install/install-production/yarn.lock
@@ -5,7 +5,9 @@
 is-array@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-array/-/is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a"
+  integrity sha1-6YUMwsyGDDvAl36EzPDdRkWEJ5o=
 
 left-pad@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.1.3.tgz#612f61c033f3a9e08e939f1caebeea41b6f3199a"
+  integrity sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=

--- a/__tests__/package-resolver.js
+++ b/__tests__/package-resolver.js
@@ -14,7 +14,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
 const path = require('path');
 
 // regexp which verifies that the cache path contains a path component ending with semver + hash
-const cachePathRe = /-\d+\.\d+\.\d+-[\dabcdef]{40}[\\\/]/;
+const cachePathRe = /-\d+\.\d+\.\d+-[\dabcdef]{40}(?:-integrity)?[\\\/]/;
 
 async function createEnv(configOptions): Object {
   const lockfile = new Lockfile();

--- a/src/config.js
+++ b/src/config.js
@@ -518,7 +518,7 @@ export default class Config {
     if (pkg.uid && pkg.version !== pkg.uid) {
       slug += `-${pkg.uid}`;
     } else if (hash) {
-      slug += `-${hash}1`;
+      slug += `-${hash}`;
     }
 
     if (pkg.remote.integrity) {

--- a/src/config.js
+++ b/src/config.js
@@ -517,12 +517,12 @@ export default class Config {
 
     if (pkg.uid && pkg.version !== pkg.uid) {
       slug += `-${pkg.uid}`;
-    } else if (pkg.remote.integrity) {
-      const integrity = pkg.remote.integrity.toString();
-      const hash = crypto.createHash('sha1').update(integrity).digest('hex');
-      slug += `-${hash}`;
     } else if (hash) {
-      slug += `-${hash}`;
+      slug += `-${hash}1`;
+    }
+
+    if (pkg.remote.integrity) {
+      slug += `-integrity`;
     }
 
     return slug;

--- a/src/config.js
+++ b/src/config.js
@@ -518,7 +518,7 @@ export default class Config {
     if (pkg.uid && pkg.version !== pkg.uid) {
       slug += `-${pkg.uid}`;
     } else if (pkg.remote.integrity) {
-      const integrity = pkg.remote.integrity;
+      const integrity = pkg.remote.integrity.toString();
       const hash = crypto.createHash('sha1').update(integrity).digest('hex');
       slug += `-${hash}`;
     } else if (hash) {

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ import {registries, registryNames} from './registries/index.js';
 import {NoopReporter} from './reporters/index.js';
 import map from './util/map.js';
 
+const crypto = require('crypto');
 const detectIndent = require('detect-indent');
 const invariant = require('invariant');
 const path = require('path');
@@ -516,6 +517,10 @@ export default class Config {
 
     if (pkg.uid && pkg.version !== pkg.uid) {
       slug += `-${pkg.uid}`;
+    } else if (pkg.remote.integrity) {
+      const integrity = pkg.remote.integrity;
+      const hash = crypto.createHash('sha1').update(integrity).digest('hex');
+      slug += `-${hash}`;
     } else if (hash) {
       slug += `-${hash}`;
     }


### PR DESCRIPTION
**Summary**

When installing a package, Yarn used to always store it based on it's old sha1 checksum. To prevent cache injection issues, we started checking that the cache was in a consistent state before installing it. Unfortunately, it means that various errors are reported when packages got installed without integrity fields and later need to be installed with an integrity field.

This diff fixes that by using different folders for those two use cases. It's slightly worse for performances (since some packages will be downloaded twice in this very specific situation), but much better from a UX perspective.

Note that the real fix will come with the v2, since the cache system will be completely different and won't suffer from this kind of problems.

Fix #7584

**Test plan**

Tested locally.