### PR TITLE
Use git reset instead of git pull to avoid attempting a merge commit

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -320,7 +320,8 @@ export default class Git implements GitRefResolvingInterface {
     return fs.lockQueue.push(gitUrl.repository, async () => {
       if (await fs.exists(cwd)) {
         await spawnGit(['fetch', '--tags'], {cwd});
-        await spawnGit(['pull'], {cwd});
+        await spawnGit(['remote', 'set-head', 'origin', '--auto'], {cwd});
+        await spawnGit(['reset', '--hard', 'origin/HEAD'], {cwd});
       } else {
         await spawnGit(['clone', gitUrl.repository, cwd]);
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Use `git reset` instead of `git pull` to avoid attempting a merge commit. Also, use `git remote set-head` in case the repository’s default branch has been renamed.

Fixes #5303.

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

Tested with this reproduction script:

```bash
#!/usr/bin/env bash
set -eux
tmpdir="$(mktemp -dt)"
trap 'rm -rf "$tmpdir"' EXIT
cd "$tmpdir"

git init some-library
cd some-library
echo '{"name": "some-library", "version": "1.0.0"}' > package.json
git add package.json
git commit -am 'Initial commit'
echo '{"name": "some-library", "version": "1.0.1"}' > package.json
git commit -am 'Bump version'
some_library="git+file://$PWD"

mkdir ../my-app
cd ../my-app
echo '{}' > package.json
XDG_CONFIG_HOME="$tmpdir" yarn add "$some_library"

cd ../some-library
echo '{"name": "some-library", "version": "1.0.2"}' > package.json
git commit --amend -am 'Force push'

# Uncomment to test branch rename:
#git branch -m develop

cd ../my-app
XDG_CONFIG_HOME="$tmpdir" yarn add "$some_library"
```

Without this fix, the second `yarn add` falis with:

```
+ yarn add git+file:///tmp/tmp.8JjoQJZXLa/some-library
yarn add v1.22.10
warning package.json: No license field
warning No license field
[1/4] Resolving packages...
error Command failed.
Exit code: 128
Command: git
Arguments: pull
Directory: /home/anders/.cache/yarn/v6/.tmp/ea609cd4e4a2249a3f41d450a33f8312
Output:
hint: Pulling without specifying how to reconcile divergent branches is
hint: discouraged. You can squelch this message by running one of the following
hint: commands sometime before your next pull:
hint: 
hint:   git config pull.rebase false  # merge (the default strategy)
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'anders@virtual-fork.(none)')
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

With this fix, it works correctly:

```
+ yarn add git+file:///tmp/tmp.IehTe8fiZv/some-library
yarn add v1.23.0-0
warning package.json: No license field
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
warning No license field
success Saved 1 new dependency.
info Direct dependencies
└─ some-library@1.0.2
info All dependencies
└─ some-library@1.0.2
Done in 0.27s.
```