### PR TITLE
Fix concurrent tarball resolution race condition

### DIFF
--- a/src/fetchers/tarball-fetcher.js
+++ b/src/fetchers/tarball-fetcher.js
@@ -267,6 +267,7 @@ export default class TarballFetcher extends BaseFetcher {
             const {hashValidateStream, integrityValidateStream, extractorStream} = this.createExtractor(
               resolve,
               reject,
+              tarballCachePath,
             );
 
             req.pipe(hashValidateStream);

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -48,14 +48,15 @@ export default class TarballResolver extends ExoticResolver {
 
   resolve(): Promise<Manifest> {
     const resolutionsInProgress = TarballResolver.resolutionsInProgress;
-    const cached = resolutionsInProgress.get(this.url);
+    const stableCacheRef = `${this.url}`;
+    const cached = resolutionsInProgress.get(stableCacheRef);
     if (cached) {
       return cached;
     }
 
     const fetchPromise = this.doResolve();
-    resolutionsInProgress.set(this.url, fetchPromise);
-    fetchPromise.then(() => resolutionsInProgress.delete(this.url));
+    resolutionsInProgress.set(stableCacheRef, fetchPromise);
+    fetchPromise.then(() => resolutionsInProgress.delete(stableCacheRef));
 
     return fetchPromise;
   }

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -23,7 +23,7 @@ export default class TarballResolver extends ExoticResolver {
 
   url: string;
   hash: string;
-  static resolutionsInProgress: Map<String, Promise<any>> = new Map();
+  static resolutionsInProgress: Map<string, Promise<any>> = new Map();
 
   static isVersion(pattern: string): boolean {
     // we can sometimes match git urls which we don't want

--- a/src/resolvers/exotics/tarball-resolver.js
+++ b/src/resolvers/exotics/tarball-resolver.js
@@ -23,6 +23,7 @@ export default class TarballResolver extends ExoticResolver {
 
   url: string;
   hash: string;
+  static resolutionsInProgress: Map<String, Promise<any>> = new Map();
 
   static isVersion(pattern: string): boolean {
     // we can sometimes match git urls which we don't want
@@ -45,7 +46,21 @@ export default class TarballResolver extends ExoticResolver {
     return false;
   }
 
-  async resolve(): Promise<Manifest> {
+  resolve(): Promise<Manifest> {
+    const resolutionsInProgress = TarballResolver.resolutionsInProgress;
+    const cached = resolutionsInProgress.get(this.url);
+    if (cached) {
+      return cached;
+    }
+
+    const fetchPromise = this.doResolve();
+    resolutionsInProgress.set(this.url, fetchPromise);
+    fetchPromise.then(() => resolutionsInProgress.delete(this.url));
+
+    return fetchPromise;
+  }
+
+  async doResolve(): Promise<Manifest> {
     const shrunk = this.request.getLocked('tarball');
     if (shrunk) {
       return shrunk;


### PR DESCRIPTION
**Summary**

Partially fixes #7212
The original issue root cause is a case where we use a specific temp folder, while another async piece of code decides to delete it.
This root cause happens in two occasions - when resolving tarballs (using `TarballResolver`) and when resolving packages from github that have a prepare script (which uses `GitFetcher`, although I'm not 100% sure it happens only in this case).

This PR is attempting to fix the tarball resolving scenario.
I described the exact scenario in [this comment](https://github.com/yarnpkg/yarn/issues/7212#issuecomment-637978197)

In my company we started using a generic storage for npm packages that shouldn't be in the registry (thus using urls to tarballs), and installations keep failing randomly, which drove us to find this issue and fix it.

**Test plan**
Since this issue is sporadic, it might be hard to test it on an integration level.
Furthermore, we need to create a custom setup as described in the comment above.
I have a thought about how to do the setup (using a local static file server), although I first wanted to see if my approach is valid, before I invest a few hours on it.


Thank you for taking the time to read and review the PR.
This issue is blocking us and we'll do whatever we can to fix it, we just ask your attention and guidance where needed :)