### PR TITLE
Added 'lo' to ignored interfaces

### DIFF
--- a/src/util/network.js
+++ b/src/util/network.js
@@ -2,7 +2,7 @@
 
 const os = require('os');
 
-const IGNORE_INTERFACES = ['lo0', 'awdl0', 'bridge0'];
+const IGNORE_INTERFACES = ['lo', 'lo0', 'awdl0', 'bridge0'];
 const LOCAL_IPS = ['127.0.0.1', '::1'];
 
 export function isOffline(): boolean {


### PR DESCRIPTION
Added 'lo' to `IGNORE_INTERFACES` array while checking whetever user is offline or not. If it is not, `isOffline()` function may return `true` even if the user is online.

**Summary**

Explain the **motivation** for making this change. What existing problem does the pull request solve? 
- Yarn was saying `You appear to be offline.` and my command was exiting with an error, even if I was online. This pull request fixes it

```js
os.networkInterfaces()
> {
  lo: [
    {
      address: '127.0.0.1',
      ...
    }
  ],
  ...
}
```
