### PR TITLE
Use cwd node_modules/.bin entry first in workspace

### DIFF
--- a/__tests__/commands/bin.js
+++ b/__tests__/commands/bin.js
@@ -10,6 +10,15 @@ const fixturesLoc = path.join(__dirname, '..', 'fixtures', 'bin');
 const runBin = buildRun.bind(null, BufferReporter, fixturesLoc, (args, flags, config, reporter): Promise<void> => {
   return run(config, reporter, flags, args);
 });
+const runInWorkspacePackage = function(cwd, config, reporter, flags, args): Promise<void> {
+  const originalCwd = config.cwd;
+  config.cwd = path.join(originalCwd, cwd);
+  const retVal = run(config, reporter, flags, args);
+  retVal.then(() => {
+    config.cwd = originalCwd;
+  });
+  return retVal;
+};
 
 test('running bin without arguments should return the folder where the binaries are stored', (): Promise<void> => {
   return runBin([], {}, '../install/install-production-bin', (config, reporter): ?Promise<void> => {
@@ -22,5 +31,17 @@ test('running bin with a binary name as the argument should return its full path
     const reporter = new BufferReporter();
     await run(config, reporter, {}, ['rimraf']);
     expect(reporter.getBufferText()).toMatch(/[\\\/]node_modules[\\\/]\.bin[\\\/]rimraf$/);
+  });
+});
+
+test('should use .bin in workspace node modules respectively', (): Promise<void> => {
+  return runInstall({binLinks: true}, 'workspaces-install-link-bin-2-versions', async (config): ?Promise<void> => {
+    const reporter1 = new BufferReporter();
+    await runInWorkspacePackage('packages/workspace-1', config, reporter1, {}, ['myBin']);
+    expect(reporter1.getBufferText()).toMatch(/[\\\/]workspace-1[\\\/]node_modules[\\\/]\.bin[\\\/]myBin$/);
+
+    const reporter2 = new BufferReporter();
+    await runInWorkspacePackage('packages/workspace-2', config, reporter2, {}, ['myBin']);
+    expect(reporter2.getBufferText()).toMatch(/[\\\/]workspace-2[\\\/]node_modules[\\\/]\.bin[\\\/]myBin$/);
   });
 });

--- a/__tests__/commands/run.js
+++ b/__tests__/commands/run.js
@@ -207,7 +207,7 @@ test('adds workspace root node_modules/.bin to path when in a workspace', (): Pr
     expect(envPaths).toContain(path.join(config.cwd, 'packages', 'pkg1', 'node_modules', '.bin'));
   }));
 
-test('adds cwd node_modules/.bin to path when in a workspace usig nohoist', (): Promise<void> =>
+test('adds cwd node_modules/.bin to path when in a workspace using nohoist', (): Promise<void> =>
   runRunInWorkspacePackage('packages/pkg1', ['env'], {}, 'nohoist-workspace', (config, reporter): ?Promise<void> => {
     const logEntry = reporter.getBuffer().find(entry => entry.type === 'log');
     const parsedLogData = JSON.parse(logEntry ? logEntry.data.toString() : '{}');

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v1/cli_v1.js
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v1/cli_v1.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('v1')
+

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v1/package.json
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "my_project_with_bin",
+  "version": "1.0.0",
+  "private": true,
+  "bin": {
+    "myBin": "./cli_v1.js"
+  }
+}

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v2/cli_v2.js
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v2/cli_v2.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('v2')
+

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v2/package.json
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/my_project_with_bin/v2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "my_project_with_bin",
+  "version": "2.0.0",
+  "private": true,
+  "bin": {
+    "myBin": "./cli_v2.js"
+  }
+}

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/package.json
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-project",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/packages/workspace-1/package.json
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/packages/workspace-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-1",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "my_project_with_bin": "file:../../my_project_with_bin/v1"
+  }
+}

--- a/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/packages/workspace-2/package.json
+++ b/__tests__/fixtures/install/workspaces-install-link-bin-2-versions/packages/workspace-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-2",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "my_project_with_bin": "file:../../my_project_with_bin/v2"
+  }
+}

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -31,8 +31,8 @@ export async function getBinEntries(config: Config): Promise<Map<string, string>
 
   // Setup the node_modules/.bin folders for analysis
   for (const registryFolder of config.registryFolders) {
-    binFolders.add(path.resolve(config.cwd, registryFolder, '.bin'));
     binFolders.add(path.resolve(config.lockfileFolder, registryFolder, '.bin'));
+    binFolders.add(path.resolve(config.cwd, registryFolder, '.bin'));
   }
 
   // Same thing, but for the pnp dependencies, located inside the cache


### PR DESCRIPTION
- If there are multiple project which has dependency for the different
  version of 3rd party modules, only workspace root .bin was resolved.
- This change fixes this bug by changing order of bin entries when
  resolving binary locations which are in several different package
  folders
- See https://github.com/sglim/yarn-workspace-bin-bug to reproduce the
  bug

**Summary**

As-is
'yarn bin myBin' always returns `node_modules/.bin` in workspace root 

To-Bo
'yarn bin myBin' returns `workspace-*/node_modules/.bin` respectively

**Test plan**

Create two project which has 'binary', my_project_with_bin/v1 with cli_v1.js, my_project_with_bin/v2 with cli_v2.js, respectively.
Also, create a workspace with two workspace projects: 'workspace-1', 'workspace-2'. 'workspace-1' depends on my_project_with_bin:v1, 'workspace-2' depends on my_project_with_bin:v2 as well.

Install them in workspace, .bin will be create in each workspace-* folder.
Check the result of output buffer report contains workspace-* folder in binary path.