### PR TITLE
Updates set-dev-version.js to set version to valid semver

### DIFF
--- a/scripts/set-dev-version.js
+++ b/scripts/set-dev-version.js
@@ -18,8 +18,9 @@ const formattedDate =
   leftPad(date.getUTCMonth() + 1) +
   leftPad(date.getUTCDate()) +
   '.' +
-  leftPad(date.getUTCHours()) +
-  leftPad(date.getUTCMinutes());
+  // Ensure valid semver (i.e. character following the `.` must not be `0`) by choosing a random "time" in the afternoon
+  Math.floor(12 + Math.random() * 12).toString() +
+  leftPad(Math.floor(Math.random() * 60).toString());
 
 // Remove any existing suffix before appending the date
 const version =


### PR DESCRIPTION
**Summary**

Updates `set-dev-version.js` to set version to valid semver. Resolves https://github.com/yarnpkg/yarn/issues/8534.

**Test plan**

- Run `./scripts/set-dev-version.js`
- See that output always contains a valid semver ending with a valid time