### PR TITLE
fix(windows) #5349 node and yarn  can't be launch on Git BASH

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -2,18 +2,24 @@
 argv0=$(echo "$0" | sed -e 's,\\,/,g')
 basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
 
+is_mingw64=0
+
 case "$(uname -s)" in
   Darwin) basedir="$( cd "$( dirname "$argv0" )" && pwd )";;
   Linux) basedir=$(dirname "$(readlink -f "$0" || echo "$argv0")");;
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
   *MSYS*) basedir=`cygpath -w "$basedir"`;;
+  *MINGW*) basedir=`cygpath -w "$basedir"` ; is_mingw64=1;;
 esac
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1;
 }
 
-if command_exists node; then
+if [ "$YARN_FORCE_WINPTY" != 1 ] && [ "$is_mingw64" = 1 ] && command_exists "node.exe" ; then
+  exec node.exe "$basedir/yarn.js" "$@"
+  ret=$?
+elif command_exists node; then
   if [ "$YARN_FORCE_WINPTY" = 1 ] || command_exists winpty && test -t 1; then
     winpty node "$basedir/yarn.js" "$@"
   else


### PR DESCRIPTION
As npm workaround, launch node.exe

See also https://github.com/npm/cli/blob/bd2721dbc3de13a5ba889eba50644475d80f6948/bin/npm

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The existing problem that is solves it that on some computers, with some installations on Git Bash https://gitforwindows.org/ . See also the corresponding issue #5349 .

It's not a big change, therefore I don't update CHANGELOG.md .

**Test plan**

With https://gitforwindows.org/ simply run for instance:

```bash
yarn --version
```