### PR TITLE
bugfix #4884 On FreeBSD read(2) can read directories. Detect them before read.

### DIFF
--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -67,9 +67,7 @@ function parseRcPaths(paths: Array<string>, parser: Function): Object {
     ...paths.map(path => {
       try {
         if (statSync(path).isDirectory()) {
-          const e = new Error();
-          e.code = 'EISDIR';
-          throw e;
+          return {};
         }
         return parser(readFileSync(path).toString(), path);
       } catch (error) {

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {readFileSync} from 'fs';
+import {readFileSync, statSync} from 'fs';
 import * as path from 'path';
 import {CONFIG_DIRECTORY} from '../constants';
 
@@ -66,6 +66,11 @@ function parseRcPaths(paths: Array<string>, parser: Function): Object {
     {},
     ...paths.map(path => {
       try {
+        if (statSync(path).isDirectory()) {
+          const e = new Error();
+          e.code = 'EISDIR';
+          throw e;
+        }
         return parser(readFileSync(path).toString(), path);
       } catch (error) {
         if (error.code === 'ENOENT' || error.code === 'EISDIR') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This is a fix for issue #4884 which shows up on FreeBSD and other OSes where it is possible to read(2) a directory (depending on the filesystem actually) and get back some binary representation of it.

This causes yarn to file as described in issue #4884.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

In the FreeBSD ports tree we are installing yarn with another patch fundamentally backing out commit 2cb2fc480. This is suboptimal, also because we are patching the compiled bundle at present. Having a proper fix included upstream would be great.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

I'll update the CHANGELOG in a new commit on this same pull request shortly.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I tested it locally by checking that the same operations failing with a clean install are not happening with the new bundle.