### PR TITLE
feat(config): add support for local config

### DIFF
--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -46,6 +46,10 @@ export function hasWrapper(flags: Object, args: Array<string>): boolean {
 
 export function setFlags(commander: Object) {
   commander.description('Manages the yarn configuration files.');
+  commander.option(
+    '-g, --global',
+    'Use the global configuration file. By default, it will use the configuration file in your working directory.',
+  );
 }
 
 export const {run, examples} = buildSubCommands('config', {
@@ -55,7 +59,13 @@ export const {run, examples} = buildSubCommands('config', {
     }
     const [key, val = true] = args;
     const yarnConfig = config.registries.yarn;
-    await yarnConfig.saveHomeConfig({[key]: val});
+
+    if (flags.global) {
+      await yarnConfig.saveHomeConfig({[key]: val});
+    } else {
+      await yarnConfig.saveConfig({[key]: val});
+    }
+
     reporter.success(reporter.lang('configSet', key, val));
     return true;
   },
@@ -76,7 +86,13 @@ export const {run, examples} = buildSubCommands('config', {
 
     const key = args[0];
     const yarnConfig = config.registries.yarn;
-    await yarnConfig.saveHomeConfig({[key]: undefined});
+
+    if (flags.global) {
+      await yarnConfig.saveHomeConfig({[key]: undefined});
+    } else {
+      await yarnConfig.saveConfig({[key]: undefined});
+    }
+
     reporter.success(reporter.lang('configDelete', key));
     return true;
   },

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -120,6 +120,24 @@ export default class YarnRegistry extends NpmRegistry {
     this.config = Object.assign({}, DEFAULTS, this.config);
   }
 
+  async saveConfig(newConfig: Object): Promise<void> {
+    const loc = `${this.cwd}/.yarnrc`;
+    let currentConfig = {};
+
+    if (await fs.exists(loc)) {
+      currentConfig = parse(await fs.readFile(loc)).object;
+    }
+
+    const nextConfig = {
+      ...currentConfig,
+      ...newConfig,
+    };
+
+    YarnRegistry.normalizeConfig(nextConfig);
+
+    await fs.writeFilePreservingEol(loc, `${stringify(nextConfig)}\n`);
+  }
+
   async saveHomeConfig(config: Object): Promise<void> {
     YarnRegistry.normalizeConfig(config);
 


### PR DESCRIPTION
**Summary**

This PR addresses #1037.

As of today, `yarn config set foo bar` will save that config key to your user directory (`~/.yarnrc`). `yarn config set foo bar -g` will do exactly the same. The former command is wrong: it should edit the "local configuration", or the configuration in the current workin directory (as pointed out by https://github.com/yarnpkg/yarn/issues/1037#issuecomment-362546925).

This PR moves the current behaviour under the `--global` flag, and makes it so invoking the command without the flag interacts with the file in the current working directory instead. If the file does not exist, it is created.

**Test plan**

I didn't write tests yet! I wanted to see the reaction to this PR first. Also, when I run the tests there is one suite failing, but not because any change I've made, so I'd like to get some assistance with that.

Thanks for your time!