### PR TITLE
fix(pack): sort files to produce identical output on Windows and Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+<!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
 ## 1.22.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+## 1.22.2
+
+- Sorts files when running `yarn pack` to produce identical layout on Windows and Unix systems
+
+  [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
+
+- Ignores `.yarnrc.yml` by default when running `yarn pack`
+
+  [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
+
 ## 1.22.1
 
 - Prevents `yarn-path` from exiting before its child exited

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -147,6 +147,7 @@ export function packWithIgnoreAndHeaders(
 ): Promise<stream$Duplex> {
   return tar.pack(cwd, {
     ignore: ignoreFunction,
+    sort: true,
     map: header => {
       const suffix = header.name === '.' ? '' : `/${header.name}`;
       header.name = `package${suffix}`;

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -36,6 +36,7 @@ const DEFAULT_IGNORE = ignoreLinesToRegex([
   'yarn-error.log',
   '.npmrc',
   '.yarnrc',
+  '.yarnrc.yml',
   '.npmignore',
   '.gitignore',
   '.DS_Store',


### PR DESCRIPTION
**Summary**

Running `yarn pack` on Windows and Unix systems produce different results, since on Unix systems the files are sorted while on Windows they aren't.

Running `yarn pack` on https://github.com/arcanis/babel-plugin-lazy-import produces this output on Windows
```sh
$ tar -ztf babel-plugin-lazy-import-v1.0.0.tgz
package
package/index.js
package/package.json
package/README.md
```
While on Unix it produces
```
$ tar -ztf babel-plugin-lazy-import-v1.0.0.tgz
package
package/README.md
package/index.js
package/package.json
```

This PR fixes this by telling `tar-fs` to sort the files before it packs them. `yarn pack` also included the `.yarnrc.yml` config file so I added it to the `DEFAULT_IGNORE` list.

**Test plan**

Run `yarn pack` in a repository containing multiple files and check that the output of `tar -ztf package.tgz` is the same on Windows and Unix
