### PR TITLE
Prevents exiting the process on sigint through yarn-path

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -629,6 +629,11 @@ async function start(): Promise<void> {
     const opts = {stdio: 'inherit', env: Object.assign({}, process.env, {YARN_IGNORE_PATH: 1})};
     let exitCode = 0;
 
+    process.on(`SIGINT`, () => {
+      // We don't want SIGINT to kill our process; we want it to kill the
+      // innermost process, whose end will cause our own to exit.
+    });
+
     try {
       if (yarnPath.endsWith(`.js`)) {
         exitCode = await spawnp(process.execPath, [yarnPath, ...argv], opts);


### PR DESCRIPTION
**Summary**

Sigint should be ignored when forwarding a process, because otherwise the outermost process (ie the global Yarn) will exit before the innermost process (ie the local Yarn) has finished its work.

**Test plan**

Tested locally.