### PR TITLE
Add --interactive-scripts CLI parameter

### DIFF
--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -22,6 +22,7 @@ const CONFIG_KEYS = [
   'binLinks',
   'ignorePlatform',
   'ignoreScripts',
+  'interactiveScripts',
   'disablePrepublish',
   'nonInteractive',
   'workspaceRootFolder',

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -85,6 +85,7 @@ export async function main({
   commander.option('--strict-semver');
   commander.option('--json', 'format Yarn log messages as lines of JSON (see jsonlines.org)');
   commander.option('--ignore-scripts', "don't run lifecycle scripts");
+  commander.option('--interactive-scripts', 'ask before running lifecycle scripts');
   commander.option('--har', 'save HAR output of network traffic');
   commander.option('--ignore-platform', 'ignore platform checks');
   commander.option('--ignore-engines', 'ignore engines check');
@@ -542,6 +543,7 @@ export async function main({
       ignorePlatform: commander.ignorePlatform,
       ignoreEngines: commander.ignoreEngines,
       ignoreScripts: commander.ignoreScripts,
+      interactiveScripts: commander.interactiveScripts,
       offline: commander.preferOffline || commander.offline,
       looseSemver: !commander.strictSemver,
       production: commander.production,

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ export type ConfigOptions = {
   linkFileDependencies?: boolean,
   captureHar?: boolean,
   ignoreScripts?: boolean,
+  interactiveScripts?: boolean,
   ignorePlatform?: boolean,
   ignoreEngines?: boolean,
   cafile?: ?string,
@@ -163,6 +164,8 @@ export default class Config {
 
   // Whether we should ignore executing lifecycle scripts
   ignoreScripts: boolean;
+
+  interactiveScripts: boolean;
 
   production: boolean;
 
@@ -476,6 +479,7 @@ export default class Config {
 
     this.ignorePlatform = !!opts.ignorePlatform;
     this.ignoreScripts = !!opts.ignoreScripts;
+    this.interactiveScripts = !!opts.interactiveScripts;
 
     this.disablePrepublish = !!opts.disablePrepublish;
 

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -268,6 +268,17 @@ export async function executeLifecycleScript({
     cmd = fixCmdWinSlashes(cmd);
   }
 
+  if (!config.nonInteractive && config.interactiveScripts) {
+    const confirmedRun = await config.reporter.questionAffirm('Run ' + cmd + ' from ' + cwd + '? [y/n]');
+    if (!confirmedRun) {
+      return {
+        cwd: '',
+        command: '',
+        stdout: '',
+      };
+    }
+  }
+
   // By default (non-interactive), pipe everything to the terminal and run child process detached
   // as long as it's not Windows (since windows does not have /dev/tty)
   let stdio = ['ignore', 'pipe', 'pipe'];


### PR DESCRIPTION
**Summary**
Adds a `--interactive-scripts` CLI parameter. It makes sure to confirm with the user interactively before executing lifecycle scripts of dependencies. I would use this because I would like to review if a package wants to run a script on install.

**Test plan**
Needs a test.

** Todo
Usage e.g. `yarn add node-sass --interactive-scripts --no-progress`. (The question prompt doesn't display right now when used with the progress bar).