### PR TITLE
refactor: fix case of GitHub

### DIFF
--- a/__tests__/commands/__snapshots__/init.js.snap
+++ b/__tests__/commands/__snapshots__/init.js.snap
@@ -39,7 +39,7 @@ Object {
 }
 `;
 
-exports[`init using Github shorthand should resolve to full repository URL: init-github 1`] = `
+exports[`init using GitHub shorthand should resolve to full repository URL: init-github 1`] = `
 Object {
   "license": "MIT",
   "main": "index.js",

--- a/__tests__/commands/init.js
+++ b/__tests__/commands/init.js
@@ -104,7 +104,7 @@ test('init should use init-* configs when defined', (): Promise<void> =>
     },
   ));
 
-test('init using Github shorthand should resolve to full repository URL', (): Promise<void> => {
+test('init using GitHub shorthand should resolve to full repository URL', (): Promise<void> => {
   const questionMap = Object.freeze({
     name: 'hi-github',
     version: '',


### PR DESCRIPTION
Changed `Github` to `GitHub`

**Summary**

Fix GitHub brand name


