### PR TITLE
fix(tests): avoid installing package from untrusted registry in integration tests [SECURITY]

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -233,16 +233,12 @@ describe('--registry option', () => {
     expect(lockfile[2]).toContain(registry);
   });
 
-  test('--registry option with non-exiting registry and show an error', async () => {
+  test('--registry option with nonexistent registry and show an error', async () => {
     const cwd = await makeTemp();
-    const registry = 'https://example-registry-doesnt-exist.com';
+    const registry = 'https://example-registry-doesnt-exist.invalid'; // RFC 6761
 
-    try {
-      await runYarn(['add', 'is-array', '--registry', registry], {cwd});
-    } catch (err) {
-      const stdoutOutput = err.message;
-      expect(stdoutOutput.toString()).toMatch(/getaddrinfo ENOTFOUND example-registry-doesnt-exist\.com/g);
-    }
+    const yarnAdd = runYarn(['add', 'is-array', '--registry', registry, '--ignore-scripts'], {cwd});
+    await expect(yarnAdd).rejects.toThrow('getaddrinfo ENOTFOUND example-registry-doesnt-exist.invalid');
   });
 
   test('registry option from yarnrc', async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
I noticed one of the tests installs a package from registry `hxxps://example-registry-doesnt-exist[.]com` with the `--registry` flag, with the intent to test the case where the registry doesn't exist.

However someone could register that domain and serve a package with malicious lifecycle scripts (e.g. `"preinstall"`)

(I managed to register and park that to domain to prevent such scenario.)

This PR makes the following improvements:
- Replaces `.com` with the `.invalid` TLD ([RFC 6761](https://datatracker.ietf.org/doc/html/rfc6761#section-6.4))
- Passes `--ignore-scripts` since lifecycle scripts are not relevant for this test
- Ensures the test fails if installing from the nonexistent registry doesn't throw an exception

**Test plan**
\- 
