### PR TITLE
Fixed: workspace entries should not be used when trying to check for peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+## Master
+
+- Ensure peer dependencies of workspace projects are appropriately checked.
+
+	[#7812](https://github.com/yarnpkg/yarn/pull/7812) - [**Antoine Malliarakis**](https://github.com/antoine-malliarakis)
+
 ## 1.22.2
 
 - Sorts files when running `yarn pack` to produce identical layout on Windows and Unix systems

--- a/__tests__/commands/install/workspaces-install.js
+++ b/__tests__/commands/install/workspaces-install.js
@@ -69,6 +69,22 @@ test.concurrent("workspaces warn and get ignored if they don't have a name and a
   );
 });
 
+test.concurrent('should only warn for unmet peer dependency on workspace package', (): Promise<void> => {
+  return buildRun(
+    reporters.BufferReporter,
+    path.join(__dirname, '..', '..', 'fixtures', 'install'),
+    async (args, flags, config, reporter, lockfile): Promise<void> => {
+      const install = new Install(flags, config, reporter, lockfile);
+      await install.init();
+      const warnings = reporter.getBuffer().filter(({type}) => type === 'warning').map(({data}) => data);
+      expect(warnings).toEqual(['" > nomore-test-b@0.0.1" has unmet peer dependency "nomore-test-a@^0.0.1".']);
+    },
+    [],
+    {},
+    'workspaces-install-transient-peer-dep-satisfied',
+  );
+});
+
 test.concurrent('installs workspaces dependencies into root folder', (): Promise<void> => {
   return runInstall({}, 'workspaces-install-basic', async (config): Promise<void> => {
     const lockfile = await fs.readFile(path.join(config.cwd, 'yarn.lock'));

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "devDependencies": {
+    "nomore-test-b": "0.0.1"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-a/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-a/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nomore-test-a",
+  "version": "0.0.1",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-b/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nomore-test-b",
+  "version": "0.0.1",
+  "dependencies": {},
+	"devDependencies": {},
+	"peerDependencies": {
+		"nomore-test-a": "^0.0.1"
+	}
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-dev-deps/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-dev-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nomore-test-dev-deps",
+  "version": "0.0.1",
+  "dependencies": {},
+  "devDependencies": {
+		"nomore-test-a": "0.0.1"
+	},
+	"peerDependencies": {
+		"nomore-test-a": "^0.0.1"
+	}
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-prod-deps/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-prod-deps/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nomore-test-prod-deps",
+  "version": "0.0.1",
+  "dependencies": {
+		"nomore-test-a": "0.0.1"
+	},
+  "devDependencies": {
+	},
+	"peerDependencies": {
+		"nomore-test-a": "^0.0.1"
+	}
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-react/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-test-react/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nomore-test-react",
+  "version": "0.0.1",
+  "dependencies": {},
+	"devDependencies": {},
+	"peerDependencies": {
+		"react": "^16.12.0"
+	}
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-transitive-dev-deps/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-transitive-dev-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nomore-transitive-dev-deps",
+  "version": "0.0.1",
+  "dependencies": {},
+  "devDependencies": {
+		"nomore-test-a": "0.0.1"
+	},
+	"peerDependencies": {
+		"nomore-test-b": "0.0.1"
+	}
+}

--- a/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-transitive-prod-deps/package.json
+++ b/__tests__/fixtures/install/workspaces-install-transient-peer-dep-satisfied/packages/nomore-transitive-prod-deps/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nomore-transitive-prod-deps",
+  "version": "0.0.1",
+  "dependencies": {
+		"nomore-test-a": "0.0.1"
+	},
+  "devDependencies": {
+	},
+	"peerDependencies": {
+		"nomore-test-b": "^0.0.1"
+	}
+}

--- a/src/package-peer-resolver.js
+++ b/src/package-peer-resolver.js
@@ -1,0 +1,182 @@
+/* @flow */
+
+import type {Manifest} from './types.js';
+import type PackageReference from './package-reference.js';
+import type PackageResolver from './package-resolver.js';
+import type Config from './config.js';
+import PackageRequest from './package-request.js';
+import {satisfiesWithPrereleases} from './util/semver.js';
+import type {Reporter} from './reporters/index.js';
+
+const invariant = require('invariant');
+
+function isWorkspaceRequest(req: PackageRequest): boolean {
+  if (req.hint === 'workspaces') {
+    return true;
+  }
+  if (req.hint || !req.parentRequest) {
+    return false;
+  }
+  return req.parentRequest.hint === 'workspaces';
+}
+
+function getLevelDistance(pkgRef: PackageReference, refTree: string[]): number {
+  let minDistance = Infinity;
+  for (const req of pkgRef.requests) {
+    if (isWorkspaceRequest(req)) {
+      continue;
+    }
+    const distance = refTree.length - req.parentNames.length;
+
+    if (distance >= 0 && distance < minDistance && req.parentNames.every((name, idx) => name === refTree[idx])) {
+      minDistance = distance;
+    }
+  }
+
+  return minDistance;
+}
+
+function getShortestPathOf(requests: PackageRequest[]): string[] {
+  return requests
+    .map((req: PackageRequest): string[] => req.parentNames)
+    .sort((arr1: string[], arr2: string[]) => arr1.length - arr2.length)[0];
+}
+
+function extractRefTrees(ref: PackageReference): string[][] {
+  if (!ref.requests.some(request => isWorkspaceRequest(request))) {
+    return [getShortestPathOf(ref.requests)];
+  }
+  const initialMap: {[id: string]: PackageRequest[]} = {};
+  const addOrSet = (map: {[id: string]: PackageRequest[]}, key: string, value: PackageRequest) => {
+    const formerList = map[key];
+    if (formerList) {
+      formerList.push(value);
+    } else {
+      map[key] = [value];
+    }
+  };
+  const refTrees: {
+    [id: string]: PackageRequest[],
+  } = ref.requests.reduce((map: {[id: string]: PackageRequest[]}, req: PackageRequest) => {
+    if (isWorkspaceRequest(req)) {
+      return map;
+    }
+    let {parentRequest} = req;
+    while (parentRequest && !isWorkspaceRequest(parentRequest)) {
+      parentRequest = parentRequest.parentRequest;
+    }
+    if (parentRequest) {
+      addOrSet(map, parentRequest.pattern, req);
+    } else {
+      addOrSet(map, '', req);
+    }
+    return map;
+  }, initialMap);
+  return Object.keys(refTrees).sort().map(requestName => getShortestPathOf(refTrees[requestName]));
+}
+
+export default class PackagePeerResolver {
+  constructor(config: Config, resolver: PackageResolver) {
+    this.config = config;
+    this.resolver = resolver;
+    this.reporter = config.reporter;
+  }
+
+  reporter: Reporter;
+  resolver: PackageResolver;
+  config: Config;
+
+  resolvePeerModules(pkgs: Array<Manifest>) {
+    for (const pkg of pkgs) {
+      const peerDeps = pkg.peerDependencies;
+      const peerDepsMeta = pkg.peerDependenciesMeta;
+
+      if (!peerDeps) {
+        continue;
+      }
+
+      const ref = pkg._reference;
+      invariant(ref, 'Package reference is missing');
+
+      const refTrees = extractRefTrees(ref);
+
+      if (refTrees.length === 0) {
+        continue;
+      }
+
+      for (const peerDepName in peerDeps) {
+        const range = peerDeps[peerDepName];
+        const meta = peerDepsMeta && peerDepsMeta[peerDepName];
+
+        const isOptional = !!(meta && meta.optional);
+
+        const onNotResolved = isOptional
+          ? (refTree, peerError) => {}
+          : (refTree, peerError) => {
+              this.reporter.warn(
+                this.reporter.lang(
+                  peerError,
+                  `${refTree.join(' > ')} > ${pkg.name}@${pkg.version}`,
+                  `${peerDepName}@${range}`,
+                ),
+              );
+            };
+
+        const peerPkgs = this.resolver.getAllInfoForPackageName(peerDepName);
+
+        const refTreesStatus = [];
+        for (let refTreeIndex = 0; refTreeIndex < refTrees.length; refTreeIndex++) {
+          const refTree: string[] = refTrees[refTreeIndex];
+          let peerError = 'unmetPeer';
+          let resolvedLevelDistance: number = Infinity;
+          let resolvedPeerPkg;
+          for (const peerPkg of peerPkgs) {
+            const peerPkgRef = peerPkg._reference;
+            if (!(peerPkgRef && peerPkgRef.patterns)) {
+              continue;
+            }
+            const levelDistance = getLevelDistance(peerPkgRef, refTree);
+            if (isFinite(levelDistance) && levelDistance < resolvedLevelDistance) {
+              if (this._satisfiesPeerDependency(range, peerPkgRef.version)) {
+                resolvedLevelDistance = levelDistance;
+                resolvedPeerPkg = peerPkgRef;
+              } else {
+                peerError = 'incorrectPeer';
+              }
+            }
+          }
+          refTreesStatus.push({
+            refTree,
+            peerError,
+            resolvedPeerPkg,
+          });
+        }
+
+        const {refTree, peerError, resolvedPeerPkg} = refTreesStatus[0];
+        if (resolvedPeerPkg) {
+          ref.addDependencies(resolvedPeerPkg.patterns);
+          this.reporter.verbose(
+            this.reporter.lang(
+              'selectedPeer',
+              `${pkg.name}@${pkg.version}`,
+              `${peerDepName}@${resolvedPeerPkg.version}`,
+              resolvedPeerPkg.level,
+            ),
+          );
+        } else {
+          onNotResolved(refTree, peerError);
+        }
+        for (let statusIndex = 1; statusIndex < refTreesStatus.length; statusIndex++) {
+          const refTreeStatus = refTreesStatus[statusIndex];
+          if (!refTreeStatus.resolvedPeerPkg) {
+            onNotResolved(refTreeStatus.refTree, refTreeStatus.peerError);
+          }
+        }
+      }
+    }
+  }
+
+  _satisfiesPeerDependency(range: string, version: string): boolean {
+    return range === '*' || satisfiesWithPrereleases(version, range, this.config.looseSemver);
+  }
+}


### PR DESCRIPTION
Fixed: the package requests introduced by workspace mechanism should be excluded from the scope of requests checked for usage
Added peer tests (all credits go to @hulkish for the initial test cases)


# Summary

The idea of this PR is to fix the following behaviour which were currently giving tons of "false positive" warnings about unused peer dependencies in workspaces context.

* Current state:

* say you have a project A within your workspace which specifies a peer dependency on a package which is *outside* the workspace. Currently you get a peer unmet warning.
* say you have a project B within your workspace which specifies a peer dependency on another project C which is *inside* the workspace and that your root project declares a dependency on B without a dependency on C. Currently you don't get a peer unmet warning.

This relates (somehow) to issue https://github.com/yarnpkg/yarn/issues/5810

# Test plan

## Simple missing peer dependency warning (prod)

Create a root project with three subprojects, `a`, `b` and `c` (we'll be using version `1.0` everywhere here). 
   - The root project has no dependency
   - `a` has `b` in its peer dependencies.
   - `c` has `a` in its prod dependencies

Run `yarn install`
Expected: a warning for `c` missing a peer dependency on `b`.

## Simple missing peer dependency warning (dev)

Create a root project with three subprojects, `a`, `b` and `c` (we'll be using version `1.0` everywhere here). 
   - The root project has no dependency
   - `a` has `b` in its peer dependencies.
   - `c` has `a` in its dev dependencies

Run `yarn install`
Expected: a warning for `c` missing a peer dependency on `b`.

## Simple unmet peer dependency warning (prod)

Create a root project with three subprojects, `a`, `b` and `c` (we'll be using version `1.0` everywhere here). 
   - The root project has no dependency
   - `a` has `b@0.5` in its peer dependencies.
   - `c` has `a` and `b@1.0` in its prod dependencies

Run `yarn install`
Expected: a warning for `c` with an unmet peer dependency on `b@0.5`.

## Simple unmet peer dependency warning (dev)

Create a root project with three subprojects, `a`, `b` and `c` (we'll be using version `1.0` everywhere here). 
   - The root project has no dependency
   - `a` has `b@0.5` in its peer dependencies.
   - `c` has `a` and `b@1.0` in its dev dependencies

Run `yarn install`
Expected: a warning for `c` with an unmet a peer dependency on `b@0.5`.

## No peer dependency issue

Create a root project with three subprojects, `a`, `b` and `c` (we'll be using version `1.0` everywhere here). 
   - The root project has no dependency
   - `a` has `b` in its peer dependencies.
   - `c` has `a` and `b` in its prod dependencies

Run `yarn install`
Expected: no warning

