### PR TITLE
Fixes arbitrary file write on fetch

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -136,6 +136,11 @@ export default class TarballFetcher extends BaseFetcher {
       chown: false, // don't chown. just leave as it is
       map: header => {
         header.mtime = now;
+        if (header.linkname) {
+          const basePath = path.posix.dirname(path.join('/', header.name));
+          const jailPath = path.posix.join(basePath, header.linkname);
+          header.linkname = path.posix.relative('/', jailPath);
+        }
         return header;
       },
       fs: patchedFs,


### PR DESCRIPTION
**Summary**

In some circumstances it was possible to write files anywhere on the disk when running `yarn install`. Although it's not that much of an issue considering that most installs are done with postinstall scripts, we don't want that to happen precisely to guarantee some level of safety for people actually using `--ignore-scripts`.

**Test plan**

Will add tests after the release.