### PR TITLE
Fix typos across yarn repo

### DIFF
--- a/__tests__/commands/global.js
+++ b/__tests__/commands/global.js
@@ -69,7 +69,7 @@ if (isCI) {
   });
 
   // don't run this test in `concurrent`, it will affect other tests
-  test('add with PREFIX enviroment variable', (): Promise<void> => {
+  test('add with PREFIX environment variable', (): Promise<void> => {
     const tmpGlobalFolder = getTempGlobalFolder();
     const envPrefix = process.env.PREFIX;
     process.env.PREFIX = tmpGlobalFolder;

--- a/__tests__/fixtures/install/workspaces-install-link-invalid/packages/left-pad/index.js
+++ b/__tests__/fixtures/install/workspaces-install-link-invalid/packages/left-pad/index.js
@@ -22,7 +22,7 @@ function leftPad(str, len, ch) {
   while (true) {
     // add `ch` to `pad` if `len` is odd
     if (len & 1) pad += ch;
-    // devide `len` by 2, ditch the fraction
+    // divide `len` by 2, ditch the fraction
     len >>= 1;
     // "double" the `ch` so this operation count grows logarithmically on `len`
     // each time `ch` is "doubled", the `len` would need to be "doubled" too

--- a/__tests__/fixtures/install/workspaces-install-link-root/packages/left-pad/index.js
+++ b/__tests__/fixtures/install/workspaces-install-link-root/packages/left-pad/index.js
@@ -22,7 +22,7 @@ function leftPad(str, len, ch) {
   while (true) {
     // add `ch` to `pad` if `len` is odd
     if (len & 1) pad += ch;
-    // devide `len` by 2, ditch the fraction
+    // divide `len` by 2, ditch the fraction
     len >>= 1;
     // "double" the `ch` so this operation count grows logarithmically on `len`
     // each time `ch` is "doubled", the `len` would need to be "doubled" too

--- a/__tests__/fixtures/install/workspaces-install-link/packages/left-pad/index.js
+++ b/__tests__/fixtures/install/workspaces-install-link/packages/left-pad/index.js
@@ -22,7 +22,7 @@ function leftPad(str, len, ch) {
   while (true) {
     // add `ch` to `pad` if `len` is odd
     if (len & 1) pad += ch;
-    // devide `len` by 2, ditch the fraction
+    // divide `len` by 2, ditch the fraction
     len >>= 1;
     // "double" the `ch` so this operation count grows logarithmically on `len`
     // each time `ch` is "doubled", the `len` would need to be "doubled" too

--- a/__tests__/fixtures/install/workspaces-install-subdeps-2/packages/left-pad/index.js
+++ b/__tests__/fixtures/install/workspaces-install-subdeps-2/packages/left-pad/index.js
@@ -22,7 +22,7 @@ function leftPad(str, len, ch) {
   while (true) {
     // add `ch` to `pad` if `len` is odd
     if (len & 1) pad += ch;
-    // devide `len` by 2, ditch the fraction
+    // divide `len` by 2, ditch the fraction
     len >>= 1;
     // "double" the `ch` so this operation count grows logarithmically on `len`
     // each time `ch` is "doubled", the `len` would need to be "doubled" too

--- a/__tests__/fixtures/install/workspaces-install-subdeps/packages/left-pad/index.js
+++ b/__tests__/fixtures/install/workspaces-install-subdeps/packages/left-pad/index.js
@@ -22,7 +22,7 @@ function leftPad(str, len, ch) {
   while (true) {
     // add `ch` to `pad` if `len` is odd
     if (len & 1) pad += ch;
-    // devide `len` by 2, ditch the fraction
+    // divide `len` by 2, ditch the fraction
     len >>= 1;
     // "double" the `ch` so this operation count grows logarithmically on `len`
     // each time `ch` is "doubled", the `len` would need to be "doubled" too

--- a/packages/pkg-tests/pkg-tests-specs/sources/workspace.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/workspace.js
@@ -7,7 +7,7 @@ const {fs: {writeFile, writeJson}} = require('pkg-tests-core');
 module.exports = (makeTemporaryEnv: PackageDriver) => {
   describe(`Workspaces tests`, () => {
     test(
-      `it should implicitely make workspaces require-able from the top-level`,
+      `it should implicitly make workspaces require-able from the top-level`,
       makeTemporaryEnv(
         {
           private: true,

--- a/src/package-hoister.js
+++ b/src/package-hoister.js
@@ -558,25 +558,25 @@ export default class PackageHoister {
       }>,
     > = new Map();
 
-    const occurences: {
+    const occurrences: {
       [packageName: string]: {
         [version: string]: {
           pattern: string,
-          occurences: Set<Manifest>,
+          occurrences: Set<Manifest>,
         },
       },
     } = {};
 
-    // visitor to be used inside add() to mark occurences of packages
+    // visitor to be used inside add() to mark occurrences of packages
     const visitAdd = (pkg: Manifest, ancestry: Array<Manifest>, pattern: string) => {
-      const versions = (occurences[pkg.name] = occurences[pkg.name] || {});
+      const versions = (occurrences[pkg.name] = occurrences[pkg.name] || {});
       const version = (versions[pkg.version] = versions[pkg.version] || {
-        occurences: new Set(),
+        occurrences: new Set(),
         pattern,
       });
 
       if (ancestry.length) {
-        version.occurences.add(ancestry[ancestry.length - 1]);
+        version.occurrences.add(ancestry[ancestry.length - 1]);
       }
     };
 
@@ -633,9 +633,9 @@ export default class PackageHoister {
       add(pattern, [], []);
     }
 
-    for (const packageName of Object.keys(occurences).sort()) {
-      const versionOccurences = occurences[packageName];
-      const versions = Object.keys(versionOccurences);
+    for (const packageName of Object.keys(occurrences).sort()) {
+      const versionOccurrences = occurrences[packageName];
+      const versions = Object.keys(versionOccurrences);
 
       if (versions.length === 1) {
         // only one package type so we'll hoist this to the top anyway
@@ -654,9 +654,9 @@ export default class PackageHoister {
 
       let mostOccurenceCount;
       let mostOccurencePattern;
-      for (const version of Object.keys(versionOccurences).sort()) {
-        const {occurences, pattern} = versionOccurences[version];
-        const occurenceCount = occurences.size;
+      for (const version of Object.keys(versionOccurrences).sort()) {
+        const {occurrences, pattern} = versionOccurrences[version];
+        const occurenceCount = occurrences.size;
 
         if (!mostOccurenceCount || occurenceCount > mostOccurenceCount) {
           mostOccurenceCount = occurenceCount;

--- a/src/util/fs-normalized.js
+++ b/src/util/fs-normalized.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-// This module serves as a wrapper for file operations that are inconsistant across node and OS versions.
+// This module serves as a wrapper for file operations that are inconsistent across node and OS versions.
 
 import fs from 'fs';
 import {promisify} from './promise.js';

--- a/src/util/generate-pnp-map-api.tpl.js
+++ b/src/util/generate-pnp-map-api.tpl.js
@@ -4,7 +4,7 @@
 /* global packageInformationStores, $$BLACKLIST, $$SETUP_STATIC_TABLES */
 
 // Used for the resolveUnqualified part of the resolution (ie resolving folder/index.js & file extensions)
-// Deconstructed so that they aren't affected by any fs monkeypatching occuring later during the execution
+// Deconstructed so that they aren't affected by any fs monkeypatching occurring later during the execution
 const {statSync, lstatSync, readlinkSync, readFileSync, existsSync, realpathSync} = require('fs');
 
 const Module = require('module');
@@ -344,7 +344,7 @@ exports.resolveToUnqualified = function resolveToUnqualified(request, issuer, {c
     if (result === false) {
       throw makeError(
         `BUILTIN_NODE_RESOLUTION_FAIL`,
-        `The builtin node resolution algorithm was unable to resolve the module referenced by "${request}" and requested from "${issuer}" (it didn't go through the pnp resolver because the issuer was explicitely ignored by the regexp "$$BLACKLIST")`,
+        `The builtin node resolution algorithm was unable to resolve the module referenced by "${request}" and requested from "${issuer}" (it didn't go through the pnp resolver because the issuer was explicitly ignored by the regexp "$$BLACKLIST")`,
         {
           request,
           issuer,


### PR DESCRIPTION
:writing_hand: **Fix typos across yarn repo**

**Files that have typos**

```
yarn/__tests__/commands/global.js:72:24: "enviroment" is a misspelling of "environment"
yarn/__tests__/fixtures/install/workspaces-install-link/packages/left-pad/index.js:25:7: "devide" is a misspelling of "divide"
yarn/__tests__/fixtures/install/workspaces-install-link-invalid/packages/left-pad/index.js:25:7: "devide" is a misspelling of "divide"
yarn/__tests__/fixtures/install/workspaces-install-link-root/packages/left-pad/index.js:25:7: "devide" is a misspelling of "divide"
yarn/__tests__/fixtures/install/workspaces-install-subdeps/packages/left-pad/index.js:25:7: "devide" is a misspelling of "divide"
yarn/__tests__/fixtures/install/workspaces-install-subdeps-2/packages/left-pad/index.js:25:7: "devide" is a misspelling of "divide"
yarn/packages/pkg-tests/pkg-tests-specs/sources/workspace.js:10:17: "implicitely" is a misspelling of "implicitly"
yarn/src/package-hoister.js:561:10: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:565:10: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:570:47: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:572:24: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:572:47: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:574:8: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:636:42: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:637:32: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:658:15: "occurences" is a misspelling of "occurrences"
yarn/src/package-hoister.js:669:38: "occured" is a misspelling of "occurred"
yarn/src/util/fs-normalized.js:3:64: "inconsistant" is a misspelling of "inconsistent"
yarn/src/util/generate-pnp-map-api.tpl.js:7:71: "occuring" is a misspelling of "occurring"
yarn/src/util/generate-pnp-map-api.tpl.js:347:200: "explicitely" is a misspelling of "explicitly"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: