### PR TITLE
Prevents libuv/E2BIG errors when a large NOTICE file exists (fixes #7783)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+## Master
+
+- Prevents libuv/E2BIG errors when a large NOTICE file exists
+
+  [#8093](https://github.com/yarnpkg/yarn/pull/8093) - [Dan Bjorge](https://github.com/dbjorge)
+
 ## 1.22.1
 
 - Prevents `yarn-path` from exiting before its child exited

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -21,6 +21,7 @@ export type LifecycleReturn = Promise<{
 export const IGNORE_MANIFEST_KEYS: Set<string> = new Set([
   'readme',
   'notice',
+  'noticeText',
   'licenseText',
   'activationEvents',
   'contributes',


### PR DESCRIPTION
**Summary**

This PR fixes #7783 by following the example from #7419 that was used to fix #5420.

TLDR: it prevents yarn from erroring out anytime you have a >40kb NOTICE file at the root of your repo and try to invoke any run-script that involves `exec()`ing a new node process.

This change has some backcompat risk (it no longer sets the `npm_package_noticeText` env var that was previously available to run scripts); I don't see any references to that variable name in an all-github code search, so I think the risk is lower than the benefit.

**Test plan**

Similarly to #7419, this doesn't add any new test code because the existing tests already cover verifying each value in the `IGNORE_MANIFEST_KEYS` list.

I manually verified that it addresses #7783 by testing it against a small test yarn project with a 40kb notice.txt file:

```powershell
C:\repos\testyarnbug | 4 | 18:49:56 05/01
> ls


    Directory: C:\repos\testyarnbug

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----            5/1/2020  6:05 PM                node_modules
-a---            5/1/2020  6:08 PM          40002 notice.txt
-a---            5/1/2020  6:06 PM            180 package.json
-a---            5/1/2020  6:05 PM           2105 yarn.lock


C:\repos\testyarnbug | 5 | 18:55:43 05/01
> type package.json
{
  "name": "test",
  "version": "1.0.0",
  "license": "MIT",
  "scripts": {
    "echo": "cross-env echo hi"
  },
  "devDependencies": {
    "cross-env": "^7.0.2"
  }
}

C:\repos\testyarnbug | 6 | 18:55:50 05/01
> yarn echo
yarn run v1.22.4
$ cross-env echo hi
Assertion failed: len < MAX_ENV_VAR_LENGTH, file c:\ws\deps\uv\src\win\util.c, line 1478
error Command failed with exit code 3221226505.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Exit code -1073740791. Command took 2.161414 seconds.

C:\repos\testyarnbug | 7 | 18:55:58 05/01
> node C:\repos\yarn\bin\yarn.js echo
yarn run v1.23.0-0
$ cross-env echo hi
"hi"
Done in 1.06s.

C:\repos\testyarnbug | 8 | 18:56:04 05/01
>
```
