### PR TITLE
[Fixes #7368] Increase mutex staleness interval to 5 minute

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -311,7 +311,7 @@ export async function main({
   const runEventuallyWithFile = (mutexFilename: ?string, isFirstTime?: boolean): Promise<void> => {
     return new Promise(resolve => {
       const lockFilename = mutexFilename || path.join(config.cwd, constants.SINGLE_INSTANCE_FILENAME);
-      lockfile.lock(lockFilename, {realpath: false}, (err: mixed, release: (() => void) => void) => {
+      lockfile.lock(lockFilename, {stale: 5 * 60 * 1000, realpath: false}, (err: mixed, release: (() => void) => void) => {
         if (err) {
           if (isFirstTime) {
             reporter.warn(reporter.lang('waitingInstance'));


### PR DESCRIPTION
**Summary**

Fixes #7368 

We hit this when the installation is busy with building packages with C++/clang for too long. The mutex gets stale after 10 seconds, probably because the main thread is busy, and everything fails.

(as using mutex is the official "solution" for the issue #683 , it would be good to have it actually work :( )
