### PR TITLE
Fixes the lockfile hydration of the `npm:` protocol

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -36,7 +36,7 @@ process.stdout.prependListener('error', err => {
   throw err;
 });
 
-function findPackageManager(base: string): ?string {
+function findPackageManager(base: string): string | null {
   let prev = null;
   let dir = base;
 
@@ -45,7 +45,7 @@ function findPackageManager(base: string): ?string {
 
     let data;
     try {
-      data = JSON.parse(fs.readFileSync(p));
+      data = JSON.parse(fs.readFileSync(p, `utf8`));
     } catch (err) {}
 
     if (data && typeof data.packageManager === `string`) {
@@ -303,12 +303,14 @@ export async function main({
         process.stderr.write(
           `Presence of the ${chalk.gray(
             `"packageManager"`,
+            // eslint-disable-next-line max-len
           )} field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.\n`,
         );
 
         process.stderr.write(
           `Corepack must currently be enabled by running ${chalk.magenta(
             `corepack enable`,
+            // $FlowIgnore
           )} in your terminal. For more information, check out ${chalk.blueBright(`https://yarnpkg.com/corepack`)}.\n`,
         );
 

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -229,18 +229,16 @@ export default class Lockfile {
       invariant(remote, 'Package is missing a remote');
 
       const remoteKey = keyForRemote(remote);
-      const seenPattern = remoteKey && seen.get(remoteKey);
+
+      const seenKey = remoteKey && `${remoteKey}#${getName(pattern)}`;
+      const seenPattern = remoteKey && seen.get(seenKey);
+
       if (seenPattern) {
         // no point in duplicating it
         lockfile[pattern] = seenPattern;
-
-        // if we're relying on our name being inferred and two of the patterns have
-        // different inferred names then we need to set it
-        if (!seenPattern.name && getName(pattern) !== pkg.name) {
-          seenPattern.name = pkg.name;
-        }
         continue;
       }
+
       const obj = implodeEntry(pattern, {
         name: pkg.name,
         version: pkg.version,
@@ -257,8 +255,8 @@ export default class Lockfile {
 
       lockfile[pattern] = obj;
 
-      if (remoteKey) {
-        seen.set(remoteKey, obj);
+      if (seenKey) {
+        seen.set(seenKey, obj);
       }
     }
 

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -230,8 +230,8 @@ export default class Lockfile {
 
       const remoteKey = keyForRemote(remote);
 
-      const seenKey = remoteKey && `${remoteKey}#${getName(pattern)}`;
-      const seenPattern = remoteKey && seen.get(seenKey);
+      const seenKey = remoteKey ? `${remoteKey}#${getName(pattern)}` : null;
+      const seenPattern = seenKey ? seen.get(seenKey) : null;
 
       if (seenPattern) {
         // no point in duplicating it

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -229,8 +229,9 @@ export default class Lockfile {
       invariant(remote, 'Package is missing a remote');
 
       const remoteKey = keyForRemote(remote);
+      const pkgName = getName(pattern);
 
-      const seenKey = remoteKey ? `${remoteKey}#${getName(pattern)}` : null;
+      const seenKey = remoteKey ? `${remoteKey}#${pkgName}` : null;
       const seenPattern = seenKey ? seen.get(seenKey) : null;
 
       if (seenPattern) {
@@ -240,7 +241,7 @@ export default class Lockfile {
       }
 
       const obj = implodeEntry(pattern, {
-        name: pkg.name,
+        name: pkgName,
         version: pkg.version,
         uid: pkg._uid,
         resolved: remote.resolved,


### PR DESCRIPTION
The lockfile hydration code is trying to unify similar lockfile entries:

```
"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
  version "6.0.1"
  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
  dependencies:
    ansi-regex "^5.0.1"
```

However, when this file is read, the code was hydrating a single copy of the package, using a single name (others were dropped). This was causing strange behaviours when generating the hoisting, as the wrong package names were used to prevent incompatible version overrides.

