### PR TITLE
chore: remove git.io

### DIFF
--- a/__tests__/commands/add.js
+++ b/__tests__/commands/add.js
@@ -1202,7 +1202,7 @@ test.concurrent('installs "latest" instead of maxSatisfying if it satisfies requ
   // not `1.0.2` even though it is newer.
   // This is behavior defined by the NPM implementation. See:
   //  * https://github.com/yarnpkg/yarn/issues/3560
-  //  * https://git.io/vFmau
+  //  * https://github.com/npm/npm/blob/d46015256941ddfff1463338e3e2f8f77624a1ff/lib/utils/pick-manifest-from-registry-metadata.js#L11
   //
   // In this test, `ui-select` has a max version of `0.20.0` but a `latest:0.19.8`
   await runAdd(['ui-select@^0.X'], {}, 'latest-version-in-package', async (config, reporter, previousAdd) => {

--- a/src/cli/commands/licenses.js
+++ b/src/cli/commands/licenses.js
@@ -139,7 +139,7 @@ export const {run, examples} = buildSubCommands('licenses', {
     // (JSON output being the primary one). This command is only for text consumption
     // and you should just be dumping it to a TXT file. Using a reporter here has the
     // potential to mess up the output since it might print ansi escapes.
-    // @kittens - https://git.io/v7uts
+    // @kittens - https://github.com/yarnpkg/yarn/pull/4036#discussion_r130739083
 
     const manifests: Array<Manifest> = await getManifests(config, flags);
     const manifest = await config.readRootManifest();

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -82,7 +82,7 @@ function keyForRemote(remote: PackageRemote): ?string {
 
 function serializeIntegrity(integrity: Integrity): string {
   // We need this because `Integrity.toString()` does not use sorting to ensure a stable string output
-  // See https://git.io/vx2Hy
+  // See https://github.com/zkat/ssri/blob/b71ef1732a17a5e440d0c239351b346d72efa9fa/index.js#L74-L86
   return integrity.toString().split(' ').sort().join(' ');
 }
 


### PR DESCRIPTION
**Summary**

All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/
