### PR TITLE
Include status message (reason phrase) in error message

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -425,7 +425,7 @@ export default class RequestManager {
         this.reporter.verbose(this.reporter.lang('verboseRequestFinish', params.url, res.statusCode));
 
         if (res.statusCode === 408 || res.statusCode >= 500) {
-          const description = `${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`;
+          const description = `${res.statusCode} ${res.statusMessage || http.STATUS_CODES[res.statusCode]}`;
           if (!queueForRetry(this.reporter.lang('internalServerErrorRetrying', description))) {
             throw new ResponseError(this.reporter.lang('requestFailed', description), res.statusCode);
           } else {
@@ -517,7 +517,7 @@ export default class RequestManager {
           return;
         }
 
-        const description = `${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`;
+        const description = `${res.statusCode} ${res.statusMessage || http.STATUS_CODES[res.statusCode]}`;
         reject(new ResponseError(this.reporter.lang('requestFailed', description), res.statusCode));
 
         req.abort();


### PR DESCRIPTION
When an HTTP request fails, the status code and description is logged/output. That description currently is derived by mapping the status code to a predefined mapping of messages. This change uses the HTTP response status line reason phrase if it is available, falling back to the predefined mapping to a message if the server didn't provide one.

The reason phrase that the server responds with may have more information that will be helpful for the user. For example, Sonatype Nexus Firewall includes a message in the reason phrase indicating the requested package is blocked. Other software similarly returns useful information in the reason phrase.

See:
* https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html
* https://nodejs.org/api/http.html#messagestatusmessage

<!-- 

  Important note: This repository is about Yarn 1.x, also called "Classic". We now release
  modern versions on the yarnpkg/berry repository, which has a completely new (and more
  stable) codebase.
  
  If you get a problem with Yarn 1.x, it is *very* likely to have been fixed in recent
  versions. We recommand that you migrate when you get the chance: the process has been
  refined over the years and should be mostly painless - check here for details:
  
    https://yarnpkg.com/getting-started/migration#why-should-you-migrate
  
  If you hit blockers that aren't addressed in this guide, feel free to ask for help on
  our Discord community server, or our GitHub discussion forum:
  
    https://discord.com/invite/yarnpkg
    https://github.com/yarnpkg/berry/discussions

  Finally, if you intend to open a bug on modern versions of Yarn, the right tracker is here:
  
    https://github.com/yarnpkg/berry

  If you decide to stay on Yarn 1 regardless, please be aware that we don't plan to
  merge pull requests or release future versions of Classic unless it's to solve an
  critical vulnerability report (which is unlikely). The modern releases are
  however very actively supported, and your help would be appreciated.

  Thanks for your understanding!

-->
