### PR TITLE
Add `--list` option to `yarn link` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+- Add a `--list` flag to yarn link, i.e. `yarn link --list` so that currently linked packages, and globally available packages can be easily seen and identified.
+
 ## 1.22.10 (and prior)
 
 - Tweak the preinstall check to not cause errors when Node is installed as root (as a downside, it won't run at all on Windows, which should be an acceptable tradeoff): https://github.com/yarnpkg/yarn/issues/8358

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -76,7 +76,7 @@ async function getLinksToRegisteredPackages(config: Config, reporter: Reporter, 
   for (const name of packageNames) {
     const folder = await getRegistryFolder(config, name);
     try {
-      const stat = await fs.stat(path.join(folder, name));
+      const stat = await fs.lstat(path.join(folder, name));
       if (stat.isSymbolicLink()) {
         linkedPackages.push(name);
       }

--- a/src/cli/commands/link.js
+++ b/src/cli/commands/link.js
@@ -10,6 +10,98 @@ const invariant = require('invariant');
 const cmdShim = require('@zkochan/cmd-shim');
 const path = require('path');
 
+// Create a link (in the current package's node_modules directory) to a global link-registered package
+async function makeLinkToRegisteredPackage(
+  registeredPackageName: string,
+  config: Config,
+  reporter: Reporter,
+) {
+  const src = path.join(config.linkFolder, registeredPackageName);
+
+  if (await fs.exists(src)) {
+    const folder = await getRegistryFolder(config, registeredPackageName);
+    const dest = path.join(folder, registeredPackageName);
+
+    await fs.unlink(dest);
+    await fs.mkdirp(path.dirname(dest));
+    await fs.symlink(src, dest);
+    reporter.success(reporter.lang("linkUsing", registeredPackageName));
+  } else {
+    throw new MessageError(reporter.lang("linkMissing", registeredPackageName));
+  }
+}
+
+// Add cwd module to the global registry of link-registered packages
+async function linkRegisterThisPackage(config: Config, reporter: Reporter, flags: Object) {
+  const manifest = await config.readRootManifest();
+  const name = manifest.name;
+  if (!name) {
+    throw new MessageError(reporter.lang('unknownPackageName'));
+  }
+
+  const linkLoc = path.join(config.linkFolder, name);
+  if (await fs.exists(linkLoc)) {
+    reporter.warn(reporter.lang('linkCollision', name));
+  } else {
+    await fs.mkdirp(path.dirname(linkLoc));
+    await fs.symlink(config.cwd, linkLoc);
+
+    // If there is a `bin` defined in the package.json,
+    // link each bin to the global bin
+    if (manifest.bin) {
+      const globalBinFolder = await getGlobalBinFolder(config, flags);
+      for (const binName in manifest.bin) {
+        const binSrc = manifest.bin[binName];
+        const binSrcLoc = path.join(linkLoc, binSrc);
+        const binDestLoc = path.join(globalBinFolder, binName);
+        if (await fs.exists(binDestLoc)) {
+          reporter.warn(reporter.lang('binLinkCollision', binName));
+        } else {
+          if (process.platform === 'win32') {
+            await cmdShim(binSrcLoc, binDestLoc, {createPwshFile: false});
+          } else {
+            await fs.symlink(binSrcLoc, binDestLoc);
+          }
+        }
+      }
+    }
+
+    reporter.success(reporter.lang('linkRegistered', name));
+    reporter.info(reporter.lang('linkRegisteredMessage', name));
+  }
+}
+
+async function getLinksToRegisteredPackages(config: Config, reporter: Reporter, packageNames: string[]): Promise<string[]> {
+  const linkedPackages = [];
+  for (const name of packageNames) {
+    const folder = await getRegistryFolder(config, name);
+    try {
+      const stat = await fs.stat(path.join(folder, name));
+      if (stat.isDirectory()) {
+        linkedPackages.push(name);
+      }
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  }
+  return linkedPackages;
+}
+
+async function getRegisteredPackages(config: Config, reporter: Reporter): Promise<string[]> {
+  let files = await fs.readdir(config.linkFolder);
+  
+  let packages = []
+  for (const file of files) {
+    if ((await fs.stat(path.join(config.linkFolder, file))).isDirectory()) {
+      packages.push(path.basename(file))
+    }
+  }
+
+  return packages
+}
+
 export async function getRegistryFolder(config: Config, name: string): Promise<string> {
   if (config.modulesFolder) {
     return config.modulesFolder;
@@ -29,62 +121,31 @@ export function hasWrapper(commander: Object, args: Array<string>): boolean {
 
 export function setFlags(commander: Object) {
   commander.description('Symlink a package folder during development.');
+  commander.option(
+    '--list',
+    `List currently linked packages and all global package candidates`
+  );
 }
 
 export async function run(config: Config, reporter: Reporter, flags: Object, args: Array<string>): Promise<void> {
-  if (args.length) {
-    for (const name of args) {
-      const src = path.join(config.linkFolder, name);
+  if (flags.list) {
+    const registeredPackages = await getRegisteredPackages(config, reporter)
+    const linkedPackages = await getLinksToRegisteredPackages(config, reporter, registeredPackages)
 
-      if (await fs.exists(src)) {
-        const folder = await getRegistryFolder(config, name);
-        const dest = path.join(folder, name);
+    if (linkedPackages.length > 0) {
+      reporter.info(`Packages currently linked (use 'yarn unlink [package]' to unlink):`)
+      reporter.list('list', linkedPackages);
+    } else {
+      reporter.info(`No packages currently linked (use 'yarn link [package]' to link)`)
+    }
 
-        await fs.unlink(dest);
-        await fs.mkdirp(path.dirname(dest));
-        await fs.symlink(src, dest);
-        reporter.success(reporter.lang('linkUsing', name));
-      } else {
-        throw new MessageError(reporter.lang('linkMissing', name));
-      }
+    reporter.info(`Packages registered and available to 'yarn link [package]':`)
+    reporter.list('list', registeredPackages);
+  } else if (args.length) {
+    for (const packageName of args) {
+      await makeLinkToRegisteredPackage(packageName, config, reporter)
     }
   } else {
-    // add cwd module to the global registry
-    const manifest = await config.readRootManifest();
-    const name = manifest.name;
-    if (!name) {
-      throw new MessageError(reporter.lang('unknownPackageName'));
-    }
-
-    const linkLoc = path.join(config.linkFolder, name);
-    if (await fs.exists(linkLoc)) {
-      reporter.warn(reporter.lang('linkCollision', name));
-    } else {
-      await fs.mkdirp(path.dirname(linkLoc));
-      await fs.symlink(config.cwd, linkLoc);
-
-      // If there is a `bin` defined in the package.json,
-      // link each bin to the global bin
-      if (manifest.bin) {
-        const globalBinFolder = await getGlobalBinFolder(config, flags);
-        for (const binName in manifest.bin) {
-          const binSrc = manifest.bin[binName];
-          const binSrcLoc = path.join(linkLoc, binSrc);
-          const binDestLoc = path.join(globalBinFolder, binName);
-          if (await fs.exists(binDestLoc)) {
-            reporter.warn(reporter.lang('binLinkCollision', binName));
-          } else {
-            if (process.platform === 'win32') {
-              await cmdShim(binSrcLoc, binDestLoc, {createPwshFile: false});
-            } else {
-              await fs.symlink(binSrcLoc, binDestLoc);
-            }
-          }
-        }
-      }
-
-      reporter.success(reporter.lang('linkRegistered', name));
-      reporter.info(reporter.lang('linkRegisteredMessage', name));
-    }
+    await linkRegisterThisPackage(config, reporter, flags)
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This adds a `--list` flag to yarn link, i.e. `yarn link --list` so that currently linked packages, and globally available packages can be easily identified.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
See #1722 

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<img width="615" alt="image" src="https://user-images.githubusercontent.com/129/97360063-4a299480-1863-11eb-9108-38c838461645.png">

<img width="752" alt="image" src="https://user-images.githubusercontent.com/129/97360117-5ca3ce00-1863-11eb-8c86-ab659223adf9.png">


Fixes #1722 
