### PR TITLE
fix: add feedback when yarn publish runs with unchanged version

### DIFF
--- a/src/cli/commands/version.js
+++ b/src/cli/commands/version.js
@@ -127,13 +127,6 @@ export async function setVersion(
       newVersion = oldVersion;
     }
 
-    if (!required && !newVersion) {
-      reporter.info(`${reporter.lang('noVersionOnPublish')}: ${oldVersion}`);
-      return function(): Promise<void> {
-        return Promise.resolve();
-      };
-    }
-
     if (isValidNewVersion(oldVersion, newVersion, config.looseSemver, identifier)) {
       break;
     } else {
@@ -141,12 +134,16 @@ export async function setVersion(
       reporter.error(reporter.lang('invalidSemver'));
     }
   }
+
   if (newVersion) {
     newVersion = semver.inc(oldVersion, newVersion, config.looseSemver, identifier) || newVersion;
   }
   invariant(newVersion, 'expected new version');
 
   if (newVersion === pkg.version) {
+    if (!required) {
+      reporter.info(`${reporter.lang('noVersionOnPublish')}: ${newVersion}`);
+    }
     return function(): Promise<void> {
       return Promise.resolve();
     };


### PR DESCRIPTION
Fixes #2940

This PR adds a feedback message when `yarn publish` proceeds without a version change.

Previously, the command would continue silently, which could make it unclear whether a new version was actually published.

With this change, users now get a clear message indicating that the version remains unchanged, improving transparency during the publish process.
