### PR TITLE
Fix: (#5816) Trailing slash breaks workspace

### DIFF
--- a/src/util/normalize-manifest/fix.js
+++ b/src/util/normalize-manifest/fix.js
@@ -350,4 +350,12 @@ export default (async function(
       }
     }
   }
+
+  // Sanitize workspaces patterns
+  if (info.workspaces) {
+    // Workspaces will not match if the pattern starts with ./ or ends with /
+    const sanitizedWorkspaces = info.workspaces.map((workspace): string =>
+      workspace.replace(/\/$/, '').replace(/^.\//, ''));
+    info.workspaces = sanitizedWorkspaces;
+  }
 });


### PR DESCRIPTION
**Summary**
This fixes #5816 for both types of failure described.  Both if the pattern starts with ./ or ends with /

With the silent nature of the failure, it makes it difficult to notice.  This will prevent the issue.
Also, if you "yarn add" anything to the workspaces a yarn.lock is created and node_modules are installed at the workspace level.

**Test plan**

Simply create a package that includes workspaces.  If you use a pattern that starts with ./ or ends with / you will get the following message when you try to run workspace functions from any directory besides the workspace root.

```sh
error Cannot find the root of your workspace - are you sure you're currently in a workspace?
info Visit https://yarnpkg.com/en/docs/cli/workspaces for documentation about this command.
```

After this change you get proper output

```json
{
  "workspace-a": {
    "location": "packages/workspace-a",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": []
  },
  "workspace-b": {
    "location": "packages/workspace-b",
    "workspaceDependencies": [
      "workspace-a"
    ],
    "mismatchedWorkspaceDependencies": []
  },
  "yarn": {
    "location": "packages/yarnsfsr",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": []
  }
}
```


