### PR TITLE
Fix tests

### DIFF
--- a/__tests__/commands/info.js
+++ b/__tests__/commands/info.js
@@ -41,10 +41,11 @@ const expectedKeys = [
   'license',
   'dist',
   'directories',
+  'scripts'
 ];
 
-// yarn now ships as built, single JS files so it has no dependencies and no scripts
-const unexpectedKeys = ['dependencies', 'devDependencies', 'scripts'];
+// yarn now ships as built, single JS files so it has no dependencies
+const unexpectedKeys = ['dependencies', 'devDependencies'];
 
 beforeEach(() => {
   // the mocked requests have stripped metadata, don't use it in the following tests

--- a/packages/pkg-tests/yarn.lock
+++ b/packages/pkg-tests/yarn.lock
@@ -1533,8 +1533,9 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 growly@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3450,9 +3450,9 @@ glogg@^1.0.0:
     sparkles "^1.0.0"
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 graphql@^14.0.0:
   version "14.0.2"


### PR DESCRIPTION
**Summary**

1. yarn now has a script field with some preinstall script so account for this in the info-command test
2. update graceful-fs to fix acceptance tests

 //cc @arcanis 

This fixes at least some tests, not sure about the pack test. It started failing with nodejs 12.16.0. it works with node 12.15.0. Just saw this is fixed with #8190.
