### PR TITLE
Fixes Node forwarding w/ yarn-path

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -617,10 +617,10 @@ async function start(): Promise<void> {
     let exitCode = 0;
 
     try {
-      exitCode = await spawnp(yarnPath, argv, opts);
+      exitCode = await forkp(yarnPath, argv, opts);
     } catch (firstError) {
       try {
-        exitCode = await forkp(yarnPath, argv, opts);
+        exitCode = await spawnp(yarnPath, argv, opts);
       } catch (error) {
         throw firstError;
       }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -617,10 +617,14 @@ async function start(): Promise<void> {
     let exitCode = 0;
 
     try {
-      exitCode = await forkp(yarnPath, argv, opts);
+      if (yarnPath.endsWith(`.js`)) {
+        exitCode = await spawnp(process.execPath, [yarnPath, ...argv], opts);
+      } else {
+        exitCode = await spawnp(yarnPath, argv, opts);
+      }
     } catch (firstError) {
       try {
-        exitCode = await spawnp(yarnPath, argv, opts);
+        exitCode = await forkp(yarnPath, argv, opts);
       } catch (error) {
         throw firstError;
       }


### PR DESCRIPTION
**Summary**

Running `yarn` with a specific version of Node would fail to propagate this Node binary to the binary targeted by `yarn-path` when the `yarn-path` setting was used.

This diff changes the execution order so that we first try to execute the process through Node before running it as a regular binary.
