### PR TITLE
Fix yarn audit to respect --registry flag

### DIFF
--- a/src/cli/commands/audit.js
+++ b/src/cli/commands/audit.js
@@ -238,7 +238,7 @@ export default class Audit {
 
   async _fetchAudit(auditTree: AuditTree): Object {
     let responseJson;
-    const registry = YARN_REGISTRY;
+    const registry = this.config.registries.npm.getRegistry('');
     this.reporter.verbose(`Audit Request: ${JSON.stringify(auditTree, null, 2)}`);
     const requestBody = await gzip(JSON.stringify(auditTree));
     const response = await this.config.requestManager.request({


### PR DESCRIPTION
## Problem

When running `yarn audit --registry https://registry.npmjs.org/`, the audit command ignores the specified registry and always uses the main yarn registry instead. This breaks CI environments with restricted external access or proxy setups.

## Solution

Modified the audit command implementation to properly pass the `--registry` flag to the underlying audit API calls. The registry parameter is now correctly respected and used for all audit requests.

## Validation

```bash
# Before fix - ignores registry flag
yarn audit --registry https://custom.registry.com/

# After fix - uses specified registry
yarn audit --registry https://custom.registry.com/
# ✅ Audit requests go to custom.registry.com
```

Fixes #7012