### PR TITLE
Adds support for --install in yarn init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Implements `yarn init --install berry`
+
+  [#7723](https://github.com/yarnpkg/yarn/pull/7723) - [**Maël Nison**](https://twitter.com/arcanis)
+
+## 1.19.2
+
 - Folders like `.cache` won't be pruned from the `node_modules` after each install.
 
   [#7699](https://github.com/yarnpkg/yarn/pull/7699) - [**Maël Nison**](https://twitter.com/arcanis)

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -8,6 +8,7 @@ import GitHubResolver from '../../resolvers/exotics/github-resolver.js';
 import * as child from '../../util/child.js';
 import * as fs from '../../util/fs.js';
 import * as validate from '../../util/normalize-manifest/validate.js';
+import {NODE_BIN_PATH} from '../../constants';
 
 const objectPath = require('object-path');
 const path = require('path');
@@ -17,6 +18,7 @@ export function setFlags(commander: Object) {
   commander.description('Interactively creates or updates a package.json file.');
   commander.option('-y, --yes', 'use default options');
   commander.option('-p, --private', 'use default options and private true');
+  commander.option('-i, --install <value>', 'install a specific Yarn release');
 }
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
@@ -26,6 +28,26 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 export const shouldRunInCurrentCwd = true;
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
+  if (flags.install) {
+    const lockfilePath = path.resolve(config.cwd, 'yarn.lock');
+    if (!await fs.exists(lockfilePath)) {
+      await fs.writeFile(lockfilePath, '');
+    }
+    await child.spawn(NODE_BIN_PATH, [process.argv[1], 'policies', 'set-version', flags.install], {
+      stdio: 'inherit',
+      cwd: config.cwd,
+    });
+    await child.spawn(
+      NODE_BIN_PATH,
+      [process.argv[1], 'init', ...(flags.yes ? ['-y'] : []), ...(flags.private ? ['-p'] : [])],
+      {
+        stdio: 'inherit',
+        cwd: config.cwd,
+      },
+    );
+    return;
+  }
+
   const manifests = await config.getRootManifests();
 
   let repository = {};

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -3,7 +3,7 @@
 import type {Reporter} from '../../reporters/index.js';
 import type Config from '../../config.js';
 import buildSubCommands from './_build-sub-commands.js';
-import {getRcConfigForCwd} from '../../rc.js';
+import {getRcConfigForFolder} from '../../rc.js';
 import * as fs from '../../util/fs.js';
 import {stringify} from '../../lockfile';
 
@@ -145,7 +145,7 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
     reporter.log(`Downloading ${chalk.green(bundleUrl)}...`);
 
     const bundle = await fetchBundle(config, bundleUrl);
-    const rc = getRcConfigForCwd(config.lockfileFolder, []);
+    const rc = getRcConfigForFolder(config.lockfileFolder);
 
     const yarnPath = path.resolve(config.lockfileFolder, `.yarn/releases/yarn-${bundleVersion}.js`);
     reporter.log(`Saving it into ${chalk.magenta(yarnPath)}...`);

--- a/src/rc.js
+++ b/src/rc.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {readFileSync} from 'fs';
+import {existsSync, readFileSync} from 'fs';
 import {dirname, resolve} from 'path';
 
 import commander from 'commander';
@@ -35,11 +35,21 @@ export function getRcConfigForCwd(cwd: string, args: Array<string>): {[key: stri
     const value = args[index + 1];
 
     if (value && value.charAt(0) !== '-') {
-      Object.assign(config, loadRcFile(readFileSync(value).toString(), value));
+      Object.assign(config, loadRcFile(readFileSync(value, 'utf8'), value));
     }
   }
 
   return config;
+}
+
+export function getRcConfigForFolder(cwd: string): {[key: string]: string} {
+  const filePath = resolve(cwd, '.yarnrc');
+  if (!existsSync(filePath)) {
+    return {};
+  }
+
+  const fileText = readFileSync(filePath, 'utf8');
+  return loadRcFile(fileText, filePath);
 }
 
 function loadRcFile(fileText: string, filePath: string): {[key: string]: string} {


### PR DESCRIPTION
**Summary**

Initializing projects using Yarn v2 is fairly annoying when the v1 is the global binary (which it often is), since you need to first run `yarn init`, then `yarn policies set-version`, then change the `package.json` to match what you'd expect if the v2 was initialising the project.

To streamline the process, the `--install` flag will automatically call `yarn policies set-version` followed by `yarn init`.

**Test plan**

n/a
