### PR TITLE
handle failed policy set-version

### DIFF
--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -122,9 +122,16 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
       bundleUrl = 'https://github.com/yarnpkg/berry/raw/master/packages/berry-cli/bin/berry.js';
       bundleVersion = 'berry';
     } else {
-      const releases = await fetchReleases(config, {
-        includePrereleases: allowRc,
-      });
+      let releases = [];
+
+      try {
+        releases = await fetchReleases(config, {
+          includePrereleases: allowRc,
+        });
+      } catch (e) {
+        reporter.error(e.message);
+        return;
+      }
 
       const release = releases.find(release => {
         // $FlowFixMe

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -358,6 +358,7 @@ const messages = {
   errorExtractingTarball: 'Extracting tar content of $1 failed, the file appears to be corrupt: $0',
   updateInstalling: 'Installing $0...',
   hostedGitResolveError: 'Error connecting to repository. Please, check the url.',
+  unauthorizedResponse: 'Received a 401 from $0. $1',
 
   unknownFetcherFor: 'Unknown fetcher for $0',
 

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -373,6 +373,11 @@ export default class RequestManager {
       rejectNext(err);
     };
 
+    const rejectWithoutUrl = function(err) {
+      err.message = err.message;
+      rejectNext(err);
+    }
+
     const queueForRetry = reason => {
       const attempts = params.retryAttempts || 0;
       if (attempts >= this.maxRetryAttempts - 1) {
@@ -426,6 +431,13 @@ export default class RequestManager {
           } else {
             return;
           }
+        }
+
+        const server = res.caseless.get('server');
+
+        if (res.statusCode === 401 && server === "GitHub.com") {
+          const message = `${res.body.message}. If using GITHUB_TOKEN in your env, check that it is valid.`
+          rejectWithoutUrl(new Error(this.reporter.lang('unauthorizedResponse', server, message)))
         }
 
         if (res.statusCode === 401 && res.headers['www-authenticate']) {

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -433,11 +433,9 @@ export default class RequestManager {
           }
         }
 
-        const server = res.caseless.get('server');
-
-        if (res.statusCode === 401 && server === 'GitHub.com') {
+        if (res.statusCode === 401 && res.caseless && res.caseless.get('server') === 'GitHub.com') {
           const message = `${res.body.message}. If using GITHUB_TOKEN in your env, check that it is valid.`;
-          rejectWithoutUrl(new Error(this.reporter.lang('unauthorizedResponse', server, message)));
+          rejectWithoutUrl(new Error(this.reporter.lang('unauthorizedResponse', res.caseless.get('server'), message)));
         }
 
         if (res.statusCode === 401 && res.headers['www-authenticate']) {

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -376,7 +376,7 @@ export default class RequestManager {
     const rejectWithoutUrl = function(err) {
       err.message = err.message;
       rejectNext(err);
-    }
+    };
 
     const queueForRetry = reason => {
       const attempts = params.retryAttempts || 0;
@@ -435,9 +435,9 @@ export default class RequestManager {
 
         const server = res.caseless.get('server');
 
-        if (res.statusCode === 401 && server === "GitHub.com") {
-          const message = `${res.body.message}. If using GITHUB_TOKEN in your env, check that it is valid.`
-          rejectWithoutUrl(new Error(this.reporter.lang('unauthorizedResponse', server, message)))
+        if (res.statusCode === 401 && server === 'GitHub.com') {
+          const message = `${res.body.message}. If using GITHUB_TOKEN in your env, check that it is valid.`;
+          rejectWithoutUrl(new Error(this.reporter.lang('unauthorizedResponse', server, message)));
         }
 
         if (res.statusCode === 401 && res.headers['www-authenticate']) {


### PR DESCRIPTION
**Summary**

Right now `policies set-version` does not handle invalid scenarios where an invalid github token is provided or the request fails.

**Test plan**

Will add a test that mocks a 401 from Github's API and that the reporter correctly logs.
