### PR TITLE
fix(workspaces): Passes arguments follwing "--" when running a workspace script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Passes arguments follwing `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
+
+  [#7776](https://github.com/yarnpkg/yarn/pull/7776) - [**Jeff Valore**](https://twitter.com/rally25rs)
+
 - Prints workspace names with `yarn workspaces` (silence with `-s`)
 
   [#7722](https://github.com/yarnpkg/yarn/pull/7722) - [**Orta**](https://twitter.com/orta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
-- Passes arguments follwing `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
+- Passes arguments following `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
 
   [#7776](https://github.com/yarnpkg/yarn/pull/7776) - [**Jeff Valore**](https://twitter.com/rally25rs)
 

--- a/__tests__/commands/workspace.js
+++ b/__tests__/commands/workspace.js
@@ -38,12 +38,8 @@ async function runWorkspace(
   }
 }
 
-// The unit tests don't use commander.js for argument parsing.
-// `originalArgs` is normally passed by index.js so we just simulate it in the tests.
-
 test('workspace run command', (): Promise<void> => {
-  const originalArgs = ['workspace-1', 'run', 'script'];
-  return runWorkspace({originalArgs}, ['workspace-1', 'run', 'script'], 'run-basic', config => {
+  return runWorkspace({}, ['workspace-1', 'run', 'script'], 'run-basic', config => {
     expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'run', 'script'], {
       stdio: 'inherit',
       cwd: path.join(fixturesLoc, 'run-basic', 'packages', 'workspace-child-1'),
@@ -52,8 +48,7 @@ test('workspace run command', (): Promise<void> => {
 });
 
 test('workspace run command forwards raw arguments', (): Promise<void> => {
-  const originalArgs = ['workspace-1', 'run', 'script', 'arg1', '--flag1'];
-  return runWorkspace({originalArgs}, ['workspace-1', 'run', 'script'], 'run-basic', config => {
+  return runWorkspace({}, ['workspace-1', 'run', 'script', 'arg1', '--flag1'], 'run-basic', config => {
     expect(spawn).toHaveBeenCalledWith(NODE_BIN_PATH, [YARN_BIN_PATH, 'run', 'script', 'arg1', '--flag1'], {
       stdio: 'inherit',
       cwd: path.join(fixturesLoc, 'run-basic', 'packages', 'workspace-child-1'),

--- a/src/cli/commands/workspace.js
+++ b/src/cli/commands/workspace.js
@@ -21,11 +21,11 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     throw new MessageError(reporter.lang('workspaceRootNotFound', config.cwd));
   }
 
-  if (flags.originalArgs < 1) {
+  if (args.length < 1) {
     throw new MessageError(reporter.lang('workspaceMissingWorkspace'));
   }
 
-  if (flags.originalArgs < 2) {
+  if (args.length < 2) {
     throw new MessageError(reporter.lang('workspaceMissingCommand'));
   }
 
@@ -33,7 +33,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
   invariant(manifest && manifest.workspaces, 'We must find a manifest with a "workspaces" property');
 
   const workspaces = await config.resolveWorkspaces(workspaceRootFolder, manifest);
-  const [workspaceName, ...rest] = flags.originalArgs || [];
+  const [workspaceName, ...rest] = args || [];
 
   if (!Object.prototype.hasOwnProperty.call(workspaces, workspaceName)) {
     throw new MessageError(reporter.lang('workspaceUnknownWorkspace', workspaceName));


### PR DESCRIPTION

fixes #7776

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Passes arguments following `--` when running a workspace script (for example `yarn workspace pkg run command -- arg`).

Previously these parameters were being trimmed off and ignored.

It seems that in `src/cli/index.js` we were trimming all params after and including the `--`, and assigning the remainder to `flags.originalArgs` which the `workspace` command was using.

Instead, this PR changes the `workspace` command to use the `args` parameter that was already being passed to the command, which includes the args after the `--`.
The `args` parameter to the command is also what the `yarn run` command uses, so it makes sense for `yarn run` and `yarn workspace run` to both use `args` instead of one using `args` and the other using `flags.originalArgs`.

**Test plan**

Since yarn parameter passing in `src/cli/index.js` is not tested, there are no additional tests.

A manual test can be performed by setting up a basic workspace project:

package.json
```
{
  "name": "yarn-7776",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "private": true,
  "workspaces": [
    "packages/*"
  ]
}
```

packages/pkg1/package.json
```
{
  "name": "pkg1",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "scripts": {
    "start": "./start.sh"
  }
}
```

packages/pkg1/start.sh
```
#!/bin/bash
echo "$@"
```

then run the yarn command
```
yarn workspace pkg1 run start -- one two three
```

The output from the script should be `one two three`