### PR TITLE
Limit finding to resolution of the advisory

### DIFF
--- a/src/reporters/json-reporter.js
+++ b/src/reporters/json-reporter.js
@@ -167,7 +167,17 @@ export default class JSONReporter extends BaseReporter {
   }
 
   auditAdvisory(resolution: AuditResolution, auditAdvisory: AuditAdvisory) {
-    this._dump('auditAdvisory', {resolution, advisory: auditAdvisory});
+    const advisory = Object.assign({}, auditAdvisory);
+    advisory.findings = advisory.findings.reduce((acc, finding) => {
+      if (finding.paths.includes(resolution.path)) {
+        acc.push({
+          version: finding.version,
+          paths: [resolution.path],
+        });
+      }
+      return acc;
+    }, []);
+    this._dump('auditAdvisory', {resolution, advisory});
   }
 
   auditSummary(auditMetadata: AuditMetadata) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Running `yarn audit --json`, json reporter produces large output unlike the console reporter. On one of our internal repositories, console reporter output was 65KB vs json reporter output which was 2.5GB which is a huge difference resulting in OOM issue.

Currently JSON Reporter includes all findings of an advisory(vulnerability) for a specific package.
For example `lodash` package has [prototype pollution vulnerability](https://www.npmjs.com/advisories/1523) and a project's yarn.lock lists lodash as a transitive dependency to 100 different packages.

So each `prototype pollution vulnerability` advisory of h `lodash` is listed 100 times and each of the advisory has references to the 99 other lodash listings resulting in **redundant data**.

The changes limit findings the redundancy of this data by including only resolution related info in the findings.

**Solves**
https://github.com/yarnpkg/yarn/issues/7404
