### PR TITLE
Unique list on packages on same destination error

### DIFF
--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -113,8 +113,11 @@ export function fetch(pkgs: Array<Manifest>, config: Config): Promise<Array<Mani
     const dest = config.generateModuleCachePath(ref);
     const otherPkg = pkgsPerDest.get(dest);
     if (otherPkg) {
+      const uniqOtherPkgPatters = [];
+      otherPkg.patterns.forEach(p => !uniqOtherPkgPatters.includes(p) && uniqOtherPkgPatters.push(p))
+
       config.reporter.warn(
-        config.reporter.lang('multiplePackagesCantUnpackInSameDestination', ref.patterns, dest, otherPkg.patterns),
+        config.reporter.lang('multiplePackagesCantUnpackInSameDestination', ref.patterns, dest, uniqOtherPkgPatters),
       );
       return false;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes the issue of the too big list of packages with exact same version. Just a readability fix.
E.g.: In my current project the list was reduced from 31 to 11 items.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**
yarn install and get `multiplePackagesCantUnpackInSameDestination` error?

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
