### PR TITLE
Fix relative symlinks when traversing a symlink boundary

### DIFF
--- a/__tests__/util/fs.js
+++ b/__tests__/util/fs.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+import path from 'path';
+import fs from 'fs';
+import mkdir from './../_temp.js';
+import {promisify} from '../../src/util/promise.js';
+import {symlink, mkdirp, stat} from '../../src/util/fs.js';
+
+const fsSymlink: (target: string, path: string, type?: 'dir' | 'file' | 'junction') => Promise<void> = promisify(
+  fs.symlink,
+);
+
+describe('symlink', () => {
+  test.concurrent("Doesn't make broken links when target itself has a deeper real path", async (): Promise<void> => {
+    const scratch = await mkdir();
+
+    // make a links directory that's actually a symlink itself
+    await mkdirp(path.join(scratch, 'parent', 'links'));
+    const linksPath = path.join(scratch, 'links');
+    await fsSymlink(path.join('parent', 'links'), linksPath);
+
+    // make a dummy package
+    const packagePath = path.join(scratch, 'dummy');
+    await mkdirp(packagePath);
+
+    // symlinking the dummy package into the symlinked links directory should be ok
+    const packageLinkPath = path.join(linksPath, 'dummy');
+    await symlink(packagePath, packageLinkPath);
+    expect(stat(packageLinkPath)).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

Currently, `yarn link` generates a broken link if the real path of the links folder is of a different depth than the nominal path because it computes the relative path using the nominal path of the links folder. A test is included to demonstrate this defect.

This PR fixes this issue by always generating the relative path against the real path of the links folder.

In order to make existing tests pass, I also added logic to successively resolve parent paths in order to generate the shorest-possible relative path, some of which are currently expected to be generated in existing tests. I'm not certain this is the best approach; happy to change it.

As an aside, some history I found:
* #94 introduced the "make all symlinks relative" behavior
* #2096 reports this defect
* #2454 fixes this defect
* #6321 reverts #2454

I do agree with the assessment that always using relative symlinks is questionable behavior, but that's probably out of scope for this PR.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->