### PR TITLE
Append --force option to git fetch

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -319,7 +319,7 @@ export default class Git implements GitRefResolvingInterface {
 
     return fs.lockQueue.push(gitUrl.repository, async () => {
       if (await fs.exists(cwd)) {
-        await spawnGit(['fetch', '--tags'], {cwd});
+        await spawnGit(['fetch', '--tags', '--force'], {cwd});
         await spawnGit(['pull'], {cwd});
       } else {
         await spawnGit(['clone', gitUrl.repository, cwd]);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

This PR appends `--force` option to `git fetch` when loading package from git repository.
Without `--force` option, the error below would be occurred when existing tag is updated in remote repository.

![image](https://user-images.githubusercontent.com/16265411/91958303-230e8500-ed42-11ea-9093-048837030b4e.png)


**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
