### PR TITLE
Spawn local yarn .cjs files also using process.execPath

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -635,7 +635,7 @@ async function start(): Promise<void> {
     });
 
     try {
-      if (yarnPath.endsWith(`.js`)) {
+      if (/\.[cm]?js$/.test(yarnPath)) {
         exitCode = await spawnp(process.execPath, [yarnPath, ...argv], opts);
       } else {
         exitCode = await spawnp(yarnPath, argv, opts);


### PR DESCRIPTION
**Summary**

Yarn 2 recently switched its local versions from the `.js` extension to the `.cjs` extension to improve support for workspaces marked as `"type": "module"` in the `package.json`. These should also be executed by `process.execPath` instead of falling back to the node version on the PATH.

https://github.com/yarnpkg/berry/pull/1354

This doesn't change anything the user will notice (berry with `.cjs` extension hasn't been released yet) so unsure what to add to changelog, if anything.

**Test plan**

ø