### PR TITLE
Fixes bin overwrites

### DIFF
--- a/__tests__/__snapshots__/normalize-manifest.js.snap
+++ b/__tests__/__snapshots__/normalize-manifest.js.snap
@@ -60,6 +60,24 @@ Array [
 ]
 `;
 
+exports[`dangerous bin name: dangerous bin name 1`] = `
+Array [
+  "foo: Invalid bin entry for \\"/tmp/foo\\" (in \\"foo\\").",
+  "foo: Invalid bin entry for \\"../tmp/foo\\" (in \\"foo\\").",
+  "foo: Invalid bin entry for \\"tmp/../../foo\\" (in \\"foo\\").",
+  "foo: No license field",
+]
+`;
+
+exports[`dangerous bin values: dangerous bin values 1`] = `
+Array [
+  "foo: Invalid bin entry for \\"foo\\" (in \\"foo\\").",
+  "foo: Invalid bin entry for \\"bar\\" (in \\"foo\\").",
+  "foo: Invalid bin entry for \\"baz\\" (in \\"foo\\").",
+  "foo: No license field",
+]
+`;
+
 exports[`dedupe all trivial dependencies: dedupe all trivial dependencies 1`] = `
 Array [
   "No license field",

--- a/__tests__/__snapshots__/normalize-manifest.js.snap
+++ b/__tests__/__snapshots__/normalize-manifest.js.snap
@@ -92,6 +92,7 @@ Array [
 
 exports[`empty bin string: empty bin string 1`] = `
 Array [
+  "foo: Invalid bin field for \\"foo\\".",
   "foo: No license field",
 ]
 `;

--- a/__tests__/fixtures/normalize-manifest/dangerous bin name/actual.json
+++ b/__tests__/fixtures/normalize-manifest/dangerous bin name/actual.json
@@ -1,0 +1,9 @@
+{
+    "name": "foo",
+    "version": "",
+    "bin": {
+        "/tmp/foo": "main.js",
+        "../tmp/foo": "main.js",
+        "tmp/../../foo": "main.js"
+    }
+}

--- a/__tests__/fixtures/normalize-manifest/dangerous bin name/expected.json
+++ b/__tests__/fixtures/normalize-manifest/dangerous bin name/expected.json
@@ -1,0 +1,5 @@
+{
+    "name": "foo",
+    "version": "",
+    "bin": {}
+}

--- a/__tests__/fixtures/normalize-manifest/dangerous bin values/actual.json
+++ b/__tests__/fixtures/normalize-manifest/dangerous bin values/actual.json
@@ -1,0 +1,9 @@
+{
+    "name": "foo",
+    "version": "",
+    "bin": {
+        "foo": "../../../../../foo",
+        "bar": "/hello/world",
+        "baz": "./foo/bar/../../../../../../foo"
+    }
+}

--- a/__tests__/fixtures/normalize-manifest/dangerous bin values/expected.json
+++ b/__tests__/fixtures/normalize-manifest/dangerous bin values/expected.json
@@ -1,0 +1,5 @@
+{
+    "name": "foo",
+    "version": "",
+    "bin": {}
+}

--- a/__tests__/fixtures/normalize-manifest/empty bin string/expected.json
+++ b/__tests__/fixtures/normalize-manifest/empty bin string/expected.json
@@ -1,5 +1,4 @@
 {
   "name": "foo",
-  "version": "",
-  "bin": ""
+  "version": ""
 }

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -26,7 +26,8 @@ const messages = {
   couldntClearPackageFromCache: "Couldn't clear package $0 from cache",
   clearedPackageFromCache: 'Cleared package $0 from cache',
   packWroteTarball: 'Wrote tarball to $0.',
-
+  invalidBinField: 'Invalid bin field for $0.',
+  invalidBinEntry: 'Invalid bin entry for $1 (in $0).',
   helpExamples: '  Examples:\n$0\n',
   helpCommands: '  Commands:\n$0\n',
   helpCommandsMore: '  Run `$0` for more information on specific commands.',

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -171,10 +171,14 @@ export default (async function(
       const target = bin[key];
       if (!VALID_BIN_KEYS.test(key) || !isValidBin(target)) {
         delete bin[key];
+        warn(reporter.lang('invalidBinEntry', info.name));
       } else {
         bin[key] = path.normalize(target);
       }
     }
+  } else {
+    delete info.bin;
+    warn(reporter.lang('invalidBinField', info.name));
   }
 
   // bundleDependencies is an alias for bundledDependencies

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -159,8 +159,6 @@ export default (async function(
     // Remove scoped package name for consistency with NPM's bin field fixing behaviour
     const name = info.name.replace(/^@[^\/]+\//, '');
     info.bin = {[name]: info.bin};
-  } else {
-    delete info.bin;
   }
 
   // Validate that the bin entries reference only files within their package, and that
@@ -171,12 +169,12 @@ export default (async function(
       const target = bin[key];
       if (!VALID_BIN_KEYS.test(key) || !isValidBin(target)) {
         delete bin[key];
-        warn(reporter.lang('invalidBinEntry', info.name));
+        warn(reporter.lang('invalidBinEntry', info.name, key));
       } else {
         bin[key] = path.normalize(target);
       }
     }
-  } else {
+  } else if (typeof info.bin !== 'undefined') {
     delete info.bin;
     warn(reporter.lang('invalidBinField', info.name));
   }

--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -2,7 +2,7 @@
 
 import {MANIFEST_FIELDS} from '../../constants';
 import type {Reporter} from '../../reporters/index.js';
-import {isValidLicense} from './util.js';
+import {isValidBin, isValidLicense} from './util.js';
 import {normalizePerson, extractDescription} from './util.js';
 import {hostedGitFragmentToGitUrl} from '../../resolvers/index.js';
 import inferLicense from './infer-license.js';
@@ -11,6 +11,8 @@ import * as fs from '../fs.js';
 const semver = require('semver');
 const path = require('path');
 const url = require('url');
+
+const VALID_BIN_KEYS = /^[a-z0-9_-]+$/i;
 
 const LICENSE_RENAMES: {[key: string]: ?string} = {
   'MIT/X11': 'MIT',
@@ -157,6 +159,22 @@ export default (async function(
     // Remove scoped package name for consistency with NPM's bin field fixing behaviour
     const name = info.name.replace(/^@[^\/]+\//, '');
     info.bin = {[name]: info.bin};
+  } else {
+    delete info.bin;
+  }
+
+  // Validate that the bin entries reference only files within their package, and that
+  // their name is a valid file name
+  if (typeof info.bin === 'object' && info.bin !== null) {
+    const bin: Object = info.bin;
+    for (const key of Object.keys(bin)) {
+      const target = bin[key];
+      if (!VALID_BIN_KEYS.test(key) || !isValidBin(target)) {
+        delete bin[key];
+      } else {
+        bin[key] = path.normalize(target);
+      }
+    }
   }
 
   // bundleDependencies is an alias for bundledDependencies

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -5,7 +5,7 @@ import type {PersonObject} from '../../types.js';
 const path = require('path');
 const validateLicense = require('validate-npm-package-license');
 
-const PARENT_PATH = /^\.\.([\\\/]|$)/g;
+const PARENT_PATH = /^\.\.([\\\/]|$)/;
 
 export function isValidLicense(license: string): boolean {
   return !!license && validateLicense(license).validForNewPackages;

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -2,10 +2,17 @@
 
 import type {PersonObject} from '../../types.js';
 
+const path = require('path');
 const validateLicense = require('validate-npm-package-license');
+
+const PARENT_PATH = /^\.\.([\///]|$)/g;
 
 export function isValidLicense(license: string): boolean {
   return !!license && validateLicense(license).validForNewPackages;
+}
+
+export function isValidBin(bin: string): boolean {
+  return !path.isAbsolute(bin) && !PARENT_PATH.test(path.normalize(bin));
 }
 
 export function stringifyPerson(person: mixed): any {

--- a/src/util/normalize-manifest/util.js
+++ b/src/util/normalize-manifest/util.js
@@ -5,7 +5,7 @@ import type {PersonObject} from '../../types.js';
 const path = require('path');
 const validateLicense = require('validate-npm-package-license');
 
-const PARENT_PATH = /^\.\.([\///]|$)/g;
+const PARENT_PATH = /^\.\.([\\\/]|$)/g;
 
 export function isValidLicense(license: string): boolean {
   return !!license && validateLicense(license).validForNewPackages;


### PR DESCRIPTION
**Summary**

In some circumstances Yarn would allow overwriting files on the filesystem with symlinks at install-time. Despite postinstall scripts having the ability to do that anyway this behavior isn't intended as Yarn installs are reputed to control side effects (the cache and temporary folders being the only exception). Bins shouldn't be able to escape the package because of Yarn.

**Test plan**

Adding tests