### PR TITLE
Add error handling if files in package is not an array

### DIFF
--- a/__tests__/commands/pack.js
+++ b/__tests__/commands/pack.js
@@ -203,3 +203,10 @@ test.concurrent('pack should match dotfiles with globs', (): Promise<void> => {
     expect(files.sort()).toEqual(expected.sort());
   });
 });
+
+test.concurrent('pack should error if files is not an array', (): Promise<void> => {
+  return runPack([], {}, 'files-not-array', (config, reporter, stdout): void => {
+    expect(stdout).not.toMatch(/Wrote tarball to/);
+    expect(stdout).toMatch(/"files" property in package\.json must be an Array/);
+  });
+});

--- a/__tests__/fixtures/pack/files-not-array/index.js
+++ b/__tests__/fixtures/pack/files-not-array/index.js
@@ -1,0 +1,2 @@
+/* @flow */
+console.log('hello world');

--- a/__tests__/fixtures/pack/files-not-array/package.json
+++ b/__tests__/fixtures/pack/files-not-array/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "files-not-array",
+    "version": "1.0.0",
+    "main": "index.js",
+    "license": "MIT",
+    "files": {}
+  }

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -82,6 +82,10 @@ export async function packTarball(
 
   // `files` field
   if (onlyFiles) {
+    if (!(onlyFiles instanceof Array)) {
+      throw new MessageError(config.reporter.lang('cacheFolderMissingPack'));
+    }
+
     let lines = [
       '*', // ignore all files except those that are explicitly included with a negation filter
     ];

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -112,6 +112,7 @@ const messages = {
     'The package $0 requires a flat dependency graph. Add `"flat": true` to your package.json and try again.',
   noName: `Package doesn't have a name.`,
   noVersion: `Package doesn't have a version.`,
+  cacheFolderMissingPack: `"files" property in package.json must be an Array`,
   answerRequired: 'An answer is required.',
   missingWhyDependency: 'Missing package name, folder or path to file to identify why a package has been installed',
   bugReport: 'If you think this is a bug, please open a bug report with the information provided in $0.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Adds improved error handling in yarn publish when "files" is not an array. 

fixes #8311 

Incorporated feedback from #8312 

**Test plan**

I have added a test in commands/pack that takes in a package.json with a "files" that's not an array. Running yarn test will run this test. 
