### PR TITLE
docs: change contribution guideline link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](https://yarnpkg.com/advanced/contributing).
 
 ## Prior art
 


### PR DESCRIPTION
change contribution guideline link

**Summary**

The actual link to the contribution guideline is broken (https://yarnpkg.com/org/contributing).
The link should be : https://yarnpkg.com/advanced/contributing
