### PR TITLE
Handle NPM_CONFIG_GLOBALCONFIG when present

### DIFF
--- a/__tests__/registries/npm-registry.js
+++ b/__tests__/registries/npm-registry.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {resolve, join as pathJoin} from 'path';
+import {resolve, join as pathJoin, sep as pathSep} from 'path';
 
 import NpmRegistry from '../../src/registries/npm-registry.js';
 import {BufferReporter} from '../../src/reporters/index.js';
@@ -835,6 +835,30 @@ describe('getPossibleConfigLocations', () => {
         expect.stringContaining(JSON.stringify(pathJoin(homeDir, '.npmrc'))),
       ]),
     );
+  });
+
+  test('aware of NPM_CONFIG_GLOBALCONFIG directory when present', async () => {
+    const customrc = pathSep + pathJoin('tmp', 'customrc')
+    try {
+      process.env.NPM_CONFIG_GLOBALCONFIG = customrc
+      const testCwd = './project/subdirectory';
+      const {mockRequestManager, mockRegistries} = createMocks();
+      const reporter = new BufferReporter({verbose: true});
+      const npmRegistry = new NpmRegistry(testCwd, mockRegistries, mockRequestManager, reporter, true, []);
+      await npmRegistry.getPossibleConfigLocations('npmrc', reporter);
+
+      const logs = reporter.getBuffer().map(logItem => logItem.data);
+      expect(logs).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(JSON.stringify(customrc)),
+          expect.stringContaining(JSON.stringify(pathJoin('project', 'subdirectory', '.npmrc'))),
+          expect.stringContaining(JSON.stringify(pathJoin('project', '.npmrc'))),
+          expect.stringContaining(JSON.stringify(pathJoin(homeDir, '.npmrc'))),
+        ]),
+      );
+    } finally {
+      delete process.env.NPM_GLOBAL_GLOBALCONFIG
+    }
   });
 });
 

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -258,9 +258,10 @@ export default class NpmRegistry extends Registry {
     }
 
     if (this.enableDefaultRc) {
-      // npmrc --> ./.npmrc, ~/.npmrc, ${prefix}/etc/npmrc
+      // npmrc --> $NPM_CONFIG_GLOBALCONFIG, ./.npmrc, ~/.npmrc, ${prefix}/etc/npmrc
       const localfile = '.' + filename;
       possibles = possibles.concat([
+        [false, process.env.NPM_CONFIG_GLOBALCONFIG],
         [false, path.join(this.cwd, localfile)],
         [true, this.config.userconfig || path.join(userHome, localfile)],
         [false, path.join(getGlobalPrefix(), 'etc', filename)],


### PR DESCRIPTION
**Summary**

This pull request is to address issue https://github.com/yarnpkg/yarn/issues/5543
I hope it helps! Any feedback to improve the code is welcome.

**Test plan**

 * Added a unit test
 * Manually tested with the following steps:
   1. Created a file `/tmp/customrc` with the content `ANSWER=42`
   1. Built the yarn binary `yarn build`
   1. Ran `NPM_CONFIG_GLOBALCONFIG=/tmp/customrc ./bin/yarn config get ANSWER`
   1. Verified that the output is `42` as expected.

