### PR TITLE
bugfix #7136: prevent rebuild when package gypfile config is false

### DIFF
--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -200,7 +200,7 @@ export default (async function(
   }
 
   // if there's a binding.gyp file and no install script then set it to `node-gyp rebuild`
-  if (!scripts.install && files.indexOf('binding.gyp') >= 0) {
+  if (!scripts.install && files.indexOf('binding.gyp') >= 0 && info.gypfile !== false) {
     scripts.install = 'node-gyp rebuild';
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Developers creating projects with partially functioning native addons will sometimes need to disable automatic compiling of said addons on yarn install commands.

This PR fixes #7136 by respecting the `gypfile: false` flag in package.json

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I have tested the fix locally, but I would love some support in figuring a way to add some tests for this in the project. :pray: 
