### PR TITLE
Add Debian keyring package

### DIFF
--- a/resources/debian/control.in
+++ b/resources/debian/control.in
@@ -1,6 +1,6 @@
 Package: yarn
 Version: $VERSION-1
-Recommends: nodejs
+Recommends: nodejs, yarn-archive-keyring
 Conflicts: nodejs (<< 4.0.0), cmdtest
 Section: devel
 Priority: optional

--- a/resources/debian/keyring.control.in
+++ b/resources/debian/keyring.control.in
@@ -1,0 +1,11 @@
+Package: $PACKAGE_NAME
+Version: $VERSION
+Section: misc
+Priority: optional
+Architecture: all
+Installed-Size: $INSTALLED_SIZE
+Maintainer: Yarn Developers <yarn@dan.cx>
+Homepage: https://yarnpkg.com/
+Description: GnuPG keyring for Yarn archives
+ This package ensures that the signing keys used to verify the integrity of the
+ package archive are kept updated.

--- a/scripts/build-deb-keyring.sh
+++ b/scripts/build-deb-keyring.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Ensure all the tools we need are available
+ensureAvailable() {
+  command -v "$1" >/dev/null 2>&1 || (echo "You need to install $1" && exit 2)
+}
+ensureAvailable dpkg-deb
+ensureAvailable lintian
+ensureAvailable gpg
+
+# If not set, $VERSION will be the current date
+: ${VERSION:=$(date +%Y.%m.%d)}
+OUTPUT_DIR=artifacts
+PACKAGE_NAME=yarn-archive-keyring
+DEB_PACKAGE_FILE="${PACKAGE_NAME}_${VERSION}_all.deb"
+PACKAGE_TMPDIR="tmp/$PACKAGE_NAME"
+
+if (( ${#@} < 1 )); then
+  echo "Usage: $0 GPG_KEY_ID" && exit 1
+else
+  GPG_KEY_ID="$1"
+fi
+
+mkdir -p $OUTPUT_DIR
+# Remove old packages
+rm -f $OUTPUT_DIR/*.deb
+
+# Create temporary directory to start building up the package
+rm -rf $PACKAGE_TMPDIR
+mkdir -p $PACKAGE_TMPDIR/
+umask 0022 # Ensure permissions are correct (0755 for dirs, 0644 for files)
+PACKAGE_TMPDIR_ABSOLUTE=$(readlink -f $PACKAGE_TMPDIR)
+
+# Create Debian package structure
+mkdir -p "${PACKAGE_TMPDIR}/etc/apt/trusted.gpg.d"
+mkdir -p "${PACKAGE_TMPDIR}/usr/share/keyrings"
+mkdir -p "${PACKAGE_TMPDIR}/usr/share/doc/${PACKAGE_NAME}"
+cp \
+  resources/debian/copyright \
+  "${PACKAGE_TMPDIR}/usr/share/doc/${PACKAGE_NAME}/copyright"
+
+gpg \
+  --export \
+  --output "${PACKAGE_TMPDIR}/etc/apt/trusted.gpg.d/${PACKAGE_NAME}.gpg" \
+  "$GPG_KEY_ID"
+cp \
+  "${PACKAGE_TMPDIR}/etc/apt/trusted.gpg.d/${PACKAGE_NAME}.gpg" \
+  "${PACKAGE_TMPDIR}/usr/share/keyrings/${PACKAGE_NAME}.gpg"
+# No changelog file at the moment
+mkdir -p $PACKAGE_TMPDIR/usr/share/lintian/overrides/
+printf "# %s\n%s: %s\n" \
+  "No changelog file at the moment" \
+  "${PACKAGE_NAME}" \
+  "changelog-file-missing-in-native-package" \
+  > "${PACKAGE_TMPDIR}/usr/share/lintian/overrides/${PACKAGE_NAME}"
+
+# Build up the control files
+mkdir -p "${PACKAGE_TMPDIR}/DEBIAN"
+echo "/etc/apt/trusted.gpg.d/${PACKAGE_NAME}.gpg" \
+  > "${PACKAGE_TMPDIR}/DEBIAN/conffiles"
+
+# Replace variables in Debian package control file
+INSTALLED_SIZE=`du -sk $PACKAGE_TMPDIR | cut -f 1`
+sed \
+  -e "s/\$VERSION/$VERSION/" \
+  -e "s/\$INSTALLED_SIZE/$INSTALLED_SIZE/" \
+  -e "s/\$PACKAGE_NAME/$PACKAGE_NAME/" \
+  < resources/debian/keyring.control.in \
+  > $PACKAGE_TMPDIR/DEBIAN/control
+fakeroot dpkg-deb -b $PACKAGE_TMPDIR $DEB_PACKAGE_FILE
+mv $DEB_PACKAGE_FILE $OUTPUT_DIR
+
+rm -rf $PACKAGE_TMPDIR
+
+# Lint the Debian package to ensure we're not doing something silly
+lintian $OUTPUT_DIR/$DEB_PACKAGE_FILE


### PR DESCRIPTION
**Summary**

This adds a script that creates a `yarn-archive-keyring` Debian package, and adds a `Recommends` relationship from the `yarn` package to `yarn-archive-keyring`. This package installs a drop-in keyring file for APT which can be easily updated as keys are rotated. I've been working with Debian packaging a fair bit recently (and did this exact task for my personal repo), so it was pretty quick.

I have not updated the changelog, as this patch doesn't actually change yarn itself.

**Test plan**

Right now the script takes a single argument, a key ID to export from gpg. I'm open to suggestions as to how you'd like to do it so it fits in with the rest of your infrastructure. The script also checks for a `VERSION` environment variable to use for the package version, but it falls back to the current date if that's not set (one possible change: base the version number on the expiration date of the key, but that feels a little weird having a date-based version far in the future).

This is a draft PR, I still need to add a postinst script that removes any old keys that were added with `apt-key`. I wanted to get some feedback on the version and key ID selection earlier though. Example usage:
```
VERSION=2021.02.04 ./scripts/build-deb-keyring.sh 23E7166788B63E1E
```

@Daniel15, you were offering to review in #7866 😉