### PR TITLE
Resolves folder options (i.e. --modules-folder) relative to cwd (#7074)

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -560,3 +560,36 @@ test('yarn init -y', async () => {
   const manifestFile = await fs.readFile(path.join(cwd, 'package.json'));
   expect(manifestFile).toEqual(initialManifestFile);
 });
+
+test('--modules-folder option', async () => {
+  /**
+   * The behavior of --modules-folder (and other folder options) was that it resolved relative not to the current
+   * working directory, but instead to the closest project root (folder containing a package.json file).
+   *
+   * This behavior was at best surprising and could result in data loss. This test captures a scenario in which
+   * there would previously have been data loss, demonstrating the fix for --modules-folder and other folder options.
+   *
+   */
+  const projectFolder = await makeTemp();
+  const libraryFolder = path.join(projectFolder, 'lib');
+
+  const initialManifestFile = JSON.stringify({name: 'test', license: 'ISC', version: '1.0.0'});
+  const importantData = 'I definitely care about this file!';
+
+  await fs.writeFile(`${projectFolder}/package.json`, initialManifestFile);
+  await fs.writeFile(`${projectFolder}/IMPORTANT_FILE.txt`, importantData);
+  await fs.mkdirp(libraryFolder);
+
+  const options = {cwd: libraryFolder};
+
+  // This yarn command fails with the previous behavior, the rest of the test is defense in depth
+  await runYarn(['add', 'left-pad', '--modules-folder', '.'], options);
+
+  // Dependencies should have been installed in the 'lib' folder
+  const libraryFolderContents = await fs.readdir(`${libraryFolder}`);
+  expect(libraryFolderContents).toContain('left-pad');
+
+  // Additionally, there should have not been any data loss in the project folder
+  const importantFile = await fs.readFile(`${projectFolder}/IMPORTANT_FILE.txt`);
+  expect(importantFile).toBe(importantData);
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -509,21 +509,26 @@ export async function main({
 
   const cwd = command.shouldRunInCurrentCwd ? commander.cwd : findProjectRoot(commander.cwd);
 
+  const folderOptionKeys = ['linkFolder', 'globalFolder', 'preferredCacheFolder', 'cacheFolder', 'modulesFolder'];
+
+  // Resolve all folder options relative to cwd
+  const resolvedFolderOptions = {};
+  folderOptionKeys.forEach(folderOptionKey => {
+    const folderOption = commander[folderOptionKey];
+    const resolvedFolderOption = folderOption ? path.resolve(commander.cwd, folderOption) : folderOption;
+    resolvedFolderOptions[folderOptionKey] = resolvedFolderOption;
+  });
+
   await config
     .init({
       cwd,
       commandName,
-
+      ...resolvedFolderOptions,
       enablePnp: commander.pnp,
       disablePnp: commander.disablePnp,
       enableDefaultRc: commander.defaultRc,
       extraneousYarnrcFiles: commander.useYarnrc,
       binLinks: commander.binLinks,
-      modulesFolder: commander.modulesFolder,
-      linkFolder: commander.linkFolder,
-      globalFolder: commander.globalFolder,
-      preferredCacheFolder: commander.preferredCacheFolder,
-      cacheFolder: commander.cacheFolder,
       preferOffline: commander.preferOffline,
       captureHar: commander.har,
       ignorePlatform: commander.ignorePlatform,


### PR DESCRIPTION
* Prevents potentially surprising behavior and data loss

* Includes integration test verifying that user-reported data loss scenario does not occur

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Motivated by high severity issue #7074, following recommended approach by @arcanis of resolving all folder options relative to the cwd (instead of potentially relative to the nearest project root). Adds an integration test illustrating there are no yarn failures, data loss, or other surprising behaviors in the scenario reported in the issue.
<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

It's relatively straightforward to reproduce the reported issue with a current version of yarn:
```
#! /bin/sh

# Create a project with a lib folder
mkdir -p my-project/my-lib

# My project is some sort of project
echo "{}" > my-project/package.json
echo "I definitely care about this file!" > my-project/IMPORTANT.TXT
cat my-project/IMPORTANT.txt

cd my-project/my-lib

# Specify (using a relative path) that I want to use my-lib as a modules folder, running inside of that folder
yarn add left-pad --modules-folder .

# Hey does my file exist?
cd ..
cat IMPORTANT.txt
```

Running this shows the yarn command failing, but IMPORTANT.txt having been deleted from the project folder. This does not occur if yarn includes this patch.
