### PR TITLE
Edit broken contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see https://yarnpkg.com/org/contributing/
+Please see https://yarnpkg.com/advanced/contributing

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](https://yarnpkg.com/advanced/contributing).
 
 ## Prior art
 


### PR DESCRIPTION
fix:
#8614 
#8426
#8350
#8335
#7950

**Summary**
While I was trying to solve an issue, I found the broken link at the README.md, then i found a few open issues about the broken link, I also found some PRs that fixes that issue, but those PRs fixed the broken link with the old (classic) link.
See:
https://github.com/yarnpkg/yarn/pull/8336
https://github.com/yarnpkg/yarn/pull/7952