### PR TITLE
Makes the CLI 2 forwarding stricter

### DIFF
--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -167,7 +167,7 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
       const rcPath = `${config.lockfileFolder}/.yarnrc.yml`;
       reporter.log(`Updating ${chalk.magenta(rcPath)}...`);
 
-      await fs.writeFilePreservingEol(rcPath, `yarnPath: ${JSON.stringify(yarnPath)}\n`);
+      await fs.writeFilePreservingEol(rcPath, `yarnPath: ${JSON.stringify(targetPath)}\n`);
     } else {
       const rcPath = `${config.lockfileFolder}/.yarnrc`;
       reporter.log(`Updating ${chalk.magenta(rcPath)}...`);

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -386,7 +386,17 @@ function parse(str: string, fileLoc: string): Object {
   parser.next();
 
   if (!fileLoc.endsWith(`.yml`)) {
-    return parser.parse();
+    try {
+      return parser.parse();
+    } catch (error1) {
+      try {
+        return safeLoad(str, {
+          schema: FAILSAFE_SCHEMA,
+        });
+      } catch (error2) {
+        throw error1;
+      }
+    }
   } else {
     return safeLoad(str, {
       schema: FAILSAFE_SCHEMA,

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -384,16 +384,13 @@ function hasMergeConflicts(str: string): boolean {
 function parse(str: string, fileLoc: string): Object {
   const parser = new Parser(str, fileLoc);
   parser.next();
-  try {
+
+  if (!fileLoc.endsWith(`.yml`)) {
     return parser.parse();
-  } catch (error1) {
-    try {
-      return safeLoad(str, {
-        schema: FAILSAFE_SCHEMA,
-      });
-    } catch (error2) {
-      throw error1;
-    }
+  } else {
+    return safeLoad(str, {
+      schema: FAILSAFE_SCHEMA,
+    });
   }
 }
 

--- a/src/rc.js
+++ b/src/rc.js
@@ -53,9 +53,9 @@ export function getRcConfigForFolder(cwd: string): {[key: string]: string} {
 }
 
 function loadRcFile(fileText: string, filePath: string): {[key: string]: string} {
-  let {object: values} = parse(fileText, 'yarnrc');
+  let {object: values} = parse(fileText, filePath);
 
-  if (filePath.match(/\.yml$/)) {
+  if (filePath.match(/\.yml$/) && typeof values.yarnPath === 'string') {
     values = {'yarn-path': values.yarnPath};
   }
 

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -68,7 +68,11 @@ function parseRcPaths(paths: Array<string>, parser: Function): Object {
       try {
         return parser(readFileSync(path).toString(), path);
       } catch (error) {
-        return {};
+        if (error.code === 'ENOENT' || error.code === 'EISDIR') {
+          return {};
+        } else {
+          throw error;
+        }
       }
     }),
   );


### PR DESCRIPTION
**Summary**

The `.yarnrc.yml` settings were ignored when the syntax was erroneous, causing it to accidentally run a Yarn 1.x install.

This diff fixes that so that invalid RC files will always throw exceptions. It also fixes the `yarn set version` command to print relative paths rather than absolute.

**Test plan**

Tested locally.