### PR TITLE
bugfix #7764 pnp path could not contain space

### DIFF
--- a/src/cli/commands/node.js
+++ b/src/cli/commands/node.js
@@ -23,7 +23,10 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
   let nodeOptions = process.env.NODE_OPTIONS || '';
   if (await fs.exists(pnpPath)) {
-    nodeOptions = `--require ${pnpPath} ${nodeOptions}`;
+    // As of node 12+, NODE_OPTIONS does support quoting its arguments
+    // If the user has a space in its $PATH, we quote the path and hope the user uses node 12+
+    // it will fail if not but it would have thrown either way without quoting...
+    nodeOptions = `--require ${quotePathIfNeeded(pnpPath)} ${nodeOptions}`;
   }
 
   try {
@@ -35,4 +38,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   } catch (err) {
     throw err;
   }
+}
+
+function quotePathIfNeeded(p: string): string {
+  return /\s/.test(p) ? JSON.stringify(p) : p;
 }

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -228,10 +228,11 @@ export async function makeEnv(
       }
     }
 
-    // Note that NODE_OPTIONS doesn't support any style of quoting its arguments at the moment
-    // For this reason, it won't work if the user has a space inside its $PATH
+    // As of node 12+, NODE_OPTIONS does support quoting its arguments
+    // If the user has a space in its $PATH, we quote the path and hope the user uses node 12+
+    // it will fail if not but it would have thrown either way without quoting...
     env.NODE_OPTIONS = env.NODE_OPTIONS || '';
-    env.NODE_OPTIONS = `--require ${pnpFile} ${env.NODE_OPTIONS}`;
+    env.NODE_OPTIONS = `--require ${quotePathIfNeeded(pnpFile)} ${env.NODE_OPTIONS}`;
   }
 
   pathParts.unshift(await getWrappersFolder(config));
@@ -240,6 +241,10 @@ export async function makeEnv(
   env[constants.ENV_PATH_KEY] = pathParts.join(path.delimiter);
 
   return env;
+}
+
+function quotePathIfNeeded(p: string): string {
+  return /\s/.test(p) ? JSON.stringify(p) : p;
 }
 
 export async function executeLifecycleScript({


### PR DESCRIPTION
**Summary**

This PR solves the #7764 bug where PnP was failing when in a path containing a space.

**Test plan**

I have no idea at the time how to test this small fix (notably because it will fix only with node 12+ that supports quoting of NODE_OPTIONS)