### PR TITLE
Update dead contributing links to their new URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see https://yarnpkg.com/org/contributing/
+Please see https://yarnpkg.com/advanced/contributing/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](https://yarnpkg.com/advanced/contributing/).
 
 ## Prior art
 


### PR DESCRIPTION
**Summary**

I noticed the “contributing” links in both the README.md and CONTRIBUTING.md are dead links. This PR updates them to point to the correct URL.
#7952 is pointing to the v1 contributing page but I’m not sure that’s correct?
