### PR TITLE
Disable load from cache for local packages #2165

### DIFF
--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -57,8 +57,8 @@ export default class TarballResolver extends ExoticResolver {
 
     // generate temp directory
     const dest = this.config.getTemp(crypto.hash(url));
-
-    if (await this.config.isValidModuleDest(dest)) {
+    // If specified using file: never load from cache
+    if (!url.match(/file:/) && await this.config.isValidModuleDest(dest)) {
       // load from local cache
       ({package: pkgJson, hash, registry} = await this.config.readPackageMetadata(dest));
     } else {


### PR DESCRIPTION
When using `yarn add file:./local-package.tgz` yarn would load the local package from a cache, negating any updates.
This was due to the hash being generated by the unchanged file path url.
This fix flat-out disables loading from cache for any url to a .tgz that includes `file:`, ie is a local package.

This is my first time trying to fork and make a PR for something, apologies if I've gone about it all wrong!