### PR TITLE
Remove dolar from command function

### DIFF
--- a/src/reporters/console/console-reporter.js
+++ b/src/reporters/console/console-reporter.js
@@ -202,7 +202,7 @@ export default class ConsoleReporter extends BaseReporter {
   }
 
   command(command: string) {
-    this.log(this.format.dim(`$ ${command}`));
+    this.log(this.format.dim(command));
   }
 
   warn(msg: string) {


### PR DESCRIPTION
This makes it easier to copy commands by tripple clicking a line or selecting in the whole line CLI. Now the dolar sign is also selected:

![image](https://user-images.githubusercontent.com/11559216/98691983-e9c04a00-236e-11eb-97c6-30b65b72096f.png)

