### PR TITLE
Add support for gitlab shorthand URLs

### DIFF
--- a/__tests__/util/git.js
+++ b/__tests__/util/git.js
@@ -79,6 +79,11 @@ test('npmUrlToGitUrl', () => {
     hostname: 'github.com',
     repository: 'ssh://git@github.com/npm-opam/ocamlfind',
   });
+  expect(Git.npmUrlToGitUrl('gitlab:npm-opam/ocamlfind.git#v1.2.3')).toEqual({
+    protocol: 'ssh:',
+    hostname: 'gitlab.com',
+    repository: 'ssh://git@gitlab.com/npm-opam/ocamlfind.git',
+  });
   expect(Git.npmUrlToGitUrl('git+file:../ocalmfind.git')).toEqual({
     protocol: 'file:',
     hostname: null,

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -54,6 +54,15 @@ const SHORTHAND_SERVICES: {[key: string]: url.parse} = map({
     hostname: 'github.com',
     pathname: `/${parsedUrl.hostname}${parsedUrl.pathname}`,
   }),
+  'gitlab:': parsedUrl => ({
+    ...parsedUrl,
+    slashes: true,
+    auth: 'git',
+    protocol: SSH_PROTOCOL,
+    host: 'gitlab.com',
+    hostname: 'gitlab.com',
+    pathname: `/${parsedUrl.hostname}${parsedUrl.pathname}`,
+  }),
   'bitbucket:': parsedUrl => ({
     ...parsedUrl,
     slashes: true,


### PR DESCRIPTION
**Summary**

Fixes https://github.com/yarnpkg/yarn/issues/2774

**Test plan**

 * module specific tests successful `node_modules/jest/bin/jest.js -i __tests__/util/git.js`
 * all tests successful `yarn test`