### PR TITLE
fix: pass SIGTERM to spawned yarn process (via `yarnPath`)

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -634,6 +634,8 @@ async function start(): Promise<void> {
       // innermost process, whose end will cause our own to exit.
     });
 
+    handleSignals();
+
     try {
       if (/\.[cm]?js$/.test(yarnPath)) {
         exitCode = await spawnp(process.execPath, [yarnPath, ...argv], opts);

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -16,8 +16,10 @@ let uid = 0;
 export const exec = promisify(child.exec);
 
 export function forkp(program: string, args: Array<string>, opts?: Object): Promise<number> {
+  const key = opts.cwd || String(++uid);
   return new Promise((resolve, reject) => {
     const proc = child.fork(program, args, opts);
+    spawnedProcesses[key] = proc;
 
     proc.on('error', error => {
       reject(error);
@@ -30,8 +32,10 @@ export function forkp(program: string, args: Array<string>, opts?: Object): Prom
 }
 
 export function spawnp(program: string, args: Array<string>, opts?: Object): Promise<number> {
+  const key = opts.cwd || String(++uid);
   return new Promise((resolve, reject) => {
     const proc = child.spawn(program, args, opts);
+    spawnedProcesses[key] = proc;
 
     proc.on('error', error => {
       reject(error);

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -16,7 +16,7 @@ let uid = 0;
 export const exec = promisify(child.exec);
 
 export function forkp(program: string, args: Array<string>, opts?: Object): Promise<number> {
-  const key = opts.cwd || String(++uid);
+  const key = String(++uid);
   return new Promise((resolve, reject) => {
     const proc = child.fork(program, args, opts);
     spawnedProcesses[key] = proc;
@@ -32,7 +32,7 @@ export function forkp(program: string, args: Array<string>, opts?: Object): Prom
 }
 
 export function spawnp(program: string, args: Array<string>, opts?: Object): Promise<number> {
-  const key = opts.cwd || String(++uid);
+  const key = String(++uid);
   return new Promise((resolve, reject) => {
     const proc = child.spawn(program, args, opts);
     spawnedProcesses[key] = proc;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`SIGTERM` would not be passed properly to yarn itself if `yarnPath` was being used

Originally reported at:

https://github.com/yarnpkg/berry/pull/2347#issuecomment-756720797

**Test plan**

<img width="1338" alt="Screenshot 2021-01-08 at 15 36 17" src="https://user-images.githubusercontent.com/697707/104021339-43a28c00-51c7-11eb-9aed-3d6e2f03f63e.png">
