### PR TITLE
Do not warn when `"bun"` is used in `"engines"` in package.json

### DIFF
--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -53,6 +53,7 @@ const ignore = [
   'rhino', // once a target for older modules
   'cordovaDependencies', // http://bit.ly/2tkUePg
   'parcel', // used for plugins of the Parcel bundler
+  'bun', // a JavaScript runtime
 ];
 
 type Versions = {


### PR DESCRIPTION
<!-- 

  Important note: This repository is about Yarn 1.x, also called "Classic". We now release
  modern versions on the yarnpkg/berry repository, which has a completely new (and more
  stable) codebase.
  
  If you get a problem with Yarn 1.x, it is *very* likely to have been fixed in recent
  versions. We recommand that you migrate when you get the chance: the process has been
  refined over the years and should be mostly painless - check here for details:
  
    https://yarnpkg.com/getting-started/migration#why-should-you-migrate
  
  If you hit blockers that aren't addressed in this guide, feel free to ask for help on
  our Discord community server, or our GitHub discussion forum:
  
    https://discord.com/invite/yarnpkg
    https://github.com/yarnpkg/berry/discussions

  Finally, if you intend to open a bug on modern versions of Yarn, the right tracker is here:
  
    https://github.com/yarnpkg/berry

  If you decide to stay on Yarn 1 regardless, please be aware that we don't plan to
  merge pull requests or release future versions of Classic unless it's to solve an
  critical vulnerability report (which is unlikely). The modern releases are
  however very actively supported, and your help would be appreciated.

  Thanks for your understanding!

-->

Currently, when `"engines"` of any package.json dependency includes `"bun"`, yarn v1 prints the warning below:

<img width="484" height="137" alt="image" src="https://github.com/user-attachments/assets/f0550c1b-e41e-424e-9bc3-a8dc41b563c0" />

This PR adds `"bun"` to the list of engines to ignore, so that yarn v1 doesn't print this warning. This will let npm packages that use the `"engines"` field specify they want to use the Bun runtime more easily.

