### PR TITLE
generate nonzero exit code when yarn 2 process is killed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,9 +22,14 @@ about: Open an issue
     https://discord.com/invite/yarnpkg
     https://github.com/yarnpkg/berry/discussions
 
+  Finally, if you intend to open a bug on Yarn 2, the right tracker is here:
+  
+    https://github.com/yarnpkg/berry
+
   If you decide to stay on Yarn 1 regardless, please be aware that we don't plan to
-  merge pull requests or release future versions of Classic unless it's to solve an critical
-  vulnerability report (which is unlikely).
+  merge pull requests or release future versions of Classic unless it's to solve an
+  critical vulnerability report (which is unlikely). By contrast, the 2.x line is very
+  actively supported. 
   
   Thanks for your understanding!
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,47 +1,31 @@
 ---
-name: Bug report
-about: Create a report
+name: Issue
+about: Open an issue
 ---
 
 <!-- 
 
-1. Please read our Rules of Conduct: https://github.com/yarnpkg/yarn/blob/master/CODE_OF_CONDUCT.md
+  Important note: This repository is about Yarn 1.x, also called "Classic". We released
+  Yarn 2 in January 2020, and multiple other minors since then (note that we slightly
+  changed how Yarn is installed, hence why `npm install -g yarn` doesn't show 2.x if
+  you run `--version`).
+  
+  If you get a problem with Yarn 1.x, it is *very* likely to have been fixed in higher
+  versions. We recommand that you migrate when you get the chance: the process has been
+  refined over the months and should be mostly painless - check here for details:
+  
+    https://yarnpkg.com/getting-started/migration#why-should-you-migrate
+  
+  If you hit blockers that aren't addressed in this guide, feel free to ask for help on
+  our Discord community server, or our GitHub discussion forum:
+  
+    https://discord.com/invite/yarnpkg
+    https://github.com/yarnpkg/berry/discussions
 
-2. Please search existing issues to avoid creating duplicates. Duplicates will be closed.
-
-3. Currently, not accepting any new feature requests. Please head over to https://github.com/yarnpkg/berry for new feature requests.
+  If you decide to stay on Yarn 1 regardless, please be aware that we don't plan to
+  merge pull requests or release future versions of Classic unless it's to solve an critical
+  vulnerability report (which is unlikely).
+  
+  Thanks for your understanding!
 
 -->
-
-
-<!-- Please fill out all sections. Issues with this not compeleted will be closed. --->
-
-
-### Bug description
-<!-- Any context around the issue or bug is helpful. -->
-
-**Command**
-
-```sh
-yarn [your command]
-```
-
-**What is the current behavior?**
-<!-- Describe how yarn is currently functioning with respect to the bug. -->
-
-
-**What is the expected behavior?**
-<!-- Describe how you expect it to work -->
-
-
-**Steps to Reproduce**
-<!-- If you can, provide a link to a public repository which contains the files necessary to reproduce this. -->
-
-1. 
-2.
-
-**Environment**
-
-- Node Version: `x.x.x`
-- Yarn v1 Version: `1.x.x` 
-- OS and version: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
 
+- Generates local yarn verions as `.cjs` files when calling `yarn set version`
+
+  [#8145](https://github.com/yarnpkg/yarn/pull/8145) - [**bgotink**](https://github.com/bgotink)
+
 ## 1.22.1
 
 - Prevents `yarn-path` from exiting before its child exited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
-## 1.22.8
+## 1.22.10 (and prior)
 
 - Tweak the preinstall check to not cause errors when Node is installed as root (as a downside, it won't run at all on Windows, which should be an acceptable tradeoff): https://github.com/yarnpkg/yarn/issues/8358
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,33 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
-## 1.22.2
+## 1.22.5
+
+- Headers won't be printed when calling `yarn init` with the `-2` flag
+
+  [**Maël Nison**](https://twitter.com/arcanis)
+
+- Files with the `.cjs` extension will be spawned by `yarnPath` using `execPath
+
+  [#8144](https://github.com/yarnpkg/yarn/pull/8144) - [**bgotink**](https://github.com/bgotink)
+
+- Generates local yarn verions as `.cjs` files when calling `yarn set version`
+
+  [#8145](https://github.com/yarnpkg/yarn/pull/8145) - [**bgotink**](https://github.com/bgotink)
 
 - Sorts files when running `yarn pack` to produce identical layout on Windows and Unix systems
 
   [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
 
+## 1.22.4 / 1.22.3
+
+Those versions didn't contain any changes and were just triggered by our infra while working on the tests.
+
+## 1.22.2
+
 - Ignores `.yarnrc.yml` by default when running `yarn pack`
 
   [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
-
-- Generates local yarn verions as `.cjs` files when calling `yarn set version`
-
-  [#8145](https://github.com/yarnpkg/yarn/pull/8145) - [**bgotink**](https://github.com/bgotink)
 
 ## 1.22.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+## 1.22.11
+
+This version fixes a problem where Yarn wasn't forwarding SIGTERM to the binary spawned via `yarnPath`. It also makes `yarn init -2` compatible with [Corepack](https://github.com/nodejs/corepack). The behaviour of `yarn init` (without `-2`) doesn't change.
+
+Remember that Yarn 1.x won't receive further functional improvements. We recommend you to switch to the recently-released 3.0, and to ping us on Discord if you find issues when migrating (also check our [Migration Guide](https://yarnpkg.com/getting-started/migration#why-should-you-migrate)).
+
 ## 1.22.10 (and prior)
 
 - Tweak the preinstall check to not cause errors when Node is installed as root (as a downside, it won't run at all on Windows, which should be an acceptable tradeoff): https://github.com/yarnpkg/yarn/issues/8358

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,21 @@
 
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
-## Master
+## 1.22.1
 
-- Passes arguments following `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
+- Prevents `yarn-path` from exiting before its child exited
 
-  [#7776](https://github.com/yarnpkg/yarn/pull/7776) - [**Jeff Valore**](https://twitter.com/rally25rs)
+  [#7957](https://github.com/yarnpkg/yarn/pull/7957) - [**Maël Nison**](https://twitter.com/arcanis)
 
-- Prints workspace names with `yarn workspaces` (silence with `-s`)
+- Generates relative paths when calling `yarn set version`
 
-  [#7722](https://github.com/yarnpkg/yarn/pull/7722) - [**Orta**](https://twitter.com/orta)
+  [#7931](https://github.com/yarnpkg/yarn/pull/7931) - [**Maël Nison**](https://twitter.com/arcanis)
 
-- Implements `yarn init --install <version>`
+- Throws an exception when the `.yarnrc.yml` file is invalid yaml
 
-  [#7723](https://github.com/yarnpkg/yarn/pull/7723) - [**Maël Nison**](https://twitter.com/arcanis)
-  
-- Implements `yarn init -2`
+  [#7931](https://github.com/yarnpkg/yarn/pull/7931) - [**Maël Nison**](https://twitter.com/arcanis)
 
-  [#7862](https://github.com/yarnpkg/yarn/pull/7862) - [**Maël Nison**](https://twitter.com/arcanis)
-
-- Implements `yarn set version <version>` as an alias for `policies set-version`
-
-  [#7862](https://github.com/yarnpkg/yarn/pull/7862) - [**Maël Nison**](https://twitter.com/arcanis)
-
-- Fixes an issue where the archive paths were incorrectly sanitized
-
-  [#7831](https://github.com/yarnpkg/yarn/pull/7831) - [**Maël Nison**](https://twitter.com/arcanis)
+## 1.22.0
 
 - Allows some dots in binary names again
 
@@ -36,6 +26,32 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
   [#7848](https://github.com/yarnpkg/yarn/pull/7848) - [**Nick Olinger**](https://github.com/olingern)
 
+- Passes arguments following `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
+
+  [#7776](https://github.com/yarnpkg/yarn/pull/7776) - [**Jeff Valore**](https://twitter.com/rally25rs)
+  
+- Fixes an issue where the archive paths were incorrectly sanitized
+
+  [#7831](https://github.com/yarnpkg/yarn/pull/7831) - [**Maël Nison**](https://twitter.com/arcanis)
+
+- Implements `yarn init -2`
+
+  [#7862](https://github.com/yarnpkg/yarn/pull/7862) - [**Maël Nison**](https://twitter.com/arcanis)
+
+- Implements `yarn set version <version>` as an alias for `policies set-version`
+
+  [#7862](https://github.com/yarnpkg/yarn/pull/7862) - [**Maël Nison**](https://twitter.com/arcanis)
+
+## 1.20 / 1.21
+
+- Prints workspace names with `yarn workspaces` (silence with `-s`)
+
+  [#7722](https://github.com/yarnpkg/yarn/pull/7722) - [**Orta**](https://twitter.com/orta)
+
+- Implements `yarn init --install <version>`
+
+  [#7723](https://github.com/yarnpkg/yarn/pull/7723) - [**Maël Nison**](https://twitter.com/arcanis)
+  
 ## 1.19.2
 
 - Folders like `.cache` won't be pruned from the `node_modules` after each install.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+## 1.22.8
+
+- Tweak the preinstall check to not cause errors when Node is installed as root (as a downside, it won't run at all on Windows, which should be an acceptable tradeoff): https://github.com/yarnpkg/yarn/issues/8358
+
 ## 1.22.7
 
 This release doesn't change anything and was caused by a publish issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 <!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
 
+## 1.22.7
+
+This release doesn't change anything and was caused by a publish issue.
+
+## 1.22.6
+
+- Running `yarn init` with the `-2` flag won't print the `set version` output anymore.
+
+- A new preinstall check will ensure that `npm install -g yarn` works even under [Corepack](https://github.com/arcanis/corepack). It doesn't have any effect on other setups.
+
 ## 1.22.5
 
 - Headers won't be printed when calling `yarn init` with the `-2` flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
-
+<!-- -->
 Please add one entry in this file for each change in Yarn's behavior. Use the same format for all entries, including the third-person verb. Make sure you don't add more than one line of text to keep it clean. Thanks!
+
+## 1.22.2
+
+- Sorts files when running `yarn pack` to produce identical layout on Windows and Unix systems
+
+  [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
+
+- Ignores `.yarnrc.yml` by default when running `yarn pack`
+
+  [#8142](https://github.com/yarnpkg/yarn/pull/8142) - [**Merceyz**](https://github.com/merceyz)
 
 ## 1.22.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see https://yarnpkg.com/org/contributing/
+The 1.x codebase is fairly old and will only accept security fixes. For new features or bugfixes, please see our new [repository](https://github.com/yarnpkg/berry) and its [contribution guide](https://yarnpkg.com/advanced/contributing).

--- a/README.md
+++ b/README.md
@@ -40,12 +40,28 @@
 <table width="100%">
   <tr>
     <td>
-      <a href="https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github">
+      <a href="https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github#gh-light-mode-only">
         <img src="https://assets.website-files.com/5de9972f49103c5df3964004/5f0c1146992a5e9e4fa553e6_logo.svg" width="140"/>
+      </a>
+      <a href="https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github#gh-dark-mode-only">
+        <img src="https://user-images.githubusercontent.com/1037931/151548177-308f0a41-fb0e-4311-9969-4a2455b08686.svg" width="140"/>
       </a>
     </td>
     <td>
       <b>All your environment variables, in one place</b>. Stop struggling with scattered API keys, hacking together home-brewed tools, and avoiding access controls. Keep your team and servers in sync with <b><a href="https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github">Doppler</a></b>.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://workos.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=berry&utm_source=github#gh-light-mode-only">
+        <img src="https://user-images.githubusercontent.com/1037931/151547094-7aa4a5cb-07e4-4b8a-ab8f-0a15fd63ab7d.svg" width="140"/>
+      </a>
+      <a href="https://workos.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=berry&utm_source=github#gh-dark-mode-only">
+        <img src="https://user-images.githubusercontent.com/1037931/151547899-3655e0d3-3bdb-4351-bd75-af2bebd3ce92.svg" width="140"/>
+      </a>
+    </td>
+    <td>
+      <b>Your app, enterprise-ready</b>. Start selling to enterprise customers with just a few lines of code. Add Single Sign-On (and more) in minutes instead of months with <b><a href="https://workos.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=berry&utm_source=github">WorkOS</a></b>.
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@
 <table width="100%">
   <tr>
     <td>
-      <a href="https://www.doppler.com/">
+      <a href="https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github">
         <img src="https://assets.website-files.com/5de9972f49103c5df3964004/5f0c1146992a5e9e4fa553e6_logo.svg" width="140"/>
       </a>
     </td>
     <td>
-      <b>All your environment variables, in one place</b>. Stop struggling with scattered API keys, hacking together home-brewed tools, and avoiding access controls. Keep your team and servers in sync with <b><a href="https://www.doppler.com/">Doppler</a></b>.
+      <b>All your environment variables, in one place</b>. Stop struggling with scattered API keys, hacking together home-brewed tools, and avoiding access controls. Keep your team and servers in sync with <b><a href="https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github">Doppler</a></b>.
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@
 * **Flat Mode.** Yarn resolves mismatched versions of dependencies to a single version to avoid creating duplicates.
 * **More emojis.** 🐈
 
+## Our supports
+
+### [Gold sponsors](https://opencollective.com/yarnpkg)
+
+<table width="100%">
+  <tr>
+    <td>
+      <a href="https://www.doppler.com/">
+        <img src="https://assets.website-files.com/5de9972f49103c5df3964004/5f0c1146992a5e9e4fa553e6_logo.svg" width="140"/>
+      </a>
+    </td>
+    <td>
+      <b>All your environment variables, in one place</b>. Stop struggling with scattered API keys, hacking together home-brewed tools, and avoiding access controls. Keep your team and servers in sync with <b><a href="https://www.doppler.com/">Doppler</a></b>.
+    </td>
+  </tr>
+</table>
+
 ## Installing Yarn
 
 Read the [Installation Guide](https://yarnpkg.com/en/docs/install) on our website for detailed instructions on how to install Yarn.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for det
 
 ## Contributing to Yarn
 
-Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
-
-See [Contributing](https://yarnpkg.com/org/contributing/).
+The 1.x codebase is fairly old and will only accept security fixes. For new features or bugfixes, please see our new [repository](https://github.com/yarnpkg/berry) and its [contribution guide](https://yarnpkg.com/advanced/contributing).
 
 ## Prior art
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1 @@
+This document moved to [our new repository](https://github.com/yarnpkg/berry/blob/master/SECURITY.md).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
 
 - job: OSX
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
 
   variables:
     os_name: OSX

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn",
   "installationMethod": "unknown",
-  "version": "1.22.0",
+  "version": "1.23.0-0",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/scripts/set-dev-version.js
+++ b/scripts/set-dev-version.js
@@ -6,6 +6,12 @@
 
 const fs = require('fs');
 
+// Leading `0` aren't valid semver, so we round it up to 10 to
+// avoid having to change the nightly version format.
+function roundToTen(value) {
+  return value < 10 ? 10 : value;
+}
+
 function leftPad(value) {
   return (value < 10 ? '0' : '') + value;
 }
@@ -18,7 +24,7 @@ const formattedDate =
   leftPad(date.getUTCMonth() + 1) +
   leftPad(date.getUTCDate()) +
   '.' +
-  leftPad(date.getUTCHours()) +
+  leftPad(roundToTen(date.getUTCHours())) +
   leftPad(date.getUTCMinutes());
 
 // Remove any existing suffix before appending the date
@@ -30,4 +36,5 @@ fs.writeFileSync(
   packageManifestFilename,
   JSON.stringify(packageManifest, null, 2) + '\n'
 );
+
 console.log('Updated version number to ' + version);

--- a/src/cli/commands/pack.js
+++ b/src/cli/commands/pack.js
@@ -36,6 +36,7 @@ const DEFAULT_IGNORE = ignoreLinesToRegex([
   'yarn-error.log',
   '.npmrc',
   '.yarnrc',
+  '.yarnrc.yml',
   '.npmignore',
   '.gitignore',
   '.DS_Store',
@@ -146,6 +147,7 @@ export function packWithIgnoreAndHeaders(
 ): Promise<stream$Duplex> {
   return tar.pack(cwd, {
     ignore: ignoreFunction,
+    sort: true,
     map: header => {
       const suffix = header.name === '.' ? '' : `/${header.name}`;
       header.name = `package${suffix}`;

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -167,7 +167,7 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
       const rcPath = `${config.lockfileFolder}/.yarnrc.yml`;
       reporter.log(`Updating ${chalk.magenta(rcPath)}...`);
 
-      await fs.writeFilePreservingEol(rcPath, `yarnPath: ${JSON.stringify(yarnPath)}\n`);
+      await fs.writeFilePreservingEol(rcPath, `yarnPath: ${JSON.stringify(targetPath)}\n`);
     } else {
       const rcPath = `${config.lockfileFolder}/.yarnrc`;
       reporter.log(`Updating ${chalk.magenta(rcPath)}...`);

--- a/src/cli/commands/policies.js
+++ b/src/cli/commands/policies.js
@@ -155,7 +155,7 @@ const {run, setFlags, examples} = buildSubCommands('policies', {
 
     const bundle = await fetchBundle(config, bundleUrl);
 
-    const yarnPath = path.resolve(config.lockfileFolder, `.yarn/releases/yarn-${bundleVersion}.js`);
+    const yarnPath = path.resolve(config.lockfileFolder, `.yarn/releases/yarn-${bundleVersion}.cjs`);
     reporter.log(`Saving it into ${chalk.magenta(yarnPath)}...`);
     await fs.mkdirp(path.dirname(yarnPath));
     await fs.writeFile(yarnPath, bundle);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -635,7 +635,7 @@ async function start(): Promise<void> {
     });
 
     try {
-      if (yarnPath.endsWith(`.js`)) {
+      if (/\.[cm]?js$/.test(yarnPath)) {
         exitCode = await spawnp(process.execPath, [yarnPath, ...argv], opts);
       } else {
         exitCode = await spawnp(yarnPath, argv, opts);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -629,6 +629,11 @@ async function start(): Promise<void> {
     const opts = {stdio: 'inherit', env: Object.assign({}, process.env, {YARN_IGNORE_PATH: 1})};
     let exitCode = 0;
 
+    process.on(`SIGINT`, () => {
+      // We don't want SIGINT to kill our process; we want it to kill the
+      // innermost process, whose end will cause our own to exit.
+    });
+
     try {
       if (yarnPath.endsWith(`.js`)) {
         exitCode = await spawnp(process.execPath, [yarnPath, ...argv], opts);

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -398,9 +398,14 @@ function parse(str: string, fileLoc: string): Object {
       }
     }
   } else {
-    return safeLoad(str, {
+    const result = safeLoad(str, {
       schema: FAILSAFE_SCHEMA,
     });
+    if (typeof result === 'object') {
+      return result;
+    } else {
+      return {};
+    }
   }
 }
 

--- a/src/lockfile/parse.js
+++ b/src/lockfile/parse.js
@@ -384,16 +384,23 @@ function hasMergeConflicts(str: string): boolean {
 function parse(str: string, fileLoc: string): Object {
   const parser = new Parser(str, fileLoc);
   parser.next();
-  try {
-    return parser.parse();
-  } catch (error1) {
+
+  if (!fileLoc.endsWith(`.yml`)) {
     try {
-      return safeLoad(str, {
-        schema: FAILSAFE_SCHEMA,
-      });
-    } catch (error2) {
-      throw error1;
+      return parser.parse();
+    } catch (error1) {
+      try {
+        return safeLoad(str, {
+          schema: FAILSAFE_SCHEMA,
+        });
+      } catch (error2) {
+        throw error1;
+      }
     }
+  } else {
+    return safeLoad(str, {
+      schema: FAILSAFE_SCHEMA,
+    });
   }
 }
 

--- a/src/rc.js
+++ b/src/rc.js
@@ -53,9 +53,9 @@ export function getRcConfigForFolder(cwd: string): {[key: string]: string} {
 }
 
 function loadRcFile(fileText: string, filePath: string): {[key: string]: string} {
-  let {object: values} = parse(fileText, 'yarnrc');
+  let {object: values} = parse(fileText, filePath);
 
-  if (filePath.match(/\.yml$/)) {
+  if (filePath.match(/\.yml$/) && typeof values.yarnPath === 'string') {
     values = {'yarn-path': values.yarnPath};
   }
 

--- a/src/util/child.js
+++ b/src/util/child.js
@@ -6,6 +6,7 @@ import BlockingQueue from './blocking-queue.js';
 import {ProcessSpawnError, ProcessTermError} from '../errors.js';
 import {promisify} from './promise.js';
 
+const os = require('os');
 const child = require('child_process');
 
 export const queue = new BlockingQueue('child', constants.CHILD_CONCURRENCY);
@@ -23,8 +24,8 @@ export function forkp(program: string, args: Array<string>, opts?: Object): Prom
       reject(error);
     });
 
-    proc.on('close', exitCode => {
-      resolve(exitCode);
+    proc.on('close', (exitCode: number, signal: string) => {
+      resolve(exitCode ?? 128 + os.constants.signals[signal]);
     });
   });
 }
@@ -37,8 +38,8 @@ export function spawnp(program: string, args: Array<string>, opts?: Object): Pro
       reject(error);
     });
 
-    proc.on('close', exitCode => {
-      resolve(exitCode);
+    proc.on('close', (exitCode: number, signal: string) => {
+      resolve(exitCode ?? 128 + os.constants.signals[signal]);
     });
   });
 }

--- a/src/util/rc.js
+++ b/src/util/rc.js
@@ -68,7 +68,11 @@ function parseRcPaths(paths: Array<string>, parser: Function): Object {
       try {
         return parser(readFileSync(path).toString(), path);
       } catch (error) {
-        return {};
+        if (error.code === 'ENOENT' || error.code === 'EISDIR') {
+          return {};
+        } else {
+          throw error;
+        }
       }
     }),
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

Yarn 2+, when SIGKILLed (due to OOM for example), fails silently as the yarn 1 process that spawns it does not recognize that it was killed (see https://github.com/yarnpkg/berry/issues/3996), resulting in issues that are difficult to debug as it appears to be successful.

Thus, in spawnp and forkp, use the bash convention of 128+signal to notify the yarn caller that the yarn 2 process was terminated via signal.

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
