### PR TITLE
fix: make `yarn bin` exit non-zero when a binary could not be found

### DIFF
--- a/src/cli/commands/bin.js
+++ b/src/cli/commands/bin.js
@@ -28,6 +28,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       reporter.log(binPath, {force: true});
     } else {
       reporter.error(reporter.lang('packageBinaryNotFound', binName));
+      process.exitCode = 1;
     }
   }
 }


### PR DESCRIPTION
**Summary**

Makes `yarn bin` exist with exit code `1` if a binary could not be found. Current behaviour is:

![joscha_Joschas-MacBook-Pro____work_canva](https://user-images.githubusercontent.com/188038/75739985-92d39100-5d5a-11ea-99fd-ae65b0fe7e92.png)

which is surprising.

**Test plan**

If the change is accepted I can add a test for the `bin` command.

cc @dillon-giacoppo
