### PR TITLE
Correct/Update the Contributing URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [Contributing](https://yarnpkg.com/org/contributing/).
+See [Contributing](https://yarnpkg.com/advanced/contributing).
 
 ## Prior art
 


### PR DESCRIPTION
**Summary**

This just updates the link in the README.md to point to the (i assume new) contributing url as the current one is a 404
