### PR TITLE
fix: update contributing link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](https://yarnpkg.com/advanced/contributing).
 
 ## Prior art
 


### PR DESCRIPTION
**Summary**

Updated the contributing link in the readme file, old link is invalid

**Test plan**

go to le link
