### PR TITLE
Defer git clone install

### DIFF
--- a/src/cli/commands/import.js
+++ b/src/cli/commands/import.js
@@ -387,7 +387,11 @@ export class Import extends Install {
       this.resolver.rootName = manifest.name;
     }
     await this.resolver.init(requests, {isFlat: this.flags.flat, isFrozen: this.flags.frozenLockfile});
-    const manifests: Array<Manifest> = await fetcher.fetch(this.resolver.getManifests(), this.config);
+    const manifests: Array<Manifest> = await fetcher.fetch(
+      this.resolver.getManifests(),
+      this.config,
+      this.fetcherDeferredTasks,
+    );
     this.resolver.updateManifests(manifests);
     await compatibility.check(this.resolver.getManifests(), this.config, this.flags.ignoreEngines);
     await this.linker.resolvePeerModules();

--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -9,12 +9,13 @@ import normalizeManifest from '../util/normalize-manifest/index.js';
 import * as constants from '../constants.js';
 import * as fs from '../util/fs.js';
 import lockMutex from '../util/mutex.js';
+import {DeferredTasks} from '../util/defer';
 
 const cmdShim = require('@zkochan/cmd-shim');
 const path = require('path');
 
 export default class BaseFetcher {
-  constructor(dest: string, remote: PackageRemote, config: Config) {
+  constructor(dest: string, remote: PackageRemote, config: Config, deferredTasks: DeferredTasks) {
     this.reporter = config.reporter;
     this.packageName = remote.packageName;
     this.reference = remote.reference;
@@ -23,6 +24,7 @@ export default class BaseFetcher {
     this.remote = remote;
     this.config = config;
     this.dest = dest;
+    this.deferredTasks = deferredTasks;
   }
 
   reporter: Reporter;
@@ -33,6 +35,7 @@ export default class BaseFetcher {
   config: Config;
   hash: ?string;
   dest: string;
+  deferredTasks: DeferredTasks;
 
   setupMirrorFromCache(): Promise<?string> {
     // fetcher subclasses may use this to perform actions such as copying over a cached tarball to the offline

--- a/src/fetchers/base-fetcher.js
+++ b/src/fetchers/base-fetcher.js
@@ -15,7 +15,7 @@ const cmdShim = require('@zkochan/cmd-shim');
 const path = require('path');
 
 export default class BaseFetcher {
-  constructor(dest: string, remote: PackageRemote, config: Config, deferredTasks: DeferredTasks) {
+  constructor(dest: string, remote: PackageRemote, config: Config, deferredTasks?: DeferredTasks) {
     this.reporter = config.reporter;
     this.packageName = remote.packageName;
     this.reference = remote.reference;
@@ -35,7 +35,7 @@ export default class BaseFetcher {
   config: Config;
   hash: ?string;
   dest: string;
-  deferredTasks: DeferredTasks;
+  deferredTasks: ?DeferredTasks;
 
   setupMirrorFromCache(): Promise<?string> {
     // fetcher subclasses may use this to perform actions such as copying over a cached tarball to the offline

--- a/src/fetchers/git-fetcher.js
+++ b/src/fetchers/git-fetcher.js
@@ -170,21 +170,24 @@ export default class GitFetcher extends BaseFetcher {
       ),
       Lockfile.fromDirectory(prepareDirectory, this.reporter),
     ]);
-    await install(prepareConfig, this.reporter, {}, prepareLockFile);
 
-    const tarballMirrorPath = this.getTarballMirrorPath();
-    const tarballCachePath = this.getTarballCachePath();
+    this.deferredTasks.submit(async () => {
+      await install(prepareConfig, this.reporter, {}, prepareLockFile);
 
-    if (tarballMirrorPath) {
-      await this._packToTarball(prepareConfig, tarballMirrorPath);
-    }
-    if (tarballCachePath) {
-      await this._packToTarball(prepareConfig, tarballCachePath);
-    }
+      const tarballMirrorPath = this.getTarballMirrorPath();
+      const tarballCachePath = this.getTarballCachePath();
 
-    await this._packToDirectory(prepareConfig, this.dest);
+      if (tarballMirrorPath) {
+        await this._packToTarball(prepareConfig, tarballMirrorPath);
+      }
+      if (tarballCachePath) {
+        await this._packToTarball(prepareConfig, tarballCachePath);
+      }
 
-    await fsUtil.unlink(prepareDirectory);
+      await this._packToDirectory(prepareConfig, this.dest);
+
+      await fsUtil.unlink(prepareDirectory);
+    });
   }
 
   async _packToTarball(config: Config, path: string): Promise<void> {

--- a/src/fetchers/workspace-fetcher.js
+++ b/src/fetchers/workspace-fetcher.js
@@ -4,14 +4,16 @@ import type {PackageRemote, FetchedMetadata, Manifest} from '../types.js';
 import type Config from '../config.js';
 import type {RegistryNames} from '../registries/index.js';
 import {fetchOneRemote} from '../package-fetcher.js';
+import {DeferredTasks} from '../util/defer';
 
 export default class WorkspaceFetcher {
-  constructor(dest: string, remote: PackageRemote, config: Config) {
+  constructor(dest: string, remote: PackageRemote, config: Config, deferredTasks: DeferredTasks) {
     this.config = config;
     this.dest = dest;
     this.registry = remote.registry;
     this.workspaceDir = remote.reference;
     this.registryRemote = remote.registryRemote;
+    this.deferredTasks = deferredTasks;
   }
 
   config: Config;
@@ -19,6 +21,7 @@ export default class WorkspaceFetcher {
   registry: RegistryNames;
   workspaceDir: string;
   registryRemote: ?PackageRemote;
+  deferredTasks: DeferredTasks;
 
   setupMirrorFromCache(): Promise<?string> {
     return Promise.resolve();
@@ -44,6 +47,6 @@ export default class WorkspaceFetcher {
   }
 
   fetchRemoteWorkspace(remote: PackageRemote, manifest: Manifest): Promise<FetchedMetadata> {
-    return fetchOneRemote(remote, manifest.name, manifest.version, this.dest, this.config);
+    return fetchOneRemote(remote, manifest.name, manifest.version, this.dest, this.config, this.deferredTasks);
   }
 }

--- a/src/util/defer.js
+++ b/src/util/defer.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+export type DeferredTask = () => Promise<void>;
+
+export class DeferredTasks {
+  constructor() {
+    this.array = [];
+  }
+
+  array: Array<DeferredTask>;
+
+  submit(task: DeferredTask) {
+    this.array.push(task);
+  }
+
+  async runAll(): Promise<void> {
+    await Promise.all(this.array.map(task => task()));
+    this.array = [];
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The approach adds deferred tasks to the fetcher step, which are executed synchronously immediately after all fetchers completed. Running `yarn install` on cloned git repositories becomes such a deferred task. 

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR was made to address [#8032](https://github.com/yarnpkg/yarn/issues/8032).  

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
`yarn run test` works as far as I can tell, with a few failures caused by some global non-default configurations on my system. There is no test that catches the bug described in the issue though (else it wouldn't exist of course).  
I tested that it works in an instance where it previously didn't when deploying a private package to zeit/now. I don't know any candidate public packages that can demonstrate this issue through being depended on via the git protocol though, if you can think of any do let me know.
