### PR TITLE
Handle GitHub Package Registry URLs

### DIFF
--- a/__tests__/fetchers.js
+++ b/__tests__/fetchers.js
@@ -353,6 +353,28 @@ test('TarballFetcher.fetch properly stores tarball for scoped package resolved f
   expect(fetcher.getTarballMirrorPath()).toBe(path.join(offlineMirrorDir, '@exponent-configurator-1.0.2.tgz'));
 });
 
+test('TarballFetcher.fetch properly stores tarball for scoped package resolved from GitHub registry', async () => {
+  const dir = await mkdir('tarball-fetcher');
+  const offlineMirrorDir = await mkdir('offline-mirror');
+
+  const config = await Config.create();
+  config.registries.npm.config['yarn-offline-mirror'] = offlineMirrorDir;
+
+  const fetcher = new TarballFetcher(
+    dir,
+    {
+      type: 'tarball',
+      hash: 'abababababababababababababababababababab',
+      reference:
+        'https://npm.pkg.github.com/download/@scope/repository/1.0.0/abababababababababababababababababababababababababababababababab',
+      registry: 'npm',
+    },
+    config,
+  );
+
+  expect(fetcher.getTarballMirrorPath()).toBe(path.join(offlineMirrorDir, '@scope-repository-1.0.0.tgz'));
+});
+
 test('TarballFetcher.fetch properly stores tarball for scoped package resolved from new  style URLs', async () => {
   const dir = await mkdir('tarball-fetcher');
   const offlineMirrorDir = await mkdir('offline-mirror');

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -910,6 +910,11 @@ export class Install {
       const resolved = lockfile[dependency].resolved;
       if (resolved) {
         const basename = path.basename(resolved.split('#')[0]);
+        const match = resolved.match(/.*\/download\/(@[^/]+)\/([^@/]+)\/([0-9.]+)\/[^/]+$/);
+        if (match) {
+          const [, scope, repository, version] = match;
+          requiredTarballs.add(`${scope}-${repository}-${version}.tgz`);
+        }
         if (dependency[0] === '@' && basename[0] !== '@') {
           requiredTarballs.add(`${dependency.split('/')[0]}-${basename}`);
         }

--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -69,12 +69,15 @@ export default class TarballFetcher extends BaseFetcher {
       return null;
     }
 
-    const match = pathname.match(RE_URL_NAME_MATCH);
+    let match = pathname.match(RE_URL_NAME_MATCH);
 
     let packageFilename;
     if (match) {
       const [, scope, tarballBasename] = match;
       packageFilename = scope ? `${scope}-${tarballBasename}` : tarballBasename;
+    } else if ((match = pathname.match(/\/download\/(@[^/]+)\/([^@/]+)\/([0-9.]+)\/[^/]+$/))) {
+      const [, scope, repository, version] = match;
+      packageFilename = `${scope}-${repository}-${version}.tgz`;
     } else {
       // fallback to base name
       packageFilename = path.basename(pathname);


### PR DESCRIPTION
**Summary**

Fix tarball name resolver to handle GitHub Package Registry (currently still in beta) to match what I've experienced using private packages via beta program signup.

Because basename part of the urls do not match scoped tarball filenames, also offline mirror pruning needs to match the filename from url.

This is not very clean code, but for me it looks like handling offline mirror pruning correctly the codebase needs some refactoring to match tarball filenames in common way usable both for tarball fetcher and offline mirror pruning.

**Test plan**

Added tarball fetcher test similar to other private package registries have. For offline mirror pruning I did not find suitable template for adding new test.
