### PR TITLE
Implements set version

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -19,6 +19,7 @@ export function setFlags(commander: Object) {
   commander.option('-y, --yes', 'use default options');
   commander.option('-p, --private', 'use default options and private true');
   commander.option('-i, --install <value>', 'install a specific Yarn release');
+  commander.option('-2', 'generates the project using Yarn 2');
 }
 
 export function hasWrapper(commander: Object, args: Array<string>): boolean {
@@ -28,12 +29,14 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 export const shouldRunInCurrentCwd = true;
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
-  if (flags.install) {
+  const installVersion = flags[`2`] ? `berry` : flags.install;
+
+  if (installVersion) {
     const lockfilePath = path.resolve(config.cwd, 'yarn.lock');
     if (!await fs.exists(lockfilePath)) {
       await fs.writeFile(lockfilePath, '');
     }
-    await child.spawn(NODE_BIN_PATH, [process.argv[1], 'policies', 'set-version', flags.install], {
+    await child.spawn(NODE_BIN_PATH, [process.argv[1], 'policies', 'set-version', installVersion], {
       stdio: 'inherit',
       cwd: config.cwd,
     });

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -187,7 +187,11 @@ export async function main({
     commandName = 'install';
     isKnownCommand = true;
   }
-
+  if (commandName === ('set': string) && args[0] === 'version') {
+    commandName = ('policies': string);
+    args.splice(0, 1, 'set-version');
+    isKnownCommand = true;
+  }
   if (!isKnownCommand) {
     // if command is not recognized, then set default to `run`
     args.unshift(commandName);


### PR DESCRIPTION
**Summary**

This command implements the `yarn set version [...]` alias for `yarn policies set-version` without breaking people who already have a `yarn set` script. This will make the transition workflow much smoother since the same commands will work on both versions.
