### PR TITLE
Store local yarn versions as .cjs files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
 
+- Generates local yarn verions as `.cjs` files when calling `yarn set version`
+
+  [#8145](https://github.com/yarnpkg/yarn/pull/8145) - [**bgotink**](https://github.com/bgotink)
+
 ## 1.22.1
 
 - Prevents `yarn-path` from exiting before its child exited

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -155,7 +155,7 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
 
     const bundle = await fetchBundle(config, bundleUrl);
 
-    const yarnPath = path.resolve(config.lockfileFolder, `.yarn/releases/yarn-${bundleVersion}.js`);
+    const yarnPath = path.resolve(config.lockfileFolder, `.yarn/releases/yarn-${bundleVersion}.cjs`);
     reporter.log(`Saving it into ${chalk.magenta(yarnPath)}...`);
     await fs.mkdirp(path.dirname(yarnPath));
     await fs.writeFile(yarnPath, bundle);


### PR DESCRIPTION
**Summary**

This improves the experience of working with yarn in workspaces that are marked as `"type": "module"` in the package.json file.

This change has also been applied in yarn 2, see yarnpkg/berry#1354

**Test plan**

Everything continues to work.
Even in node versions that don't explicitly support `.cjs` files, any unrecognised file extension is assumed to be javascript and as such any node version can load yarn as `.cjs` file.