### PR TITLE
Add JSON support for yarn install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Add support for `install --json`
+
+[#7615](https://github.com/yarnpkg/yarn/pull/7615) - [**GongT**](https://github.com/GongT)
+
 ## 1.19.1
 
 **Important:** This release contains a cache bump. It will cause the very first install following the upgrade to take slightly more time, especially if you don't use the [Offline Mirror](https://yarnpkg.com/blog/2016/11/24/offline-mirror/) feature. After that everything will be back to normal.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
# support `yarn install --flat --json`.

**Summary**

It's a simple **NDJ** - Newline Delimited Json

Yarn print JSON lines like: `{"type":"select","data":{"header":"Unable to find a suitable version for \"supports-color\", please choose one by typing one of the numbers below:","question":"Answer?","options":[{"name":"\"supports-color@^4.5.0\" which resolved to \"4.5.0\"","value":"4.5.0"},{"name":"\"supports-color@^5.3.0\" which resolved to \"5.5.0\"","value":"5.5.0"},{"name":"\"supports-color@^6.1.0\" which resolved to \"6.1.0\"","value":"6.1.0"}]}}`

Application response JSON like: `{"type":"select","answer":3}` to select `6.1.0`

Invalid JSON or answer will cause `{"type":"error","data":"xxxxx"}` and yarn exit, no retry.

Then everyone can write some simple script to workaround #1658

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

I have tried to write a test suite, but it seems not easy. Need some help(

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
