### PR TITLE
Faster yarn install with faster cycles detection

### DIFF
--- a/src/package-install-scripts.js
+++ b/src/package-install-scripts.js
@@ -292,7 +292,24 @@ export default class PackageInstallScripts {
     }
   }
 
+  addDependenciesToGraph(patterns: Array<string>, graph: Map<string, Array<string>>): void {
+    for (const pattern of patterns) {
+      if (graph.has(pattern)) {
+        continue;
+      }
+
+      const pkg = this.resolver.getStrictResolvedPattern(pattern);
+      const dependencies = pkg._reference.dependencies;
+      graph.set(pattern, dependencies);
+      this.addDependenciesToGraph(dependencies, graph);
+    }
+  }
+
   async init(seedPatterns: Array<string>): Promise<void> {
+    debugger
+    const dependencyGraph = new Map();
+    this.addDependenciesToGraph(seedPatterns, dependencyGraph);
+    debugger
     const workQueue = new Set();
     const installed = new Set();
     const pkgs = this.resolver.getTopologicalManifests(seedPatterns);


### PR DESCRIPTION
**Summary**

Detecting graph cycles during package install is currently done in o(n2), this PR is a suggestion on how we can bring it down to o(n).

benchmark: warm yarn cache, clean repo (no node_modules folders), running `yarn install`
Before: 5m45
After: 2m10

**Test plan**
This PR changes only the implementation details so it should be tested by the existing tests.
