### PR TITLE
Add a preinstall script to bypass npm's ownership check

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -39,6 +39,7 @@ cp LICENSE dist/
 # with any Node >= 4 and still small in terms of size.
 cp artifacts/yarn-legacy-$version.js dist/lib/cli.js
 cp bin/{yarn.js,yarn,yarnpkg,*.cmd} dist/bin/
+cp scripts/preinstall.js dist/preinstall.js
 chmod +x dist/bin/*
 
 # We cannot bundle v8-compile-cache as it must be loaded separately to be effective.

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,60 @@
+// This file is a bit weird, so let me explain with some context: we're working
+// to implement a tool called "pmm" in Node. This tool will allow us to provide
+// a Yarn shim to everyone using Node, meaning that they won't need to run `npm
+// install -g yarn`.
+//
+// Still, we don't want to break the experience of people that already use `npm
+// install -g yarn`! And one annoying thing with npm is that they install their
+// binaries directly inside the Node bin/ folder. And Because of this, they
+// refuse to overwrite binaries when they detect they don't belong to npm. Which
+// means that, since the Yarn "pmm" symlink belongs to pmm and not npm, running
+// `npm install -g yarn` would crash by refusing to override the binary :/
+//
+// And thus we have this preinstall script, which checks whether Yarn is being
+// installed as a global binary, and remove the existing symlink if it detects
+// it belongs to pmm. Since preinstall scripts run, in npm, before the global
+// symlink is created, we bypass this way the ownership check.
+//
+// More info:
+// https://github.com/arcanis/pmm/issues/6
+
+if (process.env.npm_config_global) {
+    var cp = require('child_process');
+    var fs = require('fs');
+    var path = require('path');
+
+    try {
+        var targetPath = cp.execFileSync(process.execPath, [process.env.npm_execpath, 'bin', '-g'], {
+            encoding: 'utf8',
+            stdio: ['ignore', undefined, 'ignore'],
+        }).replace(/\n/g, '');
+
+        var manifest = require('./package.json');
+        var binNames = typeof manifest.bin === 'string'
+            ? [manifest.name.replace(/^@[^\/]+\//, '')]
+            : typeof manifest.bin === 'object' && manifest.bin !== null
+            ? Object.keys(manifest.bin)
+            : [];
+
+        binNames.forEach(function (binName) {
+            var binPath = path.join(targetPath, binName);
+
+            var binTarget;
+            try {
+                binTarget = fs.readlinkSync(binPath);
+            } catch (err) {
+                return;
+            }
+
+            if (binTarget.startsWith('../lib/node_modules/pmm/')) {
+                try {
+                    fs.unlinkSync(binPath);
+                } catch (err) {
+                    return;
+                }
+            }
+        });
+    } catch (err) {
+        // ignore errors
+    }
+}

--- a/scripts/update-dist-manifest.js
+++ b/scripts/update-dist-manifest.js
@@ -20,8 +20,12 @@ if (!packageManifest.installationMethod) {
 
 delete packageManifest.dependencies;
 delete packageManifest.devDependencies;
-delete packageManifest.scripts;
 delete packageManifest.jest;
+
+packageManifest.scripts = {
+    preinstall: 'node ./preinstall.js',
+};
+
 fs.writeFileSync(
   packageManifestFilename,
   JSON.stringify(packageManifest, null, 2) + '\n'


### PR DESCRIPTION
**Summary**

Cf the comment in the preinstall script for more details.

Ref: https://github.com/arcanis/pmm/issues/6

**Test plan**

It's difficult to test in real circumstances given the our test pipelines. Will build the archive and publish it as a different name before landing it.