### PR TITLE
Improve `why` command to inform the user about a version set by a custom resolution

### DIFF
--- a/__tests__/commands/why.js
+++ b/__tests__/commands/why.js
@@ -96,6 +96,29 @@ test.concurrent('should determine that the module installed because it is in dev
   });
 });
 
+test.concurrent(
+  // eslint-disable-next-line max-len
+  'should inform the user that a specific version is used because they have enforced it via a custom resolution in their config',
+  (): Promise<void> => {
+    return runWhy({}, ['glob'], 'resolution', (config, reporter) => {
+      const report = reporter.getBuffer();
+      expect(report[report.length - 3].data).toEqual(reporter.lang('whyVersionEnforcedByResolution', '7.0.0'));
+    });
+  },
+);
+
+test.concurrent(
+  'should not output the version resolution info if the module isn’t affected by a custom resolution config',
+  (): Promise<void> => {
+    return runWhy({}, ['glob'], 'basic', (config, reporter) => {
+      const report = reporter.getBuffer();
+      expect(report.map(r => r.data)).not.toContain(
+        'is used because you have enforced it via a custom resolution in your config',
+      );
+    });
+  },
+);
+
 test.concurrent('should determine that the module installed because mime-types depend on it', (): Promise<void> => {
   return runWhy({}, ['mime-db'], 'basic', (config, reporter) => {
     const report = reporter.getBuffer();

--- a/__tests__/fixtures/why/basic/package.json
+++ b/__tests__/fixtures/why/basic/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.0",
   "dependencies": {
     "mime-types": "2.1.12",
     "glob": "7.1.1",

--- a/__tests__/fixtures/why/resolution/package.json
+++ b/__tests__/fixtures/why/resolution/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "foo": "file:../basic"
+  },
+  "resolutions": {
+    "glob": "7.0.0"
+  }
+}

--- a/src/cli/commands/why.js
+++ b/src/cli/commands/why.js
@@ -219,7 +219,12 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
     // prepare output: populate reporter
     reporter.info(reporter.lang('whyMatch', `${matchInfo.key}@${matchInfo.pkg.version}`));
-    //
+
+    // info: specific version is enforced via a custom resolution
+    if (matchRef.hint === 'resolution') {
+      reporter.info(reporter.lang('whyVersionEnforcedByResolution', matchInfo.pkg.version));
+    }
+
     // reason: hoisted/nohoist
     if (matchInfo.isNohoist) {
       reasons.push({

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -300,6 +300,7 @@ const messages = {
   whySpecified: `Specified in $0`,
 
   whyMatch: `\r=> Found $0`,
+  whyVersionEnforcedByResolution: `Version $0 is used because you have enforced it via a custom resolution in your config`,
 
   uninstalledPackages: 'Uninstalled packages.',
   uninstallRegenerate: 'Regenerating lockfile and installing missing dependencies',


### PR DESCRIPTION
# Summary

I was recently debugging an issue caused by a custom package resolution: the project depends on package A (which is in our `dependencies`), which itself depends on package B. Somehow, although the code was correct, a confusing error was thrown.
After a bit of investigation in our `node_modules`, I realized that the version of package B resolved by yarn was outdated and didn’t match the version required by package A.

My first intuition was that another package depended on package B and that it somehow led to the use of this outdated version so I ran `yarn why B`, and it indeed showed the outdated version being resolved, but only as a dependency of package A.
I couldn’t figure out why the wrong version would be installed until I found out that there was a `resolutions` config in the project’s `package.json`, which locked B to this outdated version.
I would have saved some time if `yarn why` directly informed me that this package was affected by a 
resolution config.

**This is what this PR aims to improve, by adding an info log to the output of `yarn why` that clearly states that this specific version is used because of a custom resolution config.**
I think in the future `yarn why` could also warn the user if the resolved version doesn’t match the version specified by another package (maybe `yarn install` already does that though?). Happy to try adding this warning in another PR/porting this to berry if you think this all makes sense?

# Test plan

This repository actually has a `resolution` config for `sshpk` which is depended on by `request`, so it makes for a good example:
<img width="1276" alt="Screenshot 2020-03-26 at 13 17 47" src="https://user-images.githubusercontent.com/9154236/77646117-36801d80-6f64-11ea-81f6-1a38a3245e34.png">

I also added two unit tests for this. Some tests are failing but they somehow were already failing before my changes.
