### PR TITLE
fix: force to use / as a path separator in yarn-path

### DIFF
--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -155,7 +155,7 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
 
     const rcPath = `${config.lockfileFolder}/.yarnrc`;
     reporter.log(`Updating ${chalk.magenta(rcPath)}...`);
-    rc['yarn-path'] = path.relative(config.lockfileFolder, yarnPath);
+    rc['yarn-path'] = path.relative(config.lockfileFolder, yarnPath).split(path.sep).join('/');
     await fs.writeFilePreservingEol(rcPath, `${stringify(rc)}\n`);
 
     reporter.log(`Done!`);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Close #7777 Close https://github.com/yarnpkg/berry/issues/858

`\\` in `yarn-path` causes a problem where `berry` cannot be run on a non-Windows environment.
This PR forces to use `/` as a path separator in `yarn-path` even on Windows.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
Welcome to Node.js v13.3.0.
Type ".help" for more information.
> 'foo\\bar\\baz'.split(path.sep).join('/')
'foo/bar/baz'
> '\\foo\\bar\\baz'.split(path.sep).join('/')
'/foo/bar/baz'
> '\\foo\\bar\\baz\\'.split(path.sep).join('/')
'/foo/bar/baz/'
> '..\\foo\\bar\\baz\\'.split(path.sep).join('/')
'../foo/bar/baz/'
```