### PR TITLE
ci(circleci): prevent timeout on circle-ci macos node10 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ docker_defaults: &docker_defaults
 
 macos_defaults: &macos_defaults
   macos:
-    xcode: "9.0"
+    xcode: "11.0"
   working_directory: ~/project/yarn
 
 attach_workspace: &attach_workspace
@@ -155,7 +155,6 @@ jobs:
           name: Install Node 10
           command: |
             brew uninstall --ignore-dependencies node
-            brew update
             HOMEBREW_NO_AUTO_UPDATE=1 brew install node@10
             brew link --overwrite --force node@10
             [[ $(node --version) =~ ^v10\. ]]
@@ -177,6 +176,8 @@ jobs:
       - *test_run
   test-macos-node6:
     <<: *macos_defaults
+    macos:
+      xcode: "9.0"
     steps:
       - run:
           name: Install Node 6


### PR DESCRIPTION
**Summary**

- sets the required xcode version to 11 -> this gets us a more up to date macOS version 
- keeps xcode 9 for node 6 as that isn't available in the homebrew associated with xcode 11 anymore
- removes the `brew update` from the macOS node 10 job
- ✖️no update of the changelog - as merging this PR won't modify yarn's behaviour

As a bonus the CI for node 10 on circleci/ macOS got 15 - 20 minutes faster.

**Why, though?**
The circle ci job for macOS on node 10 currently fails because it takes too long (both PR's #7649 and #7650 don't green because of that). Cause: the job uses a big chunk of time updating homebrew (up to ~20min). Which is necessary because the version of macOS (the one connected to xcode 9 => macOS 10.12) does not contain node 10 by default.

Using a more recent version of macOS does away with this necessity for node 8 and 10. Putting node 6 on this would've been nice, but it is not available in homebrew on the macOS images that have xcode 11 on them

**Test plan**

- [x] green ci


**Notes**

- I've rebased #7650 on the branch underlying this PR - so if that one might get merged first this PR can be closed unmerged.

- When running the xcode 9 image, the system warns it's outdated and unsupported, as is the version of macOS. If node 6 still needs to be tested on macOS via circleci it might be worth considering a different installation strategy (e.g. using nvm in stead of homebrew?).
