### PR TITLE
Fix suggestions for CLI

### DIFF
--- a/__tests__/fixtures/index/run-suggestion/package.json
+++ b/__tests__/fixtures/index/run-suggestion/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test_suggestion",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "foobar": "foobar"
+  }
+}

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -300,6 +300,10 @@ test.concurrent('should throws missing command for unknown command', async () =>
   await expectAnErrorMessage(execCommand('unknown', [], 'run-add', true), 'Command "unknown" not found');
 });
 
+test.concurrent('should suggest options for other commands when missing a command', async () => {
+  await expectAnErrorMessage(execCommand('foobarx', [], 'run-suggestion', true), 'Did you mean "foobar"?');
+});
+
 test.concurrent('should not display documentation link for unknown command', async () => {
   await expectAnInfoMessageAfterError(execCommand('unknown', [], 'run-add', true), '');
 });

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -149,7 +149,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
     } else {
       let suggestion;
 
-      for (const commandName in scripts) {
+      for (const commandName of scripts.keys()) {
         const steps = leven(commandName, action);
         if (steps < 2) {
           suggestion = commandName;


### PR DESCRIPTION
At some point the `scripts` object changes to be a map instead of an array, at which point the suggestions functionality broke. This commit includes the fix and a test to make sure it doesn't break again.