### PR TITLE
Support modifying .yarnrc if has hidden attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
+
 <!-- -->
+
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
+
+## 1.23.1
+
+- Support modifying .yarnrc if has hidden attr: https://github.com/yarnpkg/yarn/issues/4306
 
 ## 1.22.10 (and prior)
 
@@ -63,7 +69,7 @@ Those versions didn't contain any changes and were just triggered by our infra w
 - Allows some dots in binary names again
 
   [#7811](https://github.com/yarnpkg/yarn/pull/7811) - [**Valery Bugakov**](https://github.com/valerybugakov)
-  
+
 - Better error handling on `yarn set version`
 
   [#7848](https://github.com/yarnpkg/yarn/pull/7848) - [**Nick Olinger**](https://github.com/olingern)
@@ -71,7 +77,7 @@ Those versions didn't contain any changes and were just triggered by our infra w
 - Passes arguments following `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
 
   [#7776](https://github.com/yarnpkg/yarn/pull/7776) - [**Jeff Valore**](https://twitter.com/rally25rs)
-  
+
 - Fixes an issue where the archive paths were incorrectly sanitized
 
   [#7831](https://github.com/yarnpkg/yarn/pull/7831) - [**Maël Nison**](https://twitter.com/arcanis)
@@ -93,7 +99,7 @@ Those versions didn't contain any changes and were just triggered by our infra w
 - Implements `yarn init --install <version>`
 
   [#7723](https://github.com/yarnpkg/yarn/pull/7723) - [**Maël Nison**](https://twitter.com/arcanis)
-  
+
 ## 1.19.2
 
 - Folders like `.cache` won't be pruned from the `node_modules` after each install.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn",
   "installationMethod": "unknown",
-  "version": "1.23.0-0",
+  "version": "1.23.1-0",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -786,7 +786,13 @@ export async function writeFilePreservingEol(path: string, data: string): Promis
   if (eol !== '\n') {
     data = data.replace(/\n/g, eol);
   }
-  await writeFile(path, data);
+
+  if (os.platform() === 'win32' && await exists(path)) {
+    // Support modifying the file if has hidden attr
+    await writeFile(path, data, { w: "r+" });
+  } else {
+    await writeFile(path, data);
+  }
 }
 
 export async function hardlinksWork(dir: string): Promise<boolean> {


### PR DESCRIPTION
**Summary**
When manually marked as hidden on Windows, trying to update .yarnrc with the latest lastUpdateCheck time caused an EPERM error to be printed to the console and the file to not be updated. As a result, yarn would attempt an update check on every run, instead of every day, slowing the install process for Windows users as well as printing the unsightly error message.

Linked issue: https://github.com/yarnpkg/yarn/issues/4306

**Test plan**
With each test, the command `yarn install` was used.
- Verified that the file is successfully created when .yarnrc does not exist.
- Verified that the file is successfully modified when .yarnrc exists and is not hidden.
- Verified that the file is successfully modified when .yarnrc exists and is hidden.
- Verified that no error messages are printed.
