### PR TITLE
Fix contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-Contributing to Yarn V1: please see https://classic.yarnpkg.com/en/docs/getting-started
+Contributing to Yarn V1: please see https://yarnpkg.com/en/org/contributing
 
-Contributing to Yarn V2: please see https://yarnpkg.com/en/org/contributing
+Contributing to Yarn V2: please see https://yarnpkg.com/advanced/contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
-Please see https://yarnpkg.com/en/org/contributing/
+Contributing to Yarn V1: please see https://classic.yarnpkg.com/en/docs/getting-started
+
+Contributing to Yarn V2: please see https://yarnpkg.com/en/org/contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see https://yarnpkg.com/org/contributing/
+Please see https://yarnpkg.com/en/org/contributing/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](./CONTRIBUTING.md).
 
 ## Prior art
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The yarn 2 website does not redirect the `org/contributing` URL.