### PR TITLE
Fix issue with upgrade-interactive and root dependencies

### DIFF
--- a/src/cli/commands/upgrade-interactive.js
+++ b/src/cli/commands/upgrade-interactive.js
@@ -180,6 +180,9 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
           reporter.info(reporter.lang('updateInstalling', getNameFromHint(hint)));
           if (loc !== '') {
             config.cwd = path.resolve(path.dirname(loc));
+          } else {
+            // Missing loc means that a dependency is located in root of the workspace
+            config.cwd = config.workspaceRootFolder;
           }
           const add = new Add(patterns, flags, config, reporter, lockfile);
           await add.init();


### PR DESCRIPTION
**Summary**

So I encountered the following problem with the `upgrade-interactive --latest` command.

If you are using workspaces, and you have some root dependencies and some package specific dependencies. If you run `upgrade-interactive --latest` in one of the package folders, you will be given a choice to upgrade dependencies not only in the current package but also all other packages and the root workspace. If you decide to upgrade a dependency from the root of the workspace, the command won't upgrade the version of the dependency in the root `package.json` but will leave that one the same, and add that dependency to the current package folder with the new version.

So for example, in the following project: https://github.com/juresotosek/upgrade-interactive-example, if you navigate to the `packages/test` folder and run `upgrade-interactive --latest`, and then decide to upgrade `typescript`, there will be a new `devDependency` added to the `packages/test/package.json` and the version of `typescript` in root `package.json` won't be changed.

**Solution**

It turns out that `upgrade-interactive --latest` looks at the location of the dependency in the workspace, and runs that `Add` command there. Well, if the dependency is in the root, the location will be en empty string, in that case, it should default to the root of the project while now, it defaults to the current location of where the command was executed. That's what I've changed.

**Test plan**

Clone the above repo see the behavior.
