### PR TITLE
Ensure npm_config_* variables aren't set twice on Windows

### DIFF
--- a/__tests__/fixtures/lifecycle-scripts/npm_config_env_win32/log-command.js
+++ b/__tests__/fixtures/lifecycle-scripts/npm_config_env_win32/log-command.js
@@ -1,0 +1,3 @@
+const execSync = require('child_process').execSync;
+
+console.log(execSync('cmd /c set NPM_CONFIG').toString());

--- a/__tests__/fixtures/lifecycle-scripts/npm_config_env_win32/package.json
+++ b/__tests__/fixtures/lifecycle-scripts/npm_config_env_win32/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "npm_config_env_win32",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "prepublish" : "node log-command.js",
+    "pretest" : "node log-command.js",
+    "test": "node log-command.js"
+  }
+}

--- a/__tests__/lifecycle-scripts.js
+++ b/__tests__/lifecycle-scripts.js
@@ -189,3 +189,17 @@ if (process.platform === 'darwin') {
     await expect(execCommand('test', 'script-segfault')).rejects.toBeDefined();
   });
 }
+
+if (process.platform === 'win32') {
+  test('should unique-ify npm_config variables', async () => {
+    const env = Object.assign({}, process.env);
+    env.NPM_CONFIG_CACHE = 'foo';
+
+    const stdout = await execCommand('test', 'npm_config_env_win32', env);
+
+    expect(stdout).toContain('NPM_CONFIG_CACHE=foo');
+    expect(stdout).not.toContain('npm_config_cache=foo');
+  },
+
+  )
+}

--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -151,7 +151,9 @@ export async function makeEnv(
   for (const [key, val] of cleaned) {
     const cleanKey = key.replace(/^_+/, '');
     const envKey = `npm_config_${cleanKey}`.replace(INVALID_CHAR_REGEX, '_');
-    env[envKey] = val;
+    // envKey is lowercase, but the env block can come with a non-lowercase version of the env key name
+    const existingKey = Object.keys(env).find(x => x.toLowerCase() === envKey);
+    env[existingKey ? existingKey : envKey] = val;
   }
   // add npm_package_config_*
   if (manifest && manifest.name) {


### PR DESCRIPTION
**Summary**
Fixes #8334 

This fixes a bug where an yarn is wrongly setting an environment variable twice

**Test plan**

Validated that only the original casing of an environment variable is sent to the child process when yarn calls spawn()