### PR TITLE
Prevents exiting the process on sigint in case of yarn run, fixes #8895.

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -9,6 +9,7 @@ import {MessageError} from '../../errors.js';
 import {checkOne as checkCompatibility} from '../../package-compatibility.js';
 import * as fs from '../../util/fs.js';
 import * as constants from '../../constants.js';
+import {preventSigintKill} from '../../util/prevent-sigint-kill';
 
 const invariant = require('invariant');
 const leven = require('leven');
@@ -120,6 +121,8 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
       invariant(script, 'Script must exist');
       cmds.push([action, script]);
     }
+
+    preventSigintKill();
 
     if (cmds.length) {
       const ignoreEngines = !!(flags.ignoreEngines || config.getOption('ignore-engines'));

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,6 +25,7 @@ import {version} from '../util/yarn-version.js';
 import handleSignals from '../util/signal-handler.js';
 import {boolify, boolifyWithDefault} from '../util/conversion.js';
 import {ProcessTermError} from '../errors';
+import {preventSigintKill} from '../util/prevent-sigint-kill';
 
 process.stdout.prependListener('error', err => {
   // swallow err only if downstream consumer process closed pipe early
@@ -629,10 +630,7 @@ async function start(): Promise<void> {
     const opts = {stdio: 'inherit', env: Object.assign({}, process.env, {YARN_IGNORE_PATH: 1})};
     let exitCode = 0;
 
-    process.on(`SIGINT`, () => {
-      // We don't want SIGINT to kill our process; we want it to kill the
-      // innermost process, whose end will cause our own to exit.
-    });
+    preventSigintKill();
 
     try {
       if (/\.[cm]?js$/.test(yarnPath)) {

--- a/src/util/prevent-sigint-kill.js
+++ b/src/util/prevent-sigint-kill.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+export function preventSigintKill() {
+  process.on(`SIGINT`, () => {
+    // We don't want SIGINT to kill our process; we want it to kill the
+    // innermost process, whose end will cause our own to exit.
+  });
+}


### PR DESCRIPTION
## Prevents exiting the process on SIGINT in case of yarn run.

**Current behavior:**

When user presses `ctrl+C` yarn exits immediately and shell prompt is shown. If a run script needs some time to cleanup before exit and outputs something to terminal, it pollutes the prompt.

**New behavior:**

`yarn` doesn't make any decisions on when to exit, it just waits for the children.
Works the same as `npm run` now in that regard.

This PR fixes this issue: #8895

## Test cases

**Test script for this PR: example.js**

```js
const EXIT_CODE = 1;

setInterval(() => {
    console.log('tick');
}, 1000);

process.on('SIGINT', () => {
    console.log('SIGINT from script');
    setTimeout(() => process.exit(EXIT_CODE), 3000);
});
```

### Regular case

Excerpt from package.json:

```json
                "example": "node example.js",
```

Actual behavior with this script:

```bash
bash-3.2$ yarn run example
yarn run v1.22.22
$ node example.js
tick
tick
^CSIGINT from script

bash-3.2$ tick
tick
tick
```

New behavior with this script:

```bash
bash-3.2$ yarn example
yarn run v1.23.0-0
$ node example.js
tick
tick
^CSIGINT from script
tick
tick
tick
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
bash-3.2$
```

For reference, npm run behavior:

```bash
bash-3.2$ npm run example

> example
> node example.js

tick
tick
^CSIGINT from script
tick
tick
tick
bash-3.2$
```

### Using pre/post scripts

Excerpt from package.json:

```json
                "preexample": "node example.js",
                "example": "node example.js",
                "postexample": "node example.js"
```

Actual behavior with this script:

```bash
bash-3.2$ yarn example
yarn run v1.22.22
$ node example.js
tick
tick
^CSIGINT from script

bash-3.2$ tick
tick
tick
```

New behavior with this script:

```bash
bash-3.2$ yarn example
yarn run v1.23.0-0
$ node example.js
tick
tick
^CSIGINT from script
tick
tick
tick
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
bash-3.2$
```

For reference, npm run behavior:

```bash
bash-3.2$ npm run example

> preexample
> node example.js

tick
tick
^CSIGINT from script
tick
tick
tick
bash-3.2$
```

### Using pre/post scripts with zero exit code

Excerpt from package.json:

```json
                "preexample": "node example.js",
                "example": "node example.js",
                "postexample": "node example.js"
```

Modify `example.js` and set `EXIT_CODE` to `0`.

Actual behavior:

```bash
bash-3.2$ yarn example
yarn run v1.22.22
$ node example.js
tick
tick
^CSIGINT from script

bash-3.2$ tick
tick
tick
```

New behavior:

```bash
bash-3.2$ yarn example
yarn run v1.23.0-0
$ node example.js
tick
tick
^CSIGINT from script
tick
tick
tick
$ node example.js
tick
tick
^CSIGINT from script
tick
tick
tick
$ node example.js
tick
tick
^CSIGINT from script
tick
tick
tick
✨  Done in 16.77s.
bash-3.2$
```

For reference npm behavior:

```bash
bash-3.2$ npm run example

> preexample
> node example.js

tick
tick
^CSIGINT from script
tick
tick
tick

> example
> node example.js

tick
tick
^CSIGINT from script
tick
tick
tick

> postexample
> node example.js

tick
tick
^CSIGINT from script
tick
tick
tick
bash-3.2$
```