### PR TITLE
Make CVE-2020-8131 mitigation opt-in

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -136,7 +136,9 @@ export default class TarballFetcher extends BaseFetcher {
       chown: false, // don't chown. just leave as it is
       map: header => {
         header.mtime = now;
-        if (header.linkname) {
+        if (header.linkname && this.config.ignoreScripts) {
+          // Allow users to opt-in to CVE-2020-8131 mitigation (https://github.com/yarnpkg/yarn/pull/7831)
+          // This can break links (see https://github.com/yarnpkg/yarn/issues/7890)
           const basePath = path.posix.dirname(path.join('/', header.name));
           const jailPath = path.posix.join(basePath, header.linkname);
           header.linkname = path.posix.relative('/', jailPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

After reading through the [HackerOne report](https://hackerone.com/reports/730239) and [corresponding PR](https://github.com/yarnpkg/yarn/pull/7831), it looks like this mitigation was intended to prevent arbitrary file writes when `--ignore-scripts` is passed. However, this mitigation was used even when `--ignore-scripts` is not enabled and can break the installation of packages that have hard/symbolic links inside their own directories (see #7890). This PR enables the behavior only when `--ignore-scripts` is passed.

Fixes #7890 

**Test plan**

Tested with packages mentioned in #7890 (e.g. `lz4`)