### PR TITLE
chore: added neccessary keywords.

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,13 @@
       "packages/pkg-tests"
     ]
   },
+  "keywords": [
+    "yarn",
+    "packages",
+    "package-manager",
+    "npm",
+    "JavaScript"
+]
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
Which I'm using npmjs.org I forgot the name of this package but I entered `package-manager` to check for it and in returned results it wasn't included so to fix this problem we have to add neccessary keywords for better searching for those who don't know it.

<!-- 

  Important note: This repository is about Yarn 1.x, also called "Classic". We now release
  modern versions on the yarnpkg/berry repository, which has a completely new (and more
  stable) codebase.
  
  If you get a problem with Yarn 1.x, it is *very* likely to have been fixed in recent
  versions. We recommand that you migrate when you get the chance: the process has been
  refined over the years and should be mostly painless - check here for details:
  
    https://yarnpkg.com/getting-started/migration#why-should-you-migrate
  
  If you hit blockers that aren't addressed in this guide, feel free to ask for help on
  our Discord community server, or our GitHub discussion forum:
  
    https://discord.com/invite/yarnpkg
    https://github.com/yarnpkg/berry/discussions

  Finally, if you intend to open a bug on modern versions of Yarn, the right tracker is here:
  
    https://github.com/yarnpkg/berry

  If you decide to stay on Yarn 1 regardless, please be aware that we don't plan to
  merge pull requests or release future versions of Classic unless it's to solve an
  critical vulnerability report (which is unlikely). The modern releases are
  however very actively supported, and your help would be appreciated.

  Thanks for your understanding!

-->
