### PR TITLE
Pin lodash to version that is acceptable to governance scans

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "yargs": "^6.3.0"
   },
   "resolutions": {
-    "sshpk": "^1.14.2"
+    "sshpk": "^1.14.2",
+    "lodash": "4.17.21"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5026,15 +5026,10 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
-
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+lodash@4.17.21, lodash@4.17.5, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.21"
+  resolved "https://artifacthub-phx.oci.oraclecorp.com/api/npm/npmjs-registry/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!-- 

  Important note: This repository is about Yarn 1.x, also called "Classic". We now release
  modern versions on the yarnpkg/berry repository, which has a completely new (and more
  stable) codebase.
  
  If you get a problem with Yarn 1.x, it is *very* likely to have been fixed in recent
  versions. We recommand that you migrate when you get the chance: the process has been
  refined over the years and should be mostly painless - check here for details:
  
    https://yarnpkg.com/getting-started/migration#why-should-you-migrate
  
  If you hit blockers that aren't addressed in this guide, feel free to ask for help on
  our Discord community server, or our GitHub discussion forum:
  
    https://discord.com/invite/yarnpkg
    https://github.com/yarnpkg/berry/discussions

  Finally, if you intend to open a bug on modern versions of Yarn, the right tracker is here:
  
    https://github.com/yarnpkg/berry

  If you decide to stay on Yarn 1 regardless, please be aware that we don't plan to
  merge pull requests or release future versions of Classic unless it's to solve an
  critical vulnerability report (which is unlikely). The modern releases are
  however very actively supported, and your help would be appreciated.

  Thanks for your understanding!

-->

Yarn classic seems to depend on versions of lodash that are <4.17.21, which are being flagged by our governance scan checker on deploy as security risks. As a result, we can not use yarn classic. This will pin lodash to version 4.17.21, which is free of security vulnerabilities as reported by the governance scan. 
